### PR TITLE
Fix broken --remote-port parsing and add --no-remote-ports flag

### DIFF
--- a/cli/src/commands/cloud/environments/tunnel/mod.rs
+++ b/cli/src/commands/cloud/environments/tunnel/mod.rs
@@ -39,8 +39,12 @@ pub struct Tunnel {
 
     /// Remote port on the Environment to expose on localhost
     /// This argument can be repeated to specify multiple remote ports
-    #[clap(short = 'r', long, action = clap::ArgAction::Append)]
+    #[clap(short = 'r', long, action = clap::ArgAction::Append, conflicts_with = "no_remote_ports")]
     remote_port: Vec<remote::RemotePort>,
+
+    /// Disable proxying remote Environment ports to localhost
+    #[clap(long)]
+    no_remote_ports: bool,
 
     /// A name for the tunnel; a random name will be generated if not provided
     #[clap(long = "tunnel-name")]
@@ -82,7 +86,7 @@ pub async fn run_tunnel(State(env): State<CliEnv>, opts: &Tunnel) -> Result<()> 
     };
 
     let mut opts = opts.clone();
-    if opts.remote_port.is_empty() {
+    if !opts.no_remote_ports && opts.remote_port.is_empty() {
         opts.remote_port = vec![RemotePort::Ingress, RemotePort::Admin];
     }
 

--- a/cli/src/commands/cloud/environments/tunnel/remote.rs
+++ b/cli/src/commands/cloud/environments/tunnel/remote.rs
@@ -30,10 +30,13 @@ impl ValueEnum for RemotePort {
     }
 
     fn to_possible_value(&self) -> Option<builder::PossibleValue> {
-        Some(builder::PossibleValue::new(match self {
-            Self::Ingress => HttpIngressPort::default_port_str(),
-            Self::Admin => AdminPort::default_port_str(),
-        }))
+        Some(match self {
+            Self::Ingress => builder::PossibleValue::new(HttpIngressPort::default_port_str())
+                .help("Ingress HTTP port"),
+            Self::Admin => {
+                builder::PossibleValue::new(AdminPort::default_port_str()).help("Admin API port")
+            }
+        })
     }
 }
 

--- a/crates/types/src/net/address.rs
+++ b/crates/types/src/net/address.rs
@@ -26,9 +26,7 @@ pub trait ListenerPort: Clone + PartialEq + Eq {
     /// Whether this port allows binding on an anonymous unix-socket or not.
     const IS_ANONYMOUS_UDS_ALLOWED: bool;
 
-    fn default_port_str() -> &'static str {
-        stringify!(Self::DEFAULT_PORT)
-    }
+    fn default_port_str() -> &'static str;
 }
 
 /// Implemented on ports that support gRPC protocol
@@ -48,6 +46,9 @@ impl ListenerPort for HttpIngressPort {
     const DEFAULT_PORT: u16 = 8080;
     const UDS_NAME: &'static str = "ingress.sock";
     const IS_ANONYMOUS_UDS_ALLOWED: bool = true;
+    fn default_port_str() -> &'static str {
+        "8080"
+    }
 }
 
 /// Admin HTTP Service 9070
@@ -60,6 +61,9 @@ impl ListenerPort for AdminPort {
     const DEFAULT_PORT: u16 = 9070;
     const UDS_NAME: &'static str = "admin.sock";
     const IS_ANONYMOUS_UDS_ALLOWED: bool = true;
+    fn default_port_str() -> &'static str {
+        "9070"
+    }
 }
 
 /// gRPC port for control and introspection
@@ -72,6 +76,9 @@ impl ListenerPort for ControlPort {
     const DEFAULT_PORT: u16 = 5122;
     const UDS_NAME: &'static str = "control.sock";
     const IS_ANONYMOUS_UDS_ALLOWED: bool = true;
+    fn default_port_str() -> &'static str {
+        "5122"
+    }
 }
 impl GrpcPort for ControlPort {}
 
@@ -86,6 +93,9 @@ impl ListenerPort for FabricPort {
     // this is disallowed for the message fabric since we must be able to acquire a
     // non-anonymous socket address to allow server-to-server communication.
     const IS_ANONYMOUS_UDS_ALLOWED: bool = false;
+    fn default_port_str() -> &'static str {
+        "5122"
+    }
 }
 impl GrpcPort for FabricPort {}
 
@@ -97,6 +107,9 @@ impl ListenerPort for TokioConsolePort {
     const DEFAULT_PORT: u16 = 6669;
     const UDS_NAME: &'static str = "tokio.sock";
     const IS_ANONYMOUS_UDS_ALLOWED: bool = false;
+    fn default_port_str() -> &'static str {
+        "6669"
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash, derive_more::Display)]

--- a/release-notes/unreleased/fix-tunnel-remote-port.md
+++ b/release-notes/unreleased/fix-tunnel-remote-port.md
@@ -1,0 +1,9 @@
+# CLI: Fix `--remote-port` in `restate cloud env tunnel`
+
+## Bug Fix
+
+### What Changed
+
+`--remote-port` was completely broken — it rejected all input and displayed `[possible values: Self::DEFAULT_PORT, Self::DEFAULT_PORT]`. It now correctly accepts `8080` (ingress) and `9070` (admin).
+
+A new `--no-remote-ports` flag has been added to disable environment port proxying while keeping only the inbound tunnel direction.


### PR DESCRIPTION
ListenerPort::default_port_str() used stringify!(Self::DEFAULT_PORT) which stringifies the tokens literally, making clap reject all numeric input and display "[possible values: Self::DEFAULT_PORT, Self::DEFAULT_PORT]". Make it a required method with correct string values per implementor.

Also add --no-remote-ports to allow disabling environment port proxying while keeping only the inbound tunnel direction.

Before:

```
% npx @restatedev/restate cloud env tunnel --remote-port 9070
error: invalid value '9070' for '--remote-port <REMOTE_PORT>'
  [possible values: Self::DEFAULT_PORT, Self::DEFAULT_PORT]

For more information, try '--help'.
```

Now: `restate cloud env tunnel --remote-port 9070 --remote-port 8080`

```
  💡   Source                            →    💡   Destination
  🤝   tunnel://climax (3/3 connected)   →    🏠   your machine
  🏠   http://localhost:9070             →    🔒   admin API
  🏠   http://localhost:8080             →    🌎   public ingress
```

And this also becomes possible: `restate cloud env tunnel --no-remote-ports`:

```
  💡   Source                            →    💡   Destination
  🤝   tunnel://bridge (3/3 connected)   →    🏠   your machine
```