### PR TITLE
Add support for dial9 instrumentation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -26,6 +26,7 @@ rustflags = [
     "-C", "force-unwind-tables", # Include full unwind tables when aborting on panic
     "--cfg", "uuid_unstable", # Enable unstable Uuid
     "--cfg", "tokio_unstable", # Enable unstable tokio
+    "-C", "force-frame-pointers=yes", # Enable frame pointers for profiling (dial9, perf)
 ]
 
 [target.aarch64-unknown-linux-gnu]
@@ -43,6 +44,7 @@ rustflags = [
     "-C", "force-unwind-tables", # Include full unwind tables when aborting on panic
     "--cfg", "uuid_unstable", # Enable unstable Uuid
     "--cfg", "tokio_unstable", # Enable unstable tokio
+    "-C", "force-frame-pointers=yes", # Enable frame pointers for profiling (dial9, perf)
     "-C", "link-self-contained=yes", # Link statically
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "adaptive-timeout"
 version = "0.0.1-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,7 +32,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
- "gimli",
+ "gimli 0.32.3",
 ]
 
 [[package]]
@@ -1315,6 +1325,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "blazesym"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "847a0a95b041ad5aae1bdc44f2bd54743f76eb0065c4f86b139f81343c287eaf"
+dependencies = [
+ "cpp_demangle 0.5.1",
+ "crc32fast",
+ "flate2",
+ "gimli 0.33.0",
+ "libc",
+ "memmap2",
+ "rustc-demangle",
+ "tempfile",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,6 +1365,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "bon"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
+dependencies = [
+ "darling 0.23.0",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1464,6 +1515,12 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[package]]
+name = "c-enum"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd17eb909a8c6a894926bfcc3400a4bb0e732f5a57d37b1f14e8b29e329bace8"
 
 [[package]]
 name = "camino"
@@ -2021,6 +2078,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpp_demangle"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2115,6 +2181,15 @@ name = "crossbeam-epoch"
 version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -3092,6 +3167,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3143,6 +3229,134 @@ dependencies = [
  "rustc_version",
  "syn 2.0.117",
  "unicode-xid",
+]
+
+[[package]]
+name = "dial9"
+version = "0.5.0-rc2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aecf32e4c1a8399d8a83d9344a35c2fbd601f98b0338fb801086acf506f7b99b"
+dependencies = [
+ "bon",
+ "dial9-core",
+ "dial9-macro",
+ "dial9-metrique",
+ "dial9-perf-self-profile",
+ "dial9-tokio-telemetry",
+ "dial9-trace-format",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "dial9-core"
+version = "0.5.0-rc2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b578c513da9879d5d2a89fe216c90786ec101f75df1b7296a7efd564d96a85"
+dependencies = [
+ "bon",
+ "bytes",
+ "crossbeam-queue",
+ "dial9-trace-format",
+ "flate2",
+ "futures-util",
+ "libc",
+ "metrique",
+ "metrique-timesource",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "ulid",
+]
+
+[[package]]
+name = "dial9-macro"
+version = "0.5.0-rc2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc39c5cdb08aab6ce91d65bcfe41616b5c787594f3d0e0657dd7bbf04f87624"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dial9-metrique"
+version = "0.5.0-rc2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c1852fed36de3aae0027c77dbbd0c451fc850eafed6220044d47ecaab3a85f"
+dependencies = [
+ "dial9-core",
+ "dial9-trace-format",
+ "metrique",
+ "metrique-writer",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "dial9-perf-self-profile"
+version = "0.5.0-rc2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cd666bfb550acf29dd2c6049d65c5c11f804822e66e6d04e7ab3eee73ee8204"
+dependencies = [
+ "blazesym",
+ "bytes",
+ "crossbeam-utils",
+ "dial9-core",
+ "dial9-trace-format",
+ "libc",
+ "perf-event-data",
+ "perf-event-open-sys2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "dial9-tokio-telemetry"
+version = "0.5.0-rc2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f722354a5668cde750c52adff07f58865b68cb1788383c41cc67c75296061394"
+dependencies = [
+ "arc-swap",
+ "bon",
+ "bytes",
+ "dial9-core",
+ "dial9-perf-self-profile",
+ "dial9-trace-format",
+ "flate2",
+ "futures-util",
+ "hostname",
+ "libc",
+ "metrique-timesource",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "dial9-trace-format"
+version = "0.5.0-rc2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b46ecfdbf46f58d7412db8794044855a60664c645b4d881bb798a65b96d8ac9"
+dependencies = [
+ "dial9-trace-format-derive",
+ "serde",
+]
+
+[[package]]
+name = "dial9-trace-format-derive"
+version = "0.5.0-rc2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45278d1f9443369bf76c93c73bb98ec971d39dda569d710fa098b13cdd56c784"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3919,6 +4133,18 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "gimli"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+dependencies = [
+ "fnv",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "glob"
@@ -5228,9 +5454,9 @@ checksum = "b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -5470,6 +5696,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "metrics"
 version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5502,15 +5737,123 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13"
 dependencies = [
+ "aho-corasick",
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.16.1",
+ "indexmap 2.14.0",
  "metrics",
+ "ordered-float",
  "quanta",
+ "radix_trie",
  "rand 0.9.4",
  "rand_xoshiro",
  "rapidhash",
  "sketches-ddsketch",
+]
+
+[[package]]
+name = "metrique"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dedbf06ffeef4c37990c73636fbd993aa34fb1948afd736e6114f239220993db"
+dependencies = [
+ "itoa",
+ "metrique-core",
+ "metrique-macro",
+ "metrique-service-metrics",
+ "metrique-timesource",
+ "metrique-writer",
+ "metrique-writer-core",
+ "metrique-writer-macro",
+ "ryu",
+ "tokio",
+]
+
+[[package]]
+name = "metrique-core"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bd60ab3f5d8e13e36aa1d1dd9cc4920012dd21a25bd7311ae3c39810648e068"
+dependencies = [
+ "itertools 0.14.0",
+ "metrique-writer-core",
+]
+
+[[package]]
+name = "metrique-macro"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fb1f30185f53f7f6e4c9e46745c1a1350af8e77fda5a88aded44b0637a82e0"
+dependencies = [
+ "Inflector",
+ "darling 0.23.0",
+ "metrique-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "metrique-service-metrics"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ee17caa35f83b730a83c8fa8f7a9aaa61a0becc7a71feb5bfb854bc75440d7"
+dependencies = [
+ "metrique-writer",
+]
+
+[[package]]
+name = "metrique-timesource"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2faca4e4480069ff02b1763b3b79f5cec7e8628e24d9dc5b6073f53d2577a4d9"
+
+[[package]]
+name = "metrique-writer"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20bd17c1a3ca2719e31f19ce77a853948dc2102f35976b92276c42a64fdc5f3f"
+dependencies = [
+ "ahash",
+ "crossbeam-queue",
+ "crossbeam-utils",
+ "metrics",
+ "metrics-util",
+ "metrique-core",
+ "metrique-writer-core",
+ "metrique-writer-macro",
+ "rand 0.9.4",
+ "smallvec",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "metrique-writer-core"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a55b6aae1d85c557c729564c4e2b32a26dc65ba2d90d9647ca01f2bd4854c4"
+dependencies = [
+ "derive-where",
+ "itertools 0.14.0",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "metrique-writer-macro"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eef190f855405b9df4166ee0495925162fb2a7985bac62c6ae44f40061fac00"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "str_inflector",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
@@ -6239,6 +6582,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6343,6 +6695,27 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "perf-event-data"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "575828d9d7d205188048eb1508560607a03d21eafdbba47b8cade1736c1c28e1"
+dependencies = [
+ "bitflags 2.11.1",
+ "c-enum",
+ "perf-event-open-sys2",
+]
+
+[[package]]
+name = "perf-event-open-sys2"
+version = "5.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c25955321465255e437600b54296983fab1feac2cd0c38958adeb26dbae49e"
+dependencies = [
+ "libc",
+ "memoffset",
+]
 
 [[package]]
 name = "petgraph"
@@ -7794,6 +8167,7 @@ dependencies = [
  "bytestring",
  "dashmap",
  "derive_more",
+ "dial9",
  "enum-map",
  "enumset",
  "futures",
@@ -9345,6 +9719,7 @@ dependencies = [
  "getrandom 0.4.2",
  "half",
  "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
  "hashbrown 0.17.1",
  "hdrhistogram",
  "hex",
@@ -9363,6 +9738,7 @@ dependencies = [
  "libz-sys",
  "log",
  "memchr",
+ "metrics-util",
  "miniz_oxide",
  "mio",
  "nom",
@@ -10425,6 +10801,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "str_inflector"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0b848d5a7695b33ad1be00f84a3c079fe85c9278a325ff9159e6c99cef4ef7"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "str_stack"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10481,7 +10867,7 @@ version = "12.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eda470a26ea40eb5cafc35487718e23a2f19153d3a589affb9e8f7fa1aa73b3"
 dependencies = [
- "cpp_demangle",
+ "cpp_demangle 0.4.5",
  "rustc-demangle",
  "symbolic-common",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ const_format = "0.2.35"
 criterion = "0.5"
 crossterm = { version = "0.29.0" }
 dashmap = { version = "6" }
+dial9 = { version = "0.5.0-rc2", default-features = false }
 datafusion = { version = "54.0.0", default-features = false, features = [
     "crypto_expressions",
     "encoding_expressions",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -21,6 +21,7 @@ test-util = [
   "tokio/test-util"
 ]
 taskdump = []
+dial9 = ["dep:dial9"]
 
 [dependencies]
 restate-workspace-hack = { workspace = true }
@@ -75,6 +76,12 @@ tonic-reflection = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true, features = ["trace"] }
 tracing = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+dial9 = { workspace = true, optional = true, features = ["cpu-profiling", "tokio"] }
+
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+dial9 = { workspace = true, optional = true, features = ["tokio"] }
 
 [build-dependencies]
 tonic-prost-build = { workspace = true }

--- a/crates/core/src/task_center.rs
+++ b/crates/core/src/task_center.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 mod builder;
+mod dial9;
 mod extensions;
 mod handle;
 mod monitoring;
@@ -75,6 +76,8 @@ struct GlobalOverrides {
 pub enum RuntimeError {
     #[error("Runtime with name {0} already exists")]
     AlreadyExists(ReString),
+    #[error("Failed to build runtime: {0}")]
+    Build(#[from] std::io::Error),
     #[error(transparent)]
     Shutdown(#[from] ShutdownError),
 }
@@ -336,6 +339,8 @@ struct TaskCenterInner {
     /// tokio's runtime after dropping the task center.
     #[allow(dead_code)]
     default_runtime: Option<tokio::runtime::Runtime>,
+    // Declared after the owned runtimes so Dial9 flushes after their worker threads stop.
+    dial9: dial9::Dial9State,
     global_cancel_token: CancellationToken,
     shutdown_requested: AtomicBool,
     current_exit_code: AtomicI32,
@@ -354,6 +359,7 @@ impl TaskCenterInner {
     fn new(
         default_runtime_handle: tokio::runtime::Handle,
         default_runtime: Option<tokio::runtime::Runtime>,
+        dial9: dial9::Dial9State,
         // used in tests to start all runtimes with clock paused. Note that this only impacts
         // partition processor runtimes
         #[cfg(any(test, feature = "test-util"))] pause_time: bool,
@@ -371,6 +377,7 @@ impl TaskCenterInner {
             start_time: Instant::now(),
             default_runtime_handle,
             default_runtime,
+            dial9,
             global_cancel_token: CancellationToken::new(),
             shutdown_requested: AtomicBool::new(false),
             current_exit_code: AtomicI32::new(0),
@@ -729,26 +736,8 @@ impl TaskCenterInner {
 
         // todo: configure the runtime according to a new runtime kind perhaps?
         let thread_builder = std::thread::Builder::new().name(format!("rt:{runtime_name}"));
-        let mut builder = tokio::runtime::Builder::new_current_thread();
-
-        #[cfg(any(test, feature = "test-util"))]
-        builder.start_paused(self.pause_time);
-
-        let rt = builder
-            .enable_all()
-            .build()
-            .expect("runtime builder succeeds");
         let tc = self.clone();
-
-        let rt_handle = Arc::new(rt);
-
-        runtimes_guard.insert(
-            runtime_name.clone(),
-            OwnedRuntimeHandle::new(cancel.clone(), rt_handle.clone()),
-        );
-
-        // release the lock.
-        drop(runtimes_guard);
+        let dial9_handle = self.dial9.handle();
 
         let id = TaskId::default();
         let context = TaskContext {
@@ -760,43 +749,80 @@ impl TaskCenterInner {
         };
 
         let (result_tx, result_rx) = oneshot::channel();
+        let (runtime_tx, runtime_rx) = std::sync::mpsc::sync_channel(0);
+        let (registered_tx, registered_rx) = std::sync::mpsc::sync_channel(0);
 
-        // start the work on the runtime
-        let _ = thread_builder
-            .spawn({
-                let runtime_name = runtime_name.clone();
-                move || {
-                    let local_set = LocalSet::new();
-                    let result = rt_handle.block_on(local_set.run_until(unmanaged_wrapper(
-                        tc.clone(),
-                        context,
-                        root_future(),
-                    )));
-
-                    drop(rt_handle);
-                    tc.drop_runtime(runtime_name);
-
-                    // need to use an oneshot here since we cannot await a thread::JoinHandle :-(
-                    let _ = result_tx.send(result);
+        // Build current-thread runtimes on the OS thread that drives them. Dial9 installs
+        // thread-local state while attaching the runtime.
+        let thread_runtime_name = runtime_name.clone();
+        thread_builder.spawn(move || {
+            let runtime_builder = || {
+                let mut builder = tokio::runtime::Builder::new_current_thread();
+                #[cfg(any(test, feature = "test-util"))]
+                builder.start_paused(tc.pause_time);
+                builder.enable_all();
+                builder
+            };
+            let runtime = match dial9::build_runtime(
+                &dial9_handle,
+                &thread_runtime_name,
+                runtime_builder(),
+                runtime_builder,
+            ) {
+                Ok(runtime) => runtime,
+                Err(error) => {
+                    let _ = runtime_tx.send(Err(error));
+                    return;
                 }
-            })
-            .unwrap();
+            };
+            if runtime_tx.send(Ok(runtime.handle().clone())).is_err() {
+                return;
+            }
+            if registered_rx.recv().is_err() {
+                return;
+            }
+
+            let local_set = LocalSet::new();
+            let result = runtime.block_on(local_set.run_until(unmanaged_wrapper(
+                tc.clone(),
+                context,
+                root_future(),
+            )));
+
+            tc.drop_runtime(&thread_runtime_name);
+            runtime.shutdown_timeout(Duration::from_secs(2));
+            trace!(runtime = %thread_runtime_name, "Runtime shutdown completed");
+
+            // need to use an oneshot here since we cannot await a thread::JoinHandle :-(
+            let _ = result_tx.send(result);
+        })?;
+
+        let runtime_handle = runtime_rx.recv().map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "runtime thread stopped during initialization",
+            )
+        })??;
+        runtimes_guard.insert(
+            runtime_name.clone(),
+            OwnedRuntimeHandle::new(cancel.clone(), runtime_handle),
+        );
+        if registered_tx.send(()).is_err() {
+            runtimes_guard.remove(&runtime_name);
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "runtime thread stopped during registration",
+            )
+            .into());
+        }
+        drop(runtimes_guard);
 
         Ok(RuntimeTaskHandle::new(runtime_name, cancel, result_rx))
     }
 
-    /// Runs **only** after the inner main thread has completed work and no other owner exists for
-    /// the runtime handle.
-    fn drop_runtime(self: &Arc<Self>, name: ReString) {
-        let mut runtimes_guard = self.managed_runtimes.lock();
-        if let Some(runtime) = runtimes_guard.remove(&name) {
-            // We must be the only owner of runtime at this point.
+    fn drop_runtime(self: &Arc<Self>, name: &ReString) {
+        if self.managed_runtimes.lock().remove(name).is_some() {
             debug!("Runtime {} completed", name);
-            let owner = Arc::into_inner(runtime.into_inner());
-            if let Some(runtime) = owner {
-                runtime.shutdown_timeout(Duration::from_secs(2));
-                trace!("Runtime {} shutdown completed", name);
-            }
         }
     }
 
@@ -940,9 +966,7 @@ impl TaskCenterInner {
             crate::AsyncRuntime::Inherit => &tokio::runtime::Handle::current(),
             crate::AsyncRuntime::Default => &self.default_runtime_handle,
         };
-        let inner_handle = tokio_task
-            .spawn_on(fut, runtime)
-            .expect("runtime can spawn tasks");
+        let inner_handle = dial9::spawn(tokio_task, fut, runtime);
 
         TaskHandle {
             cancellation_token,
@@ -1213,16 +1237,7 @@ impl TaskCenterInner {
     }
 
     fn shutdown_managed_runtimes(self: &Arc<Self>) {
-        let mut runtimes = self.managed_runtimes.lock();
-        for (_, runtime) in runtimes.drain() {
-            if let Some(runtime) = Arc::into_inner(runtime.into_inner()) {
-                // This really isn't doing much, but it's left here for completion.
-                // The reason is: If the runtime is still running, then it'll hold the Arc until it
-                // finishes gracefully, yielding None here. If the runtime completed, it'll
-                // self-shutdown prior to reaching this point.
-                runtime.shutdown_background();
-            }
-        }
+        self.managed_runtimes.lock().clear();
     }
 }
 
@@ -1357,6 +1372,21 @@ mod tests {
         assert!(logs_contain("Hello async"));
         assert!(logs_contain("Bye async"));
         assert!(start.elapsed() >= Duration::from_secs(10));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn managed_runtime_lifecycle() -> Result<()> {
+        let tc = TaskCenterBuilder::default()
+            .default_runtime_handle(tokio::runtime::Handle::current())
+            .build()?
+            .into_handle();
+
+        let runtime =
+            tc.start_runtime(TaskKind::RoleRunner, "test-runtime", None, || async { 42 })?;
+
+        assert_that!(runtime.await, eq(42));
+        assert_that!(tc.inner.managed_runtimes.lock().len(), eq(0));
         Ok(())
     }
 }

--- a/crates/core/src/task_center/builder.rs
+++ b/crates/core/src/task_center/builder.rs
@@ -66,9 +66,18 @@ impl TaskCenterBuilder {
 
     pub fn build(mut self) -> Result<OwnedHandle, TaskCenterBuildError> {
         let options = self.options.unwrap_or_default();
+        let dial9 = if self.default_runtime_handle.is_none() {
+            super::dial9::Dial9State::new(&options.dial9)
+        } else {
+            super::dial9::Dial9State::disabled()
+        };
         if self.default_runtime_handle.is_none() {
-            let mut default_runtime_builder = tokio_builder("worker", &options);
-            let default_runtime = default_runtime_builder.build()?;
+            let default_runtime = super::dial9::build_runtime(
+                &dial9.handle(),
+                "default",
+                tokio_builder("worker", &options),
+                || tokio_builder("worker", &options),
+            )?;
             self.default_runtime_handle = Some(default_runtime.handle().clone());
             self.default_runtime = Some(default_runtime);
         }
@@ -79,6 +88,7 @@ impl TaskCenterBuilder {
         Ok(OwnedHandle::new(TaskCenterInner::new(
             self.default_runtime_handle.unwrap(),
             self.default_runtime,
+            dial9,
             #[cfg(any(test, feature = "test-util"))]
             self.pause_time,
         )))

--- a/crates/core/src/task_center/dial9.rs
+++ b/crates/core/src/task_center/dial9.rs
@@ -1,0 +1,168 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Optional Dial9 instrumentation for Task Center runtimes.
+
+#[cfg(feature = "dial9")]
+mod inner {
+    use std::time::Duration;
+
+    use dial9::{
+        Dial9Handle, Dial9HandleTokioExt, Dial9TokioHandle, DiskBuffer, Recorder,
+        TokioAttachOptions,
+    };
+
+    #[cfg(target_os = "linux")]
+    use dial9::RecorderPerfExt;
+    #[cfg(target_os = "linux")]
+    use dial9::cpu::{CpuProfilingConfig, SchedEventConfig};
+
+    use restate_types::config::Dial9Options;
+
+    /// Owns the process-wide recorder. It must be dropped after all attached runtimes.
+    pub struct Dial9State {
+        recorder: Option<Recorder>,
+        handle: Dial9Handle,
+    }
+
+    impl Dial9State {
+        pub fn new(options: &Dial9Options) -> Self {
+            let writer = DiskBuffer::builder()
+                .base_path(options.trace_dir())
+                .max_file_size(options.max_file_size.as_u64())
+                .max_total_size(options.max_total_size.as_u64())
+                .build();
+
+            let recorder = match writer {
+                Ok(writer) => {
+                    let builder = dial9::recorder(writer);
+                    #[cfg(target_os = "linux")]
+                    let builder = builder
+                        .with_cpu_profiling(CpuProfilingConfig::default().include_kernel(true))
+                        .with_sched_events(SchedEventConfig::default().include_kernel(true));
+                    Some(builder.build())
+                }
+                Err(error) => {
+                    tracing::warn!(%error, "Failed to initialize Dial9 telemetry");
+                    None
+                }
+            };
+            let handle = recorder
+                .as_ref()
+                .map_or_else(Dial9Handle::disabled, |recorder| recorder.handle().clone());
+
+            Self { recorder, handle }
+        }
+
+        pub fn disabled() -> Self {
+            Self {
+                recorder: None,
+                handle: Dial9Handle::disabled(),
+            }
+        }
+
+        pub fn handle(&self) -> Dial9Handle {
+            self.handle.clone()
+        }
+    }
+
+    impl Drop for Dial9State {
+        fn drop(&mut self) {
+            if let Some(recorder) = self.recorder.take() {
+                recorder.graceful_shutdown(Duration::from_secs(2));
+            }
+        }
+    }
+
+    pub fn build_runtime(
+        handle: &Dial9Handle,
+        runtime_name: &str,
+        builder: tokio::runtime::Builder,
+        fallback_builder: impl FnOnce() -> tokio::runtime::Builder,
+    ) -> std::io::Result<tokio::runtime::Runtime> {
+        let options = TokioAttachOptions::builder()
+            .runtime_name(runtime_name.to_owned())
+            .task_tracking_enabled(true)
+            .build();
+
+        match handle.attach_tokio_runtime(builder, options) {
+            Ok(runtime) => Ok(runtime),
+            Err(error) => {
+                tracing::warn!(%error, %runtime_name, "Failed to instrument Tokio runtime with Dial9");
+                fallback_builder().build()
+            }
+        }
+    }
+
+    pub fn spawn<F, T>(
+        task_builder: tokio::task::Builder<'_>,
+        future: F,
+        runtime: &tokio::runtime::Handle,
+    ) -> tokio::task::JoinHandle<T>
+    where
+        F: std::future::Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        Dial9TokioHandle::current().spawn_with(future, |future| {
+            task_builder
+                .spawn_on(future, runtime)
+                .expect("runtime can spawn tasks")
+        })
+    }
+}
+
+#[cfg(not(feature = "dial9"))]
+mod inner {
+    use restate_types::config::Dial9Options;
+
+    pub struct Dial9State;
+
+    impl Dial9State {
+        pub fn new(_options: &Dial9Options) -> Self {
+            Self
+        }
+
+        pub fn disabled() -> Self {
+            Self
+        }
+
+        pub fn handle(&self) -> Dial9Handle {
+            Dial9Handle
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct Dial9Handle;
+
+    pub fn build_runtime(
+        _handle: &Dial9Handle,
+        _runtime_name: &str,
+        mut builder: tokio::runtime::Builder,
+        _fallback_builder: impl FnOnce() -> tokio::runtime::Builder,
+    ) -> std::io::Result<tokio::runtime::Runtime> {
+        builder.build()
+    }
+
+    pub fn spawn<F, T>(
+        task_builder: tokio::task::Builder<'_>,
+        future: F,
+        runtime: &tokio::runtime::Handle,
+    ) -> tokio::task::JoinHandle<T>
+    where
+        F: std::future::Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        task_builder
+            .spawn_on(future, runtime)
+            .expect("runtime can spawn tasks")
+    }
+}
+
+pub(super) use inner::*;

--- a/crates/core/src/task_center/runtime.rs
+++ b/crates/core/src/task_center/runtime.rs
@@ -9,7 +9,6 @@
 // by the Apache License, Version 2.0.
 
 use std::pin::Pin;
-use std::sync::Arc;
 use std::task::{Context, Poll, ready};
 
 use futures::FutureExt;
@@ -64,32 +63,28 @@ impl<T> std::future::Future for RuntimeTaskHandle<T> {
 
 pub(super) struct OwnedRuntimeHandle {
     cancellation_token: CancellationToken,
-    inner: Arc<tokio::runtime::Runtime>,
+    runtime_handle: tokio::runtime::Handle,
 }
 
 impl OwnedRuntimeHandle {
     pub fn new(
         cancellation_token: CancellationToken,
-        runtime: Arc<tokio::runtime::Runtime>,
+        runtime_handle: tokio::runtime::Handle,
     ) -> Self {
         Self {
             cancellation_token,
-            inner: runtime,
+            runtime_handle,
         }
     }
 
     // The runtime name
     pub fn runtime_handle(&self) -> &tokio::runtime::Handle {
-        self.inner.handle()
+        &self.runtime_handle
     }
 
     /// Trigger graceful shutdown of the runtime root task. Shutdown is not guaranteed, it depends
     /// on whether the root task awaits the cancellation token or not.
     pub fn cancel(&self) {
         self.cancellation_token.cancel()
-    }
-
-    pub fn into_inner(self) -> Arc<tokio::runtime::Runtime> {
-        self.inner
     }
 }

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -675,6 +675,15 @@ pub struct CommonOptions {
     #[serde(flatten)]
     pub experimental: Experimental,
 
+    /// # Dial9 Tokio runtime telemetry
+    ///
+    /// Configuration for Dial9 runtime telemetry. Only effective when the server
+    /// is compiled with the `dial9` feature flag.
+    ///
+    /// Since v1.8.0
+    #[serde(default)]
+    pub dial9: Dial9Options,
+
     /// # Explicitly disable the `controlled-idempotent-sharding`
     ///
     /// TODO: Removed in Restate v1.8. This is a stopgap solution to
@@ -684,6 +693,55 @@ pub struct CommonOptions {
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     #[cfg_attr(feature = "schemars", schemars(skip))]
     pub disable_controlled_idempotent_sharding: bool,
+}
+
+/// # Dial9 Tokio runtime telemetry options
+///
+/// Configuration for the shared Dial9 trace written by all Restate Tokio runtimes.
+/// Only effective when the server is compiled with the `dial9` feature flag.
+///
+/// Since v1.8.0
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schemars", schemars(default))]
+#[serde(rename_all = "kebab-case")]
+pub struct Dial9Options {
+    /// Directory for the shared trace files.
+    /// Defaults to `{data-dir}/dial9-traces/`.
+    ///
+    /// Since v1.8.0
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trace_dir: Option<PathBuf>,
+
+    /// Maximum size per trace file before rotation.
+    /// Default: 10 MiB.
+    ///
+    /// Since v1.8.0
+    pub max_file_size: NonZeroByteCount,
+
+    /// Maximum total disk budget for the shared trace.
+    /// Default: 100 MiB.
+    ///
+    /// Since v1.8.0
+    pub max_total_size: NonZeroByteCount,
+}
+
+impl Dial9Options {
+    pub fn trace_dir(&self) -> PathBuf {
+        self.trace_dir
+            .clone()
+            .unwrap_or_else(|| super::node_filepath("dial9-traces"))
+    }
+}
+
+impl Default for Dial9Options {
+    fn default() -> Self {
+        Self {
+            trace_dir: None,
+            max_file_size: NonZeroByteCount::try_from(10 * 1024 * 1024).unwrap(),
+            max_total_size: NonZeroByteCount::try_from(100 * 1024 * 1024).unwrap(),
+        }
+    }
 }
 
 /// Declares the [`Experimental`] feature-flag struct from a list of feature names.
@@ -1068,6 +1126,7 @@ impl Default for CommonOptions {
             gossip: GossipOptions::default(),
             hlc_max_drift: FriendlyDuration::from_millis(5000),
             experimental: Experimental::default(),
+            dial9: Dial9Options::default(),
             disable_controlled_idempotent_sharding: false,
         }
     }

--- a/lite/Cargo.toml
+++ b/lite/Cargo.toml
@@ -17,6 +17,7 @@ dist = true
 [features]
 default = ["no-trace-logging"]
 no-trace-logging = ["tracing/max_level_trace", "tracing/release_max_level_debug"]
+dial9 = ["restate-core/dial9"]
 
 [dependencies]
 restate-workspace-hack = { workspace = true }

--- a/release-notes/unreleased/dial9-runtime-telemetry.md
+++ b/release-notes/unreleased/dial9-runtime-telemetry.md
@@ -1,0 +1,16 @@
+# Dial9 runtime telemetry
+
+## New Feature
+
+Restate can now be built with the `dial9` feature to record low-overhead Tokio runtime telemetry.
+The default runtime and all managed partition runtimes write to one shared trace, allowing their
+task scheduling, wakeups, and worker activity to be analyzed together. Linux builds also capture
+CPU profiles and scheduler events.
+
+Trace storage is configured under the common `dial9` section. `trace-dir` defaults to
+`restate-data/dial9-traces`, `max-file-size` defaults to 10 MiB, and `max-total-size` defaults to
+100 MiB for the shared trace. Dial9 initialization failures do not prevent Restate from starting;
+the affected runtimes continue without instrumentation.
+
+No migration is required. Existing builds are unchanged unless the `dial9` Cargo feature is
+enabled.

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -33,6 +33,7 @@ no-trace-logging = ["tracing/max_level_trace", "tracing/release_max_level_debug"
 metadata-api = ["restate-admin/metadata-api"]
 kafka-oidc = ["restate-node/kafka-oidc"]
 taskdump = ["restate-core/taskdump"]
+dial9 = ["restate-core/dial9"]
 
 [dependencies]
 restate-workspace-hack = { workspace = true }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -282,9 +282,11 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clap = { version = "4" }
 crossterm = { version = "0.29" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
+hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16" }
 hyper-rustls = { version = "0.27", default-features = false, features = ["aws-lc-rs", "webpki-tokio"] }
 jemalloc_pprof = { version = "0.9", default-features = false, features = ["flamegraph", "symbolize"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
+metrics-util = { version = "0.20" }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
 mio = { version = "1", features = ["net", "os-ext"] }
 num = { version = "0.4" }
@@ -304,9 +306,11 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clap = { version = "4" }
 crossterm = { version = "0.29" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
+hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16" }
 hyper-rustls = { version = "0.27", default-features = false, features = ["aws-lc-rs", "webpki-tokio"] }
 jemalloc_pprof = { version = "0.9", default-features = false, features = ["flamegraph", "symbolize"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
+metrics-util = { version = "0.20" }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
 mio = { version = "1", features = ["net", "os-ext"] }
 num = { version = "0.4" }
@@ -327,9 +331,11 @@ clap = { version = "4" }
 crossterm = { version = "0.29" }
 errno = { version = "0.3" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
+hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16" }
 hyper-rustls = { version = "0.27", default-features = false, features = ["aws-lc-rs", "webpki-tokio"] }
 jemalloc_pprof = { version = "0.9", default-features = false, features = ["flamegraph", "symbolize"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
+metrics-util = { version = "0.20" }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
 num = { version = "0.4" }
 object = { version = "0.37", default-features = false, features = ["read", "std"] }
@@ -350,9 +356,11 @@ clap = { version = "4" }
 crossterm = { version = "0.29" }
 errno = { version = "0.3" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
+hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16" }
 hyper-rustls = { version = "0.27", default-features = false, features = ["aws-lc-rs", "webpki-tokio"] }
 jemalloc_pprof = { version = "0.9", default-features = false, features = ["flamegraph", "symbolize"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
+metrics-util = { version = "0.20" }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
 num = { version = "0.4" }
 object = { version = "0.37", default-features = false, features = ["read", "std"] }


### PR DESCRIPTION
This commit adds support for dial9 instrumentation of the Tokio runtimes. The dial9 feature is feature gated via "dial9". Build the restate server with --features dial9 to enable it.