### PR TITLE
Make RangeParam generic over the integer type

### DIFF
--- a/tools/restatectl/src/commands/log/describe_log.rs
+++ b/tools/restatectl/src/commands/log/describe_log.rs
@@ -76,15 +76,15 @@ async fn describe_logs(
     let log_ids = if opts.log_id.is_empty() {
         logs.iter()
             .sorted_by(|a, b| Ord::cmp(a.0, b.0))
-            .map(|(id, _)| RangeParam::from(*id))
+            .map(|(id, _)| RangeParam::single(u32::from(*id)))
             .collect::<Vec<_>>()
     } else {
         opts.log_id.clone()
     };
 
     for range in log_ids {
-        for log_id in range.iter() {
-            describe_log(opts, &nodes_config, &logs, log_id.into(), connection).await?;
+        for log_id in &range {
+            describe_log(opts, &nodes_config, &logs, LogId::from(log_id), connection).await?;
         }
     }
 

--- a/tools/restatectl/src/util.rs
+++ b/tools/restatectl/src/util.rs
@@ -10,12 +10,8 @@
 
 use std::{
     fmt::{self, Display},
-    num::ParseIntError,
-    ops::RangeInclusive,
     str::FromStr,
 };
-
-use cling::{Collect, prelude::Parser};
 use tonic::transport::Channel;
 
 use restate_cli_util::CliContext;
@@ -77,14 +73,16 @@ pub fn write_leaf<W: fmt::Write>(
     writeln!(w, "{chr:>depth$} {title}: {value}")
 }
 
-#[derive(Parser, Collect, Clone, Debug)]
-pub struct RangeParam {
-    from: u32,
-    to: u32,
+/// A range parameter that parses `"5"` as a single value or `"1-10"` as a range.
+/// The default type parameter is `u32`; use e.g. `RangeParam<u16>` for narrower types.
+#[derive(Clone, Debug)]
+pub struct RangeParam<T: RangeParamInt = u32> {
+    from: T,
+    to: T,
 }
 
-impl RangeParam {
-    fn new(from: u32, to: u32) -> Result<Self, RangeParamError> {
+impl<T: RangeParamInt> RangeParam<T> {
+    pub fn new(from: T, to: T) -> Result<Self, RangeParamError<T>> {
         if from > to {
             Err(RangeParamError::InvalidRange(from, to))
         } else {
@@ -92,50 +90,81 @@ impl RangeParam {
         }
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = u32> {
-        self.from..=self.to
+    pub fn single(value: T) -> Self {
+        Self {
+            from: value,
+            to: value,
+        }
     }
 }
 
-impl<T> From<T> for RangeParam
-where
-    T: Into<u32>,
-{
-    fn from(value: T) -> Self {
-        let id = value.into();
-        Self::new(id, id).expect("equal values")
-    }
-}
-
-impl IntoIterator for RangeParam {
-    type IntoIter = RangeInclusive<u32>;
-    type Item = u32;
+impl<T: RangeParamInt> IntoIterator for RangeParam<T> {
+    type Item = T;
+    type IntoIter = RangeParamIter<T>;
     fn into_iter(self) -> Self::IntoIter {
-        self.from..=self.to
+        RangeParamIter {
+            current: self.from,
+            end: self.to,
+            done: false,
+        }
     }
 }
 
-impl IntoIterator for &RangeParam {
-    type IntoIter = RangeInclusive<u32>;
-    type Item = u32;
+impl<T: RangeParamInt> IntoIterator for &RangeParam<T> {
+    type Item = T;
+    type IntoIter = RangeParamIter<T>;
     fn into_iter(self) -> Self::IntoIter {
-        self.from..=self.to
+        RangeParamIter {
+            current: self.from,
+            end: self.to,
+            done: false,
+        }
     }
 }
 
-impl FromStr for RangeParam {
-    type Err = RangeParamError;
+/// Iterator over a `RangeParam<T>` range (inclusive).
+pub struct RangeParamIter<T: RangeParamInt> {
+    current: T,
+    end: T,
+    done: bool,
+}
+
+impl<T: RangeParamInt> Iterator for RangeParamIter<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        if self.done {
+            return None;
+        }
+        let value = self.current;
+        if value == self.end {
+            self.done = true;
+        } else {
+            self.current = value.next_value();
+        }
+        Some(value)
+    }
+}
+
+impl<T: RangeParamInt> FromStr for RangeParam<T> {
+    type Err = RangeParamError<T>;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let parts: Vec<&str> = s.split("-").collect();
         match parts.len() {
             1 => {
-                let n = parts[0].parse()?;
+                let n = parts[0]
+                    .parse()
+                    .map_err(|_| RangeParamError::InvalidSyntax(s.to_string()))?;
                 Ok(RangeParam::new(n, n)?)
             }
             2 => {
-                let from = parts[0].parse()?;
-                let to = parts[1].parse()?;
+                let from = parts[0]
+                    .parse()
+                    .map_err(|_| RangeParamError::InvalidSyntax(s.to_string()))?;
+                let to = parts[1]
+                    .parse()
+                    .map_err(|_| RangeParamError::InvalidSyntax(s.to_string()))?;
                 Ok(RangeParam::new(from, to)?)
             }
             _ => Err(RangeParamError::InvalidSyntax(s.to_string())),
@@ -143,12 +172,32 @@ impl FromStr for RangeParam {
     }
 }
 
+/// Trait bound for integer types usable with [`RangeParam`].
+pub trait RangeParamInt: Copy + Ord + Eq + Display + fmt::Debug + FromStr + 'static {
+    fn next_value(self) -> Self;
+}
+
+macro_rules! impl_range_param_int {
+    ($($t:ty),*) => {
+        $(impl RangeParamInt for $t {
+            fn next_value(self) -> Self { self + 1 }
+        })*
+    };
+}
+
+impl_range_param_int!(u8, u16, u32, u64);
+
+/// Convenience conversion for `From<u32>` on the default `RangeParam<u32>`.
+impl From<u32> for RangeParam<u32> {
+    fn from(value: u32) -> Self {
+        Self::single(value)
+    }
+}
+
 #[derive(Debug, Clone, thiserror::Error)]
-pub enum RangeParamError {
+pub enum RangeParamError<T: RangeParamInt = u32> {
     #[error("Invalid id range: {0}..{1} start must be <= end range")]
-    InvalidRange(u32, u32),
+    InvalidRange(T, T),
     #[error("Invalid range syntax '{0}'")]
     InvalidSyntax(String),
-    #[error(transparent)]
-    ParseError(#[from] ParseIntError),
 }


### PR DESCRIPTION
RangeParam now accepts a type parameter (defaulting to u32) so it can be instantiated with narrower types like u16. All existing call sites are unchanged since `RangeParam` without a type parameter remains `RangeParam<u32>`.