### PR TITLE
Issue 4375 : Add response compression (gzip/brotli) to Admin API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +452,18 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1221,6 +1248,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,6 +1686,26 @@ dependencies = [
  "serde",
  "static_assertions",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "concurrent-queue"
@@ -10078,13 +10146,17 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -66,7 +66,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true, features = ["transport", "codegen", "gzip", "zstd"] }
 tower = { workspace = true, features = ["load-shed", "limit"] }
-tower-http = { workspace = true, features = ["trace"] }
+tower-http = { workspace = true, features = ["compression-br", "compression-gzip", "compression-zstd", "trace"] }
 tracing = { workspace = true }
 urlencoding = { workspace = true }
 utoipa = { workspace = true, features = ["axum_extras"] }

--- a/crates/admin/src/service.rs
+++ b/crates/admin/src/service.rs
@@ -16,6 +16,7 @@ use restate_ingestion_client::IngestionClient;
 use restate_wal_protocol::Envelope;
 use tower::ServiceBuilder;
 use tower_http::classify::ServerErrorsFailureClass;
+use tower_http::compression::CompressionLayer;
 use tower_http::trace::TraceLayer;
 use tracing::{Span, debug, info, info_span};
 
@@ -183,6 +184,7 @@ where
                 "/v3",
                 with_api_version_middleware(router, AdminApiVersion::V3),
             )
+            .layer(CompressionLayer::new())
             .layer(
                 ServiceBuilder::new()
                     .layer(HandleErrorLayer::new(|_| async {

--- a/release-notes/unreleased/4375-admin-api-response-compression.md
+++ b/release-notes/unreleased/4375-admin-api-response-compression.md
@@ -1,0 +1,20 @@
+# Release Notes for Issue #4375: Admin API response compression
+
+## New Feature
+
+### What Changed
+The Admin API now supports transparent response compression using gzip, brotli, and zstd.
+Clients that send an `Accept-Encoding` header will receive compressed responses automatically.
+
+### Why This Matters
+Large API responses (e.g., listing many deployments or services) can now be significantly smaller
+over the wire, reducing bandwidth usage and improving response times for clients.
+
+### Impact on Users
+- No action required — compression is negotiated transparently via standard HTTP content encoding.
+- Clients that already send `Accept-Encoding` (most HTTP clients and browsers do by default) will
+  automatically benefit from smaller responses.
+- Clients that do not send `Accept-Encoding` will continue to receive uncompressed responses.
+
+### Related Issues
+- Issue #4375

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -126,7 +126,7 @@ toml_edit = { version = "0.22", features = ["serde"] }
 toml_parser = { version = "1" }
 tonic = { version = "0.14", features = ["gzip", "tls-native-roots", "tls-ring", "zstd"] }
 tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
-tower-http = { version = "0.6", features = ["cors", "follow-redirect", "map-response-body", "normalize-path", "trace"] }
+tower-http = { version = "0.6", features = ["compression-br", "compression-gzip", "compression-zstd", "cors", "follow-redirect", "map-response-body", "normalize-path", "trace"] }
 tracing = { version = "0.1", features = ["log", "max_level_trace", "release_max_level_debug"] }
 tracing-core = { version = "0.1" }
 tracing-log = { version = "0.2" }
@@ -258,7 +258,7 @@ toml_edit = { version = "0.22", features = ["serde"] }
 toml_parser = { version = "1" }
 tonic = { version = "0.14", features = ["gzip", "tls-native-roots", "tls-ring", "zstd"] }
 tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
-tower-http = { version = "0.6", features = ["cors", "follow-redirect", "map-response-body", "normalize-path", "trace"] }
+tower-http = { version = "0.6", features = ["compression-br", "compression-gzip", "compression-zstd", "cors", "follow-redirect", "map-response-body", "normalize-path", "trace"] }
 tracing = { version = "0.1", features = ["log", "max_level_trace", "release_max_level_debug"] }
 tracing-core = { version = "0.1" }
 tracing-log = { version = "0.2" }


### PR DESCRIPTION
 ---                                                                                                                                               
  # Add response compression (gzip/brotli) to Admin API
                                                                                                                                                    
  ---                                                                                                                                             
  ## Summary                                                                                                                                        
                                                                                                                                                  
  Issue : #4375 

  The Admin API previously sent all responses uncompressed, even for endpoints like /query that can return large JSON payloads. This PR adds        
  automatic response compression to the Admin API using tower-http's CompressionLayer.
                                                                                                                                                    
  Compression is negotiated transparently per-request based on the client's Accept-Encoding header — clients that don't send the header continue to 
  receive uncompressed responses unchanged.
                                                                                                                                                    
  Supported encodings:                                                                                                                              
  - gzip
  - brotli (br)                                                                                                                                     
                                                                                                                                                  
  Changes

  - crates/admin/Cargo.toml — enable compression-gzip and compression-br features on tower-http                                                     
  - crates/admin/src/service.rs — import and apply CompressionLayer to the Admin API middleware stack, positioned after all routes are built so it
  covers every endpoint including /query, /services, /deployments, etc.                                                                             
  - workspace-hack/Cargo.toml — regenerated via cargo hakari generate                                                                             
                                                                                                                                                    
  Testing                                                                                                                                         
                                                                                                                                                    
  Tested against a locally running server with all three scenarios:                                                                                 
   
  No Accept-Encoding header (baseline — unchanged behaviour)                                                                                        
  HTTP/1.1 200 OK                                                                                                                                 
  content-type: application/json                                                                                                                    
  vary: accept-encoding                                                                                                                           
  transfer-encoding: chunked
                                                                                                                                                    
  {"rows":[{"count(Int64(1))":0}]}
                                                                                                                                                    
  Accept-Encoding: gzip                                                                                                                           
  HTTP/1.1 200 OK
  content-type: application/json
  vary: accept-encoding         
  content-encoding: gzip
  transfer-encoding: chunked                                                                                                                        
   
  <binary gzip body>                                                                                                                                
                                                                                                                                                  
  Accept-Encoding: br
  HTTP/1.1 200 OK
  content-type: application/json                                                                                                                    
  vary: accept-encoding         
  content-encoding: br                                                                                                                              
  transfer-encoding: chunked                                                                                                                      
                            
  {"rows":[{"count(Int64(1))":0}]}
                                  
  The Vary: accept-encoding header is present on all responses (including uncompressed ones), which is correct HTTP behaviour for caching proxies
  and CDNs.                                                                                                                                         
   
  ---    