### PR TITLE
Add support for controlling the leadership of partitions

### DIFF
--- a/crates/admin/src/cluster_controller/grpc_svc_handler.rs
+++ b/crates/admin/src/cluster_controller/grpc_svc_handler.rs
@@ -30,7 +30,8 @@ use restate_core::protobuf::cluster_ctrl_svc::{
     ListLogsRequest, ListLogsResponse, MigrateMetadataRequest, MigrateMetadataResponse,
     QueryRequest, QueryResponse, QueryWarning, SealAndExtendChainRequest,
     SealAndExtendChainResponse, SealChainRequest, SealChainResponse, SealedSegment,
-    SetClusterConfigurationRequest, SetClusterConfigurationResponse, TailState, TrimLogRequest,
+    SetClusterConfigurationRequest, SetClusterConfigurationResponse, SyncEpochMetadataRequest,
+    SyncEpochMetadataResponse, TailState, TrimLogRequest,
     cluster_ctrl_svc_server::{ClusterCtrlSvc, ClusterCtrlSvcServer},
 };
 use restate_core::{Metadata, MetadataWriter};
@@ -550,6 +551,30 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
         }
 
         Ok(Response::new(MigrateMetadataResponse {}))
+    }
+
+    async fn sync_epoch_metadata(
+        &self,
+        request: Request<SyncEpochMetadataRequest>,
+    ) -> Result<Response<SyncEpochMetadataResponse>, Status> {
+        let request = request.into_inner();
+        let partition_ids: Vec<PartitionId> = request
+            .partition_ids
+            .into_iter()
+            .map(|id| {
+                u16::try_from(id)
+                    .map(PartitionId::from)
+                    .map_err(|_| Status::invalid_argument(format!("invalid partition id: {id}")))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        self.controller_handle
+            .sync_epoch_metadata(partition_ids)
+            .await
+            .map_err(|_| Status::aborted("Node is shutting down"))?
+            .map_err(|err| Status::internal(err.to_string()))?;
+
+        Ok(Response::new(SyncEpochMetadataResponse {}))
     }
 }
 

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -215,6 +215,10 @@ enum ClusterControllerCommand {
         context: std::collections::HashMap<String, String>,
         response_tx: oneshot::Sender<anyhow::Result<Lsn>>,
     },
+    SyncEpochMetadata {
+        partition_ids: Vec<PartitionId>,
+        response_tx: oneshot::Sender<anyhow::Result<()>>,
+    },
 }
 
 pub struct ClusterControllerHandle {
@@ -352,6 +356,23 @@ impl ClusterControllerHandle {
 
         response_rx.await.map_err(|_| ShutdownError)
     }
+
+    pub async fn sync_epoch_metadata(
+        &self,
+        partition_ids: Vec<PartitionId>,
+    ) -> Result<anyhow::Result<()>, ShutdownError> {
+        let (response_tx, response_rx) = oneshot::channel();
+
+        let _ = self
+            .tx
+            .send(ClusterControllerCommand::SyncEpochMetadata {
+                partition_ids,
+                response_tx,
+            })
+            .await;
+
+        response_rx.await.map_err(|_| ShutdownError)
+    }
 }
 
 impl<T: TransportConnect> Service<T> {
@@ -400,7 +421,7 @@ impl<T: TransportConnect> Service<T> {
                 },
                 Some(cmd) = self.command_rx.recv() => {
                     // it is still safe to handle cluster commands as a follower
-                    self.on_cluster_cmd(cmd).await;
+                    self.on_cluster_cmd(cmd, &state);
                 }
                 _ = config_watcher.changed() => {
                     debug!("Updating the cluster controller settings.");
@@ -469,7 +490,7 @@ impl<T: TransportConnect> Service<T> {
         };
     }
 
-    async fn on_cluster_cmd(&self, command: ClusterControllerCommand) {
+    fn on_cluster_cmd(&self, command: ClusterControllerCommand, state: &ClusterControllerState) {
         match command {
             ClusterControllerCommand::GetClusterState(tx) => {
                 let _ = tx.send(self.cluster_state_refresher.get_cluster_state());
@@ -602,6 +623,22 @@ impl<T: TransportConnect> Service<T> {
                     Ok(())
                 });
             }
+            ClusterControllerCommand::SyncEpochMetadata {
+                partition_ids,
+                response_tx,
+            } => match state {
+                ClusterControllerState::Leader(leader) => {
+                    let result = leader
+                        .sync_epoch_metadata_tx()
+                        .try_send(partition_ids)
+                        .map(|_| ())
+                        .map_err(|_| anyhow!("Scheduler task is not running"));
+                    let _ = response_tx.send(result);
+                }
+                ClusterControllerState::Follower => {
+                    let _ = response_tx.send(Err(anyhow!("Not the cluster controller leader")));
+                }
+            },
         }
     }
 }

--- a/crates/admin/src/cluster_controller/service/cluster_controller_state.rs
+++ b/crates/admin/src/cluster_controller/service/cluster_controller_state.rs
@@ -13,10 +13,12 @@ use std::mem;
 use assert2::let_assert;
 use futures::future::OptionFuture;
 use itertools::Itertools;
+use tokio::sync::mpsc;
 use tracing::info;
 
 use restate_core::network::TransportConnect;
 use restate_core::{TaskCenter, TaskId, TaskKind, my_node_id};
+use restate_types::identifiers::PartitionId;
 use restate_types::nodes_config::NodesConfiguration;
 
 use crate::cluster_controller::service::Service;
