### PR TITLE
Fix stale reads on non-leader partition processors for mutation RPCs

### DIFF
--- a/crates/worker/src/partition/rpc/pause_invocation.rs
+++ b/crates/worker/src/partition/rpc/pause_invocation.rs
@@ -31,6 +31,16 @@ where
         Request { invocation_id }: Request,
         replier: Replier<Self::Output>,
     ) -> Result<(), Self::Error> {
+        // Reading from a non-leader partition processor can return stale results
+        // (e.g. NotFound for an invocation that exists on the leader) because the
+        // follower's local store may not have replayed all log entries yet.
+        if !self.proposer.is_leader() {
+            replier.send_result(Err(PartitionProcessorRpcError::NotLeader(
+                self.proposer.partition_id(),
+            )));
+            return Ok(());
+        }
+
         // -- Figure out the invocation status
         match self.storage.get_invocation_status(&invocation_id).await {
             Ok(InvocationStatus::Invoked(_)) => {
@@ -59,5 +69,54 @@ where
         };
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::partition::rpc::MockActuator;
+    use restate_core::network::Reciprocal;
+    use test_log::test;
+
+    #[test(restate_core::test)]
+    async fn reply_not_leader_when_not_leader() {
+        let invocation_id = InvocationId::mock_random();
+
+        let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(false);
+        proposer
+            .expect_partition_id()
+            .return_const(PartitionId::from(0));
+
+        struct NoopStorage;
+        impl ReadInvocationStatusTable for NoopStorage {
+            #[allow(unreachable_code)]
+            fn get_invocation_status(
+                &mut self,
+                _: &InvocationId,
+            ) -> impl Future<Output = restate_storage_api::Result<InvocationStatus>> + Send
+            {
+                panic!("storage should not be accessed on non-leader");
+                std::future::ready(Ok(InvocationStatus::Free))
+            }
+        }
+
+        let mut storage = NoopStorage;
+
+        let (tx, rx) = Reciprocal::mock();
+        RpcHandler::handle(
+            RpcContext::new(&mut proposer, &(), &mut storage),
+            Request { invocation_id },
+            Replier::new(tx),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            rx.recv().await,
+            Err(PartitionProcessorRpcError::NotLeader(_))
+        ));
     }
 }

