### PR TITLE
Enable zstd compression for the Kafka ingress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6757,6 +6757,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "sasl2-sys",
+ "zstd-sys",
 ]
 
 [[package]]

--- a/crates/ingress-kafka/Cargo.toml
+++ b/crates/ingress-kafka/Cargo.toml
@@ -41,7 +41,7 @@ parking_lot = { workspace = true }
 # https://github.com/fede1024/rust-rdkafka/pull/803. The PR bumps librdkafka to 2.12.1 and enables WITH_CURL for
 # librdkafka if the feature curl-static is enabled. Additionally, it cherry-picks https://github.com/confluentinc/librdkafka/pull/5182
 # which prevents pulling in curl if it is not activated. The additional fixes in fix-build-script fix the musl build.
-rdkafka = { version = "0.38", git = "https://github.com/restatedev/rust-rdkafka.git", rev = "e92cad90eff797a0dc29fa524cabb89b602ae234", features = ["libz-static", "cmake-build", "ssl-vendored"] }
+rdkafka = { version = "0.38", git = "https://github.com/restatedev/rust-rdkafka.git", rev = "e92cad90eff797a0dc29fa524cabb89b602ae234", features = ["libz-static", "cmake-build", "ssl-vendored", "zstd"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync", "rt"] }
 tracing = { workspace = true }

--- a/release-notes/unreleased/4599-kafka-zstd-support.md
+++ b/release-notes/unreleased/4599-kafka-zstd-support.md
@@ -1,0 +1,19 @@
+# Release Notes for Issue #4599: Add zstd compression support for Kafka consumer
+
+## New Feature
+
+### What Changed
+The Kafka consumer now supports zstd-compressed topics. Previously, only gzip, snappy,
+and lz4 compression were supported. Consuming from a zstd-compressed topic would fail
+with a `Decompression (codec 0x4) failed: Local: Not implemented` error.
+
+### Why This Matters
+zstd is a widely used Kafka compression codec. Restate now supports all four Kafka
+compression codecs: gzip, snappy, lz4, and zstd.
+
+### Impact on Users
+- Kafka subscriptions to zstd-compressed topics now work out of the box.
+- No configuration changes required.
+
+### Related Issues
+- Issue #4599

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -95,8 +95,8 @@ prost-types = { version = "0.14" }
 protobuf = { version = "2", default-features = false, features = ["with-bytes"] }
 quanta = { version = "0.12" }
 quote = { version = "1" }
-rdkafka = { git = "https://github.com/restatedev/rust-rdkafka.git", rev = "e92cad90eff797a0dc29fa524cabb89b602ae234", features = ["cmake-build", "curl-static", "gssapi-vendored", "libz-static", "ssl-vendored"] }
-rdkafka-sys = { git = "https://github.com/restatedev/rust-rdkafka.git", rev = "e92cad90eff797a0dc29fa524cabb89b602ae234", default-features = false, features = ["cmake-build", "curl-static", "gssapi-vendored", "libz-static", "ssl-vendored"] }
+rdkafka = { git = "https://github.com/restatedev/rust-rdkafka.git", rev = "e92cad90eff797a0dc29fa524cabb89b602ae234", features = ["cmake-build", "curl-static", "gssapi-vendored", "libz-static", "ssl-vendored", "zstd"] }
+rdkafka-sys = { git = "https://github.com/restatedev/rust-rdkafka.git", rev = "e92cad90eff797a0dc29fa524cabb89b602ae234", default-features = false, features = ["cmake-build", "curl-static", "gssapi-vendored", "libz-static", "ssl-vendored", "zstd"] }
 regex = { version = "1" }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "std", "unicode"] }
 regex-syntax = { version = "0.8" }
@@ -226,8 +226,8 @@ prost-types = { version = "0.14" }
 protobuf = { version = "2", default-features = false, features = ["with-bytes"] }
 quanta = { version = "0.12" }
 quote = { version = "1" }
-rdkafka = { git = "https://github.com/restatedev/rust-rdkafka.git", rev = "e92cad90eff797a0dc29fa524cabb89b602ae234", features = ["cmake-build", "curl-static", "gssapi-vendored", "libz-static", "ssl-vendored"] }
-rdkafka-sys = { git = "https://github.com/restatedev/rust-rdkafka.git", rev = "e92cad90eff797a0dc29fa524cabb89b602ae234", default-features = false, features = ["cmake-build", "curl-static", "gssapi-vendored", "libz-static", "ssl-vendored"] }
+rdkafka = { git = "https://github.com/restatedev/rust-rdkafka.git", rev = "e92cad90eff797a0dc29fa524cabb89b602ae234", features = ["cmake-build", "curl-static", "gssapi-vendored", "libz-static", "ssl-vendored", "zstd"] }
+rdkafka-sys = { git = "https://github.com/restatedev/rust-rdkafka.git", rev = "e92cad90eff797a0dc29fa524cabb89b602ae234", default-features = false, features = ["cmake-build", "curl-static", "gssapi-vendored", "libz-static", "ssl-vendored", "zstd"] }
 regex = { version = "1" }
 regex-automata = { version = "0.4", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "std", "unicode"] }
 regex-syntax = { version = "0.8" }


### PR DESCRIPTION
Enable zstd compression so that Restate can ingest zstd compressed payloads from Kafka.

This fixes #4599.