### PR TITLE
Fix awakeable signal loss during partition leadership transitions

### DIFF
--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -94,6 +94,12 @@ pub struct NodeSpec {
     inherit_env: bool,
     #[builder(default)]
     env: Vec<(String, String)>,
+    /// If true, child processes are placed in their own process group,
+    /// isolating them from terminal signals (e.g. Ctrl+C). Default is false,
+    /// meaning children share the parent's process group and receive signals
+    /// like SIGINT directly.
+    #[builder(default = false)]
+    isolate_process_group: bool,
     #[builder(default)]
     #[serde(skip)]
     searcher: Searcher,
@@ -223,6 +229,7 @@ impl NodeSpec {
             args,
             inherit_env,
             env,
+            isolate_process_group,
             searcher,
         } = &self;
 
@@ -290,8 +297,11 @@ impl NodeSpec {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .kill_on_drop(true)
-        .process_group(0) // avoid terminal control C being propagated
         .args(args);
+
+        if *isolate_process_group {
+            cmd.process_group(0);
+        }
 
         let mut child = cmd.spawn().map_err(NodeStartError::SpawnError)?;
         let pid = child.id().expect("child to have a pid");

--- a/crates/types/src/net/partition_processor.rs
+++ b/crates/types/src/net/partition_processor.rs
@@ -92,6 +92,9 @@ impl WireDecode for PartitionProcessorRpcRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum AppendInvocationReplyOn {
     /// With this mode, the PP will reply as soon as the log append is done with [`PartitionProcessorRpcResponse::Appended`].
+    ///
+    /// The record is appended without dedup information so it is never filtered during leadership
+    /// transitions.
     Appended,
     /// With this mode, the PP will reply with the [`PartitionProcessorRpcResponse::Submitted`] when available.
     Submitted,

--- a/crates/worker/src/partition/leadership/leader_state.rs
+++ b/crates/worker/src/partition/leadership/leader_state.rs
@@ -311,14 +311,14 @@ impl LeaderState {
                     }
 
                     self.self_proposer
-                        .propose_many(commands.into_iter())
+                        .self_propose_many(commands.into_iter())
                         .await?;
                 }
                 ActionEffect::PartitionMaintenance(partition_durability) => {
                     // based on configuration, whether to consider partition-local durability in
                     // the replica-set as a sufficient source of durability, or only snapshots.
                     self.self_proposer
-                        .propose(
+                        .self_propose(
                             *self.partition_key_range.start(),
                             Command::UpdatePartitionDurability(partition_durability),
                         )
@@ -326,7 +326,7 @@ impl LeaderState {
                 }
                 ActionEffect::Invoker(invoker_effect) => {
                     self.self_proposer
-                        .propose(
+                        .self_propose(
                             invoker_effect.invocation_id.partition_key(),
                             Command::InvokerEffect(invoker_effect),
                         )
@@ -336,7 +336,7 @@ impl LeaderState {
                     // todo: Until we support partition splits we need to get rid of outboxes or introduce partition
                     //  specific destination messages that are identified by a partition_id
                     self.self_proposer
-                        .propose(
+                        .self_propose(
                             *self.partition_key_range.start(),
                             Command::TruncateOutbox(outbox_truncation.index()),
                         )
@@ -344,7 +344,7 @@ impl LeaderState {
                 }
                 ActionEffect::Timer(timer) => {
                     self.self_proposer
-                        .propose(timer.invocation_id().partition_key(), Command::Timer(timer))
+                        .self_propose(timer.invocation_id().partition_key(), Command::Timer(timer))
                         .await?;
                 }
                 ActionEffect::Cleaner(effect) => {
@@ -366,7 +366,7 @@ impl LeaderState {
                     };
 
                     self.self_proposer
-                        .propose(invocation_id.partition_key(), cmd)
+                        .self_propose(invocation_id.partition_key(), cmd)
                         .await?;
                 }
                 ActionEffect::UpsertSchema(schema) => {
@@ -374,7 +374,7 @@ impl LeaderState {
                         .is_equal_or_newer_than(&RESTATE_VERSION_1_7_0)
                     {
                         self.self_proposer
-                            .propose(
+                            .self_propose(
                                 *self.partition_key_range.start(),
                                 Command::UpsertSchema(UpsertSchema {
                                     partition_key_range: Keys::RangeInclusive(
@@ -416,7 +416,7 @@ impl LeaderState {
             }
             Entry::Vacant(v) => {
                 // In this case, no one proposed this command yet, let's try to propose it
-                if let Err(e) = self.self_proposer.propose(partition_key, cmd).await {
+                if let Err(e) = self.self_proposer.self_propose(partition_key, cmd).await {
                     reciprocal.send(Err(PartitionProcessorRpcError::Internal(e.to_string())));
                 } else {
                     v.insert(reciprocal);
@@ -425,7 +425,12 @@ impl LeaderState {
         }
     }
 
-    pub async fn self_propose_and_respond_asynchronously(
+    /// Append a command to Bifrost **without** dedup information and respond on Bifrost commit.
+    ///
+    /// Records appended this way are never filtered by the dedup mechanism during leadership
+    /// transitions, making this safe for fire-and-forget ingress commands (signals, invocation
+    /// responses).
+    pub async fn append_and_respond_asynchronously(
         &mut self,
         partition_key: PartitionKey,
         cmd: Command,
@@ -434,7 +439,7 @@ impl LeaderState {
     ) {
         match self
             .self_proposer
-            .propose_with_notification(partition_key, cmd)
+            .append_with_notification(partition_key, cmd)
             .await
         {
             Ok(commit_token) => {
@@ -449,7 +454,7 @@ impl LeaderState {
         }
     }
 
-    pub async fn propose_many_with_callback<F>(
+    pub async fn forward_many_with_callback<F>(
         &mut self,
         records: impl ExactSizeIterator<Item = IngestRecord>,
         callback: F,
@@ -458,7 +463,7 @@ impl LeaderState {
     {
         match self
             .self_proposer
-            .propose_many_with_notification(records)
+            .forward_many_with_notification(records)
             .await
         {
             Ok(commit_token) => {

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -263,7 +263,7 @@ where
         )?;
 
         self_proposer
-            .propose(*self.partition.key_range.start(), announce_leader)
+            .self_propose(*self.partition.key_range.start(), announce_leader)
             .await?;
 
         self.state = State::Candidate {
@@ -475,7 +475,7 @@ where
                     })
             {
                 self_proposer
-                    .propose(
+                    .self_propose(
                         *self.partition.key_range.start(),
                         Command::VersionBarrier(VersionBarrier {
                             version: forced_min_restate_version.clone(),
@@ -495,7 +495,7 @@ where
                 && RESTATE_VERSION_1_6_0.is_newer_than(&min_restate_version)
             {
                 self_proposer
-                    .propose(
+                    .self_propose(
                         *self.partition.key_range.start(),
                         Command::VersionBarrier(VersionBarrier {
                             version: RESTATE_VERSION_1_6_0.clone(),
@@ -690,8 +690,8 @@ impl<T, I> LeadershipState<T, I> {
         }
     }
 
-    /// Self propose to this partition, and register the reciprocal to respond asynchronously.
-    pub async fn self_propose_and_respond_asynchronously(
+    /// Append a command to Bifrost without dedup information, responding on Bifrost commit.
+    pub async fn append_and_respond_asynchronously(
         &mut self,
         partition_key: PartitionKey,
         cmd: Command,
@@ -706,7 +706,7 @@ impl<T, I> LeadershipState<T, I> {
             )),
             State::Leader(leader_state) => {
                 leader_state
-                    .self_propose_and_respond_asynchronously(
+                    .append_and_respond_asynchronously(
                         partition_key,
                         cmd,
                         reciprocal,
@@ -717,8 +717,8 @@ impl<T, I> LeadershipState<T, I> {
         }
     }
 
-    /// propose to this partition
-    pub async fn propose_many_with_callback<F>(
+    /// Forward externally-created records to this partition.
+    pub async fn forward_many_with_callback<F>(
         &mut self,
         records: impl ExactSizeIterator<Item = IngestRecord>,
         callback: F,
@@ -731,7 +731,7 @@ impl<T, I> LeadershipState<T, I> {
             )),
             State::Leader(leader_state) => {
                 leader_state
-                    .propose_many_with_callback(records, callback)
+                    .forward_many_with_callback(records, callback)
                     .await;
             }
         }

--- a/crates/worker/src/partition/leadership/self_proposer.rs
+++ b/crates/worker/src/partition/leadership/self_proposer.rs
@@ -68,11 +68,11 @@ impl SelfProposer {
         self.bifrost_appender.sender().forget_preference();
     }
 
-    /// Propose many commands to bifrost
+    /// Self-propose many commands to Bifrost, attaching ESN-based dedup information.
     ///
-    /// Note that propose_many will return an error if the number of commands is greater than the
-    /// internal channel's max capacity.
-    pub async fn propose_many(
+    /// Note that self_propose_many will return an error if the number of commands is greater than
+    /// the internal channel's max capacity.
+    pub async fn self_propose_many(
         &mut self,
         cmds: impl ExactSizeIterator<Item = (PartitionKey, Command)>,
     ) -> Result<(), Error> {
@@ -117,12 +117,13 @@ impl SelfProposer {
         Ok(())
     }
 
-    pub async fn propose(
+    /// Self-propose a single command to Bifrost, attaching ESN-based dedup information.
+    pub async fn self_propose(
         &mut self,
         partition_key: PartitionKey,
         cmd: Command,
     ) -> Result<(), Error> {
-        let envelope = Envelope::new(self.create_header(partition_key), cmd);
+        let envelope = Envelope::new(self.create_self_propose_header(partition_key), cmd);
 
         // Only blocks if background append is pushing back (queue full)
         self.bifrost_appender
@@ -134,12 +135,28 @@ impl SelfProposer {
         Ok(())
     }
 
-    pub async fn propose_with_notification(
+    /// Append a command to Bifrost **without** dedup information, returning a [`CommitToken`].
+    ///
+    /// Unlike [`Self::self_propose`], this does not attach an epoch sequence number. Records
+    /// appended this way are never filtered by the dedup mechanism during leadership transitions,
+    /// which makes them safe for fire-and-forget ingress commands (signals, invocation responses).
+    pub async fn append_with_notification(
         &mut self,
         partition_key: PartitionKey,
         cmd: Command,
     ) -> Result<CommitToken, Error> {
-        let envelope = Envelope::new(self.create_header(partition_key), cmd);
+        let header = Header {
+            dest: Destination::Processor {
+                partition_key,
+                dedup: None,
+            },
+            source: Source::Processor {
+                partition_id: None,
+                partition_key: Some(partition_key),
+                leader_epoch: self.epoch_sequence_number.leader_epoch,
+            },
+        };
+        let envelope = Envelope::new(header, cmd);
 
         let commit_token = self
             .bifrost_appender
@@ -151,7 +168,10 @@ impl SelfProposer {
         Ok(commit_token)
     }
 
-    pub async fn propose_many_with_notification(
+    /// Forward externally-created records to Bifrost, returning a [`CommitToken`].
+    ///
+    /// The records already carry their own dedup information in their headers; no ESN is attached.
+    pub async fn forward_many_with_notification(
         &mut self,
         records: impl ExactSizeIterator<Item = IngestRecord>,
     ) -> Result<CommitToken, Error> where {
@@ -193,7 +213,7 @@ impl SelfProposer {
             .map_err(|e| Error::SelfProposer(e.to_string()))
     }
 
-    fn create_header(&mut self, partition_key: PartitionKey) -> Header {
+    fn create_self_propose_header(&mut self, partition_key: PartitionKey) -> Header {
         let esn = self.epoch_sequence_number;
         self.epoch_sequence_number = self.epoch_sequence_number.next();
 

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -859,7 +859,7 @@ where
         .record(request.records.iter().fold(0, |s, r| s + r.estimate_size()) as f64);
 
         self.leadership_state
-            .propose_many_with_callback(
+            .forward_many_with_callback(
                 request.records.into_iter(),
                 |result: Result<(), PartitionProcessorRpcError>| match result {
                     Ok(_) => reciprocal.send(ResponseStatus::Ack.into()),

--- a/crates/worker/src/partition/rpc/append_invocation.rs
+++ b/crates/worker/src/partition/rpc/append_invocation.rs
@@ -43,15 +43,7 @@ impl<'a, TActuator: Actuator, TSchemas, TStorage> RpcHandler<Request>
 
         match append_invocation_reply_on {
             AppendInvocationReplyOn::Appended => {
-                self.proposer
-                    .self_propose_and_respond_asynchronously(
-                        service_invocation.partition_key(),
-                        Command::Invoke(Box::new(service_invocation)),
-                        replier,
-                        PartitionProcessorRpcResponse::Appended,
-                    )
-                    .await;
-                return Ok(());
+                // No sinks needed — respond on Bifrost commit
             }
             AppendInvocationReplyOn::Submitted => {
                 service_invocation.submit_notification_sink =
@@ -63,14 +55,26 @@ impl<'a, TActuator: Actuator, TSchemas, TStorage> RpcHandler<Request>
             }
         };
 
-        self.proposer
-            .handle_rpc_proposal_command(
-                service_invocation.partition_key(),
-                Command::Invoke(Box::new(service_invocation)),
-                request_id,
-                replier,
-            )
-            .await;
+        let partition_key = service_invocation.partition_key();
+        let cmd = Command::Invoke(Box::new(service_invocation));
+
+        match append_invocation_reply_on {
+            AppendInvocationReplyOn::Appended => {
+                self.proposer
+                    .append_and_respond_asynchronously(
+                        partition_key,
+                        cmd,
+                        replier,
+                        PartitionProcessorRpcResponse::Appended,
+                    )
+                    .await;
+            }
+            AppendInvocationReplyOn::Submitted | AppendInvocationReplyOn::Output => {
+                self.proposer
+                    .handle_rpc_proposal_command(partition_key, cmd, request_id, replier)
+                    .await;
+            }
+        }
 
         Ok(())
     }
@@ -91,7 +95,7 @@ mod tests {
     async fn reply_on_appended() {
         let mut proposer = MockActuator::new();
         proposer
-            .expect_self_propose_and_respond_asynchronously::<PartitionProcessorRpcResponse>()
+            .expect_append_and_respond_asynchronously::<PartitionProcessorRpcResponse>()
             .return_once_st(|_, cmd, _, _| {
                 let_assert!(Command::Invoke(service_invocation) = cmd);
                 assert_that!(
@@ -126,7 +130,7 @@ mod tests {
         let request_id = PartitionProcessorRpcRequestId::new();
         let mut proposer = MockActuator::new();
         proposer
-            .expect_self_propose_and_respond_asynchronously::<PartitionProcessorRpcResponse>()
+            .expect_append_and_respond_asynchronously::<PartitionProcessorRpcResponse>()
             .never();
         proposer
             .expect_handle_rpc_proposal_command::<PartitionProcessorRpcResponse>()
@@ -164,7 +168,7 @@ mod tests {
         let request_id = PartitionProcessorRpcRequestId::new();
         let mut proposer = MockActuator::new();
         proposer
-            .expect_self_propose_and_respond_asynchronously::<PartitionProcessorRpcResponse>()
+            .expect_append_and_respond_asynchronously::<PartitionProcessorRpcResponse>()
             .never();
         proposer
             .expect_handle_rpc_proposal_command::<PartitionProcessorRpcResponse>()

--- a/crates/worker/src/partition/rpc/append_invocation_response.rs
+++ b/crates/worker/src/partition/rpc/append_invocation_response.rs
@@ -32,7 +32,7 @@ impl<'a, TActuator: Actuator, TSchemas, TStorage> RpcHandler<Request>
         replier: Replier<Self::Output>,
     ) -> Result<(), Self::Error> {
         self.proposer
-            .self_propose_and_respond_asynchronously(
+            .append_and_respond_asynchronously(
                 invocation_response.partition_key(),
                 Command::InvocationResponse(invocation_response),
                 replier,

--- a/crates/worker/src/partition/rpc/append_signal.rs
+++ b/crates/worker/src/partition/rpc/append_signal.rs
@@ -35,7 +35,7 @@ impl<'a, TActuator: Actuator, TSchemas, TStorage> RpcHandler<Request>
         replier: Replier<Self::Output>,
     ) -> Result<(), Self::Error> {
         self.proposer
-            .self_propose_and_respond_asynchronously(
+            .append_and_respond_asynchronously(
                 invocation_id.partition_key(),
                 Command::NotifySignal(NotifySignalRequest {
                     invocation_id,

--- a/crates/worker/src/partition/rpc/mod.rs
+++ b/crates/worker/src/partition/rpc/mod.rs
@@ -44,20 +44,27 @@ use std::sync::Arc;
 
 #[cfg_attr(test, mockall::automock)]
 pub(super) trait Actuator {
-    fn self_propose_and_respond_asynchronously<O: 'static + Into<PartitionProcessorRpcResponse>>(
-        &mut self,
-        partition_key: PartitionKey,
-        cmd: Command,
-        replier: Replier<O>,
-        on_proposed_response: O,
-    ) -> impl Future<Output = ()>;
-
     fn handle_rpc_proposal_command<O: 'static>(
         &mut self,
         partition_key: PartitionKey,
         cmd: Command,
         request_id: PartitionProcessorRpcRequestId,
         replier: Replier<O>,
+    ) -> impl Future<Output = ()>;
+
+    /// Appends a command to Bifrost **without** dedup information, responding on Bifrost commit.
+    ///
+    /// Records appended this way are never filtered by the dedup mechanism during leadership
+    /// transitions, making this safe for fire-and-forget ingress commands (signals, invocation
+    /// responses).
+    fn append_and_respond_asynchronously<
+        O: 'static + Into<PartitionProcessorRpcResponse> + Send + Sync,
+    >(
+        &mut self,
+        partition_key: PartitionKey,
+        cmd: Command,
+        replier: Replier<O>,
+        success_response: O,
     ) -> impl Future<Output = ()>;
 
     fn notify_invoker_to_retry_now(&mut self, invocation_id: InvocationId);
@@ -78,14 +85,14 @@ where
         >,
     >,
 {
-    async fn self_propose_and_respond_asynchronously<O: Into<PartitionProcessorRpcResponse>>(
+    async fn append_and_respond_asynchronously<O: Into<PartitionProcessorRpcResponse>>(
         &mut self,
         partition_key: PartitionKey,
         cmd: Command,
         replier: Replier<O>,
         on_proposed_response: O,
     ) {
-        LeadershipState::self_propose_and_respond_asynchronously(
+        LeadershipState::append_and_respond_asynchronously(
             self,
             partition_key,
             cmd,

--- a/crates/worker/src/partition/rpc/pause_invocation.rs
+++ b/crates/worker/src/partition/rpc/pause_invocation.rs
@@ -17,10 +17,9 @@ pub(super) struct Request {
     pub(super) invocation_id: InvocationId,
 }
 
-impl<'a, TActuator: Actuator, Schemas, TStorage> RpcHandler<Request>
-    for RpcContext<'a, TActuator, Schemas, TStorage>
+impl<'a, TActuator: Actuator, TSchemas, TStorage> RpcHandler<Request>
+    for RpcContext<'a, TActuator, TSchemas, TStorage>
 where
-    TActuator: Actuator,
     TStorage: ReadInvocationStatusTable,
 {
     type Output = PauseInvocationRpcResponse;

--- a/crates/worker/src/partition/rpc/restart_as_new_invocation.rs
+++ b/crates/worker/src/partition/rpc/restart_as_new_invocation.rs
@@ -243,8 +243,9 @@ where
             let cmd = Command::Invoke(Box::new(service_invocation));
 
             // Propose and done
+            // This path should be no longer needed once we switch to the journal v2 by default.
             self.proposer
-                .self_propose_and_respond_asynchronously(
+                .append_and_respond_asynchronously(
                     invocation_id.partition_key(),
                     cmd,
                     replier,
@@ -725,7 +726,7 @@ mod tests {
         let headers_clone = vec![Header::new("key", "value")];
         let payload_clone = payload.clone();
         proposer
-            .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
+            .expect_append_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
             .return_once_st(move |_, cmd, _, response| {
                 let_assert!(Command::Invoke(service_invocation) = cmd);
                 assert_that!(
@@ -793,7 +794,7 @@ mod tests {
         let mut proposer = MockActuator::new();
         proposer.expect_is_leader().return_const(true);
         proposer
-            .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
+            .expect_append_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
             .never();
         proposer
             .expect_handle_rpc_proposal_command::<RestartAsNewInvocationRpcResponse>()
@@ -848,7 +849,7 @@ mod tests {
         let mut proposer = MockActuator::new();
         proposer.expect_is_leader().return_const(true);
         proposer
-            .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
+            .expect_append_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
             .never();
         proposer
             .expect_handle_rpc_proposal_command::<RestartAsNewInvocationRpcResponse>()
@@ -895,7 +896,7 @@ mod tests {
         let mut proposer = MockActuator::new();
         proposer.expect_is_leader().return_const(true);
         proposer
-            .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
+            .expect_append_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
             .never();
         proposer
             .expect_handle_rpc_proposal_command::<RestartAsNewInvocationRpcResponse>()
@@ -949,7 +950,7 @@ mod tests {
         let mut proposer = MockActuator::new();
         proposer.expect_is_leader().return_const(true);
         proposer
-            .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
+            .expect_append_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
             .never();
         proposer
             .expect_handle_rpc_proposal_command::<RestartAsNewInvocationRpcResponse>()
@@ -1019,7 +1020,7 @@ mod tests {
                 ready(()).boxed()
             });
         proposer
-            .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
+            .expect_append_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
             .never();
 
         let (tx, rx) = Reciprocal::mock();
@@ -1081,7 +1082,7 @@ mod tests {
                 ready(()).boxed()
             });
         proposer
-            .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
+            .expect_append_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
             .never();
 
         let (tx, rx) = Reciprocal::mock();
@@ -1112,7 +1113,7 @@ mod tests {
         let mut proposer = MockActuator::new();
         proposer.expect_is_leader().return_const(true);
         proposer
-            .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
+            .expect_append_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
             .never();
         proposer
             .expect_handle_rpc_proposal_command::<RestartAsNewInvocationRpcResponse>()
@@ -1149,7 +1150,7 @@ mod tests {
         let mut proposer = MockActuator::new();
         proposer.expect_is_leader().return_const(true);
         proposer
-            .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
+            .expect_append_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
             .never();
         proposer
             .expect_handle_rpc_proposal_command::<RestartAsNewInvocationRpcResponse>()
@@ -1208,7 +1209,7 @@ mod tests {
         let mut proposer = MockActuator::new();
         proposer.expect_is_leader().return_const(true);
         proposer
-            .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
+            .expect_append_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
             .never();
         proposer
             .expect_handle_rpc_proposal_command::<RestartAsNewInvocationRpcResponse>()
@@ -1257,7 +1258,7 @@ mod tests {
         let mut proposer = MockActuator::new();
         proposer.expect_is_leader().return_const(true);
         proposer
-            .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
+            .expect_append_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
             .never();
         proposer
             .expect_handle_rpc_proposal_command::<RestartAsNewInvocationRpcResponse>()
@@ -1355,7 +1356,7 @@ mod tests {
                 ready(()).boxed()
             });
         proposer
-            .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
+            .expect_append_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
             .never();
 
         let (tx, rx) = Reciprocal::mock();
@@ -1419,7 +1420,7 @@ mod tests {
                 ready(()).boxed()
             });
         proposer
-            .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
+            .expect_append_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
             .never();
 
         let (tx, rx) = Reciprocal::mock();
@@ -1466,7 +1467,7 @@ mod tests {
             .expect_handle_rpc_proposal_command::<RestartAsNewInvocationRpcResponse>()
             .never();
         proposer
-            .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
+            .expect_append_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
             .never();
 
         let (tx, rx) = Reciprocal::mock();
@@ -1635,7 +1636,7 @@ mod tests {
             .expect_partition_id()
             .return_const(PartitionId::from(0));
         proposer
-            .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
+            .expect_append_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
             .never();
         proposer
             .expect_handle_rpc_proposal_command::<RestartAsNewInvocationRpcResponse>()

--- a/release-notes/unreleased/4566-fix-awakeable-signal-loss-leader-transfer.md
+++ b/release-notes/unreleased/4566-fix-awakeable-signal-loss-leader-transfer.md
@@ -1,0 +1,31 @@
+# Release Notes for Issue #4566: Fix awakeable signal loss during partition leadership transitions
+
+## Bug Fix
+
+### What Changed
+
+Fixed a bug where awakeable resolutions and signal deliveries could be silently lost
+during partition leadership transitions. When a leadership change occurred, the old
+leader's self-proposed commands (e.g., `AppendSignal` for awakeable resolution) could
+be committed to the Bifrost log after the new leader's `AnnounceLeader` entry. The
+dedup mechanism then dropped these commands because entries from an earlier epoch are
+considered outdated once an entry from a newer epoch has been stored.
+
+Signal and invocation-response commands from ingress RPCs are now appended to Bifrost
+without dedup information. Without dedup, these records are never filtered during
+leadership transitions. The SDK handles potential duplicate signals gracefully.
+
+### Impact on Users
+
+- **Existing deployments**: Awakeable resolutions and signal deliveries that were
+  previously accepted by the ingress but silently dropped during leadership transitions
+  will now be reliably applied.
+- **New deployments**: No special considerations.
+
+### Migration Guidance
+
+No action required.
+
+### Related Issues
+
+- Issue #4566


### PR DESCRIPTION
Signal and invocation-response commands from ingress RPCs are now appended
to Bifrost without dedup information. Without dedup, these records are never
filtered by the epoch-based deduplication mechanism during leadership
transitions, which previously caused accepted signals to be silently
dropped.

The SelfProposer methods are renamed to clarify their dedup semantics:
- self_propose_* methods attach ESN-based dedup information
- append_* methods write to Bifrost without dedup
- forward_* methods relay records that already carry their own dedup info

Fixes: https://github.com/restatedev/restate/issues/4566