### PR TITLE
Introduce restate-sharding crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7180,6 +7180,7 @@ dependencies = [
  "bytestring",
  "rand",
  "restate-encoding-derive",
+ "restate-sharding",
  "restate-workspace-hack",
  "static_assertions",
 ]
@@ -8028,6 +8029,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "restate-sharding"
+version = "1.6.3-dev"
+dependencies = [
+ "bilrost",
+ "flexbuffers",
+ "restate-sharding",
+ "restate-workspace-hack",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "restate-storage-api"
 version = "1.6.3-dev"
 dependencies = [
@@ -8239,6 +8252,7 @@ dependencies = [
  "restate-errors",
  "restate-memory",
  "restate-serde-util",
+ "restate-sharding",
  "restate-test-util",
  "restate-time-util",
  "restate-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ restate-service-protocol = { path = "crates/service-protocol" }
 restate-service-protocol-v4 = { path = "crates/service-protocol-v4" }
 restate-storage-api = { path = "crates/storage-api" }
 restate-storage-query-datafusion = { path = "crates/storage-query-datafusion" }
+restate-sharding = { path = "crates/sharding" }
 restate-util-string = { path = "util/string" }
 restate-test-util = { path = "crates/test-util" }
 restate-time-util = { path = "crates/time-util" }

--- a/crates/encoding/Cargo.toml
+++ b/crates/encoding/Cargo.toml
@@ -18,4 +18,5 @@ bytestring = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }
+restate-sharding = { workspace = true, features = ["bilrost"] }
 static_assertions = { workspace = true }

--- a/crates/sharding/Cargo.toml
+++ b/crates/sharding/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "restate-sharding"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[features]
+default = []
+serde = ["dep:serde"]
+bilrost = ["dep:bilrost"]
+
+[dependencies]
+restate-workspace-hack = { workspace = true }
+
+bilrost = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+
+[dev-dependencies]
+restate-sharding = { path = ".", default-features = false, features = ["serde", "bilrost"] }
+
+flexbuffers = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/sharding/src/key_range.rs
+++ b/crates/sharding/src/key_range.rs
@@ -1,0 +1,441 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt;
+use std::ops::{Bound, RangeBounds};
+use std::range::RangeInclusiveIter;
+
+/// An inclusive range of partition keys `[start, end]`.
+///
+/// This is a compact, `Copy` representation of an inclusive key range backed by
+/// [`std::range::RangeInclusive<u64>`]. Compared to [`std::ops::RangeInclusive<u64>`]:
+///
+/// Wire-format compatible with `std::ops::RangeInclusive<u64>` for both serde and bilrost.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct KeyRange(std::range::RangeInclusive<u64>);
+
+impl KeyRange {
+    /// The full key space `[0, u64::MAX]`.
+    pub const FULL: Self = Self::new(u64::MIN, u64::MAX);
+
+    /// Creates a new inclusive key range `[start, end]`.
+    pub const fn new(start: u64, end: u64) -> Self {
+        Self(std::range::RangeInclusive { start, last: end })
+    }
+
+    /// The inclusive lower bound.
+    #[inline]
+    pub const fn start(&self) -> u64 {
+        self.0.start
+    }
+
+    /// The inclusive upper bound.
+    #[inline]
+    pub const fn end(&self) -> u64 {
+        self.0.last
+    }
+
+    /// Returns an iterator over all keys in this range.
+    #[inline]
+    pub fn iter(&self) -> RangeInclusiveIter<u64> {
+        self.0.iter()
+    }
+
+    /// Returns `true` if `self` and `other` share at least one key.
+    #[inline]
+    pub const fn is_overlapping(&self, other: &KeyRange) -> bool {
+        self.start() <= other.end() && other.start() <= self.end()
+    }
+
+    /// Splits this range into two roughly equal halves at the midpoint.
+    ///
+    /// Returns `None` if the range contains a single key (cannot be split).
+    /// Otherwise returns `(left, right)` where `left.end() + 1 == right.start()`.
+    pub const fn split(&self) -> Option<(KeyRange, KeyRange)> {
+        if self.start() == self.end() {
+            return None;
+        }
+        let mid = self.start() + (self.end() - self.start()) / 2;
+        Some((
+            KeyRange::new(self.start(), mid),
+            KeyRange::new(mid + 1, self.end()),
+        ))
+    }
+}
+
+impl RangeBounds<u64> for KeyRange {
+    #[inline]
+    fn start_bound(&self) -> Bound<&u64> {
+        self.0.start_bound()
+    }
+
+    #[inline]
+    fn end_bound(&self) -> Bound<&u64> {
+        self.0.end_bound()
+    }
+}
+
+impl From<std::ops::RangeInclusive<u64>> for KeyRange {
+    #[inline]
+    fn from(range: std::ops::RangeInclusive<u64>) -> Self {
+        Self::new(*range.start(), *range.end())
+    }
+}
+
+impl From<KeyRange> for std::ops::RangeInclusive<u64> {
+    #[inline]
+    fn from(range: KeyRange) -> Self {
+        range.start()..=range.end()
+    }
+}
+
+impl From<std::range::RangeInclusive<u64>> for KeyRange {
+    #[inline]
+    fn from(range: std::range::RangeInclusive<u64>) -> Self {
+        Self(range)
+    }
+}
+
+impl From<KeyRange> for std::range::RangeInclusive<u64> {
+    #[inline]
+    fn from(range: KeyRange) -> Self {
+        range.0
+    }
+}
+
+impl fmt::Display for KeyRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[{}, {}]", self.start(), self.end())
+    }
+}
+
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use super::KeyRange;
+
+    use serde::ser::SerializeStruct;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    /// Serializes as `{"start": <u64>, "end": <u64>}` to match `std::ops::RangeInclusive`'s
+    /// serde format.
+    impl Serialize for KeyRange {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            let mut state = serializer.serialize_struct("KeyRange", 2)?;
+            state.serialize_field("start", &self.start())?;
+            state.serialize_field("end", &self.end())?;
+            state.end()
+        }
+    }
+
+    /// Deserializes from `{"start": <u64>, "end": <u64>}` to match `std::ops::RangeInclusive`'s
+    /// serde format.
+    impl<'de> Deserialize<'de> for KeyRange {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            #[derive(Deserialize)]
+            #[serde(deny_unknown_fields)]
+            struct Raw {
+                start: u64,
+                end: u64,
+            }
+            let raw = Raw::deserialize(deserializer)?;
+            Ok(KeyRange::new(raw.start, raw.end))
+        }
+    }
+}
+
+#[cfg(feature = "bilrost")]
+mod bilrost_impl {
+    use super::KeyRange;
+
+    use bilrost::DecodeErrorKind;
+    use bilrost::encoding::{EmptyState, ForOverwrite, Proxiable};
+
+    impl Proxiable for KeyRange {
+        type Proxy = (u64, u64);
+
+        fn encode_proxy(&self) -> Self::Proxy {
+            (self.start(), self.end())
+        }
+
+        fn decode_proxy(&mut self, proxy: Self::Proxy) -> Result<(), DecodeErrorKind> {
+            *self = KeyRange::new(proxy.0, proxy.1);
+            Ok(())
+        }
+    }
+
+    impl ForOverwrite<(), KeyRange> for () {
+        fn for_overwrite() -> KeyRange {
+            KeyRange::new(0, 0)
+        }
+    }
+
+    impl EmptyState<(), KeyRange> for () {
+        fn empty() -> KeyRange {
+            KeyRange::new(0, 0)
+        }
+
+        fn is_empty(val: &KeyRange) -> bool {
+            val.start() == 0 && val.end() == 0
+        }
+
+        fn clear(val: &mut KeyRange) {
+            *val = <() as EmptyState<(), KeyRange>>::empty();
+        }
+    }
+
+    bilrost::delegate_proxied_encoding!(
+        use encoding (bilrost::encoding::General)
+        to encode proxied type (KeyRange)
+        with general encodings
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basics() {
+        let r = KeyRange::new(10, 20);
+        assert_eq!(r.start(), 10);
+        assert_eq!(r.end(), 20);
+        assert!(r.contains(&10));
+        assert!(r.contains(&15));
+        assert!(r.contains(&20));
+        assert!(!r.contains(&9));
+        assert!(!r.contains(&21));
+
+        // Copy
+        let r2 = r;
+        assert_eq!(r, r2);
+
+        // Display
+        assert_eq!(format!("{r}"), "[10, 20]");
+    }
+
+    #[test]
+    fn full_range() {
+        assert_eq!(KeyRange::FULL.start(), u64::MIN);
+        assert_eq!(KeyRange::FULL.end(), u64::MAX);
+        assert!(KeyRange::FULL.contains(&0));
+        assert!(KeyRange::FULL.contains(&u64::MAX));
+    }
+
+    #[test]
+    fn from_ops_range_inclusive() {
+        let ops_range: std::ops::RangeInclusive<u64> = 5..=10;
+        let kr = KeyRange::from(ops_range.clone());
+        assert_eq!(kr.start(), 5);
+        assert_eq!(kr.end(), 10);
+
+        let back: std::ops::RangeInclusive<u64> = kr.into();
+        assert_eq!(back, ops_range);
+    }
+
+    #[test]
+    fn from_range_inclusive() {
+        let range = std::range::RangeInclusive { start: 3, last: 7 };
+        let kr = KeyRange::from(range);
+        assert_eq!(kr.start(), 3);
+        assert_eq!(kr.end(), 7);
+
+        let back: std::range::RangeInclusive<u64> = kr.into();
+        assert_eq!(back, range);
+    }
+
+    #[test]
+    fn size_and_copy() {
+        assert_eq!(size_of::<KeyRange>(), 16);
+        assert_eq!(
+            size_of::<KeyRange>(),
+            size_of::<std::range::RangeInclusive<u64>>()
+        );
+        // Old type is larger due to exhausted flag + padding
+        assert!(size_of::<std::ops::RangeInclusive<u64>>() > size_of::<KeyRange>());
+    }
+
+    #[test]
+    fn bilrost_roundtrip() {
+        use bilrost::{Message, OwnedMessage};
+
+        #[derive(Debug, PartialEq, bilrost::Message)]
+        struct TestMsg {
+            #[bilrost(1)]
+            range: KeyRange,
+        }
+
+        let msg = TestMsg {
+            range: KeyRange::new(100, 200),
+        };
+        let encoded = msg.encode_to_vec();
+        let decoded = TestMsg::decode(&*encoded).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn iter() {
+        let r = KeyRange::new(5, 9);
+        let keys: Vec<u64> = r.iter().collect();
+        assert_eq!(keys, vec![5, 6, 7, 8, 9]);
+
+        let single = KeyRange::new(42, 42);
+        let keys: Vec<u64> = single.iter().collect();
+        assert_eq!(keys, vec![42]);
+    }
+
+    #[test]
+    fn is_overlapping() {
+        let a = KeyRange::new(0, 10);
+        let b = KeyRange::new(5, 15);
+        assert!(a.is_overlapping(&b));
+        assert!(b.is_overlapping(&a));
+
+        // Adjacent ranges don't overlap
+        let c = KeyRange::new(11, 20);
+        assert!(!a.is_overlapping(&c));
+
+        // Touching at boundary
+        let d = KeyRange::new(10, 20);
+        assert!(a.is_overlapping(&d));
+
+        // Contained
+        let e = KeyRange::new(2, 8);
+        assert!(a.is_overlapping(&e));
+
+        // Same range
+        assert!(a.is_overlapping(&a));
+
+        // Disjoint
+        let f = KeyRange::new(100, 200);
+        assert!(!a.is_overlapping(&f));
+    }
+
+    #[test]
+    fn split() {
+        // Even range [0, 9] → [0, 4] and [5, 9]
+        let r = KeyRange::new(0, 9);
+        let (left, right) = r.split().unwrap();
+        assert_eq!(left, KeyRange::new(0, 4));
+        assert_eq!(right, KeyRange::new(5, 9));
+
+        // Odd range [0, 10] → [0, 5] and [6, 10]
+        let r = KeyRange::new(0, 10);
+        let (left, right) = r.split().unwrap();
+        assert_eq!(left, KeyRange::new(0, 5));
+        assert_eq!(right, KeyRange::new(6, 10));
+
+        // Two-element range [5, 6] → [5, 5] and [6, 6]
+        let r = KeyRange::new(5, 6);
+        let (left, right) = r.split().unwrap();
+        assert_eq!(left, KeyRange::new(5, 5));
+        assert_eq!(right, KeyRange::new(6, 6));
+
+        // Single element cannot be split
+        assert!(KeyRange::new(42, 42).split().is_none());
+
+        // Full range
+        let (left, right) = KeyRange::FULL.split().unwrap();
+        assert_eq!(left.start(), 0);
+        assert_eq!(right.end(), u64::MAX);
+        assert_eq!(left.end() + 1, right.start());
+    }
+
+    #[test]
+    fn json_wire_compat_with_ops_range_inclusive() {
+        // KeyRange must be wire-compatible with std::ops::RangeInclusive<u64> in JSON.
+        let kr = KeyRange::new(100, 200);
+        let ops = std::ops::RangeInclusive::new(100u64, 200u64);
+
+        let kr_json = serde_json::to_string(&kr).unwrap();
+        let ops_json = serde_json::to_string(&ops).unwrap();
+        assert_eq!(kr_json, ops_json, "serialized forms must be identical");
+
+        // Cross-deserialize in both directions
+        let kr_from_ops: KeyRange = serde_json::from_str(&ops_json).unwrap();
+        assert_eq!(kr_from_ops, kr);
+
+        let ops_from_kr: std::ops::RangeInclusive<u64> = serde_json::from_str(&kr_json).unwrap();
+        assert_eq!(ops_from_kr, ops);
+    }
+
+    #[test]
+    fn json_wire_compat_boundary_values() {
+        // Verify wire compat at boundary values (0, u64::MAX)
+        for (start, end) in [(0u64, 0u64), (0, u64::MAX), (u64::MAX, u64::MAX)] {
+            let kr = KeyRange::new(start, end);
+            let ops = std::ops::RangeInclusive::new(start, end);
+
+            let kr_json = serde_json::to_string(&kr).unwrap();
+            let ops_json = serde_json::to_string(&ops).unwrap();
+            assert_eq!(kr_json, ops_json, "mismatch at ({start}, {end})");
+
+            let roundtrip: KeyRange = serde_json::from_str(&ops_json).unwrap();
+            assert_eq!(roundtrip, kr);
+        }
+    }
+
+    #[test]
+    fn flexbuffers_wire_compat_with_ops_range_inclusive() {
+        // KeyRange must be wire-compatible with std::ops::RangeInclusive<u64> in flexbuffers.
+        let kr = KeyRange::new(100, 200);
+        let ops = std::ops::RangeInclusive::new(100u64, 200u64);
+
+        let kr_buf = flexbuffers::to_vec(kr).unwrap();
+        let ops_buf = flexbuffers::to_vec(&ops).unwrap();
+        assert_eq!(kr_buf, ops_buf, "serialized forms must be identical");
+
+        // Cross-deserialize in both directions
+        let kr_from_ops: KeyRange = flexbuffers::from_slice(&ops_buf).unwrap();
+        assert_eq!(kr_from_ops, kr);
+
+        let ops_from_kr: std::ops::RangeInclusive<u64> = flexbuffers::from_slice(&kr_buf).unwrap();
+        assert_eq!(ops_from_kr, ops);
+    }
+
+    #[test]
+    fn flexbuffers_wire_compat_boundary_values() {
+        for (start, end) in [(0u64, 0u64), (0, u64::MAX), (u64::MAX, u64::MAX)] {
+            let kr = KeyRange::new(start, end);
+            let ops = std::ops::RangeInclusive::new(start, end);
+
+            let kr_buf = flexbuffers::to_vec(kr).unwrap();
+            let ops_buf = flexbuffers::to_vec(&ops).unwrap();
+            assert_eq!(kr_buf, ops_buf, "mismatch at ({start}, {end})");
+
+            let roundtrip: KeyRange = flexbuffers::from_slice(&ops_buf).unwrap();
+            assert_eq!(roundtrip, kr);
+        }
+    }
+
+    #[test]
+    fn bilrost_compat_with_ops_range() {
+        use bilrost::{Message, OwnedMessage};
+
+        // The bilrost crate's existing encoding for RangeInclusive<u64> uses RestateEncoding
+        // which is defined in restate-encoding. We can't test cross-type bilrost compat here
+        // since RestateEncoding is not available in this crate. That test belongs in
+        // restate-encoding's test suite.
+        //
+        // Here we verify that KeyRange's bilrost encoding is self-consistent.
+        #[derive(Debug, PartialEq, bilrost::Message)]
+        struct Msg {
+            #[bilrost(1)]
+            range: KeyRange,
+        }
+
+        let msg = Msg {
+            range: KeyRange::new(u64::MIN, u64::MAX),
+        };
+        let encoded = msg.encode_to_vec();
+        let decoded = Msg::decode(&*encoded).unwrap();
+        assert_eq!(msg, decoded);
+    }
+}

--- a/crates/sharding/src/lib.rs
+++ b/crates/sharding/src/lib.rs
@@ -1,0 +1,43 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod key_range;
+
+use std::sync::Arc;
+
+pub use key_range::KeyRange;
+
+/// Identifying to which partition a key belongs. This is unlike the [`PartitionId`]
+/// which identifies a consecutive range of partition keys.
+pub type PartitionKey = u64;
+
+/// Trait for data structures that have a partition key
+pub trait WithPartitionKey {
+    /// Returns the partition key
+    fn partition_key(&self) -> PartitionKey;
+}
+
+impl<T> WithPartitionKey for &T
+where
+    T: WithPartitionKey,
+{
+    fn partition_key(&self) -> PartitionKey {
+        (*self).partition_key()
+    }
+}
+
+impl<T> WithPartitionKey for Arc<T>
+where
+    T: WithPartitionKey,
+{
+    fn partition_key(&self) -> PartitionKey {
+        self.as_ref().partition_key()
+    }
+}

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -30,6 +30,7 @@ restate-memory = { workspace = true }
 restate-serde-util = { workspace = true }
 restate-test-util = { workspace = true, optional = true }
 restate-time-util = { workspace = true, features = ["serde", "serde_with"] }
+restate-sharding = { workspace = true, features = ["serde", "bilrost"] }
 restate-util-string = { workspace = true, features = ["serde", "bilrost"] }
 restate-utoipa = { workspace = true }
 

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -13,6 +13,7 @@
 mod partitioned;
 
 pub use partitioned::PartitionedResourceId;
+pub use restate_sharding::{PartitionKey, WithPartitionKey};
 
 use std::cell::RefCell;
 use std::fmt::{self, Display, Formatter};
@@ -155,10 +156,6 @@ pub type PartitionLeaderEpoch = (PartitionId, LeaderEpoch);
 // Just an alias
 pub type EntryIndex = u32;
 
-/// Identifying to which partition a key belongs. This is unlike the [`PartitionId`]
-/// which identifies a consecutive range of partition keys.
-pub type PartitionKey = u64;
-
 /// Returns the partition key computed from either the service_key, or idempotency_key, if possible
 fn deterministic_partition_key(
     service_key: Option<&str>,
@@ -203,13 +200,6 @@ fn random_unscoped_service_partition_key(service_name: &str) -> PartitionKey {
     let bucket = rand::rng().random_range(0..UNSCOPED_SERVICE_PARTITION_KEY_FANOUT);
     unscoped_service_partition_key(service_name, bucket)
 }
-
-/// Trait for data structures that have a partition key
-pub trait WithPartitionKey {
-    /// Returns the partition key
-    fn partition_key(&self) -> PartitionKey;
-}
-
 /// A family of resource identifiers that tracks the timestamp of its creation.
 pub trait TimestampAwareId {
     /// The timestamp when this ID was created.
@@ -656,12 +646,6 @@ impl WithPartitionKey for InvocationId {
     }
 }
 
-impl<T: WithInvocationId> WithPartitionKey for T {
-    fn partition_key(&self) -> PartitionKey {
-        self.invocation_id().partition_key
-    }
-}
-
 impl Display for InvocationId {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         // encode the id such that it is possible to do a string prefix search for a
@@ -813,6 +797,12 @@ impl JournalEntryId {
 impl From<(InvocationId, EntryIndex)> for JournalEntryId {
     fn from(value: (InvocationId, EntryIndex)) -> Self {
         Self::from_parts(value.0, value.1)
+    }
+}
+
+impl WithPartitionKey for JournalEntryId {
+    fn partition_key(&self) -> PartitionKey {
+        self.invocation_id.partition_key()
     }
 }
 

--- a/crates/types/src/invocation/mod.rs
+++ b/crates/types/src/invocation/mod.rs
@@ -427,6 +427,12 @@ impl InvocationRequest {
     }
 }
 
+impl WithPartitionKey for InvocationRequest {
+    fn partition_key(&self) -> PartitionKey {
+        self.header.invocation_id().partition_key()
+    }
+}
+
 impl WithInvocationId for InvocationRequest {
     fn invocation_id(&self) -> InvocationId {
         self.header.invocation_id()
@@ -590,6 +596,12 @@ impl JournalCompletionTarget {
     }
 }
 
+impl WithPartitionKey for JournalCompletionTarget {
+    fn partition_key(&self) -> PartitionKey {
+        self.caller_id.partition_key()
+    }
+}
+
 impl WithInvocationId for JournalCompletionTarget {
     fn invocation_id(&self) -> InvocationId {
         self.caller_id
@@ -605,6 +617,12 @@ impl WithInvocationId for JournalCompletionTarget {
 pub struct InvocationResponse {
     pub target: JournalCompletionTarget,
     pub result: ResponseResult,
+}
+
+impl WithPartitionKey for InvocationResponse {
+    fn partition_key(&self) -> PartitionKey {
+        self.target.invocation_id().partition_key()
+    }
 }
 
 impl WithInvocationId for InvocationResponse {
@@ -1359,6 +1377,12 @@ impl WithPartitionKey for AttachInvocationRequest {
 pub struct NotifySignalRequest {
     pub invocation_id: InvocationId,
     pub signal: Signal,
+}
+
+impl WithPartitionKey for NotifySignalRequest {
+    fn partition_key(&self) -> PartitionKey {
+        self.invocation_id.partition_key()
+    }
 }
 
 impl WithInvocationId for NotifySignalRequest {

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -81,6 +81,11 @@ pub mod memory {
     pub use restate_memory::*;
 }
 
+// Re-export restate-sharding crate for key range utilities.
+pub mod sharding {
+    pub use restate_sharding::*;
+}
+
 // Re-export metrics' SharedString (Space-efficient Cow + RefCounted variant)
 pub type SharedString = metrics::SharedString;
 

--- a/crates/wal-protocol/src/lib.rs
+++ b/crates/wal-protocol/src/lib.rs
@@ -239,15 +239,17 @@ impl HasRecordKeys for Envelope {
             Command::TruncateOutbox(_) => Keys::Single(self.partition_key()),
             Command::ProxyThrough(_) => Keys::Single(self.partition_key()),
             Command::AttachInvocation(_) => Keys::Single(self.partition_key()),
-            Command::ResumeInvocation(req) => Keys::Single(req.partition_key()),
-            Command::RestartAsNewInvocation(req) => Keys::Single(req.partition_key()),
+            Command::ResumeInvocation(req) => Keys::Single(req.invocation_id.partition_key()),
+            Command::RestartAsNewInvocation(req) => Keys::Single(req.invocation_id.partition_key()),
             // todo: Handle journal entries that request cross-partition invocations
             Command::InvokerEffect(effect) => Keys::Single(effect.invocation_id.partition_key()),
             Command::Timer(timer) => Keys::Single(timer.invocation_id().partition_key()),
             Command::ScheduleTimer(timer) => Keys::Single(timer.invocation_id().partition_key()),
             Command::InvocationResponse(response) => Keys::Single(response.partition_key()),
             Command::NotifySignal(sig) => Keys::Single(sig.partition_key()),
-            Command::NotifyGetInvocationOutputResponse(res) => Keys::Single(res.partition_key()),
+            Command::NotifyGetInvocationOutputResponse(res) => {
+                Keys::Single(res.target.partition_key())
+            }
             Command::UpsertSchema(schema) => schema.partition_key_range.clone(),
             Command::VQSchedulerDecisions(_) => Keys::Single(self.partition_key()),
         }


### PR DESCRIPTION

Part of the effort to decompose the restate-types monolith into focused,
composable utility crates.

Add a new `restate-sharding` crate (in `crates/sharding/`) that defines
the foundational sharding types:

- `KeyRange`: a compact `Copy` newtype over `std::range::RangeInclusive<u64>`.
  16 bytes (vs 24 for std::ops::RangeInclusive), wire-format compatible serde
  and bilrost encoding. Provides iter(), is_overlapping(), and split() helpers.
- `PartitionKey`: type alias for u64
- `WithPartitionKey`: trait for types that carry a partition key

The crate is re-exported from `restate-types::sharding` for ergonomic access.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4623).
* #4627
* #4626
* #4624
* __->__ #4623