### PR TITLE
KafkaClusters and Subscriptions CLI commands

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -62,6 +62,12 @@ pub enum Command {
     /// Manages your service deployments
     #[clap(subcommand)]
     Deployments(deployments::Deployments),
+    /// Manage Kafka clusters
+    #[clap(subcommand)]
+    KafkaClusters(kafkaclusters::KafkaClusters),
+    /// Manage Kafka subscriptions
+    #[clap(subcommand)]
+    Subscriptions(subscriptions::Subscriptions),
     /// Manage active invocations
     #[clap(subcommand)]
     Invocations(invocations::Invocations),

--- a/cli/src/clients/admin_interface.rs
+++ b/cli/src/clients/admin_interface.rs
@@ -16,7 +16,9 @@ use http::{Uri, Version};
 use indicatif::ProgressBar;
 use restate_admin_rest_model::deployments::*;
 use restate_admin_rest_model::invocations::RestartAsNewInvocationResponse;
+use restate_admin_rest_model::kafka_clusters::*;
 use restate_admin_rest_model::services::*;
+use restate_admin_rest_model::subscriptions::*;
 use restate_admin_rest_model::version::VersionInformation;
 use restate_futures_util::streams::StreamExt as RestateStreamExt;
 use restate_serde_util::SerdeableHeaderHashMap;
@@ -100,6 +102,58 @@ pub trait AdminClientInterface {
     fn version(
         &self,
     ) -> impl Future<Output = reqwest::Result<Envelope<VersionInformation>>> + Send + 'static;
+
+    // --- Kafka clusters ----------------------------------------------------
+
+    fn list_kafka_clusters(
+        &self,
+    ) -> impl Future<Output = reqwest::Result<Envelope<ListKafkaClustersResponse>>> + Send + 'static;
+
+    fn get_kafka_cluster(
+        &self,
+        name: &str,
+        include_subscriptions: bool,
+    ) -> impl Future<Output = reqwest::Result<Envelope<KafkaClusterResponse>>> + Send + 'static;
+
+    fn create_kafka_cluster(
+        &self,
+        body: CreateKafkaClusterRequest,
+    ) -> impl Future<Output = reqwest::Result<Envelope<SimpleKafkaClusterResponse>>> + Send + 'static;
+
+    fn update_kafka_cluster(
+        &self,
+        name: &str,
+        body: UpdateKafkaClusterRequest,
+    ) -> impl Future<Output = reqwest::Result<Envelope<SimpleKafkaClusterResponse>>> + Send + 'static;
+
+    fn delete_kafka_cluster(
+        &self,
+        name: &str,
+        force: bool,
+    ) -> impl Future<Output = reqwest::Result<Envelope<()>>> + Send + 'static;
+
+    // --- Subscriptions -----------------------------------------------------
+
+    fn list_subscriptions(
+        &self,
+        sink: Option<&str>,
+        source: Option<&str>,
+    ) -> impl Future<Output = reqwest::Result<Envelope<ListSubscriptionsResponse>>> + Send + 'static;
+
+    fn get_subscription(
+        &self,
+        id: &str,
+    ) -> impl Future<Output = reqwest::Result<Envelope<SubscriptionResponse>>> + Send + 'static;
+
+    fn create_subscription(
+        &self,
+        body: CreateSubscriptionRequest,
+    ) -> impl Future<Output = reqwest::Result<Envelope<SubscriptionResponse>>> + Send + 'static;
+
+    fn delete_subscription(
+        &self,
+        id: &str,
+    ) -> impl Future<Output = reqwest::Result<Envelope<()>>> + Send + 'static;
 }
 
 impl AdminClientInterface for AdminClient {
@@ -243,6 +297,110 @@ impl AdminClientInterface for AdminClient {
     ) -> impl Future<Output = reqwest::Result<Envelope<VersionInformation>>> + Send + 'static {
         let url = self.versioned_url(["version"]);
         self.run(reqwest::Method::GET, url)
+    }
+
+    // --- Kafka clusters ----------------------------------------------------
+
+    fn list_kafka_clusters(
+        &self,
+    ) -> impl Future<Output = reqwest::Result<Envelope<ListKafkaClustersResponse>>> + Send + 'static
+    {
+        let url = self.versioned_url(["kafka-clusters"]);
+        self.run(reqwest::Method::GET, url)
+    }
+
+    fn get_kafka_cluster(
+        &self,
+        name: &str,
+        include_subscriptions: bool,
+    ) -> impl Future<Output = reqwest::Result<Envelope<KafkaClusterResponse>>> + Send + 'static
+    {
+        let mut url = self.versioned_url(["kafka-clusters", name]);
+        if include_subscriptions {
+            url.set_query(Some("include_subscriptions=true"));
+        }
+        self.run(reqwest::Method::GET, url)
+    }
+
+    fn create_kafka_cluster(
+        &self,
+        body: CreateKafkaClusterRequest,
+    ) -> impl Future<Output = reqwest::Result<Envelope<SimpleKafkaClusterResponse>>> + Send + 'static
+    {
+        let url = self.versioned_url(["kafka-clusters"]);
+        self.run_with_body(reqwest::Method::POST, url, body)
+    }
+
+    fn update_kafka_cluster(
+        &self,
+        name: &str,
+        body: UpdateKafkaClusterRequest,
+    ) -> impl Future<Output = reqwest::Result<Envelope<SimpleKafkaClusterResponse>>> + Send + 'static
+    {
+        let url = self.versioned_url(["kafka-clusters", name]);
+        self.run_with_body(reqwest::Method::PATCH, url, body)
+    }
+
+    fn delete_kafka_cluster(
+        &self,
+        name: &str,
+        force: bool,
+    ) -> impl Future<Output = reqwest::Result<Envelope<()>>> + Send + 'static {
+        let mut url = self.versioned_url(["kafka-clusters", name]);
+        if force {
+            url.set_query(Some("force=true"));
+        }
+        self.run(reqwest::Method::DELETE, url)
+    }
+
+    // --- Subscriptions -----------------------------------------------------
+
+    fn list_subscriptions(
+        &self,
+        sink: Option<&str>,
+        source: Option<&str>,
+    ) -> impl Future<Output = reqwest::Result<Envelope<ListSubscriptionsResponse>>> + Send + 'static
+    {
+        let mut url = self.versioned_url(["subscriptions"]);
+        let mut q = url.query_pairs_mut();
+        if let Some(s) = sink {
+            q.append_pair("sink", s);
+        }
+        if let Some(s) = source {
+            q.append_pair("source", s);
+        }
+        drop(q);
+        // Avoid an empty `?` when no filters are set.
+        if url.query() == Some("") {
+            url.set_query(None);
+        }
+        self.run(reqwest::Method::GET, url)
+    }
+
+    fn get_subscription(
+        &self,
+        id: &str,
+    ) -> impl Future<Output = reqwest::Result<Envelope<SubscriptionResponse>>> + Send + 'static
+    {
+        let url = self.versioned_url(["subscriptions", id]);
+        self.run(reqwest::Method::GET, url)
+    }
+
+    fn create_subscription(
+        &self,
+        body: CreateSubscriptionRequest,
+    ) -> impl Future<Output = reqwest::Result<Envelope<SubscriptionResponse>>> + Send + 'static
+    {
+        let url = self.versioned_url(["subscriptions"]);
+        self.run_with_body(reqwest::Method::POST, url, body)
+    }
+
+    fn delete_subscription(
+        &self,
+        id: &str,
+    ) -> impl Future<Output = reqwest::Result<Envelope<()>>> + Send + 'static {
+        let url = self.versioned_url(["subscriptions", id]);
+        self.run(reqwest::Method::DELETE, url)
     }
 }
 