--- a/crates/worker/src/partition/rpc/restart_as_new_invocation.rs
+++ b/crates/worker/src/partition/rpc/restart_as_new_invocation.rs
@@ -67,6 +67,16 @@ where
         }: Request,
         replier: Replier<Self::Output>,
     ) -> Result<(), Self::Error> {
+        // Reading from a non-leader partition processor can return stale results
+        // (e.g. NotFound for an invocation that exists on the leader) because the
+        // follower's local store may not have replayed all log entries yet.
+        if !self.proposer.is_leader() {
+            replier.send_result(Err(PartitionProcessorRpcError::NotLeader(
+                self.proposer.partition_id(),
+            )));
+            return Ok(());
+        }
+
         // -- Resolve completed invocation status and input command
 
         // Retrieve the completed invocation
@@ -710,6 +720,7 @@ mod tests {
         let payload = rand::bytes();
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         let invocation_target_clone = invocation_target.clone();
         let headers_clone = vec![Header::new("key", "value")];
         let payload_clone = payload.clone();
@@ -780,6 +791,7 @@ mod tests {
         let invocation_target = InvocationTarget::mock_virtual_object();
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         proposer
             .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
             .never();
@@ -834,6 +846,7 @@ mod tests {
         let headers = vec![Header::new("k", "v")];
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         proposer
             .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
             .never();
@@ -880,6 +893,7 @@ mod tests {
         let invocation_target = InvocationTarget::mock_virtual_object();
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         proposer
             .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
             .never();
@@ -933,6 +947,7 @@ mod tests {
         let invocation_target = InvocationTarget::mock_virtual_object();
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         proposer
             .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
             .never();
@@ -988,6 +1003,7 @@ mod tests {
         );
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         proposer
             .expect_handle_rpc_proposal_command::<RestartAsNewInvocationRpcResponse>()
             .return_once_st(move |_, cmd, _, _| {
@@ -1049,6 +1065,7 @@ mod tests {
         );
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         proposer
             .expect_handle_rpc_proposal_command::<RestartAsNewInvocationRpcResponse>()
             .return_once_st(move |_, cmd, _, _| {
@@ -1093,6 +1110,7 @@ mod tests {
         let invocation_id = InvocationId::mock_random();
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         proposer
             .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
             .never();
@@ -1129,6 +1147,7 @@ mod tests {
         let invocation_id = InvocationId::mock_random();
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         proposer
             .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
             .never();
@@ -1187,6 +1206,7 @@ mod tests {
         let invocation_id = InvocationId::mock_random();
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         proposer
             .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
             .never();
@@ -1235,6 +1255,7 @@ mod tests {
         let invocation_id = InvocationId::mock_random();
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         proposer
             .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
             .never();
@@ -1318,6 +1339,7 @@ mod tests {
         );
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         proposer
             .expect_handle_rpc_proposal_command::<RestartAsNewInvocationRpcResponse>()
             .return_once_st(move |_, cmd, _, _| {
@@ -1381,6 +1403,7 @@ mod tests {
         );
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         proposer
             .expect_handle_rpc_proposal_command::<RestartAsNewInvocationRpcResponse>()
             .return_once_st(move |_, cmd, _, _| {
@@ -1438,6 +1461,7 @@ mod tests {
         );
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         proposer
             .expect_handle_rpc_proposal_command::<RestartAsNewInvocationRpcResponse>()
             .never();
@@ -1488,6 +1512,7 @@ mod tests {
         );
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         proposer
             .expect_handle_rpc_proposal_command::<RestartAsNewInvocationRpcResponse>()
             .never();
@@ -1528,6 +1553,7 @@ mod tests {
         );
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         proposer
             .expect_handle_rpc_proposal_command::<RestartAsNewInvocationRpcResponse>()
             .never();
@@ -1568,6 +1594,7 @@ mod tests {
             MockStorage::new_without_journal(invocation_id, InvocationStatus::Completed(completed));
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         proposer
             .expect_handle_rpc_proposal_command::<RestartAsNewInvocationRpcResponse>()
             .never();
@@ -1596,5 +1623,43 @@ mod tests {
                 RestartAsNewInvocationRpcResponse::Unsupported
             )
         );
+    }
+
+    #[test(restate_core::test)]
+    async fn reply_not_leader_when_not_leader() {
+        let invocation_id = InvocationId::mock_random();
+
+        let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(false);
+        proposer
+            .expect_partition_id()
+            .return_const(PartitionId::from(0));
+        proposer
+            .expect_self_propose_and_respond_asynchronously::<RestartAsNewInvocationRpcResponse>()
+            .never();
+        proposer
+            .expect_handle_rpc_proposal_command::<RestartAsNewInvocationRpcResponse>()
+            .never();
+
+        let mut storage = MockStorage::new_without_journal(invocation_id, Default::default());
+
+        let (tx, rx) = Reciprocal::mock();
+        RpcHandler::handle(
+            RpcContext::new(&mut proposer, &(), &mut storage),
+            Request {
+                request_id: Default::default(),
+                invocation_id,
+                copy_prefix_up_to_index_included: 0,
+                patch_deployment_id: Default::default(),
+            },
+            Replier::new(tx),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            rx.recv().await,
+            Err(PartitionProcessorRpcError::NotLeader(_))
+        ));
     }
 }

--- a/crates/worker/src/partition/rpc/resume_invocation.rs
+++ b/crates/worker/src/partition/rpc/resume_invocation.rs
@@ -45,6 +45,16 @@ where
         }: Request,
         replier: Replier<Self::Output>,
     ) -> Result<(), Self::Error> {
+        // Reading from a non-leader partition processor can return stale results
+        // (e.g. NotFound for an invocation that exists on the leader) because the
+        // follower's local store may not have replayed all log entries yet.
+        if !self.proposer.is_leader() {
+            replier.send_result(Err(PartitionProcessorRpcError::NotLeader(
+                self.proposer.partition_id(),
+            )));
+            return Ok(());
+        }
+
         // -- Figure out the invocation status
         match self.storage.get_invocation_status(&invocation_id).await {
             Ok(InvocationStatus::Invoked(_)) => {
@@ -193,6 +203,7 @@ mod tests {
         let invocation_id = InvocationId::mock_random();
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         proposer
             .expect_notify_invoker_to_retry_now()
             .return_once_st(move |got_invocation_id| {
@@ -238,6 +249,7 @@ mod tests {
         let invocation_id = InvocationId::mock_random();
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         proposer
             .expect_handle_rpc_proposal_command::<ResumeInvocationRpcResponse>()
             .return_once_st(move |_, cmd, request_id, replier| {
@@ -287,6 +299,7 @@ mod tests {
         let invocation_id = InvocationId::mock_random();
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         proposer
             .expect_handle_rpc_proposal_command::<PartitionProcessorRpcResponse>()
             .never();
@@ -320,6 +333,7 @@ mod tests {
         let invocation_id = InvocationId::mock_random();
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         proposer
             .expect_handle_rpc_proposal_command::<PartitionProcessorRpcResponse>()
             .never();
@@ -365,6 +379,7 @@ mod tests {
         let invocation_id = InvocationId::mock_random();
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         proposer
             .expect_handle_rpc_proposal_command::<ResumeInvocationRpcResponse>()
             .never();
@@ -417,6 +432,7 @@ mod tests {
         }
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         proposer
             .expect_handle_rpc_proposal_command::<ResumeInvocationRpcResponse>()
             .never();
@@ -492,6 +508,7 @@ mod tests {
         }
 
         let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
         proposer
             .expect_handle_rpc_proposal_command::<ResumeInvocationRpcResponse>()
             .return_once_st(move |_, cmd, request_id, replier| {
@@ -550,5 +567,42 @@ mod tests {
             rx.recv().await.unwrap(),
             PartitionProcessorRpcResponse::ResumeInvocation(ResumeInvocationRpcResponse::Ok)
         );
+    }
+
+    #[test(restate_core::test)]
+    async fn reply_not_leader_when_not_leader() {
+        let invocation_id = InvocationId::mock_random();
+
+        let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(false);
+        proposer
+            .expect_partition_id()
+            .return_const(PartitionId::from(0));
+        proposer
+            .expect_handle_rpc_proposal_command::<PartitionProcessorRpcResponse>()
+            .never();
+
+        let mut storage = MockStorage {
+            expected_invocation_id: invocation_id,
+            status: Default::default(),
+        };
+
+        let (tx, rx) = Reciprocal::mock();
+        RpcHandler::handle(
+            RpcContext::new(&mut proposer, &(), &mut storage),
+            Request {
+                request_id: Default::default(),
+                invocation_id,
+                update_deployment_id: Default::default(),
+            },
+            Replier::new(tx),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            rx.recv().await,
+            Err(PartitionProcessorRpcError::NotLeader(_))
+        ));
     }
 }


### PR DESCRIPTION
RPC handlers for restart_as_new, resume, and pause invocations read from
local storage without checking leadership first. On a follower with stale
storage (common during leader transitions in multi-node clusters), the
invocation appears as Free, returning NotFound (404) instead of NotLeader
(503). Since clients only retry on 503, this causes flaky test failures.

Add leader guards matching the existing pattern in get_invocation_output,
returning NotLeader when the partition processor is not the leader so the
request gets retried on the actual leader.

Fixes https://github.com/restatedev/restate/issues/4587