### PR TITLE
Hide state mutation payloads in debug

### DIFF
--- a/crates/types/src/state_mut.rs
+++ b/crates/types/src/state_mut.rs
@@ -22,7 +22,9 @@ use crate::identifiers::ServiceId;
 /// ExternalStateMutation
 ///
 /// represents an external request to mutate a user's state.
-#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize, bilrost::Message)]
+#[derive(
+    derive_more::Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize, bilrost::Message,
+)]
 pub struct ExternalStateMutation {
     #[bilrost(1)]
     pub service_id: ServiceId,
@@ -31,6 +33,7 @@ pub struct ExternalStateMutation {
     // flexbuffers only supports string-keyed maps :-( --> so we store it as vector of kv pairs
     #[serde_as(as = "serde_with::Seq<(_, _)>")]
     #[bilrost(3)]
+    #[debug("<hidden>")]
     pub state: HashMap<Bytes, Bytes>,
 }
 


### PR DESCRIPTION

We should not be logging payloads like this in Debug impls

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4608).
* #4611
* #4610
* __->__ #4608