--- a/cli/src/commands/kafkaclusters/create.rs
+++ b/cli/src/commands/kafkaclusters/create.rs
@@ -1,0 +1,124 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use cling::prelude::*;
+use tempfile::tempdir;
+
+use restate_admin_rest_model::kafka_clusters::CreateKafkaClusterRequest;
+use restate_cli_util::ui::console::confirm_or_exit;
+use restate_cli_util::{c_println, c_success};
+
+use crate::cli_env::CliEnv;
+use crate::clients::{AdminClient, AdminClientInterface};
+use crate::util::properties::{
+    collect_kv_pairs, parse_kv_arg, parse_librdkafka_properties, parse_properties_file,
+};
+
+use super::utils::render_properties_table;
+
+#[derive(Run, Parser, Collect, Clone)]
+#[cling(run = "run_create")]
+pub struct Create {
+    /// Kafka cluster name (must be a valid hostname).
+    name: String,
+
+    /// Read properties from a file. `.properties` / `.conf` / `-` (stdin) are
+    /// parsed as flat librdkafka properties; other extensions are parsed as
+    /// TOML with a top-level `[properties]` table.
+    #[clap(short = 'f', long = "from-file", value_name = "FILE")]
+    from_file: Option<PathBuf>,
+
+    /// Open `$EDITOR` on a librdkafka properties template instead of taking
+    /// properties from the command line. Mutually exclusive with positional
+    /// properties and `--from-file`.
+    #[clap(long, conflicts_with = "from_file")]
+    edit: bool,
+
+    /// `key=value` properties (e.g. `bootstrap.servers=broker:9092`).
+    #[clap(value_name = "KEY=VALUE", value_parser = parse_kv_arg, trailing_var_arg = true, num_args = 0..)]
+    properties: Vec<(String, String)>,
+}
+
+pub async fn run_create(State(env): State<CliEnv>, opts: &Create) -> Result<()> {
+    if opts.edit && !opts.properties.is_empty() {
+        bail!("--edit cannot be combined with positional KEY=VALUE properties");
+    }
+    if opts.from_file.is_some() && !opts.properties.is_empty() {
+        bail!("--from-file cannot be combined with positional KEY=VALUE properties");
+    }
+
+    let properties = if let Some(path) = opts.from_file.as_ref() {
+        parse_properties_file(path, "properties")?
+    } else if !opts.properties.is_empty() {
+        collect_kv_pairs(opts.properties.iter().cloned())?
+    } else {
+        edit_template_properties(&env, &opts.name)?
+    };
+
+    if properties.is_empty() {
+        bail!(
+            "no properties were supplied. Pass them as positional KEY=VALUE pairs, via --from-file, or via --edit."
+        );
+    }
+
+    let client = AdminClient::new(&env).await?;
+
+    c_println!("{}", render_properties_table(&properties));
+    confirm_or_exit(&format!("Create Kafka cluster {}?", opts.name))?;
+
+    let cluster_name = opts
+        .name
+        .parse()
+        .with_context(|| format!("invalid Kafka cluster name `{}`", opts.name))?;
+
+    let response = client
+        .create_kafka_cluster(CreateKafkaClusterRequest {
+            name: cluster_name,
+            properties,
+        })
+        .await?
+        .into_body()
+        .await?;
+
+    c_success!("Kafka cluster {} created", response.name.as_str());
+    Ok(())
+}
+
+fn edit_template_properties(env: &CliEnv, name: &str) -> Result<HashMap<String, String>> {
+    let dir = tempdir().context("failed to create a temporary directory")?;
+    let path = dir.path().join("kafka-cluster.properties");
+    std::fs::write(
+        &path,
+        format!(
+            "# Define properties for Kafka cluster '{name}'.\n\
+             # Format: librdkafka properties (key=value, # comments).\n\
+             # At least one of bootstrap.servers / metadata.broker.list is required.\n\
+             # See: https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md\n\
+             #\n\
+             # Example:\n\
+             # bootstrap.servers=broker-1:9092,broker-2:9092\n\
+             # security.protocol=SASL_SSL\n\
+             # sasl.mechanism=PLAIN\n\
+             # sasl.username=...\n\
+             # sasl.password=...\n\
+             \n",
+        ),
+    )
+    .context("failed to write the editor template")?;
+
+    env.open_default_editor(&path)?;
+
+    let edited = std::fs::read_to_string(&path).context("failed to read the edited file")?;
+    parse_librdkafka_properties(&edited)
+}

--- a/cli/src/commands/kafkaclusters/delete.rs
+++ b/cli/src/commands/kafkaclusters/delete.rs
@@ -1,0 +1,77 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::{Result, bail};
+use cling::prelude::*;
+use comfy_table::Table;
+
+use restate_cli_util::ui::console::{Styled, StyledTable, confirm_or_exit};
+use restate_cli_util::ui::stylesheet::Style;
+use restate_cli_util::{c_println, c_success, c_warn};
+
+use crate::cli_env::CliEnv;
+use crate::clients::{AdminClient, AdminClientInterface};
+
+#[derive(Run, Parser, Collect, Clone)]
+#[cling(run = "run_delete")]
+#[clap(visible_alias = "rm", alias = "remove")]
+pub struct Delete {
+    /// Kafka cluster name
+    name: String,
+
+    /// Delete the cluster even if subscriptions still reference it. Those
+    /// subscriptions will be orphaned and will stop consuming.
+    #[clap(long)]
+    force: bool,
+}
+
+pub async fn run_delete(State(env): State<CliEnv>, opts: &Delete) -> Result<()> {
+    let client = AdminClient::new(&env).await?;
+
+    let cluster = client
+        .get_kafka_cluster(&opts.name, true)
+        .await?
+        .into_body()
+        .await?;
+
+    let mut table = Table::new_styled();
+    table.add_kv_row("Name:", cluster.name.as_str());
+    table.add_kv_row("Subscriptions:", cluster.subscriptions.len());
+    c_println!("{table}");
+
+    if !cluster.subscriptions.is_empty() && !opts.force {
+        bail!(
+            "Cluster {} has {} subscription(s) attached. Re-run with {} to orphan them.",
+            Styled(Style::Info, &opts.name),
+            cluster.subscriptions.len(),
+            Styled(Style::Notice, "--force"),
+        );
+    }
+
+    if !cluster.subscriptions.is_empty() {
+        c_warn!(
+            "{} subscription(s) will be orphaned and stop consuming.",
+            cluster.subscriptions.len()
+        );
+    }
+
+    confirm_or_exit(&format!(
+        "Are you sure you want to delete Kafka cluster {}?",
+        opts.name
+    ))?;
+
+    client
+        .delete_kafka_cluster(&opts.name, opts.force)
+        .await?
+        .success_or_error()?;
+
+    c_success!("Kafka cluster {} deleted", &opts.name);
+    Ok(())
+}

