### PR TITLE
[VQueues] Introduce the restate-limiter crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7354,6 +7354,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "restate-limiter"
+version = "1.6.3-dev"
+dependencies = [
+ "bilrost",
+ "restate-limiter",
+ "restate-util-string",
+ "restate-workspace-hack",
+ "slotmap",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "restate-lite"
 version = "1.6.3-dev"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ restate-vqueues = { path = "crates/vqueues" }
 restate-wal-protocol = { path = "crates/wal-protocol" }
 restate-worker = { path = "crates/worker" }
 restate-ingestion-client = { path = "crates/ingestion-client" }
+restate-limiter = { path = "crates/limiter" }
 
 # this workspace-hack package is overridden by a patch below to use workspace-hack subdir when building in this repo
 # outside this repo, the crates.io restate-workspace-hack (an empty package) will be used instead
@@ -161,7 +162,8 @@ futures-sink = "0.3.31"
 futures-util = "0.3.31"
 gardal = { version = "0.0.1-alpha.9" }
 googletest = { version = "0.10", features = ["anyhow"] }
-hashbrown = { version = "0.16"  }
+hashbrown = { version = "0.16" }
+slotmap = { version = "1" }
 hostname = { version = "0.4.2" }
 http = "1.4.0"
 http-body = "1.0.1"

--- a/crates/limiter/Cargo.toml
+++ b/crates/limiter/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "restate-limiter"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+description = "Hierarchical concurrency limiter with 3-level rule matching"
+
+[features]
+default = []
+bilrost = ["dep:bilrost", "restate-util-string/bilrost"]
+
+[dependencies]
+restate-workspace-hack = { workspace = true }
+
+restate-util-string = { workspace = true }
+
+slotmap = { workspace = true }
+thiserror = { workspace = true }
+bilrost = { workspace = true, optional = true }
+
+[dev-dependencies]
+restate-limiter = { path = ".", default-features = false, features = ["bilrost"] }

--- a/crates/limiter/src/key.rs
+++ b/crates/limiter/src/key.rs
@@ -1,0 +1,274 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::str::FromStr;
+
+use restate_util_string::{
+    OwnedStringLike, ReString, RestrictedValue, RestrictedValueError, StringLike,
+};
+
+/// Error type for limit key parsing failures.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ParseError {
+    #[error("invalid limit-key component: {0}")]
+    InvalidComponent(#[from] RestrictedValueError),
+    #[error("too many path components in the given limit-key (max 2)")]
+    TooManyComponents,
+}
+
+/// A key that specifies 1, 2, or 3 levels of the hierarchy.
+///
+/// The depth of the key determines which counters are affected:
+/// - `L1(level1)` - Only the Level 1 counter
+/// - `L2(level1, level2)` - Level 1 and Level 2 counters
+///
+/// # Examples
+///
+/// ```
+/// use std::str::FromStr;
+/// use restate_limiter::LimitKey;
+/// use restate_util_string::RestrictedValue;
+///
+/// // Create keys from validated components
+/// let key: LimitKey<String> = "workflow/tenant1".parse().unwrap();
+/// assert_eq!(key.depth(), 2);
+/// ```
+#[derive(Clone, Debug, Default, Hash, Eq, PartialEq)]
+pub enum LimitKey<S: StringLike> {
+    #[default]
+    None,
+    /// Level 1 key (Scope only).
+    ///
+    /// Acquiring with this key only consumes from the L1 counter.
+    L1(RestrictedValue<S>),
+
+    /// Level 2 key (Level 1 + Level 2).
+    ///
+    /// Acquiring with this key consumes from L1 and L2 counters.
+    L2(RestrictedValue<S>, RestrictedValue<S>),
+}
+
+impl<S: StringLike> LimitKey<S> {
+    pub fn to_cheap_cloneable(&self) -> LimitKey<ReString> {
+        match self {
+            Self::None => LimitKey::None,
+            Self::L1(s) => LimitKey::L1(s.to_cheap_cloneable()),
+            Self::L2(s1, s2) => LimitKey::L2(s1.to_cheap_cloneable(), s2.to_cheap_cloneable()),
+        }
+    }
+    /// Create a Level 1 key.
+    #[inline]
+    pub const fn l1(level1: RestrictedValue<S>) -> Self {
+        Self::L1(level1)
+    }
+
+    /// Create a Level 2 key (Level 1 + Level 2).
+    #[inline]
+    pub const fn l2(level1: RestrictedValue<S>, level2: RestrictedValue<S>) -> Self {
+        Self::L2(level1, level2)
+    }
+
+    /// Returns the depth of this key
+    #[inline]
+    pub fn depth(&self) -> u8 {
+        match self {
+            Self::None => 0,
+            Self::L1(_) => 1,
+            Self::L2(_, _) => 2,
+        }
+    }
+
+    /// Returns true if this key is empty (no components).
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.depth() == 0
+    }
+
+    /// Returns a reference to the Level 1 component (always present).
+    #[inline]
+    pub fn level1(&self) -> Option<&RestrictedValue<S>> {
+        match self {
+            Self::None => None,
+            Self::L1(l1) | Self::L2(l1, _) => Some(l1),
+        }
+    }
+
+    /// Returns a reference to the Level 2 component, if present.
+    #[inline]
+    pub fn level2(&self) -> Option<&RestrictedValue<S>> {
+        match self {
+            Self::None => None,
+            Self::L1(_) => None,
+            Self::L2(_, l2) => Some(l2),
+        }
+    }
+}
+
+impl<S: StringLike> std::fmt::Display for LimitKey<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, ""),
+            Self::L1(l1) => write!(f, "{l1}"),
+            Self::L2(l1, l2) => write!(f, "{l1}/{l2}"),
+        }
+    }
+}
+
+/// Parse a limit key from a string
+pub fn parse_limit_key<S: OwnedStringLike>(s: &str) -> Result<LimitKey<S>, ParseError> {
+    // Split the pattern into components
+    let mut next_idx = 0;
+    let mut parts: [Option<RestrictedValue<S>>; 2] = [None, None];
+    for part in s.split_terminator('/') {
+        if next_idx >= 2 {
+            return Err(ParseError::TooManyComponents);
+        }
+
+        let part = RestrictedValue::from_str(part)?;
+        parts[next_idx] = Some(part);
+        next_idx += 1;
+    }
+
+    match next_idx {
+        0 => Ok(LimitKey::None),
+        1 => Ok(LimitKey::L1(parts[0].take().unwrap())),
+        2 => Ok(LimitKey::L2(
+            parts[0].take().unwrap(),
+            parts[1].take().unwrap(),
+        )),
+        _ => Err(ParseError::TooManyComponents),
+    }
+}
+
+impl<S: OwnedStringLike> FromStr for LimitKey<S> {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_limit_key(s)
+    }
+}
+
+#[cfg(feature = "bilrost")]
+mod bilrost_encodings {
+    use super::LimitKey;
+
+    use bilrost::encoding::{General, Proxiable};
+    use bilrost::{DecodeErrorKind, delegate_proxied_encoding, for_overwrite_via_default};
+
+    use restate_util_string::{OwnedStringLike, ReString, StringLike, ToReString};
+
+    struct ReStringTag;
+
+    for_overwrite_via_default!(LimitKey<S>,
+        with generics (S),
+        with where clause (S: StringLike + Default)
+    );
+
+    impl<S: StringLike + Default> bilrost::encoding::EmptyState<(), LimitKey<S>> for () {
+        fn is_empty(val: &LimitKey<S>) -> bool {
+            matches!(*val, LimitKey::None)
+        }
+
+        fn clear(val: &mut LimitKey<S>) {
+            *val = LimitKey::None;
+        }
+    }
+
+    impl<S: OwnedStringLike + ToReString + Default> Proxiable<ReStringTag> for LimitKey<S> {
+        type Proxy = ReString;
+
+        fn encode_proxy(&self) -> ReString {
+            self.to_restring()
+        }
+
+        fn decode_proxy(&mut self, proxy: ReString) -> Result<(), DecodeErrorKind> {
+            *self = proxy
+                .parse::<Self>()
+                .map_err(|_| ::bilrost::DecodeErrorKind::InvalidValue)?;
+            Ok(())
+        }
+    }
+
+    delegate_proxied_encoding!(
+        use encoding (General)
+        to encode proxied type (LimitKey<S>)
+        using proxy tag (ReStringTag)
+        with general encodings with generics (S: OwnedStringLike + ToReString + Default)
+    );
+
+    #[cfg(test)]
+    #[test]
+    fn bilrost_limit_key() {
+        #[derive(bilrost::Message)]
+        struct LimitKeyMessage {
+            #[bilrost(1)]
+            value: LimitKey<ReString>,
+        }
+
+        for input in ["", "hello", "hello/value"] {
+            use bilrost::{Message, OwnedMessage};
+
+            let src = LimitKeyMessage {
+                value: input.parse().unwrap(),
+            };
+            let encoded = src.encode_to_bytes();
+            let decoded = LimitKeyMessage::decode(encoded).unwrap();
+            assert_eq!(decoded.value.to_string(), input);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_limit_key() {
+        let k: LimitKey<String> = "".parse().unwrap();
+        assert_eq!(k.depth(), 0);
+        assert!(matches!(k, LimitKey::None));
+
+        let err = "/".parse::<LimitKey<String>>().unwrap_err();
+        assert!(matches!(
+            err,
+            ParseError::InvalidComponent(RestrictedValueError::Empty),
+        ));
+
+        let k: LimitKey<String> = "kimo".parse().unwrap();
+        assert_eq!(k.depth(), 1);
+        assert_eq!(k, LimitKey::L1("kimo".parse().unwrap()));
+        assert_eq!(k.to_string(), "kimo");
+
+        let k: LimitKey<String> = "kimo/".parse().unwrap();
+        assert_eq!(k.depth(), 1);
+        assert_eq!(k, LimitKey::L1("kimo".parse().unwrap()));
+        assert_eq!(k.to_string(), "kimo");
+
+        let k: LimitKey<String> = "kimo/antimo".parse().unwrap();
+        assert_eq!(k.depth(), 2);
+        assert_eq!(
+            k,
+            LimitKey::L2("kimo".parse().unwrap(), "antimo".parse().unwrap()),
+        );
+        assert_eq!(k.to_string(), "kimo/antimo");
+
+        let k: LimitKey<String> = "kimo/antimo/".parse().unwrap();
+        assert_eq!(k.depth(), 2);
+        assert_eq!(
+            k,
+            LimitKey::L2("kimo".parse().unwrap(), "antimo".parse().unwrap())
+        );
+
+        assert_eq!(k.to_string(), "kimo/antimo");
+
+        let err = "kimo/antimo//".parse::<LimitKey<String>>().unwrap_err();
+        assert!(matches!(err, ParseError::TooManyComponents));
+    }
+}

--- a/crates/limiter/src/lib.rs
+++ b/crates/limiter/src/lib.rs
@@ -1,0 +1,97 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Hierarchical concurrency limiter with 3-level rule matching.
+//!
+//! This crate provides a concurrency control mechanism that enforces limits at multiple
+//! granularity levels (Scope, Level 1, Level 2) with rule-based limit resolution.
+//!
+//! # Overview
+//!
+//! The limiter uses a 3-level hierarchy:
+//! - **Scope**: Top-level grouping (aka. Scope)
+//! - **Level 1**: Mid-level grouping
+//! - **Level 2**: Fine-grained grouping
+//!
+//! # Value Validation
+//!
+//! All key components are validated using the [`restate_util_string::RestrictedValue`] type which
+//! guarantees values are:
+//! - Non-empty strings
+//! - Maximum 36 bytes
+//! - Only `[a-zA-Z0-9_.-]` characters
+//!
+//! # Rule Matching
+//!
+//! Rules can use wildcards (`*`) to match multiple values at any level:
+//! - `SCOPE = 1000` - Limit for a specific Scope value
+//! - `* = 5000` - Default limit for any scope value (default)
+//! - `SCOPE/* = 100` - Default limit per Level 1 under specific scope (SCOPE)
+//! - `*/* = 100` - Default limit per Level 1 under any scope
+//! - `SCOPE/L1 = 250` - Specific limit for a Level 1 specific value (L1)
+//! - `SCOPE/*/* = 2` - Default limit per Level 2
+//! - `SCOPE/*/L2 = 10` - Specific limit for a Level 2 value across all Level 2 values
+
+mod key;
+mod rule;
+mod rule_store;
+
+/// Represents the hierarchy level of counters or rules
+///
+/// This enum is used throughout the limiter to identify which level
+/// of the hierarchy is being referenced.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum Level {
+    /// Level 1 - top-level grouping (aka. Scope)
+    Scope = 1,
+    /// Level 2 - mid-level grouping.
+    Level1 = 2,
+    /// Level 3 - fine-grained grouping.
+    Level2 = 3,
+}
+
+impl Level {
+    /// The number of levels in the hierarchy.
+    pub const COUNT: usize = 3;
+
+    /// Returns the level as a `u8` value (1, 2, or 3).
+    #[inline]
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+
+    /// Creates a Level from a u8 value.
+    ///
+    /// Returns `None` if the value is not 1, 2, or 3.
+    #[inline]
+    pub const fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            1 => Some(Self::Scope),
+            2 => Some(Self::Level1),
+            3 => Some(Self::Level2),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for Level {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Scope => write!(f, "Scope"),
+            Self::Level1 => write!(f, "Level1"),
+            Self::Level2 => write!(f, "Level2"),
+        }
+    }
+}
+
+pub use key::LimitKey;
+pub use rule::RulePattern;
+pub use rule_store::{Limit, Rules, StructuredLimits};