@@ -83,6 +85,7 @@ impl ClusterControllerState {
 
 pub struct Leader {
     scheduler_task: TaskId,
+    sync_epoch_metadata_tx: mpsc::Sender<Vec<PartitionId>>,
 }
 
 impl Leader {
@@ -93,6 +96,8 @@ impl Leader {
             service.replica_set_states.clone(),
         );
 
+        let (sync_epoch_metadata_tx, sync_epoch_metadata_rx) = mpsc::channel(1);
+
         // We spawn the scheduler task as a child task to make use of the built-in error handling of
         // managed tasks. Otherwise, we would have to monitor for failed tasks ourselves.
         let scheduler_task = TaskCenter::spawn_child(
@@ -102,12 +107,20 @@ impl Leader {
                 service.cluster_state_refresher.cluster_state_watcher(),
                 scheduler,
                 service.metadata_writer.raw_metadata_store_client().clone(),
+                sync_epoch_metadata_rx,
             )
             .run(),
         )
         .expect("failed to spawn scheduler task");
 
-        Self { scheduler_task }
+        Self {
+            scheduler_task,
+            sync_epoch_metadata_tx,
+        }
+    }
+
+    pub fn sync_epoch_metadata_tx(&self) -> &mpsc::Sender<Vec<PartitionId>> {
+        &self.sync_epoch_metadata_tx
     }
 
     /// Stops the leader tasks to make sure that no other leader activity is running.

--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -31,6 +31,7 @@ use restate_types::net::partition_processor_manager::{
 };
 use restate_types::nodes_config::{NodeConfig, NodesConfiguration, WorkerState};
 use restate_types::partition_table::{PartitionReplication, PartitionTable};
+use restate_types::partitions::leadership_policy::{LeaderAffinity, LeadershipPolicy};
 use restate_types::partitions::state::{PartitionReplicaSetStates, ReplicaSetState};
 use restate_types::partitions::{PartitionConfiguration, worker_candidate_filter};
 use restate_types::replication::balanced_spread_selector::{
@@ -56,24 +57,33 @@ pub enum Error {
 #[derive(Debug, Clone)]
 struct PartitionState {
     target_leader: Option<PlainNodeId>,
+    /// Policy controlling leader election for this partition.
+    leadership_policy: LeadershipPolicy,
     current: PartitionConfiguration,
     next: Option<PartitionConfiguration>,
 }
 
 impl PartitionState {
-    fn new(current: PartitionConfiguration, next: Option<PartitionConfiguration>) -> Self {
+    fn new(
+        current: PartitionConfiguration,
+        next: Option<PartitionConfiguration>,
+        leadership_policy: LeadershipPolicy,
+    ) -> Self {
         Self {
             target_leader: None,
+            leadership_policy,
             current,
             next,
         }
     }
 
-    /// Returns true if the partition configuration was updated.
-    fn update_configuration(
+    /// Returns true if the partition configuration was updated. Leadership policy changes are not
+    /// affecting the return value.
+    fn update(
         &mut self,
         current: PartitionConfiguration,
         next: Option<PartitionConfiguration>,
+        leadership_policy: LeadershipPolicy,
     ) -> bool {
         // If the provided current configuration is not valid, then this means that the epoch
         // metadata was clobbered by an old version. Reset the partition state so that the scheduler
@@ -117,6 +127,8 @@ impl PartitionState {
             updated = true;
         }
 
+        self.leadership_policy = leadership_policy;
+
         updated
     }
 
@@ -141,6 +153,7 @@ impl PartitionState {
 struct PartitionConfigurationUpdate {
     current: PartitionConfiguration,
     next: Option<PartitionConfiguration>,
+    leadership_policy: LeadershipPolicy,
 }
 
 pub struct Scheduler<T> {
@@ -175,12 +188,17 @@ impl<T: TransportConnect> Scheduler<T> {
         partition_id: PartitionId,
         current: PartitionConfiguration,
         next: Option<PartitionConfiguration>,
+        leadership_policy: LeadershipPolicy,
     ) {
         let (updated, occupied_entry) = match self.partitions.entry(partition_id) {
-            Entry::Occupied(mut entry) => {
-                (entry.get_mut().update_configuration(current, next), entry)
-            }
-            Entry::Vacant(entry) => (true, entry.insert_entry(PartitionState::new(current, next))),
+            Entry::Occupied(mut entry) => (
+                entry.get_mut().update(current, next, leadership_policy),
+                entry,
+            ),
+            Entry::Vacant(entry) => (
+                true,
+                entry.insert_entry(PartitionState::new(current, next, leadership_policy)),
+            ),
         };
 
         if updated {
@@ -232,7 +250,12 @@ impl<T: TransportConnect> Scheduler<T> {
         // instructing a new leader when we already have the metadata requires no new metadata operations and can be done nearly instantly
         // by comparison, ensure_valid_partition_configuration can take (metadata operation latency * affected partitions)
         // which might be several seconds, and leader instruction would only happen at the end.
-        self.ensure_valid_leaders(cluster_state, legacy_cluster_state, partition_table);
+        self.ensure_valid_leaders(
+            cluster_state,
+            legacy_cluster_state,
+            nodes_config,
+            partition_table,
+        );
         self.instruct_nodes(legacy_cluster_state)?;
 
         self.ensure_valid_partition_configuration(
@@ -297,11 +320,17 @@ impl<T: TransportConnect> Scheduler<T> {
         &mut self,
         cluster_state: &ClusterState,
         legacy_cluster_state: &LegacyClusterState,
+        nodes_config: &NodesConfiguration,
         partition_table: &PartitionTable,
     ) {
         for partition_id in partition_table.iter_ids() {
             // select the leader based on the observed cluster state
-            self.select_leader(partition_id, cluster_state, legacy_cluster_state);
+            self.select_leader(
+                partition_id,
+                cluster_state,
+                legacy_cluster_state,
+                nodes_config,
+            );
         }
     }
 
@@ -351,9 +380,10 @@ impl<T: TransportConnect> Scheduler<T> {
                                     next,
                                 )
                                 .await?;
-                            if entry.get_mut().update_configuration(
+                            if entry.get_mut().update(
                                 partition_configuration_update.current,
                                 partition_configuration_update.next,
+                                partition_configuration_update.leadership_policy,
                             ) {
                                 Self::note_observed_membership_update(
                                     partition_id,
@@ -416,9 +446,10 @@ impl<T: TransportConnect> Scheduler<T> {
                 )
                 .await?;
 
-                if occupied_entry.get_mut().update_configuration(
+                if occupied_entry.get_mut().update(
                     partition_configuration_update.current,
                     partition_configuration_update.next,
+                    partition_configuration_update.leadership_policy,
                 ) {
                     Self::note_observed_membership_update(
                         partition_id,
@@ -429,7 +460,12 @@ impl<T: TransportConnect> Scheduler<T> {
             }
 
             // select the leader based on the observed cluster state
-            self.select_leader(&partition_id, cluster_state, legacy_cluster_state);
+            self.select_leader(
+                &partition_id,
+                cluster_state,
+                legacy_cluster_state,
+                nodes_config,
+            );
         }
 
         Ok(())
@@ -499,9 +535,9 @@ impl<T: TransportConnect> Scheduler<T> {
             .await
         {
             Ok(Some(epoch_metadata)) if epoch_metadata.current().version() != Version::INVALID => {
-                let (_, _, current, next) = epoch_metadata.into_inner();
+                let (_, _, current, next, leadership_policy) = epoch_metadata.into_inner();
 
-                Ok(Some(PartitionState::new(current, next)))
+                Ok(Some(PartitionState::new(current, next, leadership_policy)))
             }
             Ok(_) => Ok(None), // none or invalid partition state
             Err(err) => Err(err.into()),
@@ -522,8 +558,13 @@ impl<T: TransportConnect> Scheduler<T> {
                         if epoch_metadata.current().version() == Version::INVALID {
                             Ok(epoch_metadata.set_initial_current_configuration(current.clone()))
                         } else {
-                            let (_, _, current, next) = epoch_metadata.into_inner();
-                            Err(PartitionConfigurationUpdate { current, next })
+                            let (_, _, current, next, leadership_policy) =
+                                epoch_metadata.into_inner();
+                            Err(PartitionConfigurationUpdate {
+                                current,
+                                next,
+                                leadership_policy,
+                            })
                         }
                     } else {
                         Ok(EpochMetadata::new(current.clone(), None))
@@ -533,13 +574,17 @@ impl<T: TransportConnect> Scheduler<T> {
             .await
         {
             Ok(epoch_metadata) => {
-                let (_, _, current, next) = epoch_metadata.into_inner();
+                let (_, _, current, next, leadership_policy) = epoch_metadata.into_inner();
                 debug!("Initialized partition {} with {:?}", partition_id, current);
-                Ok(PartitionState::new(current, next))
+                Ok(PartitionState::new(current, next, leadership_policy))
             }
-            Err(ReadModifyWriteError::FailedOperation(concurrent_update)) => Ok(
-                PartitionState::new(concurrent_update.current, concurrent_update.next),
-            ),
+            Err(ReadModifyWriteError::FailedOperation(concurrent_update)) => {
+                Ok(PartitionState::new(
+                    concurrent_update.current,
+                    concurrent_update.next,
+                    concurrent_update.leadership_policy,
+                ))
+            }
             Err(ReadModifyWriteError::ReadWrite(err)) => Err(err.into()),
         }
     }
@@ -566,8 +611,13 @@ impl<T: TransportConnect> Scheduler<T> {
                         {
                             Ok(epoch_metadata.reconfigure(next.clone()))
                         } else {
-                            let (_, _, current, next) = epoch_metadata.into_inner();
-                            Err(PartitionConfigurationUpdate { current, next })
+                            let (_, _, current, next, leadership_policy) =
+                                epoch_metadata.into_inner();
+                            Err(PartitionConfigurationUpdate {
+                                current,
+                                next,
+                                leadership_policy,
+                            })
                         }
                     } else {
                         // missing epoch metadata so we set next to be current right away
@@ -579,8 +629,12 @@ impl<T: TransportConnect> Scheduler<T> {
         {
             Ok(epoch_metadata) => {
                 debug!(%partition_id, "Reconfigured partition to {next:?}");
-                let (_, _, current, next) = epoch_metadata.into_inner();
-                Ok(PartitionConfigurationUpdate { current, next })
+                let (_, _, current, next, leadership_policy) = epoch_metadata.into_inner();
+                Ok(PartitionConfigurationUpdate {
+                    current,
+                    next,
+                    leadership_policy,
+                })
             }
             Err(ReadModifyWriteError::FailedOperation(concurrent_update)) => Ok(concurrent_update),
             Err(ReadModifyWriteError::ReadWrite(err)) => Err(err.into()),
@@ -605,10 +659,11 @@ impl<T: TransportConnect> Scheduler<T> {
                 Some(epoch_metadata) => {
                     let Some(actual_next_version) = epoch_metadata.next().map(|config| config.version()) else {
                         // if there is no next configuration, then a concurrent modification has happened
-                        let (_, _, current, next) = epoch_metadata.into_inner();
+                        let (_, _, current, next, leadership_policy) = epoch_metadata.into_inner();
                         return Err(PartitionConfigurationUpdate {
                             current,
                             next,
+                            leadership_policy,
                         });
                     };
 
@@ -616,10 +671,11 @@ impl<T: TransportConnect> Scheduler<T> {
                         Ordering::Less => unreachable!("we should not know about a newer next configuration than the metadata store"),
                         Ordering::Equal => Ok(epoch_metadata.complete_reconfiguration()),
                         Ordering::Greater => {
-                            let (_, _, current, next) = epoch_metadata.into_inner();
+                            let (_, _, current, next, leadership_policy) = epoch_metadata.into_inner();
                             Err(PartitionConfigurationUpdate {
                                 current,
                                 next,
+                                leadership_policy,
                             })
                         }
                     }
@@ -632,10 +688,11 @@ impl<T: TransportConnect> Scheduler<T> {
                     old_replica_set = %partition_state.current.replica_set(),
                     new_replica_set = %epoch_metadata.current().replica_set(),
                     "Transitioned from partition configuration {current_version} to {expected_next_version}");
-                let (_, _, current, next) = epoch_metadata.into_inner();
+                let (_, _, current, next, leadership_policy) = epoch_metadata.into_inner();
                 Ok(PartitionConfigurationUpdate {
                     current,
                     next,
+                    leadership_policy,
                 })
             }
             Err(ReadModifyWriteError::FailedOperation(concurrent_update)) => {
@@ -727,56 +784,63 @@ impl<T: TransportConnect> Scheduler<T> {
             .ok()
     }
 
-    /// Selects a leader based on the current target leader, observed cluster state and preferred leader.
+    /// Selects a leader based on the leadership policy, observed cluster state and replica set.
     ///
-    /// 1. Prefer worker nodes that are caught up
-    /// 2. Pick worker nodes that are alive
+    /// Scores each alive replica in a single pass. Higher score wins:
+    /// - 3: matches affinity + caught up
+    /// - 2: caught up (no affinity match)
+    /// - 1: matches affinity + alive (not caught up)
+    /// - 0: alive only (baseline)
+    ///
+    /// If `freeze` is set, the current target leader is kept unchanged.
     fn select_leader(
         &mut self,
         partition_id: &PartitionId,
         cluster_state: &ClusterState,
         legacy_cluster_state: &LegacyClusterState,
+        nodes_config: &NodesConfiguration,
     ) {
         let Some(partition) = self.partitions.get_mut(partition_id) else {
             return;
         };
 
-        if let Some(leader) = Self::select_leader_by_priority(partition, cluster_state, |node_id| {
-            legacy_cluster_state.is_partition_processor_active(partition_id, &node_id)
-        }) {
-            partition.target_leader = Some(leader);
+        // Freeze: keep the current target leader, do not elect a new one.
+        if partition.leadership_policy.freeze.is_some() {
             return;
         }
 
-        if let Some(leader) =
-            Self::select_leader_by_priority(partition, cluster_state, |_node_id| true)
+        let affinity = partition.leadership_policy.affinity.as_ref();
+
+        let best = partition
+            .current
+            .replica_set()
+            .iter()
+            .copied()
+            .filter(|node_id| cluster_state.is_alive(NodeId::from(*node_id)))
+            .max_by_key(|node_id| {
+                let has_affinity =
+                    affinity.is_some_and(|a| matches_affinity(*node_id, a, nodes_config));
+                let is_caught_up =
+                    legacy_cluster_state.is_partition_processor_active(partition_id, node_id);
+                match (has_affinity, is_caught_up) {
+                    (true, true) => 3u8,
+                    (false, true) => 2,
+                    (true, false) => 1,
+                    (false, false) => 0,
+                }
+            });
+
+        if let Some(best) = best
+            && partition.target_leader != Some(best)
         {
-            partition.target_leader = Some(leader);
+            debug!(
+                "Selecting node {} as partition processor leader for partition {partition_id}",
+                best
+            );
+            partition.target_leader = Some(best);
         }
 
         // keep the current target leader as we couldn't find any suitable substitute
-    }
-
-    fn select_leader_by_priority(
-        partition: &PartitionState,
-        cluster_state: &ClusterState,
-        additional_criterion: impl Fn(PlainNodeId) -> bool,
-    ) -> Option<PlainNodeId> {
-        // select any of the alive nodes in current
-        if let Some(alive_replica) =
-            partition
-                .current
-                .replica_set()
-                .iter()
-                .copied()
-                .find(|node_id| {
-                    cluster_state.is_alive(NodeId::from(*node_id)) && additional_criterion(*node_id)
-                })
-        {
-            return Some(alive_replica);
-        }
-
-        None
     }
 
     fn instruct_nodes(&self, legacy_cluster_state: &LegacyClusterState) -> Result<(), Error> {
@@ -840,5 +904,24 @@ impl<T: TransportConnect> Scheduler<T> {
         }
 
         Ok(())
+    }
+}
+
+/// Returns `true` if the given node matches the leader affinity expression.
+fn matches_affinity(
+    node_id: PlainNodeId,
+    affinity: &LeaderAffinity,
+    nodes_config: &NodesConfiguration,
+) -> bool {
+    match affinity {
+        LeaderAffinity::Node(preferred) => node_id == *preferred,
+        LeaderAffinity::Location(location) => nodes_config
+            .find_node_by_id(node_id)
+            .map(|config| {
+                config
+                    .location
+                    .shares_domain_with(location, location.smallest_defined_scope())
+            })
+            .unwrap_or(false),
     }
 }

--- a/crates/admin/src/cluster_controller/service/scheduler_task.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler_task.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use futures::future::OptionFuture;
+use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
 use restate_core::network::TransportConnect;
@@ -36,6 +37,7 @@ pub struct SchedulerTask<T> {
     cluster_state_watcher: ClusterStateWatcher,
     metadata_client: MetadataStoreClient,
     scheduler: Scheduler<T>,
+    sync_epoch_metadata_rx: mpsc::Receiver<Vec<PartitionId>>,
 }
 
 impl<T> SchedulerTask<T>
@@ -46,11 +48,13 @@ where
         cluster_state_watcher: ClusterStateWatcher,
         scheduler: Scheduler<T>,
         metadata_client: MetadataStoreClient,
+        sync_epoch_metadata_rx: mpsc::Receiver<Vec<PartitionId>>,
     ) -> Self {
         Self {
             cluster_state_watcher,
             scheduler,
             metadata_client,
+            sync_epoch_metadata_rx,
         }
     }
 
@@ -70,7 +74,7 @@ where
         let cs = TaskCenter::with_current(|tc| tc.cluster_state().clone());
         let mut cs_changed = std::pin::pin!(cs.changed());
 
-        let mut fetch_epoch_metadata_task = Some(self.spawn_fetch_epoch_metadata_task()?);
+        let mut fetch_epoch_metadata_task = Some(self.spawn_fetch_epoch_metadata_task(Vec::new())?);
 
         let mut next_fetch_interval = tokio::time::interval(Duration::from_secs(30));
 
@@ -109,8 +113,8 @@ where
                     match epoch_metadata {
                         Ok(epoch_metadata) => {
                             for (partition_id, epoch_metadata) in epoch_metadata {
-                                let (_, _, current, next) = epoch_metadata.into_inner();
-                                self.scheduler.update_partition_configuration(partition_id, current, next);
+                                let (_, _, current, next, leadership_policy) = epoch_metadata.into_inner();
+                                self.scheduler.update_partition_configuration(partition_id, current, next, leadership_policy);
                             }
 
                             // changed partition configurations might mean that we need to select a new
@@ -124,9 +128,23 @@ where
 
                     fetch_epoch_metadata_task = None;
                 }
+                Some(partition_ids) = self.sync_epoch_metadata_rx.recv() => {
+                    debug!("Received sync epoch metadata signal for {partition_ids:?}");
+                    // Cancel any in-flight fetch and restart with the requested partitions.
+                    if let Some(task) = fetch_epoch_metadata_task.take() {
+                        task.abort();
+                        let _ = task.await;
+                    }
+                    match self.spawn_fetch_epoch_metadata_task(partition_ids) {
+                        Ok(task) => fetch_epoch_metadata_task = Some(task),
+                        Err(err) => {
+                            warn!("Failed to spawn fetch epoch metadata task: {err}");
+                        }
+                    }
+                }
                 _ = next_fetch_interval.tick() => {
                     if fetch_epoch_metadata_task.is_none() {
-                        fetch_epoch_metadata_task = Some(self.spawn_fetch_epoch_metadata_task()?);
+                        fetch_epoch_metadata_task = Some(self.spawn_fetch_epoch_metadata_task(Vec::new())?);
                     }
                 }
             }
@@ -144,11 +162,12 @@ where
 
     fn spawn_fetch_epoch_metadata_task(
         &mut self,
+        partition_ids: Vec<PartitionId>,
     ) -> Result<TaskHandle<HashMap<PartitionId, EpochMetadata>>, ShutdownError> {
         TaskCenter::spawn_unmanaged(
             TaskKind::Background,
             "fetch-epoch-metadata",
-            FetchEpochMetadataTask::new(self.metadata_client.clone()).run(),
+            FetchEpochMetadataTask::new(self.metadata_client.clone(), partition_ids).run(),
         )
     }
 
@@ -185,19 +204,29 @@ where
 
 struct FetchEpochMetadataTask {
     metadata_client: MetadataStoreClient,
+    /// Partitions to fetch. Empty = all known partitions.
+    partition_ids: Vec<PartitionId>,
 }
 
 impl FetchEpochMetadataTask {
-    pub fn new(metadata_client: MetadataStoreClient) -> Self {
-        Self { metadata_client }
+    pub fn new(metadata_client: MetadataStoreClient, partition_ids: Vec<PartitionId>) -> Self {
+        Self {
+            metadata_client,
+            partition_ids,
+        }
     }
 
     pub async fn run(self) -> HashMap<PartitionId, EpochMetadata> {
         let mut latest_epoch_metadata = HashMap::default();
 
-        let partition_table = Metadata::with_current(|m| m.partition_table_snapshot());
+        let partition_ids: Vec<PartitionId> = if self.partition_ids.is_empty() {
+            let partition_table = Metadata::with_current(|m| m.partition_table_snapshot());
+            partition_table.iter_ids().cloned().collect()
+        } else {
+            self.partition_ids
+        };
 
-        for partition_id in partition_table.iter_ids() {
+        for partition_id in &partition_ids {
             // todo replace with multi get
             match self
                 .metadata_client

--- a/crates/core/protobuf/cluster_ctrl_svc.proto
+++ b/crates/core/protobuf/cluster_ctrl_svc.proto
@@ -43,6 +43,11 @@ service ClusterCtrlSvc {
   rpc Query(QueryRequest) returns (stream QueryResponse);
 
   rpc MigrateMetadata(MigrateMetadataRequest) returns (MigrateMetadataResponse);
+
+  // Signal the cluster controller to re-fetch epoch metadata for the given
+  // partitions. An empty list means all known partitions.
+  rpc SyncEpochMetadata(SyncEpochMetadataRequest)
+      returns (SyncEpochMetadataResponse);
 }
 
 message SetClusterConfigurationResponse {}
@@ -205,3 +210,10 @@ message MigrateMetadataRequest {
 }
 
 message MigrateMetadataResponse {}
+
+message SyncEpochMetadataRequest {
+  // Partitions to re-fetch. Empty = all known partitions.
+  repeated uint32 partition_ids = 1;
+}
+
+message SyncEpochMetadataResponse {}

--- a/crates/types/src/epoch.rs
+++ b/crates/types/src/epoch.rs
@@ -12,6 +12,7 @@
 
 use crate::identifiers::{LeaderEpoch, PartitionId};
 use crate::partitions::PartitionConfiguration;
+use crate::partitions::leadership_policy::LeadershipPolicy;
 use crate::{GenerationalNodeId, Version, Versioned, flexbuffers_storage_encode_decode};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -22,6 +23,10 @@ pub struct EpochMetadata {
     epoch: LeaderEpoch,
     current: PartitionConfiguration,
     next: Option<PartitionConfiguration>,
+    /// Policy controlling leader election for this partition.
+    /// Since v1.7.0
+    #[serde(default, skip_serializing_if = "LeadershipPolicy::is_default")]
+    leadership_policy: LeadershipPolicy,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -44,6 +49,7 @@ impl EpochMetadata {
             current,
             next,
             epoch: LeaderEpoch::INITIAL,
+            leadership_policy: LeadershipPolicy::default(),
         }
     }
 
@@ -54,8 +60,15 @@ impl EpochMetadata {
         LeaderEpoch,
         PartitionConfiguration,
         Option<PartitionConfiguration>,
+        LeadershipPolicy,
     ) {
-        (self.version, self.epoch, self.current, self.next)
+        (
+            self.version,
+            self.epoch,
+            self.current,
+            self.next,
+            self.leadership_policy,
+        )
     }
 
     pub fn epoch(&self) -> LeaderEpoch {
@@ -69,9 +82,8 @@ impl EpochMetadata {
                 node_id,
                 partition_id,
             }),
-            current: self.current,
-            next: self.next,
             epoch: self.epoch.next(),
+            ..self
         }
     }
 
@@ -99,6 +111,7 @@ impl EpochMetadata {
             current: initial_current,
             next: self.next,
             epoch: self.epoch,
+            leadership_policy: self.leadership_policy,
         }
     }
 
@@ -111,10 +124,8 @@ impl EpochMetadata {
 
         Self {
             version: self.version.next(),
-            leader_metadata: self.leader_metadata,
-            current: self.current,
             next: Some(next),
-            epoch: self.epoch,
+            ..self
         }
     }
 
@@ -125,10 +136,9 @@ impl EpochMetadata {
 
         Self {
             version: self.version.next(),
-            leader_metadata: self.leader_metadata,
             current: next,
             next: None,
-            epoch: self.epoch,
+            ..self
         }
     }
 
@@ -139,6 +149,22 @@ impl EpochMetadata {
     pub fn next(&self) -> Option<&PartitionConfiguration> {
         self.next.as_ref()
     }
+
+    /// Returns the leadership policy for this partition.
+    /// Since v1.7.0
+    pub fn leadership_policy(&self) -> &LeadershipPolicy {
+        &self.leadership_policy
+    }
+
+    /// Sets the leadership policy for this partition.
+    /// Since v1.7.0
+    pub fn set_leadership_policy(self, policy: LeadershipPolicy) -> Self {
+        Self {
+            version: self.version.next(),
+            leadership_policy: policy,
+            ..self
+        }
+    }
 }
 
 flexbuffers_storage_encode_decode!(EpochMetadata);
@@ -148,6 +174,7 @@ mod compatibility {
     use crate::epoch::{EpochMetadata, LeaderMetadata};
     use crate::identifiers::LeaderEpoch;
     use crate::partitions::PartitionConfiguration;
+    use crate::partitions::leadership_policy::LeadershipPolicy;
 
     #[derive(Debug, serde::Deserialize)]
     pub struct EpochMetadataShadow {
@@ -159,6 +186,9 @@ mod compatibility {
         epoch: Option<LeaderEpoch>,
         current: Option<PartitionConfiguration>,
         next: Option<PartitionConfiguration>,
+
+        // added in v1.7.0
+        leadership_policy: Option<LeadershipPolicy>,
     }
 
     impl From<EpochMetadataShadow> for EpochMetadata {
@@ -174,6 +204,7 @@ mod compatibility {
                 }),
                 current: value.current.unwrap_or_default(),
                 next: value.next,
+                leadership_policy: value.leadership_policy.unwrap_or_default(),
             }
         }
     }

--- a/crates/types/src/partitions.rs
+++ b/crates/types/src/partitions.rs
@@ -9,11 +9,13 @@
 // by the Apache License, Version 2.0.
 
 mod configuration;
+pub mod leadership_policy;
 pub mod state;
 
 use crate::PlainNodeId;
 use crate::nodes_config::{NodeConfig, Role, WorkerState};
 pub use configuration::*;
+pub use leadership_policy::*;
 // re-exports of partition-related types in preparation for moving them under this module
 pub use super::epoch::*;
 pub use super::partition_table::*;

--- a/crates/types/src/partitions/leadership_policy.rs
+++ b/crates/types/src/partitions/leadership_policy.rs
@@ -1,0 +1,58 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::PlainNodeId;
+use crate::locality::NodeLocation;
+
+/// Policy controlling leader election for a partition.
+/// Stored on [`super::EpochMetadata`] and survives reconfigurations.
+///
+/// Since v1.7.0
+#[derive(Debug, Clone, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct LeadershipPolicy {
+    /// If set, leader election is frozen. The current leader stays;
+    /// no new leader is elected even if the current leader dies.
+    /// Freeze takes precedence over affinity.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub freeze: Option<ElectionFreeze>,
+
+    /// Preferred leader affinity. The scheduler will prefer nodes
+    /// matching this affinity if they are alive and in the replica set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub affinity: Option<LeaderAffinity>,
+}
+
+impl LeadershipPolicy {
+    pub fn is_default(&self) -> bool {
+        self == &LeadershipPolicy::default()
+    }
+}
+
+/// Operator-initiated freeze of leader election.
+///
+/// Since v1.7.0
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ElectionFreeze {
+    /// Human-readable reason for the freeze (for observability).
+    pub reason: String,
+}
+
+/// Affinity expression for leader selection.
+/// New variants may be added in future versions (requires version gap).
+///
+/// Since v1.7.0
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum LeaderAffinity {
+    /// Prefer a specific node by ID.
+    Node(PlainNodeId),
+    /// Prefer any node whose location matches this prefix
+    /// (e.g., `"us-east-1"` for region, `"us-east-1.az2"` for zone).
+    Location(NodeLocation),
+}

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -96,7 +96,7 @@ pub struct LeadershipInfo {
 
 impl From<EpochMetadata> for LeadershipInfo {
     fn from(value: EpochMetadata) -> Self {
-        let (version, leader_epoch, current, next) = value.into_inner();
+        let (version, leader_epoch, current, next, _) = value.into_inner();
 
         Self {
             version,

--- a/release-notes/unreleased/4576-set-preferred-partition-leader.md
+++ b/release-notes/unreleased/4576-set-preferred-partition-leader.md
@@ -1,0 +1,47 @@
+# Release Notes for Issue #4576: Leadership policy for partition processors
+
+## New Feature
+
+### What Changed
+Users can now control leader election for partition processors via `restatectl partition leader`.
+The leadership policy supports two independent controls:
+
+- **Pin to node**: pin a partition's leader to a specific node
+- **Election freeze**: pause leader election with a reason; the current leader stays, and no
+  new leader is elected even if the current one dies
+
+The policy is persisted in the metadata store and survives cluster controller restarts.
+
+### Usage
+```bash
+# Pin leader to a specific node
+restatectl partition leader pin 0-4 --node 2
+
+# Unpin leader (return to automatic selection)
+restatectl partition leader unpin 0-4
+
+# Freeze leader election
+restatectl partition leader freeze 0 --reason "Maintenance window"
+
+# Unfreeze leader election
+restatectl partition leader unfreeze 0
+
+# Show current leadership policy
+restatectl partition leader show 0-4
+```
+
+### Why This Matters
+This enables operators to:
+- Pin leaders to a specific node for predictable placement
+- Freeze leader election during sensitive operations (e.g. maintenance windows)
+
+### Impact on Users
+- No action required for existing clusters — the default behavior (automatic leader selection)
+  is unchanged.
+- Pinning is a soft preference: if the pinned node is unavailable, the scheduler falls
+  back to automatic selection.
+- Election freeze is a hard stop: even if the leader dies, no new leader will be elected until
+  the freeze is lifted.
+
+### Related Issues
+- Issue #4576

--- a/tools/restatectl/src/commands/partition/leader/freeze.rs
+++ b/tools/restatectl/src/commands/partition/leader/freeze.rs
@@ -1,0 +1,66 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::Context;
+use cling::prelude::*;
+use tracing::error;
+
+use crate::connection::ConnectionInfo;
+use crate::util::RangeParam;
+use restate_cli_util::c_println;
+use restate_types::identifiers::PartitionId;
+use restate_types::partitions::leadership_policy::ElectionFreeze;
+
+use super::{signal_sync_epoch_metadata, update_epoch_metadata};
+
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[cling(run = "freeze_election")]
+pub struct FreezeOpts {
+    /// The partition id or range, e.g. "0", "1-4"
+    #[arg(required = true)]
+    partition_id: Vec<RangeParam<u16>>,
+
+    /// Reason for freezing leader election
+    #[arg(long, required = true)]
+    reason: String,
+}
+
+async fn freeze_election(connection: &ConnectionInfo, opts: &FreezeOpts) -> anyhow::Result<()> {
+    let partition_table = connection.get_partition_table().await?;
+    let mut updated = Vec::new();
+
+    for id in opts.partition_id.iter().flatten() {
+        let partition_id = PartitionId::new_unchecked(id);
+        if !partition_table.contains(&partition_id) {
+            error!("Partition {partition_id} does not exist, skipping.");
+            continue;
+        }
+
+        update_epoch_metadata(connection, partition_id, |epoch_metadata| {
+            let epoch_metadata = epoch_metadata
+                .context(format!("partition {partition_id} has not been created yet"))?;
+            let mut policy = epoch_metadata.leadership_policy().clone();
+            policy.freeze = Some(ElectionFreeze {
+                reason: opts.reason.clone(),
+            });
+            Ok(epoch_metadata.set_leadership_policy(policy))
+        })
+        .await?;
+        updated.push(partition_id);
+
+        c_println!("Froze leader election for partition {partition_id}.");
+    }
+
+    if !updated.is_empty() {
+        signal_sync_epoch_metadata(connection, &updated).await?;
+    }
+
+    Ok(())
+}

--- a/tools/restatectl/src/commands/partition/leader/mod.rs
+++ b/tools/restatectl/src/commands/partition/leader/mod.rs
@@ -1,0 +1,114 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod freeze;
+mod pin;
+mod show;
+mod unfreeze;
+mod unpin;
+
+use anyhow::bail;
+use cling::prelude::*;
+
+use crate::connection::ConnectionInfo;
+use restate_cli_util::CliContext;
+use restate_core::protobuf::cluster_ctrl_svc::{SyncEpochMetadataRequest, new_cluster_ctrl_client};
+use restate_metadata_store::MetadataStoreClient;
+use restate_metadata_store::protobuf::metadata_proxy_svc::client::MetadataStoreProxy;
+use restate_metadata_store::protobuf::metadata_proxy_svc::{
+    GetRequest, client::new_metadata_proxy_client,
+};
+use restate_types::config::MetadataClientOptions;
+use restate_types::epoch::EpochMetadata;
+use restate_types::identifiers::PartitionId;
+use restate_types::metadata_store::keys::partition_processor_epoch_key;
+use restate_types::nodes_config::Role;
+use restate_types::storage::StorageCodec;
+
+#[derive(Run, Subcommand, Clone)]
+pub enum Leader {
+    /// Pin partition leader to a specific node
+    Pin(pin::PinOpts),
+    /// Unpin partition leader (clear node preference)
+    Unpin(unpin::UnpinOpts),
+    /// Freeze leader election for partitions
+    Freeze(freeze::FreezeOpts),
+    /// Unfreeze leader election for partitions
+    Unfreeze(unfreeze::UnfreezeOpts),
+    /// Show the leadership policy for partitions
+    Show(show::ShowOpts),
+}
+
+pub(super) async fn read_epoch_metadata(
+    connection: &ConnectionInfo,
+    partition_id: PartitionId,
+) -> anyhow::Result<EpochMetadata> {
+    let get_request = GetRequest {
+        key: partition_processor_epoch_key(partition_id).to_string(),
+    };
+
+    let get_response = connection
+        .try_each(None, |channel| async {
+            new_metadata_proxy_client(channel, &CliContext::get().network)
+                .get(get_request.clone())
+                .await
+        })
+        .await?
+        .into_inner();
+
+    match get_response.value {
+        Some(mut value) => Ok(StorageCodec::decode::<EpochMetadata, _>(&mut value.bytes)?),
+        None => bail!("Partition {partition_id} has no epoch metadata"),
+    }
+}
+
+pub(super) async fn update_epoch_metadata<F>(
+    connection: &ConnectionInfo,
+    partition_id: PartitionId,
+    modify: F,
+) -> anyhow::Result<()>
+where
+    F: Fn(Option<EpochMetadata>) -> anyhow::Result<EpochMetadata>,
+{
+    let backoff_policy = &MetadataClientOptions::default().backoff_policy;
+
+    connection
+        .try_each(None, |channel| async {
+            let metadata_store_proxy = MetadataStoreProxy::new(channel, &CliContext::get().network);
+            let metadata_store_client =
+                MetadataStoreClient::new(metadata_store_proxy, Some(backoff_policy.clone()));
+
+            metadata_store_client
+                .read_modify_write(partition_processor_epoch_key(partition_id), &modify)
+                .await
+        })
+        .await?;
+
+    Ok(())
+}
+
+pub(super) async fn signal_sync_epoch_metadata(
+    connection: &ConnectionInfo,
+    partition_ids: &[PartitionId],
+) -> anyhow::Result<()> {
+    let request = SyncEpochMetadataRequest {
+        partition_ids: partition_ids.iter().map(|id| u32::from(*id)).collect(),
+    };
+
+    connection
+        .try_each(Some(Role::Admin), |channel| async {
+            new_cluster_ctrl_client(channel, &CliContext::get().network)
+                .sync_epoch_metadata(request.clone())
+                .await
+        })
+        .await?;
+
+    Ok(())
+}

--- a/tools/restatectl/src/commands/partition/leader/pin.rs
+++ b/tools/restatectl/src/commands/partition/leader/pin.rs
@@ -1,0 +1,72 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::{Context, anyhow};
+use cling::prelude::*;
+use tracing::error;
+
+use restate_cli_util::c_println;
+use restate_types::PlainNodeId;
+use restate_types::identifiers::PartitionId;
+use restate_types::partitions::leadership_policy::LeaderAffinity;
+
+use crate::connection::ConnectionInfo;
+use crate::util::RangeParam;
+
+use super::{signal_sync_epoch_metadata, update_epoch_metadata};
+
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[cling(run = "pin_leader")]
+pub struct PinOpts {
+    /// The partition id or range, e.g. "0", "1-4"
+    #[arg(required = true)]
+    partition_id: Vec<RangeParam<u16>>,
+
+    /// Pin leadership to this node (e.g. 2)
+    #[arg(long, required = true)]
+    node: PlainNodeId,
+}
+
+async fn pin_leader(connection: &ConnectionInfo, opts: &PinOpts) -> anyhow::Result<()> {
+    let nodes_configuration = connection.get_nodes_configuration().await?;
+    nodes_configuration
+        .find_node_by_id(opts.node)
+        .map_err(|_| anyhow!("Node {} is not part of the cluster.", opts.node))?;
+
+    let partition_table = connection.get_partition_table().await?;
+    let mut updated = Vec::new();
+
+    for id in opts.partition_id.iter().flatten() {
+        let partition_id = PartitionId::new_unchecked(id);
+        if !partition_table.contains(&partition_id) {
+            error!("Partition {partition_id} does not exist, skipping.");
+            continue;
+        }
+
+        update_epoch_metadata(connection, partition_id, |epoch_metadata| {
+            let epoch_metadata = epoch_metadata
+                .context(format!("partition {partition_id} has not been created yet"))?;
+            let mut policy = epoch_metadata.leadership_policy().clone();
+            policy.affinity = Some(LeaderAffinity::Node(opts.node));
+            Ok(epoch_metadata.set_leadership_policy(policy))
+        })
+        .await?;
+        updated.push(partition_id);
+
+        let node_id = u32::from(opts.node);
+        c_println!("Pinned partition {partition_id} leader to node N{node_id}.");
+    }
+
+    if !updated.is_empty() {
+        signal_sync_epoch_metadata(connection, &updated).await?;
+    }
+
+    Ok(())
+}

--- a/tools/restatectl/src/commands/partition/leader/show.rs
+++ b/tools/restatectl/src/commands/partition/leader/show.rs
@@ -1,0 +1,179 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::HashMap;
+
+use cling::prelude::*;
+use tracing::error;
+
+use restate_cli_util::_comfy_table::{Attribute, Cell, Color, Table};
+use restate_cli_util::ui::console::StyledTable;
+use restate_cli_util::{CliContext, c_println};
+use restate_core::protobuf::cluster_ctrl_svc::{ClusterStateRequest, new_cluster_ctrl_client};
+use restate_types::PlainNodeId;
+use restate_types::identifiers::PartitionId;
+use restate_types::nodes_config::Role;
+use restate_types::partitions::leadership_policy::LeaderAffinity;
+use restate_types::protobuf::cluster::{RunMode, node_state};
+use restate_types::replication::NodeSet;
+
+use crate::connection::ConnectionInfo;
+use crate::util::RangeParam;
+
+use super::read_epoch_metadata;
+
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[cling(run = "show_policy")]
+pub struct ShowOpts {
+    /// The partition id or range, e.g. "0", "1-4". Defaults to all partitions.
+    #[arg()]
+    partition_id: Vec<RangeParam<u16>>,
+}
+
+async fn show_policy(connection: &ConnectionInfo, opts: &ShowOpts) -> anyhow::Result<()> {
+    let partition_table = connection.get_partition_table().await?;
+
+    // Resolve partition IDs: if none specified, use all partitions.
+    let partition_ids: Vec<_> = if opts.partition_id.is_empty() {
+        partition_table.iter_ids().cloned().collect()
+    } else {
+        opts.partition_id
+            .iter()
+            .flatten()
+            .map(PartitionId::new_unchecked)
+            .collect()
+    };
+
+    // Fetch cluster state to determine current leaders per partition.
+    let cluster_state = connection
+        .try_each(Some(Role::Admin), |channel| async {
+            new_cluster_ctrl_client(channel, &CliContext::get().network)
+                .get_cluster_state(ClusterStateRequest::default())
+                .await
+        })
+        .await?
+        .into_inner()
+        .cluster_state;
+
+    let current_leaders = extract_current_leaders(&cluster_state);
+
+    let mut table = Table::new_styled();
+    table.set_styled_header(vec!["PARTITION", "LEADER", "FREEZE"]);
+
+    for partition_id in partition_ids {
+        if !partition_table.contains(&partition_id) {
+            error!("Partition {partition_id} does not exist, skipping.");
+            continue;
+        }
+
+        let epoch_metadata = match read_epoch_metadata(connection, partition_id).await {
+            Ok(em) => em,
+            Err(err) => {
+                error!("Failed to get epoch metadata for partition {partition_id}: {err}");
+                continue;
+            }
+        };
+
+        let policy = epoch_metadata.leadership_policy();
+        let current_leader = current_leaders.get(&partition_id);
+        let replica_set = epoch_metadata.current().replica_set();
+
+        let pinned_node = policy.affinity.as_ref().and_then(|a| match a {
+            LeaderAffinity::Node(id) => Some(*id),
+            _ => None,
+        });
+
+        let leader_cell = render_leader(current_leader, pinned_node, replica_set);
+
+        let freeze_cell = match &policy.freeze {
+            Some(f) => Cell::new(format!("FROZEN: {}", f.reason))
+                .fg(Color::Red)
+                .add_attribute(Attribute::Bold),
+            None => Cell::new("-"),
+        };
+
+        table.add_row(vec![Cell::new(partition_id), leader_cell, freeze_cell]);
+    }
+
+    c_println!("{}", table);
+
+    Ok(())
+}
+
+fn render_leader(
+    current_leader: Option<&PlainNodeId>,
+    pinned_node: Option<PlainNodeId>,
+    replica_set: &NodeSet,
+) -> Cell {
+    let leader_str = current_leader
+        .map(|l| format!("N{}", u32::from(*l)))
+        .unwrap_or_else(|| "none".to_owned());
+
+    match pinned_node {
+        None => {
+            // No pin set
+            if current_leader.is_some() {
+                Cell::new(leader_str)
+            } else {
+                Cell::new(leader_str).fg(Color::Yellow)
+            }
+        }
+        Some(pin) => {
+            if current_leader.is_some_and(|l| *l == pin) {
+                // Pin satisfied
+                Cell::new(leader_str)
+                    .fg(Color::Green)
+                    .add_attribute(Attribute::Bold)
+            } else {
+                let in_replica_set = replica_set.contains(pin);
+                if in_replica_set {
+                    // Pin not yet satisfied but reachable
+                    Cell::new(format!("{leader_str} \u{2192} {pin}")).fg(Color::Yellow)
+                } else {
+                    // Pin target not in replica set
+                    Cell::new(format!("{leader_str} \u{2192} {pin} \u{2717}")).fg(Color::Red)
+                }
+            }
+        }
+    }
+}
+
+/// Extract the current leader node ID for each partition from the cluster state.
+fn extract_current_leaders(
+    cluster_state: &Option<restate_types::protobuf::cluster::ClusterState>,
+) -> HashMap<PartitionId, PlainNodeId> {
+    let mut leaders = HashMap::new();
+
+    let Some(state) = cluster_state else {
+        return leaders;
+    };
+
+    for node_state in state.nodes.values() {
+        let Some(ref state) = node_state.state else {
+            continue;
+        };
+        let node_state::State::Alive(alive) = state else {
+            continue;
+        };
+        for (partition_id, status) in &alive.partitions {
+            if status.effective_mode() == RunMode::Leader
+                && let Some(ref gen_node_id) = alive.generational_node_id
+                && let Ok(id) = u16::try_from(*partition_id)
+            {
+                leaders.insert(
+                    PartitionId::new_unchecked(id),
+                    PlainNodeId::from(gen_node_id.id),
+                );
+            }
+        }
+    }
+
+    leaders
+}

--- a/tools/restatectl/src/commands/partition/leader/unfreeze.rs
+++ b/tools/restatectl/src/commands/partition/leader/unfreeze.rs
@@ -1,0 +1,58 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::Context;
+use cling::prelude::*;
+use tracing::error;
+
+use super::{signal_sync_epoch_metadata, update_epoch_metadata};
+use crate::connection::ConnectionInfo;
+use crate::util::RangeParam;
+use restate_cli_util::c_println;
+use restate_types::identifiers::PartitionId;
+
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[cling(run = "unfreeze_election")]
+pub struct UnfreezeOpts {
+    /// The partition id or range, e.g. "0", "1-4"
+    #[arg(required = true)]
+    partition_id: Vec<RangeParam<u16>>,
+}
+
+async fn unfreeze_election(connection: &ConnectionInfo, opts: &UnfreezeOpts) -> anyhow::Result<()> {
+    let partition_table = connection.get_partition_table().await?;
+    let mut updated = Vec::new();
+
+    for id in opts.partition_id.iter().flatten() {
+        let partition_id = PartitionId::new_unchecked(id);
+        if !partition_table.contains(&partition_id) {
+            error!("Partition {partition_id} does not exist, skipping.");
+            continue;
+        }
+
+        update_epoch_metadata(connection, partition_id, |epoch_metadata| {
+            let epoch_metadata = epoch_metadata
+                .context(format!("partition {partition_id} has not been created yet"))?;
+            let mut policy = epoch_metadata.leadership_policy().clone();
+            policy.freeze = None;
+            Ok(epoch_metadata.set_leadership_policy(policy))
+        })
+        .await?;
+        updated.push(partition_id);
+
+        c_println!("Unfroze leader election for partition {partition_id}.");
+    }
+
+    if !updated.is_empty() {
+        signal_sync_epoch_metadata(connection, &updated).await?;
+    }
+
+    Ok(())
+}

--- a/tools/restatectl/src/commands/partition/leader/unpin.rs
+++ b/tools/restatectl/src/commands/partition/leader/unpin.rs
@@ -1,0 +1,58 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::Context;
+use cling::prelude::*;
+use tracing::error;
+
+use super::{signal_sync_epoch_metadata, update_epoch_metadata};
+use crate::connection::ConnectionInfo;
+use crate::util::RangeParam;
+use restate_cli_util::c_println;
+use restate_types::identifiers::PartitionId;
+
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[cling(run = "unpin_leader")]
+pub struct UnpinOpts {
+    /// The partition id or range, e.g. "0", "1-4"
+    #[arg(required = true)]
+    partition_id: Vec<RangeParam<u16>>,
+}
+
+async fn unpin_leader(connection: &ConnectionInfo, opts: &UnpinOpts) -> anyhow::Result<()> {
+    let partition_table = connection.get_partition_table().await?;
+    let mut updated = Vec::new();
+
+    for id in opts.partition_id.iter().flatten() {
+        let partition_id = PartitionId::new_unchecked(id);
+        if !partition_table.contains(&partition_id) {
+            error!("Partition {partition_id} does not exist, skipping.");
+            continue;
+        }
+
+        update_epoch_metadata(connection, partition_id, |epoch_metadata| {
+            let epoch_metadata = epoch_metadata
+                .context(format!("partition {partition_id} has not been created yet"))?;
+            let mut policy = epoch_metadata.leadership_policy().clone();
+            policy.affinity = None;
+            Ok(epoch_metadata.set_leadership_policy(policy))
+        })
+        .await?;
+        updated.push(partition_id);
+
+        c_println!("Unpinned leader for partition {partition_id}.");
+    }
+
+    if !updated.is_empty() {
+        signal_sync_epoch_metadata(connection, &updated).await?;
+    }
+
+    Ok(())
+}

--- a/tools/restatectl/src/commands/partition/mod.rs
+++ b/tools/restatectl/src/commands/partition/mod.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 mod gen_metadata;
+mod leader;
 pub mod list;
 mod reconfigure;
 
@@ -23,4 +24,7 @@ pub enum Partitions {
     GenerateMetadata(gen_metadata::GeneratePartitionTableOpts),
     /// Reconfigures the processors of the specified partition
     Reconfigure(reconfigure::ReconfigureOpts),
+    /// Control leader election policy for partitions
+    #[clap(subcommand)]
+    Leader(leader::Leader),
 }

--- a/tools/restatectl/src/commands/partition/reconfigure.rs
+++ b/tools/restatectl/src/commands/partition/reconfigure.rs
@@ -13,21 +13,14 @@ use anyhow::{anyhow, bail};
 use clap::Parser;
 use cling::{Collect, Run};
 
-use restate_cli_util::{CliContext, c_println};
-use restate_metadata_store::protobuf::metadata_proxy_svc::{
-    GetRequest, PutRequest, client::new_metadata_proxy_client,
-};
-use restate_metadata_store::serialize_value;
+use crate::commands::partition::leader::{signal_sync_epoch_metadata, update_epoch_metadata};
+use crate::connection::ConnectionInfo;
+use restate_cli_util::c_println;
+use restate_types::PlainNodeId;
 use restate_types::epoch::EpochMetadata;
 use restate_types::identifiers::PartitionId;
-use restate_types::metadata::Precondition;
-use restate_types::metadata_store::keys::partition_processor_epoch_key;
 use restate_types::partitions::PartitionConfiguration;
 use restate_types::replication::ReplicationProperty;
-use restate_types::storage::StorageCodec;
-use restate_types::{PlainNodeId, Versioned};
-
-use crate::connection::ConnectionInfo;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[cling(run = "reconfigure_partition")]
@@ -62,25 +55,6 @@ pub async fn reconfigure_partition(
         })?;
     }
 
-    let get_request = GetRequest {
-        key: partition_processor_epoch_key(opts.id).to_string(),
-    };
-
-    let get_response = connection
-        .try_each(None, |channel| async {
-            new_metadata_proxy_client(channel, &CliContext::get().network)
-                .get(get_request.clone())
-                .await
-        })
-        .await?
-        .into_inner();
-
-    let latest_epoch_metadata = if let Some(mut value) = get_response.value {
-        Some(StorageCodec::decode::<EpochMetadata, _>(&mut value.bytes)?)
-    } else {
-        None
-    };
-
     let next = PartitionConfiguration::new(
         ReplicationProperty::new_unchecked(
             u8::try_from(opts.replicas.len())
@@ -90,31 +64,16 @@ pub async fn reconfigure_partition(
         HashMap::default(),
     );
 
-    let (precondition, new_epoch_metadata) =
-        if let Some(latest_epoch_metadata) = latest_epoch_metadata {
-            (
-                Precondition::MatchesVersion(latest_epoch_metadata.version()),
-                latest_epoch_metadata.reconfigure(next),
-            )
-        } else {
-            (Precondition::DoesNotExist, EpochMetadata::new(next, None))
-        };
-
-    let request = PutRequest {
-        key: partition_processor_epoch_key(opts.id).to_string(),
-        precondition: Some(precondition.into()),
-        value: Some(serialize_value(&new_epoch_metadata)?.into()),
-    };
-
-    connection
-        .try_each(None, |channel| async {
-            new_metadata_proxy_client(channel, &CliContext::get().network)
-                .put(request.clone())
-                .await
-        })
-        .await?;
+    update_epoch_metadata(connection, opts.id, |epoch_metadata| {
+        Ok(epoch_metadata
+            .map(|epoch_metadata| epoch_metadata.reconfigure(next.clone()))
+            .unwrap_or(EpochMetadata::new(next.clone(), None)))
+    })
+    .await?;
 
     c_println!("Successfully reconfigured partition {}.", opts.id);
+
+    signal_sync_epoch_metadata(connection, &[opts.id]).await?;
 
     Ok(())
 }


### PR DESCRIPTION
Introduce a `LeadershipPolicy` on `EpochMetadata` that gives operators
control over partition leader election. The policy supports two
independent controls:

- **Leader affinity**: prefer a specific node (`LeaderAffinity::Node`) or
  any node matching a location prefix (`LeaderAffinity::Location`).
- **Election freeze**: pause leader election with a reason string. The
  current leader stays; no new leader is elected even if the current one
  dies. Freeze takes precedence over affinity.

The policy is persisted in the metadata store via a new
`SetLeadershipPolicy` gRPC RPC that supports partial updates using proto
field presence (absent = unchanged, present+populated = set,
present+empty = clear). A generic `FieldUpdate<T>` enum replaces
`Option<Option<T>>` for clarity.

The scheduler selects leaders in a single pass with scoring:
affinity+caught-up (3) > caught-up (2) > affinity+alive (1) > alive (0).

New `restatectl partitions leader` subcommands:
- `set-affinity` / `clear-affinity` — control leader placement
- `freeze` / `unfreeze` — pause/resume leader election
- `show` — table display with current leader, affinity match indicator
  (green checkmark / yellow cross), and freeze status (bold red)
- `clear` — reset entire policy

Closes https://github.com/restatedev/restate/issues/4576