--- a/cli/src/commands/kafkaclusters/describe.rs
+++ b/cli/src/commands/kafkaclusters/describe.rs
@@ -1,0 +1,77 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::Result;
+use cling::prelude::*;
+use comfy_table::Table;
+
+use restate_cli_util::ui::console::StyledTable;
+use restate_cli_util::ui::watcher::Watch;
+use restate_cli_util::{c_println, c_title};
+
+use crate::cli_env::CliEnv;
+use crate::clients::{AdminClient, AdminClientInterface};
+use crate::ui::datetime::DateTimeExt;
+
+use super::utils::{brokers_property, render_properties_table};
+
+#[derive(Run, Parser, Collect, Clone)]
+#[cling(run = "run_describe")]
+#[clap(visible_alias = "get")]
+pub struct Describe {
+    /// Kafka cluster name
+    name: String,
+
+    #[clap(flatten)]
+    watch: Watch,
+}
+
+pub async fn run_describe(State(env): State<CliEnv>, opts: &Describe) -> Result<()> {
+    opts.watch.run(|| describe(&env, opts)).await
+}
+
+async fn describe(env: &CliEnv, opts: &Describe) -> Result<()> {
+    let client = AdminClient::new(env).await?;
+    let cluster = client
+        .get_kafka_cluster(&opts.name, true)
+        .await?
+        .into_body()
+        .await?;
+
+    let mut summary = Table::new_styled();
+    summary.add_kv_row("Name:", cluster.name.as_str());
+    summary.add_kv_row(
+        "Brokers:",
+        brokers_property(&cluster.properties).unwrap_or("-"),
+    );
+    summary.add_kv_row("Properties:", cluster.properties.len());
+    summary.add_kv_row("Subscriptions:", cluster.subscriptions.len());
+    summary.add_kv_row("Created at:", cluster.created_at.display());
+
+    c_title!("📜", "Kafka Cluster");
+    c_println!("{summary}");
+    c_println!();
+
+    c_title!("⚙️", "Properties");
+    c_println!("{}", render_properties_table(&cluster.properties));
+
+    if !cluster.subscriptions.is_empty() {
+        c_println!();
+        c_title!("📨", "Subscriptions");
+        let mut sub_table = Table::new_styled();
+        sub_table.set_styled_header(vec!["ID", "SOURCE", "SINK"]);
+        for sub in cluster.subscriptions {
+            sub_table.add_row(vec![sub.id.to_string(), sub.source, sub.sink]);
+        }
+        c_println!("{sub_table}");
+    }
+
+    Ok(())
+}

--- a/cli/src/commands/kafkaclusters/edit.rs
+++ b/cli/src/commands/kafkaclusters/edit.rs
@@ -1,0 +1,102 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::HashMap;
+
+use anyhow::{Context, Result};
+use cling::prelude::*;
+use tempfile::tempdir;
+
+use restate_cli_util::c_println;
+
+use crate::cli_env::CliEnv;
+use crate::clients::{AdminClient, AdminClientInterface};
+use crate::util::properties::{
+    REDACTION_PLACEHOLDER, parse_librdkafka_properties, redacted_keys,
+    serialize_librdkafka_properties,
+};
+
+use super::patch::apply_kafka_cluster_update;
+
+#[derive(Run, Parser, Collect, Clone)]
+#[cling(run = "run_edit")]
+pub struct Edit {
+    /// Kafka cluster name
+    name: String,
+}
+
+pub async fn run_edit(State(env): State<CliEnv>, opts: &Edit) -> Result<()> {
+    let client = AdminClient::new(&env).await?;
+    let cluster = client
+        .get_kafka_cluster(&opts.name, false)
+        .await?
+        .into_body()
+        .await?;
+
+    let baseline_with_redaction = cluster.properties.clone();
+    let redacted = redacted_keys(&baseline_with_redaction);
+    // The non-redacted baseline is used for diffing — secret values are
+    // unknown to us so we treat them as "preserved" rather than "changed".
+    let mut baseline_visible: HashMap<String, String> = baseline_with_redaction
+        .iter()
+        .filter(|(_, v)| v.as_str() != REDACTION_PLACEHOLDER)
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+
+    let dir = tempdir().context("failed to create a temporary directory")?;
+    let path = dir.path().join("kafka-cluster.properties");
+
+    let mut prelude = format!(
+        "# Editing Kafka cluster '{}'.\n\
+         # Format: librdkafka properties (key=value, # comments).\n\
+         # Save and exit to apply changes; abort by leaving the file unchanged.\n",
+        opts.name
+    );
+    if !redacted.is_empty() {
+        prelude.push_str(
+            "#\n\
+             # Lines beginning with `# REDACTED:` are server-redacted secret\n\
+             # properties. To preserve them, leave the line commented. To replace\n\
+             # one, uncomment the line and supply the new value.\n",
+        );
+    }
+    prelude.push('\n');
+
+    let body = serialize_librdkafka_properties(&baseline_with_redaction);
+    std::fs::write(&path, format!("{prelude}{body}"))
+        .context("failed to write the editor template")?;
+
+    env.open_default_editor(&path)?;
+
+    let edited_text = std::fs::read_to_string(&path).context("failed to read the edited file")?;
+    let edited = parse_librdkafka_properties(&edited_text)?;
+
+    // Merge: any redacted key the user did not explicitly re-set is preserved
+    // by carrying the original (still-redacted) value forward. The PATCH
+    // endpoint replaces the full properties map, so we have to send those
+    // back; the server will preserve them if they're identical to the current
+    // value (placeholder included).
+    let mut to_send = edited.clone();
+    for k in &redacted {
+        if !to_send.contains_key(k) {
+            to_send.insert(k.clone(), REDACTION_PLACEHOLDER.to_string());
+            // Make redacted properties show as "unchanged" in the diff by
+            // adding them to the visible baseline with the same placeholder.
+            baseline_visible.insert(k.clone(), REDACTION_PLACEHOLDER.to_string());
+        }
+    }
+
+    if to_send == baseline_with_redaction {
+        c_println!("No changes detected. Aborting.");
+        return Ok(());
+    }
+
+    apply_kafka_cluster_update(&client, &opts.name, &baseline_visible, to_send).await
+}

--- a/cli/src/commands/kafkaclusters/list.rs
+++ b/cli/src/commands/kafkaclusters/list.rs
@@ -1,0 +1,68 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::Result;
+use cling::prelude::*;
+use comfy_table::{Cell, Table};
+
+use restate_cli_util::c_println;
+use restate_cli_util::ui::console::StyledTable;
+use restate_cli_util::ui::watcher::Watch;
+
+use crate::cli_env::CliEnv;
+use crate::clients::{AdminClient, AdminClientInterface};
+use crate::ui::datetime::DateTimeExt;
+
+use super::utils::brokers_property;
+
+#[derive(Run, Parser, Collect, Clone)]
+#[cling(run = "run_list")]
+#[clap(visible_alias = "ls")]
+pub struct List {
+    #[clap(flatten)]
+    watch: Watch,
+}
+
+pub async fn run_list(State(env): State<CliEnv>, opts: &List) -> Result<()> {
+    opts.watch.run(|| list(&env)).await
+}
+
+async fn list(env: &CliEnv) -> Result<()> {
+    let client = AdminClient::new(env).await?;
+    let mut clusters = client
+        .list_kafka_clusters()
+        .await?
+        .into_body()
+        .await?
+        .clusters;
+
+    if clusters.is_empty() {
+        c_println!("No Kafka clusters registered.");
+        return Ok(());
+    }
+
+    clusters.sort_by(|a, b| a.name.as_str().cmp(b.name.as_str()));
+
+    let mut table = Table::new_styled();
+    table.set_styled_header(vec!["NAME", "BROKERS", "PROPERTIES", "CREATED-AT"]);
+    for cluster in clusters {
+        let brokers = brokers_property(&cluster.properties)
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        table.add_row(vec![
+            Cell::new(cluster.name.as_str()),
+            Cell::new(brokers),
+            Cell::new(cluster.properties.len()),
+            Cell::new(cluster.created_at.display()),
+        ]);
+    }
+    c_println!("{table}");
+    Ok(())
+}

