### PR TITLE
Fix inactivity timeout never firing in bidi-stream loop

### DIFF
--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
@@ -530,6 +530,8 @@ where
     {
         let mut release_interval = tokio::time::interval(Self::BUDGET_RELEASE_INTERVAL);
         release_interval.tick().await; // consume initial immediate tick
+        let mut inactivity_timeout =
+            std::pin::pin!(tokio::time::sleep(self.invocation_task.inactivity_timeout));
         loop {
             tokio::select! {
                 opt_completion = self.invocation_task.invoker_rx.recv() => {
@@ -575,6 +577,8 @@ where
                             return TerminalLoopState::Continue(())
                         },
                     }
+
+                    inactivity_timeout.as_mut().reset(tokio::time::Instant::now() + self.invocation_task.inactivity_timeout);
                 },
                 chunk = http_stream_rx.next() => {
                     match crate::shortcircuit!(chunk.transpose()) {
@@ -586,11 +590,13 @@ where
                             crate::shortcircuit!(self.handle_message(parent_span_context, message_header, message));
                         }
                     }
+
+                    inactivity_timeout.as_mut().reset(tokio::time::Instant::now() + self.invocation_task.inactivity_timeout);
                 },
                 _ = release_interval.tick() => {
                     outbound_budget.release_excess();
                 },
-                _ = tokio::time::sleep(self.invocation_task.inactivity_timeout) => {
+                _ = &mut inactivity_timeout => {
                     debug!("Inactivity detected, going to suspend invocation");
                     // Just return. This will drop the invoker_rx and http_stream_tx,
                     // closing the request stream and the invoker input channel.


### PR DESCRIPTION
Fix inactivity timeout never firing in bidi-stream loop

Summary:
The `inactivity_timeout` in the v4 protocol runner's bidi-stream loop was
recreated as a fresh `tokio::time::sleep` future on every `tokio::select!`
iteration. Since `release_interval` (budget release) ticks more frequently than the inactivity
timeout, the sleep was perpetually reset before it could expire, effectively
disabling inactivity-based suspension.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4604).
* #4601
* #4600
* __->__ #4604