### PR TITLE
Preserve error retryability across metadata store proxy boundary

### DIFF
--- a/crates/metadata-providers/src/replicated.rs
+++ b/crates/metadata-providers/src/replicated.rs
@@ -29,8 +29,7 @@ use restate_metadata_store::{
     MetadataStore, MetadataStoreClient, ProvisionError, ReadError, WriteError,
 };
 use restate_types::config::Configuration;
-use restate_types::errors::ConversionError;
-use restate_types::errors::SimpleStatus;
+use restate_types::errors::{ConversionError, SimpleStatus, is_retryable_status};
 use restate_types::metadata::{Precondition, VersionedValue};
 use restate_types::net::address::{AdvertisedAddress, FabricPort};
 use restate_types::net::connect_opts::{CommonClientConnectionOptions, GrpcConnectionOptions};
@@ -470,25 +469,6 @@ fn map_status_to_provision_error(
         ProvisionError::retryable(StatusError::new(address, status))
     } else {
         ProvisionError::terminal(StatusError::new(address, status))
-    }
-}
-
-/// Check if a gRPC status represents a retryable error.
-///
-/// Transport errors can manifest in different ways:
-/// - `Unknown`: General transport errors
-/// - `Unavailable`: Server is not reachable
-/// - `Cancelled`: Connection was terminated (common with UDS when server is killed)
-/// - `Internal` with h2 errors: HTTP/2 protocol errors (e.g., connection reset, stream errors)
-fn is_retryable_status(status: &Status) -> bool {
-    match status.code() {
-        Code::Unavailable | Code::Unknown | Code::Cancelled => true,
-        // h2 protocol errors surface as Internal errors but are transport-related and retryable
-        Code::Internal => {
-            let message = status.message();
-            message.contains("h2 protocol error") || message.contains("http2 error")
-        }
-        _ => false,
     }
 }
 