--- a/cli/src/commands/kafkaclusters/mod.rs
+++ b/cli/src/commands/kafkaclusters/mod.rs
@@ -1,0 +1,36 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod create;
+mod delete;
+mod describe;
+mod edit;
+mod list;
+mod patch;
+pub(crate) mod utils;
+
+use cling::prelude::*;
+
+#[derive(Run, Subcommand, Clone)]
+#[clap(visible_alias = "kc", alias = "kafkacluster")]
+pub enum KafkaClusters {
+    /// List the registered Kafka clusters
+    List(list::List),
+    /// Register a new Kafka cluster
+    Create(create::Create),
+    /// Print detailed information about a Kafka cluster
+    Describe(describe::Describe),
+    /// Open an editor to interactively update a Kafka cluster's properties
+    Edit(edit::Edit),
+    /// Update a Kafka cluster's properties non-interactively (CI / scripting)
+    Patch(patch::Patch),
+    /// Remove a Kafka cluster
+    Delete(delete::Delete),
+}

--- a/cli/src/commands/kafkaclusters/mod.rs
+++ b/cli/src/commands/kafkaclusters/mod.rs
@@ -19,11 +19,12 @@ pub(crate) mod utils;
 use cling::prelude::*;
 
 #[derive(Run, Subcommand, Clone)]