--- a/crates/limiter/src/rule.rs
+++ b/crates/limiter/src/rule.rs
@@ -1,0 +1,502 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Rule types and storage for the hierarchical limiter.
+
+use std::str::FromStr;
+
+use restate_util_string::{OwnedStringLike, RestrictedValue, RestrictedValueError, StringLike};
+
+use crate::{Level, LimitKey};
+
+slotmap::new_key_type! { pub struct RuleHandle; }
+
+/// Error type for pattern parsing failures.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ParseError {
+    /// The pattern is empty.
+    #[error("pattern cannot be empty")]
+    EmptyPattern,
+    /// A component is invalid.
+    #[error("invalid component: {0}")]
+    InvalidComponent(#[from] RestrictedValueError),
+    /// Too many path components (max 3).
+    #[error("too many path components (max 3)")]
+    TooManyComponents,
+}
+
+/// To Parse a pattern
+/// This represents the "key" part of a rule, without the limit value.
+///
+/// let pattern: RulePattern<String> = "scope1/*".parse().unwrap();
+///
+/// # Format for parsing rule patterns
+///
+/// Patterns specify which keys a rule applies to. SCOPE can be an exact value or
+/// a wildcard (`*`) for global defaults:
+///
+/// - `scope`       - Scope exact: matches specific scope
+/// - `*`           - Scope wildcard: default for any scope (global defaults)
+/// - `scope/*`     - Level 1 wildcard: matches any L1 under `scope`
+/// - `scope/l1`    - Level 1 exact: matches `l1` under `scope`
+/// - `*/l1`        - Level 1 exact with wildcard scope: default for specific L1 under any scope
+/// - `scope/*/*`   - Level 2 wildcard: matches any L2 under `scope`
+/// - `scope/*/l2`  - Level 2 with wildcard L1: matches specific L2 across all L1
+/// - `scope/l1/*`  - Level 2 with wildcard L2: matches any L2 under specific L1 and `scope`
+/// - `scope/l1/l2` - Level 2 exact: matches specific L1 and L1 and `scope`
+///
+/// The wildcard character is `*`. Component values must be valid restricted values
+/// (only `[a-zA-Z0-9_.-]`, non-empty, max 36 bytes).
+#[derive(Debug, Eq, PartialEq)]
+pub enum RulePattern<S: StringLike> {
+    /// A rule that defines a limit for the scope level
+    Scope(Pattern<S>),
+    /// A rule that defines a limit for level 1 of the limit key
+    L1 { scope: Pattern<S>, l1: Pattern<S> },
+    /// A rule that defines a limit for level 2 of the limit key
+    L2 {
+        scope: Pattern<S>,
+        l1: Pattern<S>,
+        l2: Pattern<S>,
+    },
+}
+
+impl<S: StringLike> RulePattern<S> {
+    /// Returns the level of this pattern
+    pub fn level(&self) -> Level {
+        match self {
+            RulePattern::Scope(_) => Level::Scope,
+            RulePattern::L1 { .. } => Level::Level1,
+            RulePattern::L2 { .. } => Level::Level2,
+        }
+    }
+
+    /// Computes a precedence rank for this pattern against the given scope and
+    /// limit key. Returns `None` if the pattern does not match the input.
+    ///
+    /// The rank is a bitmask where each bit corresponds to a hierarchy level
+    /// (scope = bit 2, L1 = bit 1, L2 = bit 0). An exact match at a level sets
+    /// its bit to 1; a wildcard leaves it at 0. Higher rank values indicate more
+    /// specific matches and should take precedence.
+    ///
+    /// A pattern only matches inputs at the same depth — an L1 pattern requires
+    /// the limit key to have at least one component, an L2 pattern requires two.
+    ///
+    /// # Precedence table (for L2 patterns)
+    ///
+    /// | Rank | Scope | L1  | L2  | Example             |
+    /// |------|-------|-----|-----|---------------------|
+    /// |  0   |  `*`  | `*` | `*` | `*/*/*`             |
+    /// |  1   |  `*`  | `*` | exact | `*/*/bar`         |
+    /// |  2   |  `*`  | exact | `*` | `*/foo/*`         |
+    /// |  3   |  `*`  | exact | exact | `*/foo/bar`     |
+    /// |  4   | exact | `*` | `*` | `scope/*/*`         |
+    /// |  5   | exact | `*` | exact | `scope/*/bar`     |
+    /// |  6   | exact | exact | `*` | `scope/foo/*`     |
+    /// |  7   | exact | exact | exact | `scope/foo/bar` |
+    pub fn rank(&self, scope: &str, input_limit_key: &LimitKey<S>) -> Option<u8> {
+        // Precedence Rules (lowest to highest):
+        //  0 0 0  *     / *   / *    = 0
+        //  0 0 1  *     / *   / bar  = 1
+        //  0 1 0  *     / foo / *    = 2
+        //  0 1 1  *     / foo / bar  = 3
+        //  1 0 0  scope / *   / *    = 4
+        //  1 0 1  scope / *   / bar  = 5
+        //  1 1 0  scope / foo / *    = 6
+        //  1 1 1  scope / foo / bar  = 7
+        match self {
+            // depth = 0
+            RulePattern::Scope(pat) => pat.rank(scope, Level::Scope),
+            // depth = 2
+            RulePattern::L1 {
+                scope: scope_pat,
+                l1,
+            } => {
+                let mut result = scope_pat.rank(scope, Level::Scope)?;
+                result |= l1.rank(input_limit_key.level1()?.as_str(), Level::Level1)?;
+                Some(result)
+            }
+            // depth = 3
+            RulePattern::L2 {
+                scope: scope_pat,
+                l1,
+                l2,
+            } => {
+                let mut result = scope_pat.rank(scope, Level::Scope)?;
+                result |= l1.rank(input_limit_key.level1()?.as_str(), Level::Level1)?;
+                result |= l2.rank(input_limit_key.level2()?.as_str(), Level::Level2)?;
+                Some(result)
+            }
+        }
+    }
+}
+
+/// Builds a rule with a wildcard scope (matches any scope value).
+impl<S: StringLike> Default for RulePattern<S> {
+    fn default() -> Self {
+        Self::Scope(Pattern::Wildcard)
+    }
+}
+
+impl<S: OwnedStringLike> FromStr for RulePattern<S> {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_rule_pattern(s)
+    }
+}
+
+impl<S: StringLike> std::fmt::Display for RulePattern<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Scope(p) => std::fmt::Display::fmt(p, f),
+            Self::L1 { scope, l1 } => write!(f, "{scope}/{l1}"),
+            Self::L2 { scope, l1, l2 } => write!(f, "{scope}/{l1}/{l2}"),
+        }
+    }
+}
+
+/// A pattern component that matches either an exact value or any value (wildcard).
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub enum Pattern<S: StringLike> {
+    /// Match a specific value.
+    Exact(RestrictedValue<S>),
+    /// Match any value (wildcard).
+    #[default]
+    Wildcard,
+}
+
+impl<S: StringLike> Pattern<S> {
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Exact(k) => k.as_str().len(),
+            Self::Wildcard => 1,
+        }
+    }
+
+    /// Matches the input and returns a ranking value's most signifcant bit
+    fn rank(&self, input: &str, level: Level) -> Option<u8> {
+        let msb = Level::COUNT - level as usize;
+        match self {
+            Self::Exact(pat) => (*pat == *input).then_some(1 << msb),
+            Self::Wildcard => Some(0),
+        }
+    }
+}
+
+impl<S: StringLike> AsRef<str> for Pattern<S> {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::Exact(k) => k.as_ref(),
+            Self::Wildcard => "*",
+        }
+    }
+}
+
+impl<S: StringLike> std::fmt::Display for Pattern<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Exact(v) => std::fmt::Display::fmt(v, f),
+            Self::Wildcard => write!(f, "*"),
+        }
+    }
+}
+
+/// Parse a rule pattern from a string.
+pub fn parse_rule_pattern<S: OwnedStringLike>(s: &str) -> Result<RulePattern<S>, ParseError> {
+    let s = s.trim();
+    if s.is_empty() {
+        return Err(ParseError::EmptyPattern);
+    }
+
+    // Split the pattern into components
+    let mut next_idx = 0;
+    let mut parts: [Option<Pattern<S>>; 3] = [None, None, None];
+
+    for part in s.split_terminator('/') {
+        if next_idx >= 3 {
+            return Err(ParseError::TooManyComponents);
+        }
+        let pattern = parse_pattern_component(part)?;
+        parts[next_idx] = Some(pattern);
+        next_idx += 1;
+    }
+
+    match next_idx {
+        0 => Err(ParseError::EmptyPattern),
+        1 => Ok(RulePattern::Scope(parts[0].take().unwrap())),
+        2 => Ok(RulePattern::L1 {
+            scope: parts[0].take().unwrap(),
+            l1: parts[1].take().unwrap(),
+        }),
+        3 => Ok(RulePattern::L2 {
+            scope: parts[0].take().unwrap(),
+            l1: parts[1].take().unwrap(),
+            l2: parts[2].take().unwrap(),
+        }),
+        _ => Err(ParseError::TooManyComponents),
+    }
+}
+
+fn parse_pattern_component<S: OwnedStringLike>(s: &str) -> Result<Pattern<S>, ParseError> {
+    let s = s.trim();
+    if s == "*" {
+        return Ok(Pattern::Wildcard);
+    }
+    Ok(Pattern::Exact(RestrictedValue::from_str(s)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_scope_patterns() {
+        let pattern: RulePattern<String> = "scope1".parse().unwrap();
+        assert_eq!(pattern.level(), Level::Scope);
+        assert_eq!(pattern.to_string(), "scope1");
+        assert_eq!(
+            pattern,
+            RulePattern::Scope(Pattern::Exact("scope1".parse().unwrap())),
+        );
+
+        // Bad scope
+        let err = "s*".parse::<RulePattern<String>>().unwrap_err();
+        assert!(matches!(
+            err,
+            ParseError::InvalidComponent(RestrictedValueError::InvalidChar('*')),
+        ));
+
+        let err = "".parse::<RulePattern<String>>().unwrap_err();
+        assert!(matches!(err, ParseError::EmptyPattern));
+
+        let err = "/".parse::<RulePattern<String>>().unwrap_err();
+        assert!(matches!(
+            err,
+            ParseError::InvalidComponent(RestrictedValueError::Empty),
+        ));
+
+        let err = "/*".parse::<RulePattern<String>>().unwrap_err();
+        assert!(matches!(
+            err,
+            ParseError::InvalidComponent(RestrictedValueError::Empty),
+        ));
+    }
+
+    #[test]
+    fn parse_level1() {
+        let pattern: RulePattern<String> = "scope1/*".parse().unwrap();
+        assert_eq!(pattern.level(), Level::Level1);
+        assert_eq!(pattern.to_string(), "scope1/*");
+        assert_eq!(
+            pattern,
+            RulePattern::L1 {
+                scope: Pattern::Exact("scope1".parse().unwrap()),
+                l1: Pattern::Wildcard,
+            }
+        );
+
+        let pattern: RulePattern<String> = "scope1/tenant1".parse().unwrap();
+        assert_eq!(pattern.level(), Level::Level1);
+        assert_eq!(pattern.to_string(), "scope1/tenant1");
+        assert_eq!(
+            pattern,
+            RulePattern::L1 {
+                scope: Pattern::Exact("scope1".parse().unwrap()),
+                l1: Pattern::Exact("tenant1".parse().unwrap()),
+            }
+        );
+
+        // a trailing / doesn't matter
+        let pattern: RulePattern<String> = "scope1/*/".parse().unwrap();
+        assert_eq!(pattern.level(), Level::Level1);
+        assert_eq!(pattern.to_string(), "scope1/*");
+        assert_eq!(
+            pattern,
+            RulePattern::L1 {
+                scope: Pattern::Exact("scope1".parse().unwrap()),
+                l1: Pattern::Wildcard,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_level2() {
+        let pattern: RulePattern<String> = "scope1/*/*".parse().unwrap();
+        assert_eq!(pattern.level(), Level::Level2);
+        assert_eq!(pattern.to_string(), "scope1/*/*");
+        assert_eq!(
+            pattern,
+            RulePattern::L2 {
+                scope: Pattern::Exact("scope1".parse().unwrap()),
+                l1: Pattern::Wildcard,
+                l2: Pattern::Wildcard,
+            }
+        );
+
+        let pattern: RulePattern<String> = "scope1/tenant1/*".parse().unwrap();
+        assert_eq!(pattern.level(), Level::Level2);
+        assert_eq!(pattern.to_string(), "scope1/tenant1/*");
+        assert_eq!(
+            pattern,
+            RulePattern::L2 {
+                scope: Pattern::Exact("scope1".parse().unwrap()),
+                l1: Pattern::Exact("tenant1".parse().unwrap()),
+                l2: Pattern::Wildcard,
+            }
+        );
+
+        let pattern: RulePattern<String> = "scope1/*/user1".parse().unwrap();
+        assert_eq!(pattern.level(), Level::Level2);
+        assert_eq!(pattern.to_string(), "scope1/*/user1");
+        assert_eq!(
+            pattern,
+            RulePattern::L2 {
+                scope: Pattern::Exact("scope1".parse().unwrap()),
+                l1: Pattern::Wildcard,
+                l2: Pattern::Exact("user1".parse().unwrap()),
+            }
+        );
+
+        let pattern: RulePattern<String> = "*/*/*".parse().unwrap();
+        assert_eq!(pattern.level(), Level::Level2);
+        assert_eq!(pattern.to_string(), "*/*/*");
+        assert_eq!(
+            pattern,
+            RulePattern::L2 {
+                scope: Pattern::Wildcard,
+                l1: Pattern::Wildcard,
+                l2: Pattern::Wildcard,
+            }
+        );
+
+        // a trailing / doesn't matter
+        let pattern: RulePattern<String> = "scope1/*/*/".parse().unwrap();
+        assert_eq!(pattern.level(), Level::Level2);
+        assert_eq!(pattern.to_string(), "scope1/*/*");
+        assert_eq!(
+            pattern,
+            RulePattern::L2 {
+                scope: Pattern::Exact("scope1".parse().unwrap()),
+                l1: Pattern::Wildcard,
+                l2: Pattern::Wildcard,
+            }
+        );
+    }
+
+    #[test]
+    fn ranking_no_match() {
+        // raw check
+        let pattern: Pattern<String> = Pattern::Exact("abc".parse().unwrap());
+        // not a match
+        assert_eq!(pattern.rank("xyz", Level::Scope), None);
+
+        // pattern no match
+        let pattern: RulePattern<String> = "scope1/*".parse().unwrap();
+        assert!(matches!(pattern.level(), Level::Level1));
+
+        assert_eq!(pattern.rank("jim", &LimitKey::<_>::None), None);
+
+        // This is a Level1 rule, input must be 2 levels-deep (scope + L1)
+        assert_eq!(pattern.rank("scope1", &LimitKey::<_>::None), None);
+
+        let pattern: RulePattern<String> = "*/*".parse().unwrap();
+        // Same thing, This is a Level1 rule, input must be 2 levels-deep (scope + L1)
+        assert_eq!(pattern.rank("scope1", &LimitKey::<_>::None), None);
+
+        let pattern: RulePattern<String> = "*/*/*".parse().unwrap();
+        // This is a Level2 rule, input must be 3 levels-deep (scope + L1 + L2)
+        assert_eq!(pattern.rank("scope1", &LimitKey::<_>::None), None);
+        assert_eq!(
+            pattern.rank("scope1", &LimitKey::<_>::L1("foo".parse().unwrap())),
+            None
+        );
+    }
+
+    #[test]
+    fn ranking_raw() {
+        let pattern: Pattern<String> = Pattern::Wildcard;
+        // wildcard's MSB is zero, always.
+        assert_eq!(pattern.rank("abc", Level::Scope), Some(0));
+        assert_eq!(pattern.rank("abc", Level::Level1), Some(0));
+        assert_eq!(pattern.rank("abc", Level::Level2), Some(0));
+
+        let pattern: Pattern<String> = Pattern::Exact("abc".parse().unwrap());
+        assert_eq!(pattern.rank("abc", Level::Scope), Some(4));
+        assert_eq!(pattern.rank("abc", Level::Level1), Some(2));
+        assert_eq!(pattern.rank("abc", Level::Level2), Some(1));
+    }
+
+    #[test]
+    fn scope_ranking() {
+        // scope-level rules
+        let rules: &[RulePattern<String>] = &["*".parse().unwrap(), "scope1".parse().unwrap()];
+        let ranks = rules
+            .iter()
+            .map(|r| r.rank("scope1", &LimitKey::<_>::None))
+            .collect::<Vec<_>>();
+
+        assert_eq!(ranks, [Some(0), Some(4)]);
+    }
+
+    #[test]
+    fn l1_ranking() {
+        // l1 rules
+        let rules: &[RulePattern<String>] = &[
+            "*/*".parse().unwrap(),
+            "scope1/*".parse().unwrap(),
+            "*/tenant1".parse().unwrap(),
+            "scope1/tenant1".parse().unwrap(),
+            "unmatched/tenant1".parse().unwrap(),
+        ];
+
+        // scope1/tenant1 scores the highest (exact match)
+        // but scope1/ wins over */tenant1 and over */*
+        let ranks = rules
+            .iter()
+            .map(|r| r.rank("scope1", &"tenant1".parse().unwrap()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(ranks, [Some(0), Some(4), Some(2), Some(6), None]);
+    }
+
+    #[test]
+    fn l2_ranking() {
+        // l2 rules
+        let rules: &[RulePattern<String>] = &[
+            "*/*/*".parse().unwrap(),
+            "scope1/*/*".parse().unwrap(),
+            "*/org1/*".parse().unwrap(),
+            "*/*/tenant1".parse().unwrap(),
+            "scope1/org1/*".parse().unwrap(),
+            "scope1/org1/tenant1".parse().unwrap(),
+            "unmatched/org1/tenant1".parse().unwrap(),
+        ];
+
+        // scope1/org1/tenant1 scores the highest (exact match)
+        // Effective Precedence (for input scope1/org1/tenant1)
+        //   - scope1/org1/tenant1 = 7
+        //   - scope1/org1/* = 6
+        //   - scope1/*/*  (scope has higher precedence than L1) = 4
+        //   - */org1/*  = 2
+        //   - */*/tenant1 = 1
+        //   - */*/*  = 0
+        //
+        let ranks = rules
+            .iter()
+            .map(|r| r.rank("scope1", &"org1/tenant1".parse().unwrap()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            ranks,
+            [Some(0), Some(4), Some(2), Some(1), Some(6), Some(7), None]
+        );
+    }
+}

--- a/crates/limiter/src/rule_store.rs
+++ b/crates/limiter/src/rule_store.rs
@@ -1,0 +1,341 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use slotmap::{SecondaryMap, SlotMap};
+
+use restate_util_string::{OwnedStringLike, StringLike};
+
+use crate::rule::RuleHandle;
+use crate::{Level, LimitKey, RulePattern};
+
+#[derive(Debug, Clone, Default)]
+pub enum Limit<V> {
+    /// A limit is not defined at this level. The meaning of undefined depends on
+    /// the use-case.
+    #[default]
+    Undefined,
+    Defined(RuleHandle, V),
+}
+
+/// The concrete limits that apply for after matching a limit key to the set of
+/// rules from the rule store.
+#[derive(Debug)]
+pub struct StructuredLimits<V> {
+    scope: Limit<V>,
+    l1: Limit<V>,
+    l2: Limit<V>,
+}
+
+impl<V> Default for StructuredLimits<V> {
+    fn default() -> Self {
+        Self {
+            scope: Limit::Undefined,
+            l1: Limit::Undefined,
+            l2: Limit::Undefined,
+        }
+    }
+}
+
+impl<S: OwnedStringLike, V> Rules<S, V> {
+    /// Look up the limits for a given scope + limit key combination.
+    #[inline]
+    pub fn lookup(&self, scope: &str, limit_key: &LimitKey<S>) -> StructuredLimits<&V> {
+        let mut limits = StructuredLimits::default();
+        limits.scope = self
+            .lookup_scope_rule(scope)
+            .map(|handle| Limit::Defined(handle, self.limits.get(handle).unwrap()))
+            .unwrap_or(Limit::Undefined);
+
+        match limit_key {
+            LimitKey::None => {}
+            limit @ LimitKey::L1(_) => {
+                limits.l1 = self
+                    .lookup_l1_rule(scope, limit)
+                    .map(|handle| Limit::Defined(handle, self.limits.get(handle).unwrap()))
+                    .unwrap_or(Limit::Undefined);
+            }
+            limit @ LimitKey::L2(_, _) => {
+                limits.l1 = self
+                    .lookup_l1_rule(scope, limit)
+                    .map(|handle| Limit::Defined(handle, self.limits.get(handle).unwrap()))
+                    .unwrap_or(Limit::Undefined);
+
+                limits.l2 = self
+                    .lookup_l2_rule(scope, limit)
+                    .map(|handle| Limit::Defined(handle, self.limits.get(handle).unwrap()))
+                    .unwrap_or(Limit::Undefined);
+            }
+        }
+
+        limits
+    }
+
+    pub fn get_limit(&self, handle: RuleHandle) -> Option<&V> {
+        self.limits.get(handle)
+    }
+
+    pub fn get_pattern(&self, handle: RuleHandle) -> Option<&RulePattern<S>> {
+        self.rules.get(handle)
+    }
+
+    pub fn get(&self, handle: RuleHandle) -> Option<(&RulePattern<S>, &V)> {
+        let rule = self.rules.get(handle)?;
+        self.limits.get(handle).map(|l| (rule, l))
+    }
+
+    fn lookup_scope_rule(&self, scope: &str) -> Option<RuleHandle> {
+        self.scope_rules
+            .iter()
+            .filter_map(|handle| {
+                let rank = self.rules.get(*handle)?.rank(scope, &LimitKey::None)?;
+                Some((*handle, rank))
+            })
+            .max_by_key(|&(_, y)| y)
+            .map(|(x, _)| x)
+    }
+
+    fn lookup_l1_rule(&self, scope: &str, limit_key: &LimitKey<S>) -> Option<RuleHandle> {
+        self.l1_rules
+            .iter()
+            .filter_map(|handle| {
+                let rank = self.rules.get(*handle)?.rank(scope, limit_key)?;
+                Some((*handle, rank))
+            })
+            .max_by_key(|&(_, y)| y)
+            .map(|(x, _)| x)
+    }
+
+    fn lookup_l2_rule(&self, scope: &str, limit_key: &LimitKey<S>) -> Option<RuleHandle> {
+        self.l2_rules
+            .iter()
+            .filter_map(|handle| {
+                let rank = self.rules.get(*handle)?.rank(scope, limit_key)?;
+                Some((*handle, rank))
+            })
+            .max_by_key(|&(_, y)| y)
+            .map(|(x, _)| x)
+    }
+}
+
+#[derive(Debug)]
+pub struct Rules<S: StringLike, V> {
+    rules: SlotMap<RuleHandle, RulePattern<S>>,
+    limits: SecondaryMap<RuleHandle, V>,
+
+    scope_rules: Vec<RuleHandle>,
+    l1_rules: Vec<RuleHandle>,
+    l2_rules: Vec<RuleHandle>,
+}
+
+impl<S: StringLike, V> Rules<S, V> {
+    /// Create a rule store from an iterator of rules.
+    pub fn from_rules(rules: impl IntoIterator<Item = (RulePattern<S>, V)>) -> Self {
+        let mut store = Self::default();
+        for (pattern, limit) in rules {
+            store.add_rule(pattern, limit);
+        }
+        store
+    }
+    /// Add a rule to the store.
+    pub fn add_rule(&mut self, pattern: RulePattern<S>, limit: V) {
+        let level = pattern.level();
+        let handle = self.rules.insert(pattern);
+        self.limits.insert(handle, limit);
+
+        match level {
+            Level::Scope => self.scope_rules.push(handle),
+            Level::Level1 => self.l1_rules.push(handle),
+            Level::Level2 => self.l2_rules.push(handle),
+        }
+    }
+
+    /// Clear all rules.
+    pub fn clear(&mut self) {
+        self.scope_rules.clear();
+        self.l1_rules.clear();
+        self.l2_rules.clear();
+        self.limits.clear();
+        self.rules.clear();
+    }
+}
+
+impl<S: StringLike, V> Default for Rules<S, V> {
+    fn default() -> Self {
+        Self {
+            scope_rules: Default::default(),
+            l1_rules: Default::default(),
+            l2_rules: Default::default(),
+            limits: Default::default(),
+            rules: Default::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store_with_rules(specs: &[(&str, u32)]) -> Rules<String, u32> {
+        Rules::from_rules(
+            specs
+                .iter()
+                .map(|(pat, limit)| (pat.parse::<RulePattern<String>>().unwrap(), *limit)),
+        )
+    }
+
+    #[test]
+    fn add_and_retrieve_rules() {
+        let store = store_with_rules(&[
+            ("*", 1000),
+            ("scope1", 500),
+            ("scope1/*", 100),
+            ("scope1/tenant1", 50),
+            ("scope1/*/*", 10),
+            ("scope1/tenant1/user1", 5),
+        ]);
+
+        // Verify rules are categorized by level
+        assert_eq!(store.scope_rules.len(), 2);
+        assert_eq!(store.l1_rules.len(), 2);
+        assert_eq!(store.l2_rules.len(), 2);
+
+        // Verify get/get_limit/get_pattern round-trip through handles
+        for &handle in &store.scope_rules {
+            let (pat, limit) = store.get(handle).unwrap();
+            assert_eq!(pat.level(), Level::Scope);
+            assert_eq!(store.get_limit(handle), Some(limit));
+            assert_eq!(store.get_pattern(handle), Some(pat));
+        }
+    }
+
+    #[test]
+    fn clear_removes_everything() {
+        let mut store = store_with_rules(&[("*", 1000), ("scope1/*", 100)]);
+        assert_eq!(store.scope_rules.len(), 1);
+        assert_eq!(store.l1_rules.len(), 1);
+
+        store.clear();
+        assert!(store.scope_rules.is_empty());
+        assert!(store.l1_rules.is_empty());
+        assert!(store.l2_rules.is_empty());
+        assert!(store.rules.is_empty());
+        assert!(store.limits.is_empty());
+    }
+
+    #[test]
+    fn lookup_scope_prefers_exact_over_wildcard() {
+        let store = store_with_rules(&[("*", 1000), ("scope1", 500)]);
+
+        // Exact match wins for scope1
+        let result = store.lookup("scope1", &LimitKey::None);
+        assert!(matches!(result.scope, Limit::Defined(_, 500)));
+
+        // Wildcard used for unknown scope
+        let result = store.lookup("other", &LimitKey::None);
+        assert!(matches!(result.scope, Limit::Defined(_, 1000)));
+    }
+
+    #[test]
+    fn lookup_l1_precedence() {
+        let store = store_with_rules(&[
+            ("*/*", 1000),
+            ("scope1/*", 100),
+            ("*/tenant1", 200),
+            ("scope1/tenant1", 50),
+        ]);
+
+        let key: LimitKey<String> = "tenant1".parse().unwrap();
+
+        // Exact scope + exact L1 wins
+        let result = store.lookup("scope1", &key);
+        assert!(matches!(result.l1, Limit::Defined(_, 50)));
+        assert!(matches!(result.l2, Limit::Undefined));
+
+        // Wildcard scope + exact L1
+        let result = store.lookup("other", &key);
+        assert!(matches!(result.l1, Limit::Defined(_, 200)));
+
+        // Exact scope + wildcard L1
+        let other_key: LimitKey<String> = "other_tenant".parse().unwrap();
+        let result = store.lookup("scope1", &other_key);
+        assert!(matches!(result.l1, Limit::Defined(_, 100)));
+
+        // Wildcard scope + wildcard L1
+        let result = store.lookup("other", &other_key);
+        assert!(matches!(result.l1, Limit::Defined(_, 1000)));
+    }
+
+    #[test]
+    fn lookup_l2_precedence() {
+        let store = store_with_rules(&[
+            ("*/*/*", 1000),
+            ("scope1/*/*", 500),
+            ("scope1/org1/*", 100),
+            ("scope1/org1/user1", 10),
+        ]);
+
+        let key: LimitKey<String> = "org1/user1".parse().unwrap();
+
+        // Full exact match
+        let result = store.lookup("scope1", &key);
+        assert!(matches!(result.l2, Limit::Defined(_, 10)));
+
+        // scope1/org1/* for unknown user
+        let key2: LimitKey<String> = "org1/user99".parse().unwrap();
+        let result = store.lookup("scope1", &key2);
+        assert!(matches!(result.l2, Limit::Defined(_, 100)));
+
+        // scope1/*/* for unknown org
+        let key3: LimitKey<String> = "org99/user1".parse().unwrap();
+        let result = store.lookup("scope1", &key3);
+        assert!(matches!(result.l2, Limit::Defined(_, 500)));
+
+        // */*/* for unknown scope
+        let result = store.lookup("other", &key);
+        assert!(matches!(result.l2, Limit::Defined(_, 1000)));
+    }
+
+    #[test]
+    fn lookup_returns_undefined_when_no_rules_match() {
+        let store: Rules<String, u32> = Rules::default();
+
+        let result = store.lookup("scope1", &LimitKey::None);
+        assert!(matches!(result.scope, Limit::Undefined));
+
+        let key: LimitKey<String> = "tenant1".parse().unwrap();
+        let result = store.lookup("scope1", &key);
+        assert!(matches!(result.l1, Limit::Undefined));
+    }
+
+    #[test]
+    fn lookup_only_populates_matching_depth() {
+        let store = store_with_rules(&[("*", 1000), ("*/*", 100), ("*/*/*", 10)]);
+
+        // Scope-only query: only scope is populated
+        let result = store.lookup("s", &LimitKey::None);
+        assert!(matches!(result.scope, Limit::Defined(_, 1000)));
+        assert!(matches!(result.l1, Limit::Undefined));
+        assert!(matches!(result.l2, Limit::Undefined));
+
+        // L1 query: scope + l1
+        let key: LimitKey<String> = "t".parse().unwrap();
+        let result = store.lookup("s", &key);
+        assert!(matches!(result.scope, Limit::Defined(_, 1000)));
+        assert!(matches!(result.l1, Limit::Defined(_, 100)));
+        assert!(matches!(result.l2, Limit::Undefined));
+
+        // L2 query: scope + l2 (l1 stays undefined since lookup branches on key variant)
+        let key: LimitKey<String> = "t/u".parse().unwrap();
+        let result = store.lookup("s", &key);
+        assert!(matches!(result.scope, Limit::Defined(_, 1000)));
+        assert!(matches!(result.l1, Limit::Defined(_, 100)));
+        assert!(matches!(result.l2, Limit::Defined(_, 10)));
+    }
+}

--- a/crates/vqueues/Cargo.toml
+++ b/crates/vqueues/Cargo.toml
@@ -19,10 +19,10 @@ restate-types = { workspace = true }
 bilrost = { workspace = true, features = ["smallvec"] }
 derive_more = { workspace = true, features = ["debug", "into_iterator", "is_variant"] }
 gardal = { workspace = true, features = ["tokio"] }
-hashbrown = { workspace = true  }
+hashbrown = { workspace = true }
 metrics = { workspace = true }
 pin-project = { workspace = true }
-slotmap = { version = "1" }
+slotmap = { workspace = true }
 smallvec = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 tokio-util = { workspace = true, features = ["time"] }


### PR DESCRIPTION

Add a hierarchical rule-matching crate for concurrency limiting. The
limiter resolves limits across a 3-level key hierarchy (Scope / Level1
/ Level2) using ranked wildcard pattern matching. Also moves slotmap
to a workspace dependency.

## Rule Pattern Syntax

Rules are parsed from slash-separated patterns where each component is
either an exact `RestrictedValue` (`[a-zA-Z0-9_.-]`, 1–36 bytes) or a
wildcard (`*`). The number of components determines the rule's depth:

| Depth | Format        | Description                              |
|-------|---------------|------------------------------------------|
| 1     | `scope`       | Exact scope                              |
| 1     | `*`           | Wildcard scope (global default)          |
| 2     | `scope/l1`    | Exact scope + exact L1                   |
| 2     | `scope/*`     | Exact scope + wildcard L1                |
| 2     | `*/l1`        | Wildcard scope + exact L1                |
| 3     | `scope/l1/l2` | Exact scope + exact L1 + exact L2        |
| 3     | `scope/*/l2`  | Exact scope + wildcard L1 + exact L2     |
| 3     | `scope/l1/*`  | Exact scope + exact L1 + wildcard L2     |
| 3     | `*/*/*`       | All wildcards (broadest L2 default)      |

## Rule Resolution (Lookup)

`Rules::lookup(scope, limit_key)` returns a `StructuredLimits` with
independently resolved limits for each level present in the input:

- **Scope limit**: best-matching depth-1 rule for the given scope.
- **L1 limit** (if `limit_key` is `L1` or `L2`): best-matching
  depth-2 rule.
- **L2 limit** (if `limit_key` is `L2`): best-matching depth-3 rule.

Rules only match inputs at their own depth — a depth-2 rule never
matches a scope-only query, and a depth-3 rule requires both L1 and
L2 components.

## Precedence

Each matching rule is assigned a bitmask rank: one bit per hierarchy
level, set to 1 for an exact match and 0 for a wildcard. The
highest-ranked rule wins. For depth-3 rules this gives:

| Rank | Scope | L1    | L2    | Example         |
|------|-------|-------|-------|-----------------|
| 0    | `*`   | `*`   | `*`   | `*/*/*`         |
| 1    | `*`   | `*`   | exact | `*/*/bar`       |
| 2    | `*`   | exact | `*`   | `*/foo/*`       |
| 3    | `*`   | exact | exact | `*/foo/bar`     |
| 4    | exact | `*`   | `*`   | `scope/*/*`     |
| 5    | exact | `*`   | exact | `scope/*/bar`   |
| 6    | exact | exact | `*`   | `scope/foo/*`   |
| 7    | exact | exact | exact | `scope/foo/bar` |

The same principle applies to depth-1 (1 bit, ranks 0–1) and depth-2
(2 bits, ranks 0–3) rules.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4525).
* #4528
* __->__ #4525