### PR TITLE
[service-protocol] Respect service-protocol-version for message encode/decode

### DIFF
--- a/crates/service-protocol-v4/src/lib.rs
+++ b/crates/service-protocol-v4/src/lib.rs
@@ -19,6 +19,18 @@ pub mod message_codec;
 // We need to allow dead code because the entry-codec feature only uses a subset of the defined
 // service protocol messages. Otherwise, crates depending only on this feature fail clippy.
 #[allow(dead_code)]
-mod proto {
+pub mod proto {
     include!(concat!(env!("OUT_DIR"), "/dev.restate.service.protocol.rs"));
+
+    #[cfg(feature = "message-codec")]
+    crate::message_codec::default_encode_decode!(
+        StartMessage,
+        SuspensionMessage,
+        ErrorMessage,
+        EndMessage,
+        CommandAckMessage,
+        ProposeRunCompletionMessage,
+        CallCommandMessage,
+        OneWayCallCommandMessage
+    );
 }

--- a/crates/service-protocol-v4/src/message_codec/encoding.rs
+++ b/crates/service-protocol-v4/src/message_codec/encoding.rs
@@ -19,13 +19,13 @@ use bytes_utils::SegmentedBuf;
 use tracing::warn;
 
 use restate_serde_util::ByteCount;
-use restate_types::service_protocol::ServiceProtocolVersion;
+use restate_types::{errors::GenericError, service_protocol::ServiceProtocolVersion};
 
 #[derive(Debug, codederror::CodedError, thiserror::Error)]
 #[code(restate_errors::RT0012)]
 pub enum EncodingError {
-    #[error("cannot decode message type {0:?}. This looks like a bug of the SDK. Reason: {1:?}")]
-    DecodeMessage(MessageType, #[source] prost::DecodeError),
+    #[error("cannot decode message type {0:?}. Reason: {1:?}")]
+    MessageEncoding(MessageType, #[source] MessageEncodingError),
     #[error(transparent)]
     UnknownMessageType(#[from] UnknownMessageType),
     #[error("hit message size limit: {0} >= {1}")]
@@ -33,6 +33,78 @@ pub enum EncodingError {
     MessageSizeLimit(usize, NonZeroUsize),
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum MessageEncodingError {
+    #[error("unknown service protocol version {0:?}")]
+    UnknownServiceProtocolVersion(ServiceProtocolVersion),
+    #[error("cannot encode message {0}")]
+    Encoding(
+        #[source]
+        #[from]
+        prost::EncodeError,
+    ),
+    #[error("cannot decode message {0}. This looks like a bug of the SDK.")]
+    Decoding(
+        #[source]
+        #[from]
+        prost::DecodeError,
+    ),
+    #[error(transparent)]
+    Generic(GenericError),
+}
+
+pub trait ServiceWireEncoder {
+    fn encode(
+        &self,
+        buf: &mut impl bytes::BufMut,
+        service_protocol_version: ServiceProtocolVersion,
+    ) -> Result<(), MessageEncodingError>;
+
+    fn encoded_len(&self, service_protocol_version: ServiceProtocolVersion) -> usize;
+}
+
+pub trait ServiceWireDecoder: Sized {
+    fn decode(
+        buf: impl bytes::Buf,
+        service_protocol_version: ServiceProtocolVersion,
+    ) -> Result<Self, MessageEncodingError>;
+}
+
+/// Implements [`ServiceWireEncoder`] and [`ServiceWireDecoder`] for the given protobuf message
+/// types by delegating directly to [`prost::Message`], ignoring the `service_protocol_version`.
+///
+/// Types that need version-specific encoding/decoding should implement the traits manually instead.
+macro_rules! default_encode_decode {
+    ($ty:ident) => {
+        impl crate::message_codec::ServiceWireEncoder for $ty {
+            fn encode(
+                &self,
+                buf: &mut impl bytes::BufMut,
+                _service_protocol_version: restate_types::service_protocol::ServiceProtocolVersion,
+            ) -> Result<(), crate::message_codec::MessageEncodingError> {
+                prost::Message::encode(self, buf).map_err(Into::into)
+            }
+
+            fn encoded_len(&self, _service_protocol_version: restate_types::service_protocol::ServiceProtocolVersion) -> usize {
+                prost::Message::encoded_len(self)
+            }
+        }
+
+        impl crate::message_codec::ServiceWireDecoder for $ty {
+            fn decode(
+                buf: impl bytes::Buf,
+                _service_protocol_version: restate_types::service_protocol::ServiceProtocolVersion,
+            ) -> Result<Self, crate::message_codec::MessageEncodingError> {
+                prost::Message::decode(buf).map_err(Into::into)
+            }
+        }
+    };
+    ($($ty:ident),*) => {
+        $($crate::message_codec::default_encode_decode!($ty);)*
+    }
+}
+
+pub(crate) use default_encode_decode;
 // --- Input message encoder
 
 // TODO: To reduce allocation overhead for small messages (completions, acks), we could
@@ -40,7 +112,9 @@ pub enum EncodingError {
 //  The key constraint is that it must not grow unbounded — the previous arena retained the
 //  high-water-mark capacity (up to 32 MiB) for the entire invocation lifetime, wasting
 //  memory across thousands of concurrent long-lived invocations. See #4364.
-pub struct Encoder;
+pub struct Encoder {
+    service_protocol_version: ServiceProtocolVersion,
+}
 
 impl Encoder {
     pub fn new(service_protocol_version: ServiceProtocolVersion) -> Self {
@@ -49,7 +123,9 @@ impl Encoder {
             ServiceProtocolVersion::Unspecified,
             "A protocol version should be specified"
         );
-        Self
+        Self {
+            service_protocol_version,
+        }
     }
 
     /// Encodes a message to bytes.
@@ -61,11 +137,11 @@ impl Encoder {
     // Todo: Once we merge thread-local buffer pools (https://github.com/restatedev/restate/pull/4366),
     //  we can consider passing in a reusable buffer.
     pub fn encode(&mut self, msg: Message) -> Bytes {
-        let len = 8 + msg.encoded_len();
+        let len = 8 + msg.encoded_len(self.service_protocol_version);
         let mut buf = BytesMut::with_capacity(len);
-        let header = generate_header(&msg);
+        let header = generate_header(&msg, self.service_protocol_version);
         buf.put_u64(header.into());
-        msg.encode(&mut buf).expect(
+        msg.encode(&mut buf, self.service_protocol_version).expect(
             "Encoding messages should be infallible, \
             this error indicates a bug in the invoker code. \
             Please contact the Restate developers.",
@@ -89,9 +165,12 @@ impl Encoder {
 }
 
 #[inline(always)]
-fn generate_header(msg: &Message) -> MessageHeader {
+fn generate_header(
+    msg: &Message,
+    service_protocol_version: ServiceProtocolVersion,
+) -> MessageHeader {
     let len: u32 = msg
-        .encoded_len()
+        .encoded_len(service_protocol_version)
         .try_into()
         .expect("Protocol messages can't be larger than u32");
     let ty = msg.ty();
@@ -104,6 +183,7 @@ fn generate_header(msg: &Message) -> MessageHeader {
 pub struct Decoder {
     buf: SegmentedBuf<Bytes>,
     state: DecoderState,
+    service_protocol_version: ServiceProtocolVersion,
     message_size_warning: NonZeroUsize,
     message_size_limit: NonZeroUsize,
 }
@@ -122,6 +202,7 @@ impl Decoder {
         Self {
             buf: SegmentedBuf::new(),
             state: DecoderState::WaitingHeader,
+            service_protocol_version,
             message_size_warning,
             message_size_limit,
         }
@@ -147,6 +228,7 @@ impl Decoder {
 
             if let Some(res) = self.state.decode(
                 &mut self.buf,
+                self.service_protocol_version,
                 self.message_size_warning,
                 self.message_size_limit,
             )? {
@@ -174,6 +256,7 @@ impl DecoderState {
     fn decode(
         &mut self,
         mut buf: impl Buf,
+        service_protocol_version: ServiceProtocolVersion,
         message_size_warning: NonZeroUsize,
         message_size_limit: NonZeroUsize,
     ) -> Result<Option<(MessageHeader, Message)>, EncodingError> {
@@ -207,8 +290,11 @@ impl DecoderState {
             DecoderState::WaitingPayload(h) => {
                 let msg = h
                     .message_type()
-                    .decode(buf.take(h.frame_length() as usize))
-                    .map_err(|e| EncodingError::DecodeMessage(h.message_type(), e))?;
+                    .decode(
+                        buf.take(h.frame_length() as usize),
+                        service_protocol_version,
+                    )
+                    .map_err(|e| EncodingError::MessageEncoding(h.message_type(), e))?;
                 res = Some((h, msg));
                 DecoderState::WaitingHeader
             }
@@ -316,7 +402,7 @@ mod tests {
 
         let mut encoder = Encoder::new(ServiceProtocolVersion::V1);
         let message = Message::InputCommand((0..=u8::MAX).collect::<Vec<_>>().into());
-        let expected_msg_size = message.encoded_len();
+        let expected_msg_size = message.encoded_len(ServiceProtocolVersion::V1);
         let msg = encoder.encode(message);
 
         decoder.push(msg.clone());

--- a/crates/service-protocol-v4/src/message_codec/mod.rs
+++ b/crates/service-protocol-v4/src/message_codec/mod.rs
@@ -17,17 +17,17 @@ use std::time::Duration;
 mod encoding;
 mod header;
 
-pub use encoding::{Decoder, Encoder, EncodingError};
+pub(crate) use encoding::default_encode_decode;
+pub use encoding::{
+    Decoder, Encoder, EncodingError, MessageEncodingError, ServiceWireDecoder, ServiceWireEncoder,
+};
 pub use header::MessageHeader;
 pub use proto::start_message::StateEntry;
 use restate_types::journal_v2::{
     CommandIndex, CommandType, CompletionType, EntryType, NotificationType,
 };
 
-/// Protobuf protocol messages
-pub mod proto {
-    pub use crate::proto::*;
-}
+pub use crate::proto;
 
 const CUSTOM_MESSAGE_MASK: u16 = 0xFC00;
 
@@ -66,22 +66,22 @@ macro_rules! gen_message {
 
     (@gen_message_enum_encoded_len [] -> [$($body:tt)*]) => {
         impl Message {
-            pub(crate) fn encoded_len(&self) -> usize {
-                match self {
+            pub(crate) fn encoded_len(&self, service_protocol_version: restate_types::service_protocol::ServiceProtocolVersion) -> usize {
+                match (self, service_protocol_version) {
                     $($body)*
-                    Message::Custom(_, b) => b.len()
+                    (Message::Custom(_, b), _) => b.len()
                 }
             }
         }
     };
     (@gen_message_enum_encoded_len [$variant:ident Control = $id:literal, $($tail:tt)*] -> [$($body:tt)*]) => {
-        gen_message!(@gen_message_enum_encoded_len [$($tail)*] -> [Message::$variant(msg) => prost::Message::encoded_len(msg), $($body)*]);
+        paste::paste! { gen_message!(@gen_message_enum_encoded_len [$($tail)*] -> [(Message::$variant(msg), service_protocol_version) => <proto::[< $variant Message >] as $crate::message_codec::encoding::ServiceWireEncoder>::encoded_len(msg, service_protocol_version), $($body)*]); }
     };
     (@gen_message_enum_encoded_len [$variant:ident $ty:ident noparse $($ignore:ident)* = $id:literal, $($tail:tt)*] -> [$($body:tt)*]) => {
-        paste::paste! { gen_message!(@gen_message_enum_encoded_len [$($tail)*] -> [Message::[< $variant $ty >](b) => b.len(), $($body)*]); }
+        paste::paste! { gen_message!(@gen_message_enum_encoded_len [$($tail)*] -> [(Message::[< $variant $ty >](b), _) => b.len(), $($body)*]); }
     };
     (@gen_message_enum_encoded_len [$variant:ident $ty:ident $($ignore:ident)* = $id:literal, $($tail:tt)*] -> [$($body:tt)*]) => {
-        paste::paste! { gen_message!(@gen_message_enum_encoded_len [$($tail)*] -> [Message::[< $variant $ty >](msg) => prost::Message::encoded_len(msg), $($body)*]); }
+        paste::paste! { gen_message!(@gen_message_enum_encoded_len [$($tail)*] -> [(Message::[< $variant $ty >](msg), service_protocol_version) => <proto::[< $variant $ty Message >] as $crate::message_codec::encoding::ServiceWireEncoder>::encoded_len(msg, service_protocol_version), $($body)*]); }
     };
 
     (@gen_message_enum_ty [] -> [$($body:tt)*]) => {
@@ -103,23 +103,23 @@ macro_rules! gen_message {
 
     (@gen_message_enum_encode [] -> [$($body:tt)*]) => {
         impl Message {
-            pub(crate) fn encode(&self, buf: &mut impl bytes::BufMut) -> Result<(), prost::EncodeError> {
-                match (self, buf) {
+            pub(crate) fn encode(&self, buf: &mut impl bytes::BufMut, service_protocol_version: restate_types::service_protocol::ServiceProtocolVersion) -> Result<(), $crate::message_codec::encoding::MessageEncodingError> {
+                match (self, service_protocol_version, buf) {
                     $($body)*
-                    (Message::Custom(_, b), buf) => buf.put(b.clone())
+                    (Message::Custom(_, b), _, buf) => buf.put(b.clone())
                 };
                 Ok(())
             }
         }
     };
     (@gen_message_enum_encode [$variant:ident Control = $id:literal, $($tail:tt)*] -> [$($body:tt)*]) => {
-        gen_message!(@gen_message_enum_encode [$($tail)*] -> [(Message::$variant(msg), buf) => prost::Message::encode(msg, buf)?, $($body)*]);
+        paste::paste! { gen_message!(@gen_message_enum_encode [$($tail)*] -> [(Message::$variant(msg), service_protocol_version, buf) => <proto::[< $variant Message >] as $crate::message_codec::encoding::ServiceWireEncoder>::encode(msg, buf, service_protocol_version)?, $($body)*]); }
     };
     (@gen_message_enum_encode [$variant:ident $ty:ident noparse $($ignore:ident)* = $id:literal, $($tail:tt)*] -> [$($body:tt)*]) => {
-        paste::paste! { gen_message!(@gen_message_enum_encode [$($tail)*] -> [(Message::[< $variant $ty >](b), buf) => buf.put(b.clone()), $($body)*]); }
+        paste::paste! { gen_message!(@gen_message_enum_encode [$($tail)*] -> [(Message::[< $variant $ty >](b), _, buf) => buf.put(b.clone()), $($body)*]); }
     };
     (@gen_message_enum_encode [$variant:ident $ty:ident $($ignore:ident)* = $id:literal, $($tail:tt)*] -> [$($body:tt)*]) => {
-        paste::paste! { gen_message!(@gen_message_enum_encode [$($tail)*] -> [(Message::[< $variant $ty >](msg), buf) => prost::Message::encode(msg, buf)?, $($body)*]); }
+        paste::paste! { gen_message!(@gen_message_enum_encode [$($tail)*] -> [(Message::[< $variant $ty >](msg), service_protocol_version, buf) => <proto::[< $variant $ty Message >] as $crate::message_codec::encoding::ServiceWireEncoder>::encode(msg, buf, service_protocol_version)?, $($body)*]); }
     };
 
     (@gen_message_enum_proto_debug [] -> [$($body:tt)*]) => {
@@ -181,22 +181,22 @@ macro_rules! gen_message {
 
     (@gen_message_type_enum_decode [] -> [$($body:tt)*]) => {
         impl MessageType {
-            pub(crate) fn decode(&self, buf: impl bytes::Buf) -> Result<Message, prost::DecodeError> {
-                match (self, buf) {
+            pub(crate) fn decode(&self, buf: impl bytes::Buf,  service_protocol_version: restate_types::service_protocol::ServiceProtocolVersion) -> Result<Message, $crate::message_codec::encoding::MessageEncodingError> {
+                match (self, buf, service_protocol_version) {
                     $($body)*
-                    (MessageType::Custom(t), mut buf) => Ok(Message::Custom(*t, buf.copy_to_bytes(buf.remaining())))
+                    (MessageType::Custom(t), mut buf, _) => Ok(Message::Custom(*t, buf.copy_to_bytes(buf.remaining())))
                 }
             }
         }
     };
     (@gen_message_type_enum_decode [$variant:ident Control = $id:literal, $($tail:tt)*] -> [$($body:tt)*]) => {
-        paste::paste! { gen_message!(@gen_message_type_enum_decode [$($tail)*] -> [(MessageType::$variant, buf) => Ok(Message::$variant(<proto::[< $variant Message >] as prost::Message>::decode(buf)?)), $($body)*]); }
+        paste::paste! { gen_message!(@gen_message_type_enum_decode [$($tail)*] -> [(MessageType::$variant, buf, service_protocol_version) => Ok(Message::$variant(<proto::[< $variant Message >] as $crate::message_codec::encoding::ServiceWireDecoder>::decode(buf, service_protocol_version)?)), $($body)*]); }
     };
     (@gen_message_type_enum_decode [$variant:ident $ty:ident noparse $($ignore:ident)* = $id:literal, $($tail:tt)*] -> [$($body:tt)*]) => {
-        paste::paste! { gen_message!(@gen_message_type_enum_decode [$($tail)*] -> [(MessageType::[< $variant $ty >], mut buf) => Ok(Message::[< $variant $ty >](buf.copy_to_bytes(buf.remaining()))), $($body)*]); }
+        paste::paste! { gen_message!(@gen_message_type_enum_decode [$($tail)*] -> [(MessageType::[< $variant $ty >], mut buf, _) => Ok(Message::[< $variant $ty >](buf.copy_to_bytes(buf.remaining()))), $($body)*]); }
     };
     (@gen_message_type_enum_decode [$variant:ident $ty:ident $($ignore:ident)* = $id:literal, $($tail:tt)*] -> [$($body:tt)*]) => {
-        paste::paste! { gen_message!(@gen_message_type_enum_decode [$($tail)*] -> [(MessageType::[< $variant $ty >], buf) => Ok(Message::[< $variant $ty >](<proto::[< $variant $ty Message >] as prost::Message>::decode(buf)?)), $($body)*]); }
+        paste::paste! { gen_message!(@gen_message_type_enum_decode [$($tail)*] -> [(MessageType::[< $variant $ty >], buf, service_protocol_version) => Ok(Message::[< $variant $ty >](<proto::[< $variant $ty Message >] as $crate::message_codec::encoding::ServiceWireDecoder>::decode(buf, service_protocol_version)?)), $($body)*]); }
     };
 
     (@gen_to_id [] -> [$($variant:ident, $id:literal,)*]) => {


### PR DESCRIPTION
[service-protocol] Respect service-protocol-version for message encode/decode

Summary:
This PR allows the messages (MessageType) to know the current service-protocol-version
and then decide how to decode/encode to work the support version for the deployment.

Note: For opaque messages, these are written as is to bifrost, and hence can't be verified against
the select protocol-version.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4600).
* #4601
* __->__ #4600