-#[clap(visible_alias = "kc", alias = "kafkacluster")]
+#[clap(visible_alias = "kc", alias = "kafkaclusters", alias = "kafkacluster")]
 pub enum KafkaClusters {
     /// List the registered Kafka clusters
     List(list::List),
     /// Register a new Kafka cluster
+    #[clap(alias = "register")]
     Create(create::Create),
     /// Print detailed information about a Kafka cluster
     Describe(describe::Describe),

--- a/cli/src/commands/kafkaclusters/patch.rs
+++ b/cli/src/commands/kafkaclusters/patch.rs
@@ -1,0 +1,131 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use anyhow::{Result, bail};
+use cling::prelude::*;
+
+use restate_admin_rest_model::kafka_clusters::UpdateKafkaClusterRequest;
+use restate_cli_util::ui::console::confirm_or_exit;
+use restate_cli_util::{c_println, c_success};
+
+use crate::cli_env::CliEnv;
+use crate::clients::{AdminClient, AdminClientInterface};
+use crate::util::properties::{
+    collect_kv_pairs, parse_kv_arg, parse_properties_file, redacted_keys,
+};
+
+use super::utils::render_diff_table;
+
+#[derive(Run, Parser, Collect, Clone)]
+#[cling(run = "run_patch")]
+pub struct Patch {
+    /// Kafka cluster name
+    name: String,
+
+    /// Set or replace a property (`KEY=VALUE`). Repeatable.
+    #[clap(long = "set", value_name = "KEY=VALUE", value_parser = parse_kv_arg)]
+    set: Vec<(String, String)>,
+
+    /// Remove a property. Repeatable.
+    #[clap(long = "unset", value_name = "KEY")]
+    unset: Vec<String>,
+
+    /// Use the given file as the new properties baseline (full replacement).
+    /// `--set` / `--unset` are applied on top. Without `-f`, the current
+    /// server-side properties are used as the baseline.
+    #[clap(short = 'f', long = "from-file", value_name = "FILE")]
+    from_file: Option<PathBuf>,
+}
+
+pub async fn run_patch(State(env): State<CliEnv>, opts: &Patch) -> Result<()> {
+    if opts.set.is_empty() && opts.unset.is_empty() && opts.from_file.is_none() {
+        bail!("no changes requested: pass --set KEY=VALUE, --unset KEY, or --from-file FILE");
+    }
+    // Detect duplicate --set keys eagerly so the error mentions --set instead
+    // of bubbling up from collect_kv_pairs as a generic message.
+    let sets = collect_kv_pairs(opts.set.iter().cloned())?;
+
+    let client = AdminClient::new(&env).await?;
+
+    // Baseline + visible-baseline: visible-baseline is what we render in the
+    // diff (without any *** values). The baseline used for the actual PATCH
+    // payload may include redacted values from the server, which is why we
+    // refuse to send those when they survived through to the final map.
+    let (baseline, visible_baseline) = if let Some(path) = opts.from_file.as_ref() {
+        let m = parse_properties_file(path, "properties")?;
+        (m.clone(), m)
+    } else {
+        let current = client
+            .get_kafka_cluster(&opts.name, false)
+            .await?
+            .into_body()
+            .await?
+            .properties;
+        let visible = current
+            .iter()
+            .filter(|(_, v)| v.as_str() != crate::util::properties::REDACTION_PLACEHOLDER)
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        (current, visible)
+    };
+
+    let mut new_props = baseline.clone();
+    for k in &opts.unset {
+        new_props.remove(k);
+    }
+    for (k, v) in sets {
+        new_props.insert(k, v);
+    }
+
+    let still_redacted = redacted_keys(&new_props);
+    if !still_redacted.is_empty() {
+        bail!(
+            "the following properties have redacted (***) values: {}. \
+             Re-set them via --set KEY=VALUE, or pass a complete config with --from-file.",
+            still_redacted.join(", ")
+        );
+    }
+
+    apply_kafka_cluster_update(&client, &opts.name, &visible_baseline, new_props).await
+}
+
+/// Renders the diff, asks for confirmation and submits the PATCH. Used both
+/// here and from `edit`.
+pub(super) async fn apply_kafka_cluster_update(
+    client: &AdminClient,
+    name: &str,
+    visible_baseline: &HashMap<String, String>,
+    new_props: HashMap<String, String>,
+) -> Result<()> {
+    let diff = render_diff_table(visible_baseline, &new_props);
+    if diff.row_count() == 0 {
+        c_println!("No changes detected. Aborting.");
+        return Ok(());
+    }
+    c_println!("{diff}");
+    confirm_or_exit(&format!("Apply these changes to Kafka cluster {name}?"))?;
+
+    let _ = client
+        .update_kafka_cluster(
+            name,
+            UpdateKafkaClusterRequest {
+                properties: new_props,
+            },
+        )
+        .await?
+        .into_body()
+        .await?;
+
+    c_success!("Kafka cluster {name} updated");
+    Ok(())
+}

--- a/cli/src/commands/kafkaclusters/utils.rs
+++ b/cli/src/commands/kafkaclusters/utils.rs
@@ -1,0 +1,93 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Helpers shared between the Kafka cluster subcommands.
+
+use std::collections::{BTreeSet, HashMap};
+
+use comfy_table::{Cell, Table};
+
+use restate_cli_util::ui::console::{Styled, StyledTable};
+use restate_cli_util::ui::stylesheet::Style;
+
+use crate::util::properties::REDACTION_PLACEHOLDER;
+
+/// Returns `bootstrap.servers`, falling back to `metadata.broker.list`. Returns
+/// `None` if neither is set or if the value is the redaction placeholder.
+pub fn brokers_property(properties: &HashMap<String, String>) -> Option<&str> {
+    for key in ["bootstrap.servers", "metadata.broker.list"] {
+        if let Some(v) = properties.get(key)
+            && v != REDACTION_PLACEHOLDER
+            && !v.is_empty()
+        {
+            return Some(v.as_str());
+        }
+    }
+    None
+}
+
+/// Renders a properties map for `describe`-style output. Sensitive properties
+/// (those whose value is the redaction placeholder) are styled in `Warn` so
+/// they're visually distinguishable from regular values.
+pub fn render_properties_table(properties: &HashMap<String, String>) -> Table {
+    let mut table = Table::new_styled();
+    table.set_styled_header(vec!["KEY", "VALUE"]);
+
+    let mut keys: Vec<&String> = properties.keys().collect();
+    keys.sort();
+    for k in keys {
+        let v = &properties[k];
+        let cell = if v == REDACTION_PLACEHOLDER {
+            Cell::new(format!("{}", Styled(Style::Warn, REDACTION_PLACEHOLDER)))
+        } else {
+            Cell::new(v)
+        };
+        table.add_row(vec![Cell::new(k), cell]);
+    }
+    table
+}
+
+/// Renders a property diff between two maps, with rows sorted by key. Values
+/// equal to [`REDACTION_PLACEHOLDER`] are rendered as `***` so the user can
+/// see that a server-redacted field is being preserved or replaced.
+pub fn render_diff_table(old: &HashMap<String, String>, new: &HashMap<String, String>) -> Table {
+    let mut keys: BTreeSet<&String> = BTreeSet::new();
+    keys.extend(old.keys());
+    keys.extend(new.keys());
+
+    let mut table = Table::new_styled();
+    table.set_styled_header(vec!["PROPERTY", "OLD", "NEW"]);
+
+    for k in keys {
+        let old_v = old.get(k);
+        let new_v = new.get(k);
+        if old_v == new_v {
+            continue;
+        }
+        let (old_cell, new_cell) = match (old_v, new_v) {
+            (None, Some(v)) => (
+                Cell::new(format!("{}", Styled(Style::Notice, "(unset)"))),
+                Cell::new(format!("{}", Styled(Style::Success, v))),
+            ),
+            (Some(v), None) => (
+                Cell::new(format!("{}", Styled(Style::Danger, v))),
+                Cell::new(format!("{}", Styled(Style::Notice, "(removed)"))),
+            ),
+            (Some(o), Some(n)) => (
+                Cell::new(format!("{}", Styled(Style::Danger, o))),
+                Cell::new(format!("{}", Styled(Style::Success, n))),
+            ),
+            (None, None) => unreachable!(),
+        };
+        table.add_row(vec![Cell::new(k), old_cell, new_cell]);
+    }
+
+    table
+}

--- a/cli/src/commands/subscriptions/create.rs
+++ b/cli/src/commands/subscriptions/create.rs
@@ -1,0 +1,182 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use cling::prelude::*;
+use comfy_table::Table;
+use http::Uri;
+use tempfile::tempdir;
+
+use restate_admin_rest_model::kafka_clusters::KafkaClusterResponse;
+use restate_admin_rest_model::subscriptions::CreateSubscriptionRequest;
+use restate_cli_util::ui::console::{StyledTable, confirm_or_exit};
+use restate_cli_util::{c_println, c_success};
+
+use crate::cli_env::CliEnv;
+use crate::clients::{AdminClient, AdminClientInterface};
+use crate::commands::kafkaclusters::utils as kc_shared;
+use crate::util::properties::{
+    collect_kv_pairs, parse_kv_arg, parse_librdkafka_properties, parse_properties_file,
+};
+
+#[derive(Run, Parser, Collect, Clone)]
+#[cling(run = "run_create")]
+pub struct Create {
+    /// Source URI, e.g. `kafka://<cluster_name>/<topic>`. May be omitted
+    /// when `--from-file` or `--edit` is used.
+    source: Option<String>,
+
+    /// Sink URI, e.g. `service://<service>/<handler>`. May be omitted when
+    /// `--from-file` or `--edit` is used.
+    sink: Option<String>,
+
+    /// Read source/sink/options from a file. `.properties` / `.conf` / `-`
+    /// are parsed as flat librdkafka properties (recognised top-level keys:
+    /// `source`, `sink`); other extensions are TOML with top-level `source`,
+    /// `sink`, and an `[options]` table.
+    #[clap(short = 'f', long = "from-file", value_name = "FILE")]
+    from_file: Option<PathBuf>,
+
+    /// Open `$EDITOR` on a librdkafka template instead of taking values from
+    /// the command line.
+    #[clap(long, conflicts_with = "from_file")]
+    edit: bool,
+
+    /// `key=value` options (e.g. `group.id=my-group`).
+    #[clap(value_name = "KEY=VALUE", value_parser = parse_kv_arg, trailing_var_arg = true, num_args = 0..)]
+    options: Vec<(String, String)>,
+}
+
+pub async fn run_create(State(env): State<CliEnv>, opts: &Create) -> Result<()> {
+    if opts.edit && (!opts.options.is_empty() || opts.source.is_some() || opts.sink.is_some()) {
+        bail!(
+            "--edit cannot be combined with positional arguments; pass everything through the editor"
+        );
+    }
+    if opts.from_file.is_some() && !opts.options.is_empty() {
+        bail!("--from-file cannot be combined with positional KEY=VALUE options");
+    }
+
+    let (source, sink, options) = if let Some(path) = opts.from_file.as_ref() {
+        let mut full = parse_properties_file(path, "options")?;
+        let source = opts
+            .source
+            .clone()
+            .or_else(|| full.remove("source"))
+            .context("`source` was not provided on the CLI nor in the file")?;
+        let sink = opts
+            .sink
+            .clone()
+            .or_else(|| full.remove("sink"))
+            .context("`sink` was not provided on the CLI nor in the file")?;
+        (source, sink, full)
+    } else if opts.edit {
+        let (source, sink, options) = edit_template(&env)?;
+        (source, sink, options)
+    } else {
+        let source = opts
+            .source
+            .clone()
+            .context("`source` is required (or pass --from-file/--edit)")?;
+        let sink = opts
+            .sink
+            .clone()
+            .context("`sink` is required (or pass --from-file/--edit)")?;
+        let options = collect_kv_pairs(opts.options.iter().cloned())?;
+        (source, sink, options)
+    };
+
+    let client = AdminClient::new(&env).await?;
+
+    let source_uri: Uri = source
+        .parse()
+        .with_context(|| format!("invalid source URI `{source}`"))?;
+    let sink_uri: Uri = sink
+        .parse()
+        .with_context(|| format!("invalid sink URI `{sink}`"))?;
+
+    print_summary(&source, &sink, &options, None);
+    confirm_or_exit("Create this subscription?")?;
+
+    let response = client
+        .create_subscription(CreateSubscriptionRequest {
+            source: source_uri,
+            sink: sink_uri,
+            options: if options.is_empty() {
+                None
+            } else {
+                Some(options)
+            },
+        })
+        .await?
+        .into_body()
+        .await?;
+
+    c_success!("Subscription {} created", response.id);
+    Ok(())
+}
+
+fn print_summary(
+    source: &str,
+    sink: &str,
+    options: &HashMap<String, String>,
+    cluster: Option<&KafkaClusterResponse>,
+) {
+    let mut table = Table::new_styled();
+    table.add_kv_row("Source:", source);
+    table.add_kv_row("Sink:", sink);
+    if let Some(c) = cluster
+        && let Some(brokers) = kc_shared::brokers_property(&c.properties)
+    {
+        table.add_kv_row("Kafka brokers:", brokers);
+    }
+    table.add_kv_row("Options:", options.len());
+    c_println!("{table}");
+
+    if !options.is_empty() {
+        c_println!("{}", kc_shared::render_properties_table(options));
+    }
+}
+
+fn edit_template(env: &CliEnv) -> Result<(String, String, HashMap<String, String>)> {
+    let dir = tempdir().context("failed to create a temporary directory")?;
+    let path = dir.path().join("subscription.properties");
+    std::fs::write(
+        &path,
+        "# Define a subscription.\n\
+         # Format: librdkafka properties (key=value, # comments).\n\
+         # Required:\n\
+         #   source=kafka://<cluster_name>/<topic_name>\n\
+         #   sink=service://<service_name>/<handler_name>\n\
+         # All other keys are passed through as Kafka consumer options.\n\
+         #\n\
+         # Example:\n\
+         # source=kafka://my-cluster/orders\n\
+         # sink=service://Counter/count\n\
+         # group.id=order-processor\n\
+         \n",
+    )
+    .context("failed to write the editor template")?;
+
+    env.open_default_editor(&path)?;
+
+    let edited_text = std::fs::read_to_string(&path).context("failed to read the edited file")?;
+    let mut full = parse_librdkafka_properties(&edited_text)?;
+    let source = full
+        .remove("source")
+        .context("the edited file is missing `source=...`")?;
+    let sink = full
+        .remove("sink")
+        .context("the edited file is missing `sink=...`")?;
+    Ok((source, sink, full))
+}

--- a/cli/src/commands/subscriptions/create.rs
+++ b/cli/src/commands/subscriptions/create.rs
@@ -140,10 +140,12 @@ fn print_summary(
     {
         table.add_kv_row("Kafka brokers:", brokers);
     }
-    table.add_kv_row("Options:", options.len());
     c_println!("{table}");
 
-    if !options.is_empty() {
+    if options.is_empty() {
+        c_println!("Options: (none)");
+    } else {
+        c_println!("Options:");
         c_println!("{}", kc_shared::render_properties_table(options));
     }
 }

--- a/cli/src/commands/subscriptions/delete.rs
+++ b/cli/src/commands/subscriptions/delete.rs
@@ -1,0 +1,49 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::Result;
+use cling::prelude::*;
+use comfy_table::Table;
+
+use restate_cli_util::c_println;
+use restate_cli_util::c_success;
+use restate_cli_util::ui::console::{StyledTable, confirm_or_exit};
+
+use crate::cli_env::CliEnv;
+use crate::clients::{AdminClient, AdminClientInterface};
+
+#[derive(Run, Parser, Collect, Clone)]
+#[cling(run = "run_delete")]
+#[clap(visible_alias = "rm", alias = "remove")]
+pub struct Delete {
+    /// Subscription ID
+    id: String,
+}
+
+pub async fn run_delete(State(env): State<CliEnv>, opts: &Delete) -> Result<()> {
+    let client = AdminClient::new(&env).await?;
+    let sub = client.get_subscription(&opts.id).await?.into_body().await?;
+
+    let mut table = Table::new_styled();
+    table.add_kv_row("ID:", sub.id.to_string());
+    table.add_kv_row("Source:", &sub.source);
+    table.add_kv_row("Sink:", &sub.sink);
+    c_println!("{table}");
+
+    confirm_or_exit(&format!("Delete subscription {}?", opts.id))?;
+
+    client
+        .delete_subscription(&opts.id)
+        .await?
+        .success_or_error()?;
+
+    c_success!("Subscription {} deleted", &opts.id);
+    Ok(())
+}

--- a/cli/src/commands/subscriptions/describe.rs
+++ b/cli/src/commands/subscriptions/describe.rs
@@ -1,0 +1,79 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::Result;
+use cling::prelude::*;
+use comfy_table::Table;
+use tracing::debug;
+
+use restate_cli_util::ui::console::StyledTable;
+use restate_cli_util::ui::watcher::Watch;
+use restate_cli_util::{c_println, c_title};
+
+use crate::cli_env::CliEnv;
+use crate::clients::{AdminClient, AdminClientInterface};
+use crate::commands::kafkaclusters::utils as kc_shared;
+use crate::commands::subscriptions::kafka_cluster_from_source;
+
+#[derive(Run, Parser, Collect, Clone)]
+#[cling(run = "run_describe")]
+#[clap(visible_alias = "get")]
+pub struct Describe {
+    /// Subscription ID
+    id: String,
+
+    #[clap(flatten)]
+    watch: Watch,
+}
+
+pub async fn run_describe(State(env): State<CliEnv>, opts: &Describe) -> Result<()> {
+    opts.watch.run(|| describe(&env, opts)).await
+}
+
+async fn describe(env: &CliEnv, opts: &Describe) -> Result<()> {
+    let client = AdminClient::new(env).await?;
+    let sub = client.get_subscription(&opts.id).await?.into_body().await?;
+
+    let mut summary = Table::new_styled();
+    summary.add_kv_row("ID:", sub.id.to_string());
+    summary.add_kv_row("Source:", &sub.source);
+    summary.add_kv_row("Sink:", &sub.sink);
+
+    // Best-effort cluster resolution. Failures are logged at debug only — we
+    // never want describe to fail because the cluster lookup tripped.
+    if let Some(cluster_name) = kafka_cluster_from_source(&sub.source) {
+        match client
+            .get_kafka_cluster(&cluster_name, false)
+            .await
+            .map_err(anyhow::Error::from)
+        {
+            Ok(envelope) => match envelope.into_body().await {
+                Ok(cluster) => {
+                    if let Some(brokers) = kc_shared::brokers_property(&cluster.properties) {
+                        summary.add_kv_row("Kafka brokers:", brokers);
+                    }
+                }
+                Err(e) => debug!("could not load Kafka cluster {cluster_name}: {e}"),
+            },
+            Err(e) => debug!("could not request Kafka cluster {cluster_name}: {e}"),
+        }
+    }
+
+    c_title!("📜", "Subscription");
+    c_println!("{summary}");
+
+    if !sub.options.is_empty() {
+        c_println!();
+        c_title!("⚙️", "Options");
+        c_println!("{}", kc_shared::render_properties_table(&sub.options));
+    }
+
+    Ok(())
+}

--- a/cli/src/commands/subscriptions/list.rs
+++ b/cli/src/commands/subscriptions/list.rs
@@ -1,0 +1,70 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::Result;
+use cling::prelude::*;
+use comfy_table::{Cell, Table};
+
+use restate_cli_util::c_println;
+use restate_cli_util::ui::console::StyledTable;
+use restate_cli_util::ui::watcher::Watch;
+
+use crate::cli_env::CliEnv;
+use crate::clients::{AdminClient, AdminClientInterface};
+
+#[derive(Run, Parser, Collect, Clone)]
+#[cling(run = "run_list")]
+#[clap(visible_alias = "ls")]
+pub struct List {
+    /// Filter by exact source URI (e.g. `kafka://my-cluster/orders`)
+    #[clap(long)]
+    source: Option<String>,
+
+    /// Filter by exact sink URI (e.g. `service://Counter/count`)
+    #[clap(long)]
+    sink: Option<String>,
+
+    #[clap(flatten)]
+    watch: Watch,
+}
+
+pub async fn run_list(State(env): State<CliEnv>, opts: &List) -> Result<()> {
+    opts.watch.run(|| list(&env, opts)).await
+}
+
+async fn list(env: &CliEnv, opts: &List) -> Result<()> {
+    let client = AdminClient::new(env).await?;
+    let mut subs = client
+        .list_subscriptions(opts.sink.as_deref(), opts.source.as_deref())
+        .await?
+        .into_body()
+        .await?
+        .subscriptions;
+
+    if subs.is_empty() {
+        c_println!("No subscriptions registered.");
+        return Ok(());
+    }
+
+    subs.sort_by(|a, b| a.id.to_string().cmp(&b.id.to_string()));
+
+    let mut table = Table::new_styled();
+    table.set_styled_header(vec!["ID", "SOURCE", "SINK", "OPTIONS"]);
+    for sub in subs {
+        table.add_row(vec![
+            Cell::new(sub.id.to_string()),
+            Cell::new(sub.source),
+            Cell::new(sub.sink),
+            Cell::new(sub.options.len()),
+        ]);
+    }
+    c_println!("{table}");
+    Ok(())
+}

--- a/cli/src/commands/subscriptions/mod.rs
+++ b/cli/src/commands/subscriptions/mod.rs
@@ -1,0 +1,40 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod create;
+mod delete;
+mod describe;
+mod list;
+
+use cling::prelude::*;
+
+#[derive(Run, Subcommand, Clone)]
+#[clap(visible_alias = "sub", alias = "subscription")]
+pub enum Subscriptions {
+    /// List the registered subscriptions
+    List(list::List),
+    /// Register a new subscription
+    Create(create::Create),
+    /// Print detailed information about a subscription
+    Describe(describe::Describe),
+    /// Remove a subscription
+    Delete(delete::Delete),
+}
+
+/// Parses `kafka://<cluster>/<topic>` and returns the cluster name. Returns
+/// `None` for any other scheme. Used to opportunistically resolve the
+/// referenced cluster's broker addresses on `describe`.
+pub(crate) fn kafka_cluster_from_source(source: &str) -> Option<String> {
+    let uri: http::Uri = source.parse().ok()?;
+    if uri.scheme_str() != Some("kafka") {
+        return None;
+    }
+    uri.host().map(|s| s.to_string())
+}

--- a/cli/src/commands/subscriptions/mod.rs
+++ b/cli/src/commands/subscriptions/mod.rs
@@ -21,6 +21,7 @@ pub enum Subscriptions {
     /// List the registered subscriptions
     List(list::List),
     /// Register a new subscription
+    #[clap(alias = "register")]
     Create(create::Create),
     /// Print detailed information about a subscription
     Describe(describe::Describe),

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -15,6 +15,7 @@ mod cli_env;
 mod clients;
 mod commands;
 mod ui;
+mod util;
 
 pub use app::CliApp;
 pub(crate) use restate_cli_util::ui::console;

--- a/cli/src/util/mod.rs
+++ b/cli/src/util/mod.rs
@@ -8,18 +8,4 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-#[cfg(feature = "cloud")]
-pub mod cloud;
-pub mod completions;
-pub mod config;
-pub mod deployments;
-#[cfg(feature = "dev-cmd")]
-pub mod dev;
-pub mod examples;
-pub mod invocations;
-pub mod kafkaclusters;
-pub mod services;
-pub mod sql;
-pub mod state;
-pub mod subscriptions;
-pub mod whoami;
+pub mod properties;

--- a/cli/src/util/properties.rs
+++ b/cli/src/util/properties.rs
@@ -1,0 +1,297 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Shared parsing helpers for `KEY=VALUE` style configuration maps used by the
+//! Kafka cluster and subscription commands. Inputs are accepted as:
+//!
+//! * Trailing positional `key=value` pairs (`parse_kv_arg`),
+//! * librdkafka-style properties files (`.properties`, `.conf`, or stdin),
+//! * TOML files with a `[properties]` (or caller-supplied) table.
+
+use std::collections::HashMap;
+use std::io::Read;
+use std::path::Path;
+
+use anyhow::{Context, Result, anyhow, bail};
+
+/// Placeholder string used by the admin server in place of redacted secret
+/// values returned from `GET` responses.
+pub const REDACTION_PLACEHOLDER: &str = "***";
+
+/// Parses a single `KEY=VALUE` argument. The first `=` separates the key from
+/// the value, so values may contain `=` (e.g. `sasl.jaas.config=... password=foo`).
+///
+/// Used as a clap `value_parser`.
+pub fn parse_kv_arg(s: &str) -> Result<(String, String), String> {
+    let (k, v) = s
+        .split_once('=')
+        .ok_or_else(|| format!("expected KEY=VALUE, got `{s}`"))?;
+    let k = k.trim();
+    if k.is_empty() {
+        return Err(format!("property key is empty in `{s}`"));
+    }
+    Ok((k.to_string(), v.to_string()))
+}
+
+/// Collects a slice of `(key, value)` pairs into a map, rejecting duplicates so
+/// the user notices `--set` typos rather than silently losing the first value.
+pub fn collect_kv_pairs<I>(pairs: I) -> Result<HashMap<String, String>>
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    let mut out = HashMap::new();
+    for (k, v) in pairs {
+        if out.insert(k.clone(), v).is_some() {
+            bail!("property `{k}` was specified more than once");
+        }
+    }
+    Ok(out)
+}
+
+/// Reads a properties file. Format is detected from the path extension:
+///
+/// * `.properties` / `.conf` → librdkafka-style (one `key=value` per line, `#`
+///   comments).
+/// * `-` → read from stdin and parse as librdkafka-style.
+/// * anything else → TOML; the map is taken from `toml_table` (typically
+///   `"properties"` or `"options"`), or the whole document if `toml_table`
+///   refers to the root and the document is a flat string-string table.
+pub fn parse_properties_file(path: &Path, toml_table: &str) -> Result<HashMap<String, String>> {
+    let raw = if path == Path::new("-") {
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .context("failed to read properties from stdin")?;
+        buf
+    } else {
+        std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read properties file `{}`", path.display()))?
+    };
+
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase());
+
+    match ext.as_deref() {
+        Some("properties") | Some("conf") | Some("env") => parse_librdkafka_properties(&raw),
+        Some("toml") => parse_toml_properties(&raw, toml_table),
+        _ if path == Path::new("-") => parse_librdkafka_properties(&raw),
+        _ => {
+            // Best-effort: try TOML first, then fall back to librdkafka.
+            parse_toml_properties(&raw, toml_table)
+                .or_else(|_| parse_librdkafka_properties(&raw))
+                .with_context(|| {
+                    format!(
+                        "could not parse `{}` as TOML or librdkafka properties",
+                        path.display()
+                    )
+                })
+        }
+    }
+}
+
+/// Parses a flat librdkafka-style properties string. Blank lines and lines
+/// starting with `#` (after trimming) are ignored. Each value line is split on
+/// the first `=`. Whitespace around the key is trimmed; the value is taken
+/// verbatim after trimming a single leading space (matching librdkafka).
+pub fn parse_librdkafka_properties(s: &str) -> Result<HashMap<String, String>> {
+    let mut out = HashMap::new();
+    for (lineno, raw_line) in s.lines().enumerate() {
+        let trimmed = raw_line.trim_start();
+        if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with(';') {
+            continue;
+        }
+        let (k, v) = trimmed.split_once('=').ok_or_else(|| {
+            anyhow!(
+                "line {}: expected `key=value`, got `{}`",
+                lineno + 1,
+                raw_line
+            )
+        })?;
+        let key = k.trim().to_string();
+        if key.is_empty() {
+            bail!("line {}: empty property key", lineno + 1);
+        }
+        // Strip a single leading space so `key = value` works as well as
+        // `key=value`. Trailing whitespace (including \r from CRLF) is dropped.
+        let value = v.strip_prefix(' ').unwrap_or(v).trim_end().to_string();
+        if out.insert(key.clone(), value).is_some() {
+            bail!(
+                "line {}: property `{}` is defined more than once",
+                lineno + 1,
+                key
+            );
+        }
+    }
+    Ok(out)
+}
+
+fn parse_toml_properties(s: &str, table: &str) -> Result<HashMap<String, String>> {
+    let doc: toml::Value = toml::from_str(s).context("failed to parse properties file as TOML")?;
+
+    let table_value = doc
+        .as_table()
+        .and_then(|t| t.get(table))
+        .ok_or_else(|| anyhow!("missing `[{table}]` table in TOML properties file"))?;
+
+    let table_map = table_value
+        .as_table()
+        .ok_or_else(|| anyhow!("`[{table}]` is not a TOML table"))?;
+
+    let mut out = HashMap::with_capacity(table_map.len());
+    for (k, v) in table_map {
+        let s = v.as_str().ok_or_else(|| {
+            anyhow!(
+                "`{table}.{k}` must be a string (TOML type was {:?})",
+                v.type_str()
+            )
+        })?;
+        out.insert(k.clone(), s.to_string());
+    }
+    Ok(out)
+}
+
+/// Serializes a properties map as a librdkafka-style `key=value` document with
+/// keys sorted alphabetically. Properties whose value equals
+/// [`REDACTION_PLACEHOLDER`] are emitted as commented-out `# REDACTED:` lines
+/// so a round-trip through an editor never accidentally overwrites a real
+/// secret with `***`.
+pub fn serialize_librdkafka_properties(map: &HashMap<String, String>) -> String {
+    let mut keys: Vec<&String> = map.keys().collect();
+    keys.sort();
+
+    let mut out = String::new();
+    for k in keys {
+        let v = &map[k];
+        if v == REDACTION_PLACEHOLDER {
+            out.push_str("# REDACTED: ");
+            out.push_str(k);
+            out.push_str("=\n");
+        } else {
+            out.push_str(k);
+            out.push('=');
+            out.push_str(v);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+/// Returns the keys whose value is the redaction placeholder.
+pub fn redacted_keys(map: &HashMap<String, String>) -> Vec<String> {
+    let mut keys: Vec<String> = map
+        .iter()
+        .filter(|(_, v)| *v == REDACTION_PLACEHOLDER)
+        .map(|(k, _)| k.clone())
+        .collect();
+    keys.sort();
+    keys
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kv_arg_splits_on_first_equals() {
+        assert_eq!(
+            parse_kv_arg("bootstrap.servers=a:9092,b:9092").unwrap(),
+            ("bootstrap.servers".to_string(), "a:9092,b:9092".to_string())
+        );
+        // value containing =
+        assert_eq!(
+            parse_kv_arg("sasl.jaas.config=foo=bar baz=qux").unwrap(),
+            (
+                "sasl.jaas.config".to_string(),
+                "foo=bar baz=qux".to_string()
+            )
+        );
+        assert!(parse_kv_arg("no-equals").is_err());
+        assert!(parse_kv_arg("=oops").is_err());
+    }
+
+    #[test]
+    fn librdkafka_properties_round_trip() {
+        let input = "\
+            # a comment\n\
+            \n\
+            bootstrap.servers=broker:9092\n\
+            client.id = restate\n\
+            sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username=u password=p\n\
+            ; semicolon comment\n\
+        ";
+        let map = parse_librdkafka_properties(input).unwrap();
+        assert_eq!(map.get("bootstrap.servers").unwrap(), "broker:9092");
+        assert_eq!(map.get("client.id").unwrap(), "restate");
+        assert!(
+            map.get("sasl.jaas.config").unwrap().ends_with("password=p"),
+            "value with `=` survived: {:?}",
+            map.get("sasl.jaas.config")
+        );
+
+        let serialized = serialize_librdkafka_properties(&map);
+        let round = parse_librdkafka_properties(&serialized).unwrap();
+        assert_eq!(map, round);
+    }
+
+    #[test]
+    fn librdkafka_rejects_duplicate_keys() {
+        let err = parse_librdkafka_properties("a=1\na=2\n").unwrap_err();
+        assert!(err.to_string().contains("more than once"), "{err}");
+    }
+
+    #[test]
+    fn redacted_values_are_commented_in_serialization() {
+        let mut map = HashMap::new();
+        map.insert("bootstrap.servers".to_string(), "broker:9092".to_string());
+        map.insert("sasl.password".to_string(), REDACTION_PLACEHOLDER.into());
+
+        let s = serialize_librdkafka_properties(&map);
+        assert!(s.contains("bootstrap.servers=broker:9092"), "{s}");
+        assert!(s.contains("# REDACTED: sasl.password="), "{s}");
+
+        let parsed = parse_librdkafka_properties(&s).unwrap();
+        // Redacted line is a comment and must not round-trip into the map.
+        assert!(!parsed.contains_key("sasl.password"));
+        assert_eq!(redacted_keys(&map), vec!["sasl.password".to_string()]);
+    }
+
+    #[test]
+    fn toml_properties_table() {
+        let input = r#"
+            [properties]
+            "bootstrap.servers" = "broker:9092"
+            "client.id" = "restate"
+        "#;
+        let map = parse_toml_properties(input, "properties").unwrap();
+        assert_eq!(map.get("bootstrap.servers").unwrap(), "broker:9092");
+        assert_eq!(map.get("client.id").unwrap(), "restate");
+    }
+
+    #[test]
+    fn toml_properties_rejects_non_string_values() {
+        let input = r#"
+            [properties]
+            "request.timeout.ms" = 30000
+        "#;
+        let err = parse_toml_properties(input, "properties").unwrap_err();
+        assert!(err.to_string().contains("must be a string"), "{err}");
+    }
+
+    #[test]
+    fn collect_kv_pairs_rejects_dupes() {
+        let pairs = vec![
+            ("a".to_string(), "1".to_string()),
+            ("a".to_string(), "2".to_string()),
+        ];
+        assert!(collect_kv_pairs(pairs).is_err());
+    }
+}

--- a/release-notes/unreleased/4546-cli-kafkaclusters-subscriptions.md
+++ b/release-notes/unreleased/4546-cli-kafkaclusters-subscriptions.md
@@ -1,0 +1,33 @@
+# Release Notes for Issue #4546: CLI commands for Kafka clusters and subscriptions
+
+## New Feature
+
+### What Changed
+The `restate` CLI can now manage Kafka clusters and subscriptions directly,
+backed by the dynamic Kafka cluster admin API from #4224.
+
+```
+restate kafkaclusters | kc        list | create | describe | edit | patch | delete
+restate subscriptions | sub       list | create | describe | delete
+```
+
+### Examples
+
+```bash
+# Kafka clusters
+restate kc create my-cluster bootstrap.servers=broker:9092 security.protocol=SASL_SSL
+restate kc create my-cluster -f confluent-cloud.properties
+restate kc edit my-cluster
+restate kc patch my-cluster --set client.id=restate-cli
+
+# Subscriptions
+restate sub create kafka://my-cluster/orders service://Counter/count group.id=g1
+restate sub list
+restate sub describe <id>
+```
+
+Run `restate kc --help` or `restate sub --help` for everything else.
+
+### Related Issues
+- Issue #4546: CLI Kafka clusters and subscription commands
+- Issue #4224: Configure KafkaCluster dynamically


### PR DESCRIPTION
(AI slop)

```
# Kafka clusters
restate kc create my-cluster bootstrap.servers=broker:9092 security.protocol=SASL_SSL
restate kc create my-cluster -f confluent-cloud.properties
restate kc edit my-cluster
restate kc patch my-cluster --set client.id=restate-cli

# Subscriptions
restate sub create kafka://my-cluster/orders service://Counter/count group.id=g1
restate sub list
restate sub describe <id>
```