--- a/crates/metadata-store/src/protobuf.rs
+++ b/crates/metadata-store/src/protobuf.rs
@@ -26,7 +26,7 @@ pub mod metadata_proxy_svc {
         use tonic::{Code, Status};
         use tonic::{codec::CompressionEncoding, transport::Channel};
 
-        use restate_types::errors::SimpleStatus;
+        use restate_types::errors::{SimpleStatus, is_retryable_status};
         use restate_types::{
             Version,
             metadata::{Precondition, VersionedValue},
@@ -143,21 +143,20 @@ pub mod metadata_proxy_svc {
         }
 
         fn to_read_err(status: Status) -> ReadError {
-            // Currently, we treat all returned statuses as terminal errors since
-            // retryability is not encoded in the status response.
-            //
-            // Additionally, users of this proxy client (e.g., `restatectl`) are
-            // unlikely to retry on errors and will typically attempt to use
-            // another node instead.
-            ReadError::terminal(SimpleStatus::from(status))
+            if is_retryable_status(&status) {
+                ReadError::retryable(SimpleStatus::from(status))
+            } else {
+                ReadError::terminal(SimpleStatus::from(status))
+            }
         }
 
         fn to_write_err(status: Status) -> WriteError {
-            match status.code() {
-                Code::FailedPrecondition => {
-                    WriteError::FailedPrecondition(SimpleStatus::from(status).to_string())
-                }
-                _ => WriteError::terminal(SimpleStatus::from(status)),
+            if status.code() == Code::FailedPrecondition {
+                WriteError::FailedPrecondition(SimpleStatus::from(status).to_string())
+            } else if is_retryable_status(&status) {
+                WriteError::retryable(SimpleStatus::from(status))
+            } else {
+                WriteError::terminal(SimpleStatus::from(status))
             }
         }
     }

--- a/crates/node/src/network_server/grpc_svc_handler.rs
+++ b/crates/node/src/network_server/grpc_svc_handler.rs
@@ -33,10 +33,10 @@ use restate_core::protobuf::node_ctl_svc::{
 };
 use restate_core::{Identification, MetadataWriter};
 use restate_core::{Metadata, MetadataKind};
-use restate_metadata_store::{MetadataStoreClient, WriteError};
+use restate_metadata_store::{MetadataStoreClient, ReadError, WriteError};
 use restate_types::Version;
 use restate_types::config::{Configuration, NetworkingOptions};
-use restate_types::errors::ConversionError;
+use restate_types::errors::{ConversionError, MaybeRetryableError};
 use restate_types::logs::metadata::{NodeSetSize, ProviderConfiguration};
 use restate_types::metadata::VersionedValue;
 use restate_types::nodes_config::Role;
@@ -304,7 +304,7 @@ impl MetadataProxySvc for MetadataProxySvcHandler {
             .inner()
             .get(request.key.into())
             .await
-            .map_err(|err| Status::internal(err.to_string()))?;
+            .map_err(read_err_to_status)?;
 
         let response = GetResponse {
             value: value.map(Into::into),
@@ -324,7 +324,7 @@ impl MetadataProxySvc for MetadataProxySvcHandler {
             .inner()
             .get_version(request.key.into())
             .await
-            .map_err(|err| Status::internal(err.to_string()))?;
+            .map_err(read_err_to_status)?;
 
         let response = GetVersionResponse {
             version: value.map(Into::into),
@@ -351,10 +351,7 @@ impl MetadataProxySvc for MetadataProxySvcHandler {
             .inner()
             .put(request.key.into(), value, precondition)
             .await
-            .map_err(|err| match err {
-                WriteError::FailedPrecondition(msg) => Status::failed_precondition(msg),
-                err => Status::internal(err.to_string()),
-            })?;
+            .map_err(write_err_to_status)?;
 
         Ok(Response::new(()))
     }
@@ -373,11 +370,24 @@ impl MetadataProxySvc for MetadataProxySvcHandler {
             .inner()
             .delete(request.key.into(), precondition)
             .await
-            .map_err(|err| match err {
-                WriteError::FailedPrecondition(msg) => Status::failed_precondition(msg),
-                err => Status::internal(err.to_string()),
-            })?;
+            .map_err(write_err_to_status)?;
 
         Ok(Response::new(()))
+    }
+}
+
+fn read_err_to_status(err: ReadError) -> Status {
+    if err.retryable() {
+        Status::unavailable(err.to_string())
+    } else {
+        Status::internal(err.to_string())
+    }
+}
+
+fn write_err_to_status(err: WriteError) -> Status {
+    match err {
+        WriteError::FailedPrecondition(msg) => Status::failed_precondition(msg),
+        err if err.retryable() => Status::unavailable(err.to_string()),
+        err => Status::internal(err.to_string()),
     }
 }

--- a/crates/types/src/errors.rs
+++ b/crates/types/src/errors.rs
@@ -456,6 +456,24 @@ impl std::error::Error for SimpleStatus {
     }
 }
 
+/// Check if a gRPC status represents a retryable error.
+///
+/// Transport errors can manifest in different ways:
+/// - `Unknown`: General transport errors
+/// - `Unavailable`: Server is not reachable or temporarily unable to serve
+/// - `Cancelled`: Connection was terminated (common with UDS when server is killed)
+/// - `Internal` with h2 errors: HTTP/2 protocol errors (e.g., connection reset, stream errors)
+pub fn is_retryable_status(status: &tonic::Status) -> bool {
+    match status.code() {
+        tonic::Code::Unavailable | tonic::Code::Unknown | tonic::Code::Cancelled => true,
+        tonic::Code::Internal => {
+            let message = status.message();
+            message.contains("h2 protocol error") || message.contains("http2 error")
+        }
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
The metadata store proxy handler was mapping all non-FailedPrecondition errors to Status::internal, and the proxy client was treating all non-FailedPrecondition statuses as terminal. This caused transient errors (e.g. metadata server leadership changes) to be incorrectly classified as terminal, preventing retry logic from kicking in.

Fix the proxy server to map retryable errors to Status::unavailable and the proxy client to decode retryability using is_retryable_status. Extract the shared is_retryable_status function into restate_types::errors to avoid duplication between the proxy and replicated metadata store clients.

This fixes #4523.