### PR TITLE
Support dual-stack by defaulting bind-ip to :: instead of 0.0.0.0 (#4529)

### DIFF
--- a/crates/types/src/config/cli_option_overrides.rs
+++ b/crates/types/src/config/cli_option_overrides.rs
@@ -123,7 +123,7 @@ pub struct CommonOptionCliOverride {
     #[clap(long, global = true)]
     pub metadata_store_address: Option<AdvertisedAddress<FabricPort>>,
 
-    /// Address to bind for the node-to-node communication. e.g. `0.0.0.0:5122`.
+    /// Address to bind for the node-to-node communication. e.g. `[::]:5122`.
     /// This overrides bind-ip and bind-port if set.
     #[clap(long, env = "RESTATE_BIND_ADDRESS", global = true)]
     pub bind_address: Option<BindAddress<FabricPort>>,

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -329,7 +329,7 @@ pub struct CommonOptions {
     pub log_disable_ansi_codes: bool,
 
     /// Address to bind for the tokio-console tracing subscriber. If unset and restate-server is
-    /// built with tokio-console support, it'll listen on `0.0.0.0:6669`.
+    /// built with tokio-console support, it'll listen on `[::]:6669`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     pub tokio_console_bind_address: Option<BindAddress<TokioConsolePort>>,

--- a/crates/types/src/net/address.rs
+++ b/crates/types/src/net/address.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::OnceLock;
@@ -151,7 +151,7 @@ pub struct BindAddress<P: ListenerPort> {
 }
 
 /// Local interface address to listen on (INET sockets only)
-/// tcp: bind_address (0.0.0.0:5122)
+/// tcp: bind_address ([::]:5122)
 impl<P: ListenerPort> BindAddress<P> {
     pub const fn new(addr: SocketAddr) -> Self {
         Self {
@@ -161,10 +161,12 @@ impl<P: ListenerPort> BindAddress<P> {
     }
 
     /// If `use_random_port` is true, the port will be chosen randomly unless `port` is set.
+    /// When no IP is specified, defaults to `::` (IPv6 unspecified) which on most systems
+    /// creates a dual-stack socket accepting both IPv4 and IPv6 connections.
     pub fn from_parts(ip: Option<IpAddr>, port: Option<u16>, use_random_port: bool) -> Self {
         Self {
             inner: SocketAddr::new(
-                ip.unwrap_or(IpAddr::V4(Ipv4Addr::UNSPECIFIED)),
+                ip.unwrap_or(IpAddr::V6(Ipv6Addr::UNSPECIFIED)),
                 port.unwrap_or(if use_random_port { 0 } else { P::DEFAULT_PORT }),
             ),
             _phantom: std::marker::PhantomData,
@@ -222,7 +224,7 @@ impl<P: ListenerPort> schemars::JsonSchema for BindAddress<P> {
             P::DEFAULT_PORT,
             P::UDS_NAME
         ),
-            "examples": [format!("0.0.0.0:{}", P::DEFAULT_PORT), format!("127.0.0.1:{}", P::DEFAULT_PORT)]
+            "examples": [format!("[::]:{}",P::DEFAULT_PORT), format!("0.0.0.0:{}", P::DEFAULT_PORT), format!("127.0.0.1:{}", P::DEFAULT_PORT)]
         })
     }
 }
@@ -542,33 +544,37 @@ impl<P: ListenerPort> FromStr for AdvertisedAddress<P> {
 }
 
 /// A helper function that attempts to derive the public routable IP address of
-/// the local machine. Falls back to `127.0.0.1` if the guessing fails.
+/// the local machine. Tries IPv6 first, then falls back to IPv4 for IPv4-only
+/// environments. Falls back to `127.0.0.1` if all guessing fails.
 fn guess_my_routable_ip() -> &'static str {
     static MY_IP: OnceLock<Option<String>> = OnceLock::new();
     static LOCALHOST: &str = "127.0.0.1";
-    // guesses the publicly reachable IP address by creating a datagram socket
-    // to 1.1.1.1 and then reading the source address of the response.
-    // Note that this does not send any packets, but it will use the system's
-    // routing table to determine the local interface that is used to reach the
-    // default gateway.
+    // Guesses the publicly reachable IP address by creating a datagram socket
+    // and then reading the source address. This does not send any packets, but
+    // it will use the system's routing table to determine the local interface
+    // that is used to reach the default gateway.
     //
-    // We fallback to `127.0.0.1` if we failed to guess the public IP address.
+    // We try IPv6 first (connect to 2606:4700:4700::1111), then IPv4 (connect
+    // to 1.1.1.1) for IPv4-only environments. We fall back to `127.0.0.1` if
+    // both fail.
     MY_IP
-        .get_or_init(|| {
-            let socket = std::net::UdpSocket::bind("0.0.0.0:0").ok()?;
-            socket.connect("1.1.1.1:80").ok()?;
-            let ip = socket.local_addr().ok()?.ip();
-            let ip = if ip.is_ipv6() {
-                // we need to wrap the IPv6 address in brackets to be compatible with
-                // the URI specification.
-                format!("[{}]", ip)
-            } else {
-                ip.to_string()
-            };
-            Some(ip)
-        })
+        .get_or_init(|| guess_routable_ipv6().or_else(guess_routable_ipv4))
         .as_deref()
         .unwrap_or(LOCALHOST)
+}
+
+fn guess_routable_ipv4() -> Option<String> {
+    let socket = std::net::UdpSocket::bind("0.0.0.0:0").ok()?;
+    socket.connect("1.1.1.1:80").ok()?;
+    Some(socket.local_addr().ok()?.ip().to_string())
+}
+
+fn guess_routable_ipv6() -> Option<String> {
+    let socket = std::net::UdpSocket::bind("[::]:0").ok()?;
+    socket.connect("[2606:4700:4700::1111]:80").ok()?;
+    let ip = socket.local_addr().ok()?.ip();
+    // IPv6 addresses in URIs must be wrapped in brackets per RFC 3986
+    Some(format!("[{ip}]"))
 }
 
 #[inline]
@@ -585,9 +591,27 @@ fn parse_uri(s: &str) -> Result<Uri, anyhow::Error> {
 
 #[cfg(test)]
 mod tests {
-    use std::net::Ipv6Addr;
-
     use super::*;
+
+    #[test]
+    fn test_from_parts_defaults_to_ipv6_unspecified() {
+        let addr = BindAddress::<ControlPort>::from_parts(None, None, false);
+        assert_eq!(addr.inner.ip(), IpAddr::V6(Ipv6Addr::UNSPECIFIED));
+        assert_eq!(addr.inner.port(), ControlPort::DEFAULT_PORT);
+
+        // Explicit IPv4 still works
+        let addr = BindAddress::<ControlPort>::from_parts(
+            Some(IpAddr::V4(Ipv4Addr::UNSPECIFIED)),
+            None,
+            false,
+        );
+        assert_eq!(addr.inner.ip(), IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+
+        // Random port
+        let addr = BindAddress::<ControlPort>::from_parts(None, None, true);
+        assert_eq!(addr.inner.ip(), IpAddr::V6(Ipv6Addr::UNSPECIFIED));
+        assert_eq!(addr.inner.port(), 0);
+    }
 
     #[test]
     fn test_parse_bind_address() {

--- a/release-notes/unreleased/4529-dual-stack-bind-address.md
+++ b/release-notes/unreleased/4529-dual-stack-bind-address.md
@@ -1,0 +1,57 @@
+# Dual-stack support: default bind address changed to `::`
+
+## Behavioral Change
+
+### What Changed
+
+The default `bind-ip` has changed from `0.0.0.0` (IPv4 only) to `::` (IPv6
+unspecified), which on most systems creates a dual-stack socket that accepts
+both IPv4 and IPv6 connections.
+
+Additionally, the automatic routable IP detection now tries IPv6 as a fallback
+when IPv4 detection fails, improving support for IPv6-only environments.
+
+### Why This Matters
+
+In IPv6-only environments (e.g. Kubernetes clusters with IPv6-only networking),
+Restate would fail to start because `0.0.0.0` cannot bind when no IPv4 stack
+is available. In dual-stack environments where DNS resolves peer addresses to
+IPv6, nodes were unreachable because the server only listened on IPv4. Users
+had to manually set `bind-ip = "::"` as a workaround.
+
+By defaulting to `::`, the server now listens on both IPv4 and IPv6 interfaces,
+making it reachable regardless of which address family peers or clients use.
+
+### Impact on Users
+
+- **Existing IPv4 deployments**: No action required. On Linux and macOS, `::` with
+  the default `IPV6_V6ONLY=false` kernel setting creates a dual-stack socket that
+  continues to accept IPv4 connections via IPv4-mapped IPv6 addresses.
+- **IPv6-only deployments**: Restate now starts and works out of the box without
+  needing to configure `bind-ip`.
+- **Dual-stack deployments**: Restate is now reachable over both IPv4 and IPv6,
+  regardless of which address family peers resolve to.
+- **Explicit `bind-ip` configured**: If you have already set `bind-ip` in your
+  configuration, this change has no effect — your explicit value takes precedence.
+- **Edge case**: On the rare Linux systems where `net.ipv6.bindv6only=1` is set,
+  binding to `::` will only accept IPv6 connections. Set `bind-ip = "0.0.0.0"` to
+  restore IPv4-only behavior.
+
+### Migration Guidance
+
+No migration is required for the vast majority of deployments. If you need to
+restore the previous behavior:
+
+```toml
+# Restore IPv4-only binding
+bind-ip = "0.0.0.0"
+```
+
+Or via environment variable:
+
+```bash
+RESTATE_BIND_IP=0.0.0.0
+```
+
+### Related Issues
+- [#4529](https://github.com/restatedev/restate/issues/4529): Add support for dual-stack


### PR DESCRIPTION
Change the default bind address from 0.0.0.0 (IPv4 only) to :: (IPv6 unspecified), which creates a dual-stack socket accepting both IPv4 and IPv6 connections on most systems.

This fixes two problems:
- In IPv6-only environments (e.g. K8s clusters), 0.0.0.0 fails to bind entirely because no IPv4 stack is available.
- In dual-stack environments where DNS resolves peer addresses to IPv6, nodes were unreachable because the server only listened on IPv4.

Also add an IPv6 fallback probe to the routable IP detection so that advertised addresses are correctly derived in IPv6-only environments.

This fixes #4529 