### PR TITLE
Migrate partition key ranges to KeyRange and extract sharding types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ If these rules conflict with normal behavior, always follow the rules above.
 1. Check crates/cli-util/README.md when doing CLI changes to make sure that you are adhering to the CLI style guide.
 1. New or deprecated config options must have `/// Since vX.Y.Z` in their doc comment.
 1. Use `ByteCount::from(value)` (from `restate_memory`) when displaying byte sizes in errors/logs.
+1. Use `KeyRange` (from `restate_sharding`, re-exported via `restate_types::sharding::KeyRange`) instead of `std::ops::RangeInclusive<PartitionKey>` for partition key ranges. `KeyRange` is `Copy`, 16 bytes (vs 24), and has wire-compatible serde/bilrost encoding.
 
 
 # Validation Before Committing Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7180,6 +7180,7 @@ dependencies = [
  "bytestring",
  "rand",
  "restate-encoding-derive",
+ "restate-sharding",
  "restate-workspace-hack",
  "static_assertions",
 ]
@@ -8028,6 +8029,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "restate-sharding"
+version = "1.6.3-dev"
+dependencies = [
+ "bilrost",
+ "flexbuffers",
+ "restate-sharding",
+ "restate-workspace-hack",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "restate-storage-api"
 version = "1.6.3-dev"
 dependencies = [
@@ -8239,6 +8252,7 @@ dependencies = [
  "restate-errors",
  "restate-memory",
  "restate-serde-util",
+ "restate-sharding",
  "restate-test-util",
  "restate-time-util",
  "restate-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.8.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -341,7 +341,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "lexical-core",
  "memchr",
@@ -540,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "aws-config"
-version = "1.8.15"
+version = "1.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11493b0bad143270fb8ad284a096dd529ba91924c5409adeac856cc1bf047dbc"
+checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -582,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -593,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -605,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
+checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -631,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.109.0"
+version = "1.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ea214e9da6b960547bfd61cc16afc0b064d8070473f1b485b7222eec7dd415"
+checksum = "fc418346e3cb248c7d59e642acbcb06488b7c7cd2ba6ebc79e8003f618c60099"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -655,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-lambda"
-version = "1.119.0"
+version = "1.121.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bcacc7c2d94698c49fb73086d16ccdff68442ed21a70fbaa924c46158e37a93"
+checksum = "13b84b01daefb9e3e9b657d74eb2255b64c826801f2c87db02c38848b2280460"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -680,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.97.0"
+version = "1.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aadc669e184501caaa6beafb28c6267fc1baef0810fb58f9b205485ca3f2567"
+checksum = "d69c77aafa20460c68b6b3213c84f6423b6e76dbf89accd3e1789a686ffd9489"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -704,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.99.0"
+version = "1.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1342a7db8f358d3de0aed2007a0b54e875458e39848d54cc1d46700b2bfcb0a8"
+checksum = "1c7e7b09346d5ca22a2a08267555843a6a0127fb20d8964cb6ecfb8fdb190225"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -728,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.101.0"
+version = "1.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab41ad64e4051ecabeea802d6a17845a91e83287e1dd249e6963ea1ba78c428a"
+checksum = "c2249b81a2e73a8027c41c378463a81ec39b8510f184f2caab87de912af0f49b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -753,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
+checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -765,11 +765,11 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.0",
  "percent-encoding",
- "sha2",
+ "sha2 0.11.0",
  "time",
  "tracing",
 ]
@@ -872,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.10.3"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
+checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -897,11 +897,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.6"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
+checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
@@ -910,6 +911,17 @@ dependencies = [
  "tokio",
  "tracing",
  "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -949,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.14"
+version = "1.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
+checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -963,9 +975,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -1108,9 +1120,9 @@ dependencies = [
 
 [[package]]
 name = "bilrost"
-version = "0.1014.1"
+version = "0.1014.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be62a88fe2e8da9012cbf81085cc86f53ce9a8584507180e3eb9918a9b77b02f"
+checksum = "7dcaabc24217713f7e0975d5f1276293f89cf458d8c8f3d470f8f1b1a323a705"
 dependencies = [
  "autocfg",
  "bilrost-derive",
@@ -1121,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "bilrost-derive"
-version = "0.1014.1"
+version = "0.1014.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a770fdbaa701326b4fe9400bb5dada1ec01a8b026f078154f010ffed544a5da1"
+checksum = "afe16e422c489419db85690b3e53864835963af62316f35b0e16ec914dbd30a1"
 dependencies = [
  "eyre",
  "itertools 0.14.0",
@@ -1148,7 +1160,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -1183,9 +1195,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitvec"
@@ -1205,21 +1217,21 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -1229,6 +1241,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1413,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1443,6 +1464,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -1510,7 +1542,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -1527,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1569,18 +1601,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1627,12 +1659,18 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "codederror"
@@ -1775,10 +1813,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -1802,11 +1846,12 @@ dependencies = [
 
 [[package]]
 name = "const_format"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
 dependencies = [
  "const_format_proc_macros",
+ "konst",
 ]
 
 [[package]]
@@ -1863,9 +1908,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.5.1"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
 dependencies = [
  "cfg-if",
 ]
@@ -1875,6 +1920,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1972,7 +2026,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -2010,6 +2064,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2042,10 +2105,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl-sys"
-version = "0.4.86+curl-8.19.0"
+name = "ctutils"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1dd6a487cf4532ce0d801634b82aa2deb7c9c3ed930b9dadfce904df000745"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.87+curl-8.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a460380f0ef783703dcbe909107f39c162adeac050d73c850055118b5b6327"
 dependencies = [
  "cc",
  "libc",
@@ -2219,7 +2291,7 @@ dependencies = [
  "log",
  "object_store 0.12.5",
  "parking_lot",
- "rand",
+ "rand 0.9.4",
  "regex",
  "sqlparser",
  "tempfile",
@@ -2285,7 +2357,7 @@ dependencies = [
  "chrono",
  "half",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "libc",
  "log",
  "object_store 0.12.5",
@@ -2329,7 +2401,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "object_store 0.12.5",
- "rand",
+ "rand 0.9.4",
  "tokio",
  "url",
 ]
@@ -2420,7 +2492,7 @@ dependencies = [
  "log",
  "object_store 0.12.5",
  "parking_lot",
- "rand",
+ "rand 0.9.4",
  "tempfile",
  "url",
 ]
@@ -2439,7 +2511,7 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "paste",
  "recursive",
@@ -2454,7 +2526,7 @@ source = "git+https://github.com/restatedev/datafusion?branch=branch-52#fd253adc
 dependencies = [
  "arrow",
  "datafusion-common",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "paste",
 ]
@@ -2482,9 +2554,9 @@ dependencies = [
  "log",
  "md-5",
  "num-traits",
- "rand",
+ "rand 0.9.4",
  "regex",
- "sha2",
+ "sha2 0.10.9",
  "unicode-segmentation",
  "uuid",
 ]
@@ -2617,7 +2689,7 @@ dependencies = [
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-physical-expr",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "log",
  "recursive",
@@ -2639,7 +2711,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "half",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "parking_lot",
  "paste",
@@ -2673,7 +2745,7 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr-common",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "parking_lot",
 ]
@@ -2718,7 +2790,7 @@ dependencies = [
  "futures",
  "half",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "log",
  "parking_lot",
@@ -2800,7 +2872,7 @@ dependencies = [
  "chrono",
  "datafusion-common",
  "datafusion-expr",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "recursive",
  "regex",
@@ -2818,9 +2890,9 @@ dependencies = [
 
 [[package]]
 name = "deflate64"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
 name = "deranged"
@@ -2910,9 +2982,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -2963,7 +3047,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "block2",
  "libc",
  "objc2",
@@ -3121,18 +3205,18 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
  "env_filter",
  "log",
@@ -3245,9 +3329,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "figment"
@@ -3302,7 +3386,7 @@ version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "rustc_version",
 ]
 
@@ -3379,9 +3463,9 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
 dependencies = [
  "lazy_static",
  "num",
@@ -3389,9 +3473,12 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "fs_extra"
@@ -3586,6 +3673,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -3650,7 +3738,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3702,6 +3790,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "hdrhistogram"
 version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3749,7 +3843,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand",
+ "rand 0.9.4",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
@@ -3771,7 +3865,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.9.4",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.18",
@@ -3785,7 +3879,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3883,10 +3986,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
-name = "hyper"
-version = "1.8.1"
+name = "hybrid-array"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3899,7 +4011,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -3907,9 +4018,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.0",
  "hyper",
@@ -3917,7 +4028,6 @@ dependencies = [
  "log",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -3954,7 +4064,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -3989,12 +4099,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -4002,9 +4113,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -4015,9 +4126,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -4029,15 +4140,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -4049,15 +4160,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -4139,12 +4250,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -4178,7 +4289,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
 dependencies = [
  "ahash",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "is-terminal",
  "itoa",
  "log",
@@ -4201,7 +4312,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "env_logger",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "log",
  "num-format",
@@ -4223,7 +4334,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "inotify-sys",
  "libc",
 ]
@@ -4248,14 +4359,15 @@ dependencies = [
 
 [[package]]
 name = "ipconfig"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.5.10",
+ "socket2",
  "widestring",
- "windows-sys 0.48.0",
- "winreg",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4266,9 +4378,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -4339,9 +4451,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc_pprof"
@@ -4428,10 +4540,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -4541,6 +4655,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4571,9 +4700,9 @@ dependencies = [
 
 [[package]]
 name = "lambda_runtime"
-version = "1.1.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23583c918bee8de7bc005ba2ad8ebd84529894bfd9a863cf24226bb6c7787690"
+checksum = "fcfafa53f881580c291de6a487e7f6d3c5830744fb004581cc82736cac258e2a"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -4596,9 +4725,9 @@ dependencies = [
 
 [[package]]
 name = "lambda_runtime_api_client"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4873061514cb57ffb6a599b77c46c65d6d783efe9bad8fd56b7cba7f0459ef"
+checksum = "b5e9ffa99f1e87b21d42ac98fe7eac55f4cfb9ed14677a64a7dab4d8f44399a4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -4684,15 +4813,15 @@ dependencies = [
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+checksum = "b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"
@@ -4712,18 +4841,18 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "libz-sys"
-version = "1.1.25"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
 dependencies = [
  "cc",
  "libc",
@@ -4759,9 +4888,9 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -4795,11 +4924,11 @@ dependencies = [
  "codederror",
  "comfy-table",
  "hdrhistogram",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "libc",
  "metrics",
  "metrics-exporter-prometheus",
- "rand",
+ "rand 0.9.4",
  "restate-cli-util",
  "restate-core",
  "restate-errors",
@@ -4852,7 +4981,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47bb1e988e6fb779cf720ad431242d3f03167c1b3f2b1aae7f1a94b2495b36ae"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4890,7 +5019,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4935,7 +5064,7 @@ checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
 dependencies = [
  "base64 0.22.1",
  "hyper-util",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "metrics",
  "metrics-util",
  "quanta",
@@ -4954,7 +5083,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "metrics",
  "quanta",
- "rand",
+ "rand 0.9.4",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -4993,9 +5122,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -5103,9 +5232,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -5142,7 +5271,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -5154,7 +5283,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -5176,7 +5305,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -5207,7 +5336,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -5260,9 +5389,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-format"
@@ -5427,16 +5556,18 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2858065e55c148d294a9f3aae3b0fa9458edadb41a108397094566f4e3c0dfb"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
  "chrono",
  "form_urlencoded",
- "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
  "http 1.4.0",
  "http-body-util",
  "httparse",
@@ -5446,8 +5577,8 @@ dependencies = [
  "md-5",
  "parking_lot",
  "percent-encoding",
- "quick-xml 0.38.4",
- "rand",
+ "quick-xml 0.39.2",
+ "rand 0.10.1",
  "reqwest",
  "ring",
  "rustls-pki-types",
@@ -5528,9 +5659,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "open"
-version = "5.3.3"
+version = "5.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
 dependencies = [
  "is-wsl",
  "libc",
@@ -5545,18 +5676,18 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.5+3.5.5"
+version = "300.6.0+3.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -5606,9 +5737,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http 1.4.0",
  "opentelemetry",
@@ -5658,7 +5789,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand",
+ "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -5733,8 +5864,8 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
- "hmac",
+ "digest 0.10.7",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -5784,7 +5915,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
 ]
 
@@ -5840,9 +5971,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -5880,18 +6011,18 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -6008,7 +6139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93980406f12d9f8140ed5abe7155acb10bb1e69ea55c88960b9c2f117445ef96"
 dependencies = [
  "equivalent",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
 ]
 
@@ -6028,7 +6159,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.5+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -6077,13 +6208,13 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "num-traits",
- "rand",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -6218,9 +6349,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
 dependencies = [
  "ar_archive_writer",
  "cc",
@@ -6228,11 +6359,11 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.1"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c41efbf8f90ac44de7f3a868f0867851d261b56291732d0cbf7cceaaeb55a6"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "memchr",
  "unicase",
 ]
@@ -6335,21 +6466,12 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -6365,7 +6487,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6381,7 +6503,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -6402,7 +6524,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6443,7 +6565,7 @@ dependencies = [
  "fxhash",
  "getset",
  "raft-proto",
- "rand",
+ "rand 0.9.4",
  "slog",
  "slog-envlogger",
  "slog-stdlog",
@@ -6463,12 +6585,23 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -6500,6 +6633,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6523,14 +6662,14 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -6604,7 +6743,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -6791,7 +6930,7 @@ dependencies = [
  "mime_guess",
  "parking_lot",
  "prost-dto",
- "rand",
+ "rand 0.9.4",
  "restate-admin-rest-model",
  "restate-bifrost",
  "restate-core",
@@ -6858,7 +6997,7 @@ dependencies = [
  "http 1.4.0",
  "mock-service-endpoint",
  "pprof",
- "rand",
+ "rand 0.9.4",
  "reqwest",
  "restate-clock",
  "restate-core",
@@ -6883,7 +7022,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "async-trait",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "bytestring",
  "criterion",
@@ -6899,7 +7038,7 @@ dependencies = [
  "pin-project",
  "pprof",
  "prost",
- "rand",
+ "rand 0.9.4",
  "restate-bifrost",
  "restate-clock",
  "restate-core",
@@ -6970,7 +7109,7 @@ dependencies = [
  "mock-service-endpoint",
  "octocrab",
  "open",
- "rand",
+ "rand 0.9.4",
  "reqwest",
  "restate-admin-rest-model",
  "restate-cli-util",
@@ -7038,7 +7177,7 @@ dependencies = [
  "jiff",
  "libc",
  "prost-types",
- "rand",
+ "rand 0.9.4",
  "restate-clock",
  "restate-encoding",
  "restate-workspace-hack",
@@ -7095,7 +7234,7 @@ dependencies = [
  "pin-project-lite",
  "prost",
  "prost-dto",
- "rand",
+ "rand 0.9.4",
  "restate-core",
  "restate-core-derive",
  "restate-futures-util",
@@ -7178,7 +7317,7 @@ dependencies = [
  "bilrost",
  "bytes",
  "bytestring",
- "rand",
+ "rand 0.9.4",
  "restate-encoding-derive",
  "restate-sharding",
  "restate-workspace-hack",
@@ -7461,7 +7600,7 @@ dependencies = [
  "http 1.4.0",
  "itertools 0.14.0",
  "nix 0.30.1",
- "rand",
+ "rand 0.9.4",
  "regex",
  "reqwest",
  "restate-clock",
@@ -7491,7 +7630,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "async-trait",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "chrono",
  "codederror",
@@ -7569,10 +7708,10 @@ dependencies = [
  "const_format",
  "derive_more",
  "etcd-client",
- "indexmap 2.13.0",
- "object_store 0.13.1",
+ "indexmap 2.14.0",
+ "object_store 0.13.2",
  "parking_lot",
- "rand",
+ "rand 0.9.4",
  "restate-core",
  "restate-metadata-server-grpc",
  "restate-metadata-store",
@@ -7610,7 +7749,7 @@ dependencies = [
  "protobuf",
  "raft",
  "raft-proto",
- "rand",
+ "rand 0.9.4",
  "restate-core",
  "restate-metadata-providers",
  "restate-metadata-server-grpc",
@@ -7695,13 +7834,13 @@ dependencies = [
  "futures",
  "googletest",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "jemalloc_pprof",
  "metrics",
  "metrics-exporter-prometheus",
  "prost-dto",
- "rand",
+ "rand 0.9.4",
  "restate-admin",
  "restate-bifrost",
  "restate-core",
@@ -7750,7 +7889,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "futures",
- "object_store 0.13.1",
+ "object_store 0.13.2",
  "restate-types",
  "restate-workspace-hack",
  "tracing",
@@ -7776,12 +7915,12 @@ dependencies = [
  "jiff",
  "metrics",
  "num-bigint",
- "object_store 0.13.1",
+ "object_store 0.13.2",
  "parking_lot",
  "paste",
  "pin-project",
  "prost",
- "rand",
+ "rand 0.9.4",
  "restate-clock",
  "restate-core",
  "restate-errors",
@@ -7889,7 +8028,7 @@ dependencies = [
  "http-body-util",
  "mock-service-endpoint",
  "octocrab",
- "rand",
+ "rand 0.9.4",
  "regex",
  "reqwest",
  "restate-admin",
@@ -7955,7 +8094,7 @@ dependencies = [
  "pem",
  "pin-project",
  "pprof",
- "rand",
+ "rand 0.9.4",
  "restate-service-client",
  "restate-types",
  "restate-workspace-hack",
@@ -8033,6 +8172,7 @@ name = "restate-sharding"
 version = "1.6.3-dev"
 dependencies = [
  "bilrost",
+ "derive_more",
  "flexbuffers",
  "restate-sharding",
  "restate-workspace-hack",
@@ -8117,7 +8257,7 @@ dependencies = [
  "pretty_assertions",
  "prost",
  "prost-types",
- "rand",
+ "rand 0.9.4",
  "restate-workspace-hack",
 ]
 
@@ -8167,7 +8307,7 @@ dependencies = [
  "console-subscriber",
  "criterion",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "metrics",
  "metrics-exporter-prometheus",
  "nu-ansi-term",
@@ -8201,7 +8341,7 @@ dependencies = [
  "base62",
  "base64 0.22.1",
  "bilrost",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "bytestring",
  "chrono",
@@ -8224,7 +8364,7 @@ dependencies = [
  "googletest",
  "hostname",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "jsonptr 0.7.1",
  "jsonschema",
@@ -8243,7 +8383,7 @@ dependencies = [
  "prost-build",
  "prost-dto",
  "prost-types",
- "rand",
+ "rand 0.9.4",
  "regex",
  "regress",
  "restate-base64-util",
@@ -8266,7 +8406,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "static_assertions",
  "strum",
@@ -8306,7 +8446,7 @@ dependencies = [
 name = "restate-utoipa"
 version = "1.6.3-dev"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "restate-utoipa",
  "restate-workspace-hack",
  "serde",
@@ -8336,7 +8476,7 @@ dependencies = [
  "restate-types",
  "restate-util-string",
  "restate-workspace-hack",
- "sha2",
+ "sha2 0.10.9",
  "slotmap",
  "smallvec",
  "tokio",
@@ -8392,7 +8532,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "prost",
- "rand",
+ "rand 0.9.4",
  "restate-bifrost",
  "restate-clock",
  "restate-core",
@@ -8459,7 +8599,7 @@ dependencies = [
  "aws-smithy-types",
  "axum",
  "bilrost",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "bytestring",
  "cc",
@@ -8476,7 +8616,7 @@ dependencies = [
  "dashmap",
  "derive_more",
  "derive_more-impl",
- "digest",
+ "digest 0.10.7",
  "either",
  "enum-map",
  "errno",
@@ -8495,12 +8635,11 @@ dependencies = [
  "hashbrown 0.16.1",
  "hdrhistogram",
  "hex",
- "hmac",
  "hyper",
  "hyper-rustls",
  "hyper-util",
  "idna",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "ipnet",
  "itertools 0.14.0",
  "jemalloc_pprof",
@@ -8531,6 +8670,7 @@ dependencies = [
  "prost-types",
  "protobuf",
  "quanta",
+ "quick-xml 0.39.2",
  "quote",
  "rdkafka",
  "rdkafka-sys",
@@ -8578,10 +8718,9 @@ dependencies = [
  "utoipa",
  "utoipa-gen",
  "uuid",
- "winnow 1.0.0",
+ "winnow 1.0.2",
  "xxhash-rust",
  "zerocopy",
- "zeroize",
  "zstd",
  "zstd-safe",
  "zstd-sys",
@@ -8612,7 +8751,7 @@ dependencies = [
  "itertools 0.14.0",
  "json-patch 2.0.0",
  "prost-types",
- "rand",
+ "rand 0.9.4",
  "restate-bifrost",
  "restate-cli-util",
  "restate-clock",
@@ -8748,9 +8887,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -8767,7 +8906,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -8776,9 +8915,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -8950,7 +9089,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -8969,9 +9108,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -9053,9 +9192,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -9094,7 +9233,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -9134,8 +9273,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -9145,8 +9284,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -9234,9 +9384,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simdutf8"
@@ -9401,16 +9551,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -9458,15 +9598,15 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacker"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9516,9 +9656,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symbolic-common"
-version = "12.17.2"
+version = "12.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751a2823d606b5d0a7616499e4130a516ebd01a44f39811be2b9600936509c23"
+checksum = "4bbc8b4f883265fb2207a0d6ce67095f4bd6cf13e5f9183eb8b3e73fa1b2466a"
 dependencies = [
  "debugid",
  "memmap2",
@@ -9528,14 +9668,20 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.17.2"
+version = "12.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b237cfbe320601dd24b4ac817a5b68bb28f5508e33f08d42be0682cadc8ac9"
+checksum = "8eda470a26ea40eb5cafc35487718e23a2f19153d3a589affb9e8f7fa1aa73b3"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
  "symbolic-common",
 ]
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -9585,7 +9731,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -9657,12 +9803,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9673,23 +9819,33 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-log"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d53ac171c92a39e4769491c4b4dde7022c60042254b5fc044ae409d34a24d4"
+checksum = "2f46bf474f0a4afebf92f076d54fd5e63423d9438b8c278a3d2ccb0f47f7cdb3"
 dependencies = [
  "test-log-macros",
  "tracing-subscriber",
 ]
 
 [[package]]
-name = "test-log-macros"
-version = "0.2.19"
+name = "test-log-core"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be35209fd0781c5401458ab66e4f98accf63553e8fae7425503e92fdd319783b"
+checksum = "37d4d41320b48bc4a211a9021678fcc0c99569b594ea31c93735b8e517102b4c"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9beb9249a81e430dffd42400a49019bcf548444f1968ff23080a625de0d4d320"
+dependencies = [
+ "syn 2.0.117",
+ "test-log-core",
 ]
 
 [[package]]
@@ -9835,9 +9991,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -9870,9 +10026,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "backtrace",
  "bytes",
@@ -9881,7 +10037,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -9889,9 +10045,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9953,9 +10109,9 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
- "serde_spanned 1.0.4",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -9982,9 +10138,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -9995,7 +10151,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
@@ -10006,7 +10162,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -10016,23 +10172,23 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.5+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 1.0.1+spec-1.1.0",
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow 1.0.2",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -10043,9 +10199,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -10068,7 +10224,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "rustls-native-certs",
- "socket2 0.6.3",
+ "socket2",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -10141,7 +10297,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -10159,7 +10315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -10201,12 +10357,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "parking_lot",
+ "symlink",
  "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
@@ -10374,9 +10531,9 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "typify"
@@ -10431,7 +10588,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand",
+ "rand 0.9.4",
  "serde",
  "web-time",
 ]
@@ -10471,9 +10628,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -10554,7 +10711,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -10587,9 +10744,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -10672,11 +10829,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -10685,14 +10842,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -10703,23 +10860,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -10727,9 +10880,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -10740,9 +10893,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -10764,7 +10917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -10788,17 +10941,17 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10817,9 +10970,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -11182,21 +11335,11 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -11207,6 +11350,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -11227,7 +11376,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -11257,8 +11406,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -11277,7 +11426,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -11289,9 +11438,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -11345,9 +11494,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -11356,9 +11505,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11368,18 +11517,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11388,18 +11537,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11412,26 +11561,12 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -11440,9 +11575,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -11451,9 +11586,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11462,9 +11597,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "8.2.0"
+version = "8.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b680f2a0cd479b4cff6e1233c483fdead418106eae419dc60200ae9850f6d004"
+checksum = "dcab981e19633ebcf0b001ddd37dd802996098bc1864f90b7c5d970ce76c1d59"
 dependencies = [
  "aes",
  "bzip2",
@@ -11473,8 +11608,8 @@ dependencies = [
  "deflate64",
  "flate2",
  "getrandom 0.4.2",
- "hmac",
- "indexmap 2.13.0",
+ "hmac 0.12.1",
+ "indexmap 2.14.0",
  "lzma-rust2",
  "memchr",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ restate-service-protocol = { path = "crates/service-protocol" }
 restate-service-protocol-v4 = { path = "crates/service-protocol-v4" }
 restate-storage-api = { path = "crates/storage-api" }
 restate-storage-query-datafusion = { path = "crates/storage-query-datafusion" }
+restate-sharding = { path = "crates/sharding" }
 restate-util-string = { path = "util/string" }
 restate-test-util = { path = "crates/test-util" }
 restate-time-util = { path = "crates/time-util" }

--- a/crates/encoding/Cargo.toml
+++ b/crates/encoding/Cargo.toml
@@ -18,4 +18,5 @@ bytestring = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }
+restate-sharding = { workspace = true, features = ["bilrost"] }
 static_assertions = { workspace = true }

--- a/crates/encoding/Cargo.toml
+++ b/crates/encoding/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 restate-workspace-hack = { workspace = true }
 
 restate-encoding-derive = { version = "0.1.0", path = "derive" }
+restate-sharding = { workspace = true }
 
 bilrost = { workspace = true }
 bytes = { workspace = true }

--- a/crates/encoding/src/lib.rs
+++ b/crates/encoding/src/lib.rs
@@ -98,6 +98,7 @@ where
 
 impl<V> NetSerde for HashSet<V> where V: NetSerde {}
 impl<Idx> NetSerde for RangeInclusive<Idx> where Idx: NetSerde {}
+impl NetSerde for restate_sharding::PartitionId {}
 impl<T> NetSerde for Arc<T> where T: NetSerde {}
 impl<T> NetSerde for Arc<[T]> where T: NetSerde {}
 impl<T> NetSerde for Box<T> where T: NetSerde {}
@@ -130,5 +131,50 @@ mod test {
         let y = Flattened::decode(bytes).expect("decodes");
 
         assert_eq!(x.id.0, y.id);
+    }
+
+    /// Validates that `KeyRange`'s general bilrost encoding produces the same
+    /// wire format as `RangeInclusive<u64>` with `RestateEncoding`. This ensures
+    /// that `KeyRange` fields can use `#[bilrost(N)]` and remain wire-compatible
+    /// with the old `#[bilrost(tag(N), encoding(RestateEncoding))] RangeInclusive<u64>`.
+    #[test]
+    fn key_range_wire_compat_with_range_inclusive() {
+        use restate_sharding::KeyRange;
+
+        use super::RestateEncoding;
+
+        #[derive(Debug, PartialEq, bilrost::Message)]
+        struct WithKeyRange {
+            #[bilrost(1)]
+            range: KeyRange,
+        }
+
+        #[derive(Debug, PartialEq, bilrost::Message)]
+        struct WithRangeInclusive {
+            #[bilrost(tag(1), encoding(RestateEncoding))]
+            range: std::ops::RangeInclusive<u64>,
+        }
+
+        for (start, end) in [(0u64, 0u64), (1, 100), (0, u64::MAX), (42, 42)] {
+            let kr = KeyRange::new(start, end);
+            let ri = start..=end;
+
+            let kr_bytes = WithKeyRange { range: kr }.encode_to_vec();
+            let ri_bytes = WithRangeInclusive { range: ri.clone() }.encode_to_vec();
+
+            assert_eq!(
+                kr_bytes, ri_bytes,
+                "wire format mismatch for range ({start}, {end})"
+            );
+
+            // Cross-decode
+            let decoded: WithRangeInclusive =
+                WithRangeInclusive::decode(&*kr_bytes).expect("cross-decode KeyRange→RI");
+            assert_eq!(decoded.range, ri);
+
+            let decoded: WithKeyRange =
+                WithKeyRange::decode(&*ri_bytes).expect("cross-decode RI→KeyRange");
+            assert_eq!(decoded.range, kr);
+        }
     }
 }

--- a/crates/ingestion-client/src/client.rs
+++ b/crates/ingestion-client/src/client.rs
@@ -440,7 +440,7 @@ mod test {
             let partition = pt.get(&partition_id).unwrap();
             client
                 .ingest(
-                    *partition.key_range.start(),
+                    partition.key_range.start(),
                     InputRecord::from_str(format!("partition {p}")),
                 )
                 .await

--- a/crates/invoker-api/src/handle.rs
+++ b/crates/invoker-api/src/handle.rs
@@ -8,17 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::ops::RangeInclusive;
-
-use restate_types::vqueues::VQueueId;
 use tokio::sync::mpsc;
 
 use restate_errors::NotRunningError;
 use restate_futures_util::concurrency::Permit;
 use restate_memory::MemoryLease;
-use restate_types::identifiers::{EntryIndex, InvocationId, PartitionKey, PartitionLeaderEpoch};
+use restate_types::identifiers::{EntryIndex, InvocationId, PartitionLeaderEpoch};
 use restate_types::invocation::InvocationTarget;
 use restate_types::journal_v2::{CommandIndex, NotificationId};
+use restate_types::sharding::KeyRange;
+use restate_types::vqueues::VQueueId;
 
 use super::Effect;
 
@@ -89,7 +88,7 @@ pub trait InvokerHandle<SR> {
     fn register_partition(
         &mut self,
         partition: PartitionLeaderEpoch,
-        partition_key_range: RangeInclusive<PartitionKey>,
+        partition_key_range: KeyRange,
         storage_reader: SR,
         sender: mpsc::Sender<Box<Effect>>,
     ) -> Result<(), NotRunningError>;

--- a/crates/invoker-api/src/lib.rs
+++ b/crates/invoker-api/src/lib.rs
@@ -26,7 +26,6 @@ pub mod test_util {
     use super::*;
     use std::convert::Infallible;
     use std::marker::PhantomData;
-    use std::ops::RangeInclusive;
 
     use bytes::Bytes;
     use tokio::sync::mpsc::Sender;
@@ -36,10 +35,9 @@ pub mod test_util {
     use restate_memory::{
         IgnorePinnableMemoryStream, LocalMemoryLease, LocalMemoryPool, MemoryLease,
     };
-    use restate_types::identifiers::{
-        EntryIndex, InvocationId, PartitionKey, PartitionLeaderEpoch, ServiceId,
-    };
+    use restate_types::identifiers::{EntryIndex, InvocationId, PartitionLeaderEpoch, ServiceId};
     use restate_types::invocation::{InvocationTarget, ServiceInvocationSpanContext};
+    use restate_types::sharding::KeyRange;
     use restate_types::time::MillisSinceEpoch;
     use restate_types::vqueues::VQueueId;
 
@@ -238,7 +236,7 @@ pub mod test_util {
         fn register_partition(
             &mut self,
             _partition: PartitionLeaderEpoch,
-            _partition_key_range: RangeInclusive<PartitionKey>,
+            _partition_key_range: KeyRange,
             _storage_reader: SR,
             _sender: Sender<Box<Effect>>,
         ) -> Result<(), NotRunningError> {

--- a/crates/invoker-api/src/status_handle.rs
+++ b/crates/invoker-api/src/status_handle.rs
@@ -8,15 +8,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::future::Future;
+use std::time::SystemTime;
+
 use codederror::Code;
+
 use restate_types::errors::InvocationError;
-use restate_types::identifiers::{DeploymentId, InvocationId, PartitionKey};
+use restate_types::identifiers::{DeploymentId, InvocationId};
 use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionLeaderEpoch};
 use restate_types::journal::{EntryIndex, EntryType};
 use restate_types::service_protocol::ServiceProtocolVersion;
-use std::future::Future;
-use std::ops::RangeInclusive;
-use std::time::SystemTime;
+use restate_types::sharding::KeyRange;
 
 // -- Status data structure
 
@@ -125,10 +127,7 @@ pub trait StatusHandle {
     /// filtered by the partition key range
     ///
     /// The data returned by this method is eventually consistent.
-    fn read_status(
-        &self,
-        keys: RangeInclusive<PartitionKey>,
-    ) -> impl Future<Output = Self::Iterator> + Send;
+    fn read_status(&self, keys: KeyRange) -> impl Future<Output = Self::Iterator> + Send;
 }
 
 #[cfg(any(test, feature = "test-util"))]
@@ -148,7 +147,7 @@ pub mod test_util {
     impl StatusHandle for MockStatusHandle {
         type Iterator = std::vec::IntoIter<InvocationStatusReport>;
 
-        async fn read_status(&self, _keys: RangeInclusive<PartitionKey>) -> Self::Iterator {
+        async fn read_status(&self, _keys: KeyRange) -> Self::Iterator {
             self.0.clone().into_iter()
         }
     }

--- a/crates/invoker-impl/src/input_command.rs
+++ b/crates/invoker-impl/src/input_command.rs
@@ -8,16 +8,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::ops::RangeInclusive;
-
 use tokio::sync::mpsc;
 
 use restate_errors::NotRunningError;
 use restate_futures_util::concurrency::Permit;
 use restate_memory::MemoryLease;
-use restate_types::identifiers::{EntryIndex, InvocationId, PartitionKey, PartitionLeaderEpoch};
+use restate_types::identifiers::{EntryIndex, InvocationId, PartitionLeaderEpoch};
 use restate_types::invocation::InvocationTarget;
 use restate_types::journal_v2::{CommandIndex, NotificationId};
+use restate_types::sharding::KeyRange;
 use restate_types::vqueues::VQueueId;
 
 use restate_invoker_api::{Effect, InvocationStatusReport, StatusHandle};
@@ -93,7 +92,7 @@ pub(crate) enum InputCommand<SR> {
     // needed for dynamic registration at Invoker
     RegisterPartition {
         partition: PartitionLeaderEpoch,
-        partition_key_range: RangeInclusive<PartitionKey>,
+        partition_key_range: KeyRange,
         storage_reader: SR,
         sender: mpsc::Sender<Box<Effect>>,
     },
@@ -241,7 +240,7 @@ impl<SR: Send> restate_invoker_api::InvokerHandle<SR> for InvokerHandle<SR> {
     fn register_partition(
         &mut self,
         partition: PartitionLeaderEpoch,
-        partition_key_range: RangeInclusive<PartitionKey>,
+        partition_key_range: KeyRange,
         storage_reader: SR,
         sender: mpsc::Sender<Box<Effect>>,
     ) -> Result<(), NotRunningError> {
@@ -259,10 +258,7 @@ impl<SR: Send> restate_invoker_api::InvokerHandle<SR> for InvokerHandle<SR> {
 #[derive(Debug, Clone)]
 pub struct ChannelStatusReader(
     pub(super)  mpsc::UnboundedSender<
-        restate_futures_util::command::Command<
-            RangeInclusive<PartitionKey>,
-            Vec<InvocationStatusReport>,
-        >,
+        restate_futures_util::command::Command<KeyRange, Vec<InvocationStatusReport>>,
     >,
 );
 
@@ -272,7 +268,7 @@ impl StatusHandle for ChannelStatusReader {
         std::vec::IntoIter<InvocationStatusReport>,
     >;
 
-    async fn read_status(&self, keys: RangeInclusive<PartitionKey>) -> Self::Iterator {
+    async fn read_status(&self, keys: KeyRange) -> Self::Iterator {
         let (cmd, rx) = restate_futures_util::command::Command::prepare(keys);
         if self.0.send(cmd).is_err() {
             return itertools::Either::Left(std::iter::empty::<InvocationStatusReport>());

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -20,7 +20,7 @@ mod status_store;
 
 use std::collections::{HashMap, HashSet};
 use std::io::ErrorKind;
-use std::ops::RangeInclusive;
+use std::ops::RangeBounds;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::time::{Duration, Instant, SystemTime};
@@ -49,7 +49,7 @@ use restate_service_client::{AssumeRoleCacheMode, ServiceClient};
 use restate_time_util::DurationExt;
 use restate_types::config::{Configuration, InvokerOptions, ServiceClientOptions};
 use restate_types::deployment::PinnedDeployment;
-use restate_types::identifiers::{DeploymentId, InvocationId, PartitionKey, WithPartitionKey};
+use restate_types::identifiers::{DeploymentId, InvocationId, WithPartitionKey};
 use restate_types::identifiers::{PartitionId, PartitionLeaderEpoch};
 use restate_types::invocation::InvocationTarget;
 use restate_types::journal::EntryIndex;
@@ -61,6 +61,7 @@ use restate_types::journal_v2::{CommandIndex, EntryMetadata, NotificationId};
 use restate_types::live::{Live, LiveLoad};
 use restate_types::schema::deployment::DeploymentResolver;
 use restate_types::schema::invocation_target::InvocationTargetResolver;
+use restate_types::sharding::KeyRange;
 use tokio_util::time::DelayQueue;
 use tokio_util::time::delay_queue::Key as RetryTimerKey;
 
@@ -203,10 +204,7 @@ pub struct Service<StorageReader, EntryEnricher, Schemas> {
     // Used for constructing the invoker sender and status reader
     input_tx: mpsc::UnboundedSender<InputCommand<StorageReader>>,
     status_tx: mpsc::UnboundedSender<
-        restate_futures_util::command::Command<
-            RangeInclusive<PartitionKey>,
-            Vec<InvocationStatusReport>,
-        >,
+        restate_futures_util::command::Command<KeyRange, Vec<InvocationStatusReport>>,
     >,
     // For the segment queue
     tmp_dir: PathBuf,
@@ -386,10 +384,7 @@ where
 struct ServiceInner<InvocationTaskRunner, Schemas, StorageReader> {
     input_rx: mpsc::UnboundedReceiver<InputCommand<StorageReader>>,
     status_rx: mpsc::UnboundedReceiver<
-        restate_futures_util::command::Command<
-            RangeInclusive<PartitionKey>,
-            Vec<InvocationStatusReport>,
-        >,
+        restate_futures_util::command::Command<KeyRange, Vec<InvocationStatusReport>>,
     >,
 
     // Channel to communicate with invocation tasks
@@ -449,10 +444,10 @@ where
 
         tokio::select! {
             Some(cmd) = self.status_rx.recv() => {
-                let keys = cmd.payload();
+                let keys = *cmd.payload();
                 let statuses = self
                     .invocation_state_machine_manager
-                    .registered_partitions_with_keys(keys.clone())
+                    .registered_partitions_with_keys(keys)
                     .flat_map(|partition| self.status_store.status_for_partition(partition))
                     .filter(|status| keys.contains(&status.invocation_id().partition_key()))
                     .collect();
@@ -607,7 +602,7 @@ where
     fn handle_register_partition(
         &mut self,
         partition: PartitionLeaderEpoch,
-        partition_key_range: RangeInclusive<PartitionKey>,
+        partition_key_range: KeyRange,
         storage_reader: IR,
         sender: mpsc::Sender<Box<Effect>>,
     ) {
@@ -1850,10 +1845,7 @@ mod tests {
         ) -> (
             mpsc::UnboundedSender<InputCommand<IR>>,
             mpsc::UnboundedSender<
-                restate_futures_util::command::Command<
-                    RangeInclusive<PartitionKey>,
-                    Vec<InvocationStatusReport>,
-                >,
+                restate_futures_util::command::Command<KeyRange, Vec<InvocationStatusReport>>,
             >,
             Self,
         ) {
@@ -1887,7 +1879,7 @@ mod tests {
             let (partition_tx, partition_rx) = mpsc::channel(1024);
             self.handle_register_partition(
                 MOCK_PARTITION,
-                RangeInclusive::new(0, 0),
+                KeyRange::new(0, 0),
                 storage_reader,
                 partition_tx,
             );
@@ -2139,7 +2131,7 @@ mod tests {
         handle
             .register_partition(
                 partition_leader_epoch,
-                RangeInclusive::new(0, 0),
+                KeyRange::new(0, 0),
                 EmptyStorageReader,
                 output_tx,
             )

--- a/crates/invoker-impl/src/state_machine_manager.rs
+++ b/crates/invoker-impl/src/state_machine_manager.rs
@@ -9,11 +9,10 @@
 // by the Apache License, Version 2.0.
 
 use super::*;
-use std::ops::RangeInclusive;
 
 use restate_invoker_api::Effect;
 use restate_invoker_api::invocation_reader::InvocationReader;
-use restate_types::identifiers::PartitionKey;
+use restate_types::sharding::KeyRange;
 
 /// Tree of [InvocationStateMachine] held by the [Service].
 #[derive(Debug)]
@@ -33,7 +32,7 @@ impl<SR> Default for InvocationStateMachineManager<SR> {
 struct PartitionInvocationStateMachineCoordinator<IR> {
     output_tx: mpsc::Sender<Box<Effect>>,
     invocation_state_machines: HashMap<InvocationId, InvocationStateMachine>,
-    partition_key_range: RangeInclusive<PartitionKey>,
+    partition_key_range: KeyRange,
     storage_reader: IR,
 }
 
@@ -115,7 +114,7 @@ where
     pub(super) fn register_partition(
         &mut self,
         partition: PartitionLeaderEpoch,
-        partition_key_range: RangeInclusive<PartitionKey>,
+        partition_key_range: KeyRange,
         storage_reader: IR,
         sender: mpsc::Sender<Box<Effect>>,
     ) {
@@ -150,7 +149,7 @@ where
 
     pub(super) fn registered_partitions_with_keys(
         &self,
-        keys: RangeInclusive<PartitionKey>,
+        keys: KeyRange,
     ) -> impl Iterator<Item = PartitionLeaderEpoch> + '_ {
         self.partitions
             .iter()

--- a/crates/partition-store/benches/basic_benchmark.rs
+++ b/crates/partition-store/benches/basic_benchmark.rs
@@ -8,8 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::ops::RangeInclusive;
-
 use criterion::{Criterion, criterion_group, criterion_main};
 use tokio::runtime::Builder;
 
@@ -22,6 +20,7 @@ use restate_storage_api::deduplication_table::{
 };
 use restate_types::identifiers::{PartitionId, PartitionKey};
 use restate_types::partitions::Partition;
+use restate_types::sharding::KeyRange;
 
 async fn writing_to_rocksdb(mut rocksdb: PartitionStore) {
     //
@@ -57,7 +56,7 @@ fn basic_writing_reading_benchmark(c: &mut Criterion) {
             .expect("DB creation succeeds");
         manager
             .open(
-                &Partition::new(PartitionId::MIN, RangeInclusive::new(0, PartitionKey::MAX)),
+                &Partition::new(PartitionId::MIN, KeyRange::new(0, PartitionKey::MAX)),
                 None,
             )
             .await

--- a/crates/partition-store/src/idempotency_table/mod.rs
+++ b/crates/partition-store/src/idempotency_table/mod.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::ops::{ControlFlow, RangeInclusive};
+use std::ops::ControlFlow;
 
 use bytes::Bytes;
 use bytestring::ByteString;
@@ -20,6 +20,7 @@ use restate_storage_api::idempotency_table::{
 use restate_storage_api::protobuf_types::PartitionStoreProtobufValue;
 use restate_storage_api::{Result, StorageError};
 use restate_types::identifiers::{IdempotencyId, PartitionKey, WithPartitionKey};
+use restate_types::sharding::KeyRange;
 
 use crate::keys::{DecodeTableKey, KeyKind, define_table_key};
 use crate::scan::TableScan;
@@ -92,7 +93,7 @@ impl ScanIdempotencyTable for PartitionStore {
         F: FnMut((IdempotencyId, IdempotencyMetadata)) -> ControlFlow<()> + Send + Sync + 'static,
     >(
         &self,
-        range: RangeInclusive<PartitionKey>,
+        range: KeyRange,
         mut f: F,
     ) -> Result<impl Future<Output = Result<()>> + Send> {
         self.iterator_for_each(

--- a/crates/partition-store/src/inbox_table/mod.rs
+++ b/crates/partition-store/src/inbox_table/mod.rs
@@ -22,6 +22,7 @@ use restate_storage_api::protobuf_types::PartitionStoreProtobufValue;
 use restate_storage_api::{Result, StorageError};
 use restate_types::identifiers::{PartitionKey, ServiceId, WithPartitionKey};
 use restate_types::message::MessageIndex;
+use restate_types::sharding::KeyRange;
 
 use crate::TableKind::Inbox;
 use crate::keys::{DecodeTableKey, KeyKind, define_table_key};
@@ -103,7 +104,7 @@ impl ScanInboxTable for PartitionStore {
         F: FnMut(SequenceNumberInboxEntry) -> ControlFlow<()> + Send + Sync + 'static,
     >(
         &self,
-        range: std::ops::RangeInclusive<PartitionKey>,
+        range: KeyRange,
         mut f: F,
     ) -> Result<impl Future<Output = Result<()>> + Send> {
         self.iterator_for_each(

--- a/crates/partition-store/src/invocation_status_table/mod.rs
+++ b/crates/partition-store/src/invocation_status_table/mod.rs
@@ -121,7 +121,7 @@ impl ScanInvocationStatusTable for PartitionStore {
         self.iterator_filter_map(
             "scan-all-invoked",
             Priority::High,
-            FullScanPartitionKeyRange::<InvocationStatusKey>(self.partition_key_range().clone()),
+            FullScanPartitionKeyRange::<InvocationStatusKey>(self.partition_key_range()),
             read_invoked_full_invocation_id,
         )
         .map_err(|_| StorageError::OperationalError)
@@ -221,7 +221,7 @@ impl ScanInvocationStatusTable for PartitionStore {
                 "df-filter-map-invocation-status",
                 Priority::Low,
                 TableScan::FullScanPartitionKeyRange::<InvocationStatusKey>(
-                    self.partition_key_range().clone(),
+                    self.partition_key_range(),
                 ),
                 {
                     move |(mut key, mut value)| {

--- a/crates/partition-store/src/journal_table_v2/mod.rs
+++ b/crates/partition-store/src/journal_table_v2/mod.rs
@@ -349,7 +349,7 @@ pub fn cleanup_orphaned_completion_id_index_entries(
     let mut cancelled = false;
 
     let scan_store = storage.clone();
-    let partition_key_range = scan_store.partition_key_range().clone();
+    let partition_key_range = scan_store.partition_key_range();
     let scan = TableScan::FullScanPartitionKeyRange::<JournalCompletionIdToCommandIndexKeyBuilder>(
         partition_key_range,
     );

--- a/crates/partition-store/src/locks_table/mod.rs
+++ b/crates/partition-store/src/locks_table/mod.rs
@@ -8,8 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::ops::RangeInclusive;
-
 use anyhow::Context;
 use bilrost::{Message, OwnedMessage};
 use bytes::{Buf, BufMut};
@@ -18,6 +16,7 @@ use restate_rocksdb::Priority;
 use restate_storage_api::StorageError;
 use restate_storage_api::lock_table::{LoadLocks, LockState, ScanLocksTable, WriteLockTable};
 use restate_types::identifiers::{PartitionKey, WithPartitionKey};
+use restate_types::sharding::KeyRange;
 use restate_types::{CanonicalLockId, LockName, Scope};
 use restate_util_string::InternedReString;
 
@@ -137,13 +136,13 @@ impl LoadLocks for PartitionDb {
         let mut key_buf = [0u8; KeyKind::SERIALIZED_LENGTH + std::mem::size_of::<PartitionKey>()];
         // Setting up iterator bounds
         EncodeTableKeyPrefix::serialize_to(
-            &LockKey::builder().partition_key(*self.partition().key_range.start()),
+            &LockKey::builder().partition_key(self.partition().key_range.start()),
             &mut key_buf.as_mut(),
         );
         iterator_opts.set_iterate_lower_bound(key_buf);
 
         EncodeTableKeyPrefix::serialize_to(
-            &LockKey::builder().partition_key(*self.partition().key_range.end()),
+            &LockKey::builder().partition_key(self.partition().key_range.end()),
             &mut key_buf.as_mut(),
         );
         // End key is exclusive in rocksdb iterators, so the end prefix is one byte
@@ -223,7 +222,7 @@ impl ScanLocksTable for PartitionStore {
             + 'static,
     >(
         &self,
-        range: RangeInclusive<PartitionKey>,
+        range: KeyRange,
         mut f: F,
     ) -> Result<impl Future<Output = Result<()>> + Send> {
         self.iterator_for_each(

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -9,7 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use std::ops::ControlFlow;
-use std::ops::RangeInclusive;
+use std::ops::RangeBounds;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -37,6 +37,7 @@ use restate_types::config::Configuration;
 use restate_types::identifiers::{PartitionId, PartitionKey, SnapshotId, WithPartitionKey};
 use restate_types::logs::Lsn;
 use restate_types::partitions::Partition;
+use restate_types::sharding::KeyRange;
 use restate_types::storage::StorageCodec;
 use restate_types::storage::StorageDecode;
 use restate_types::storage::StorageEncode;
@@ -251,13 +252,13 @@ impl PartitionStore {
         self.db.partition().partition_id
     }
 
-    pub fn partition_key_range(&self) -> &RangeInclusive<PartitionKey> {
-        &self.db.partition().key_range
+    pub fn partition_key_range(&self) -> KeyRange {
+        self.db.partition().key_range
     }
 
     #[inline]
     pub(crate) fn assert_partition_key(&self, partition_key: &impl WithPartitionKey) -> Result<()> {
-        assert_partition_key_or_err(&self.db.partition().key_range, partition_key)
+        assert_partition_key_or_err(self.db.partition().key_range, partition_key)
     }
 
     pub fn contains_partition_key(&self, key: PartitionKey) -> bool {
@@ -686,7 +687,7 @@ impl PartitionStore {
             db_comparator_name: export_files.get_db_comparator_name(),
             log_id: self.db.partition().log_id(),
             min_applied_lsn: applied_lsn,
-            key_range: self.db.partition().key_range.clone(),
+            key_range: self.db.partition().key_range,
         })
     }
 
@@ -946,12 +947,12 @@ impl PartitionStoreTransaction<'_> {
 
     #[inline]
     pub(crate) fn assert_partition_key(&self, partition_key: &impl WithPartitionKey) -> Result<()> {
-        assert_partition_key_or_err(&self.meta.key_range, partition_key)
+        assert_partition_key_or_err(self.meta.key_range, partition_key)
     }
 }
 
 fn assert_partition_key_or_err(
-    partition_key_range: &RangeInclusive<PartitionKey>,
+    partition_key_range: KeyRange,
     partition_key: &impl WithPartitionKey,
 ) -> Result<()> {
     let partition_key = partition_key.partition_key();
@@ -1324,6 +1325,7 @@ mod tests {
     use restate_storage_api::{IsolationLevel, StorageError, Transaction};
     use restate_types::identifiers::{PartitionId, PartitionKey};
     use restate_types::partitions::Partition;
+    use restate_types::sharding::KeyRange;
 
     impl EncodeTableKey for String {
         const TABLE: TableKind = TableKind::State;
@@ -1358,7 +1360,10 @@ mod tests {
         let partition_store_manager = PartitionStoreManager::create().await?;
         let mut partition_store = partition_store_manager
             .open(
-                &Partition::new(PartitionId::MIN, PartitionKey::MIN..=PartitionKey::MAX),
+                &Partition::new(
+                    PartitionId::MIN,
+                    KeyRange::new(PartitionKey::MIN, PartitionKey::MAX),
+                ),
                 None,
             )
             .await?;

--- a/crates/partition-store/src/promise_table/mod.rs
+++ b/crates/partition-store/src/promise_table/mod.rs
@@ -8,8 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::ops::RangeInclusive;
-
 use bytes::Bytes;
 use bytestring::ByteString;
 
@@ -20,6 +18,7 @@ use restate_storage_api::promise_table::{
 use restate_storage_api::protobuf_types::PartitionStoreProtobufValue;
 use restate_storage_api::{Result, StorageError};
 use restate_types::identifiers::{PartitionKey, ServiceId, WithPartitionKey};
+use restate_types::sharding::KeyRange;
 
 use crate::keys::{DecodeTableKey, KeyKind, define_table_key};
 use crate::scan::TableScan;
@@ -101,7 +100,7 @@ impl ScanPromiseTable for PartitionStore {
         F: FnMut(OwnedPromiseRow) -> std::ops::ControlFlow<()> + Send + Sync + 'static,
     >(
         &self,
-        range: RangeInclusive<PartitionKey>,
+        range: KeyRange,
         mut f: F,
     ) -> Result<impl Future<Output = Result<()>> + Send> {
         self.iterator_for_each(

--- a/crates/partition-store/src/scan.rs
+++ b/crates/partition-store/src/scan.rs
@@ -16,7 +16,7 @@ use crate::scan::TableScan::{
 use crate::{PaddedPartitionId, ScanMode, TableKind};
 use bytes::BytesMut;
 use restate_types::identifiers::{PartitionId, PartitionKey};
-use std::ops::RangeInclusive;
+use restate_types::sharding::KeyRange;
 
 // Note: we take extra arguments like (PartitionId or PartitionKey) only to make sure that
 // call-sites know what they are opting to. Those values might not actually be used to perform the
@@ -27,7 +27,7 @@ pub enum TableScan<K> {
     SinglePartition(PartitionId),
     /// Scan an inclusive key-range potentially across partitions.
     /// Requires total seek order
-    FullScanPartitionKeyRange(RangeInclusive<PartitionKey>),
+    FullScanPartitionKeyRange(KeyRange),
     /// Scan within a single partition key
     SinglePartitionKeyPrefix(PartitionKey, K),
     /// Inclusive Key Range in a single partition.
@@ -74,7 +74,8 @@ impl<K: EncodeTableKeyPrefix> From<TableScan<K>> for PhysicalScan {
                 PhysicalScan::Prefix(K::TABLE, K::KEY_KIND, prefix_start)
             }
             FullScanPartitionKeyRange(range) => {
-                let (start, end) = (range.start(), range.end());
+                let start = range.start();
+                let end = range.end();
                 let mut start_bytes =
                     BytesMut::with_capacity(start.serialized_length() + KeyKind::SERIALIZED_LENGTH);
                 K::serialize_key_kind(&mut start_bytes);

--- a/crates/partition-store/src/service_status_table/mod.rs
+++ b/crates/partition-store/src/service_status_table/mod.rs
@@ -8,8 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::ops::RangeInclusive;
-
 use bytestring::ByteString;
 
 use restate_rocksdb::{Priority, RocksDbPerfGuard};
@@ -20,6 +18,7 @@ use restate_storage_api::service_status_table::{
 };
 use restate_storage_api::{Result, StorageError};
 use restate_types::identifiers::{PartitionKey, ServiceId, WithPartitionKey};
+use restate_types::sharding::KeyRange;
 
 use crate::keys::{DecodeTableKey, KeyKind, define_table_key};
 use crate::scan::TableScan;
@@ -95,7 +94,7 @@ impl ScanVirtualObjectStatusTable for PartitionStore {
             + 'static,
     >(
         &self,
-        range: RangeInclusive<PartitionKey>,
+        range: KeyRange,
         mut f: F,
     ) -> Result<impl Future<Output = Result<()>> + Send> {
         self.iterator_for_each(

--- a/crates/partition-store/src/snapshots/metadata.rs
+++ b/crates/partition-store/src/snapshots/metadata.rs
@@ -8,7 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::ops::RangeInclusive;
 use std::path::PathBuf;
 
 use rocksdb::LiveFile;
@@ -16,9 +15,10 @@ use serde::{Deserialize, Serialize};
 use serde_with::hex::Hex;
 use serde_with::{DeserializeAs, SerializeAs, serde_as};
 
-use restate_types::identifiers::{PartitionId, PartitionKey, SnapshotId};
+use restate_types::identifiers::{PartitionId, SnapshotId};
 use restate_types::logs::{LogId, Lsn};
 use restate_types::nodes_config::ClusterFingerprint;
+use restate_types::sharding::KeyRange;
 
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum SnapshotFormatVersion {
@@ -59,7 +59,7 @@ pub struct PartitionSnapshotMetadata {
 
     /// The partition key range that the partition processor which generated this snapshot was
     /// responsible for, at the time the snapshot was generated.
-    pub key_range: RangeInclusive<PartitionKey>,
+    pub key_range: KeyRange,
 
     /// The log id backing the partition.
     pub log_id: LogId,
@@ -118,7 +118,7 @@ struct PartitionSnapshotMetadataShadow {
     #[serde(with = "serde_with::As::<serde_with::DisplayFromStr>")]
     pub created_at: jiff::Timestamp,
     pub snapshot_id: SnapshotId,
-    pub key_range: RangeInclusive<PartitionKey>,
+    pub key_range: KeyRange,
     pub log_id: Option<LogId>,
     pub min_applied_lsn: Lsn,
     pub db_comparator_name: String,
@@ -158,7 +158,7 @@ pub struct LocalPartitionSnapshot {
     pub min_applied_lsn: Lsn,
     pub db_comparator_name: String,
     pub files: Vec<LiveFile>,
-    pub key_range: RangeInclusive<PartitionKey>,
+    pub key_range: KeyRange,
 }
 /// RocksDB SST file that is part of a snapshot. Serialization wrapper around [LiveFile].
 #[serde_as]

--- a/crates/partition-store/src/snapshots/repository.rs
+++ b/crates/partition-store/src/snapshots/repository.rs
@@ -889,7 +889,7 @@ impl SnapshotRepository {
             min_applied_lsn: snapshot_metadata.min_applied_lsn,
             db_comparator_name: snapshot_metadata.db_comparator_name,
             files: snapshot_metadata.files,
-            key_range: snapshot_metadata.key_range.clone(),
+            key_range: snapshot_metadata.key_range,
         }))
     }
 
@@ -1132,9 +1132,10 @@ mod tests {
     use restate_core::{Metadata, TestCoreEnv};
     use restate_object_store_util::create_object_store_client;
     use restate_types::config::{ObjectStoreOptions, SnapshotsOptions};
-    use restate_types::identifiers::{PartitionId, PartitionKey, SnapshotId};
+    use restate_types::identifiers::{PartitionId, SnapshotId};
     use restate_types::logs::{LogId, Lsn, SequenceNumber};
     use restate_types::retries::RetryPolicy;
+    use restate_types::sharding::KeyRange;
 
     use crate::snapshots::repository::LatestSnapshotVersion;
 
@@ -1353,7 +1354,7 @@ mod tests {
             partition_id: PartitionId::MIN,
             created_at: jiff::Timestamp::now(),
             snapshot_id: SnapshotId::new(),
-            key_range: PartitionKey::MIN..=PartitionKey::MAX,
+            key_range: KeyRange::FULL,
             log_id: LogId::MIN,
             min_applied_lsn: Lsn::new(1),
             db_comparator_name: "leveldb.BytewiseComparator".to_string(),

--- a/crates/partition-store/src/snapshots/snapshot_task.rs
+++ b/crates/partition-store/src/snapshots/snapshot_task.rs
@@ -119,7 +119,7 @@ impl SnapshotPartitionTask {
             partition_id: self.partition_id,
             created_at: created_at.into_timestamp(),
             snapshot_id: self.snapshot_id,
-            key_range: snapshot.key_range.clone(),
+            key_range: snapshot.key_range,
             log_id: snapshot.log_id,
             min_applied_lsn: snapshot.min_applied_lsn,
             db_comparator_name: snapshot.db_comparator_name.clone(),

--- a/crates/partition-store/src/state_table/mod.rs
+++ b/crates/partition-store/src/state_table/mod.rs
@@ -8,7 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::ops::RangeInclusive;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -25,6 +24,7 @@ use restate_rocksdb::{Priority, RocksDbPerfGuard};
 use restate_storage_api::state_table::{ReadStateTable, ScanStateTable, WriteStateTable};
 use restate_storage_api::{BudgetedReadError, Result, StorageError};
 use restate_types::identifiers::{PartitionKey, ServiceId, WithPartitionKey};
+use restate_types::sharding::KeyRange;
 
 use crate::TableKind::State;
 use crate::keys::{DecodeTableKey, KeyKind, define_table_key};
@@ -211,7 +211,7 @@ impl ScanStateTable for PartitionStore {
         F: FnMut((ServiceId, Bytes, &[u8])) -> std::ops::ControlFlow<()> + Send + Sync + 'static,
     >(
         &self,
-        range: RangeInclusive<PartitionKey>,
+        range: KeyRange,
         mut f: F,
     ) -> Result<impl Future<Output = Result<()>> + Send> {
         self.iterator_for_each(

--- a/crates/partition-store/src/tests/barrier_test.rs
+++ b/crates/partition-store/src/tests/barrier_test.rs
@@ -19,6 +19,7 @@ use restate_types::{
     SemanticRestateVersion,
     identifiers::{PartitionId, PartitionKey},
     partitions::Partition,
+    sharding::KeyRange,
 };
 
 use crate::PartitionStoreManager;
@@ -35,7 +36,10 @@ async fn barrier_fsm() -> googletest::Result<()> {
 
     let partition_store_manager = PartitionStoreManager::create().await?;
 
-    let partition = Partition::new(PartitionId::MIN, PartitionKey::MIN..=PartitionKey::MAX);
+    let partition = Partition::new(
+        PartitionId::MIN,
+        KeyRange::new(PartitionKey::MIN, PartitionKey::MAX),
+    );
     let mut partition_store = partition_store_manager.open(&partition, None).await?;
 
     // we default to unknown if FSM doesn't have a min version, in that case, any "real" version

--- a/crates/partition-store/src/tests/durable_lsn_tracking_test.rs
+++ b/crates/partition-store/src/tests/durable_lsn_tracking_test.rs
@@ -20,13 +20,16 @@ use restate_types::{
     identifiers::{PartitionId, PartitionKey},
     logs::Lsn,
     partitions::Partition,
+    sharding::KeyRange,
     time::MillisSinceEpoch,
 };
 
 use crate::PartitionStoreManager;
 
-const PARTITION: Partition =
-    Partition::new(PartitionId::MIN, PartitionKey::MIN..=PartitionKey::MAX);
+const PARTITION: Partition = Partition::new(
+    PartitionId::MIN,
+    KeyRange::new(PartitionKey::MIN, PartitionKey::MAX),
+);
 
 #[restate_core::test]
 async fn track_latest_applied_lsn() -> googletest::Result<()> {

--- a/crates/partition-store/src/tests/mod.rs
+++ b/crates/partition-store/src/tests/mod.rs
@@ -10,7 +10,6 @@
 
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::ops::RangeInclusive;
 use std::pin::pin;
 use std::sync::Arc;
 
@@ -26,6 +25,7 @@ use restate_types::identifiers::{
     InvocationId, PartitionId, PartitionKey, PartitionProcessorRpcRequestId, ServiceId,
 };
 use restate_types::invocation::{InvocationTarget, ServiceInvocation, Source};
+use restate_types::sharding::KeyRange;
 use restate_types::state_mut::ExternalStateMutation;
 
 mod barrier_test;
@@ -60,10 +60,7 @@ async fn storage_test_environment_with_manager() -> (Arc<PartitionStoreManager>,
     // A single partition store that spans all keys.
     let store = manager
         .open(
-            &Partition::new(
-                PartitionId::MIN,
-                RangeInclusive::new(0, PartitionKey::MAX - 1),
-            ),
+            &Partition::new(PartitionId::MIN, KeyRange::new(0, PartitionKey::MAX - 1)),
             None,
         )
         .await

--- a/crates/partition-store/src/tests/snapshots_test/mod.rs
+++ b/crates/partition-store/src/tests/snapshots_test/mod.rs
@@ -8,7 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::ops::RangeInclusive;
 use std::sync::Arc;
 
 use tempfile::tempdir;
@@ -18,6 +17,7 @@ use restate_storage_api::fsm_table::{ReadFsmTable, WriteFsmTable};
 use restate_types::identifiers::{PartitionKey, SnapshotId};
 use restate_types::logs::{LogId, Lsn};
 use restate_types::partitions::Partition;
+use restate_types::sharding::KeyRange;
 use restate_types::time::MillisSinceEpoch;
 
 use crate::snapshots::{LocalPartitionSnapshot, PartitionSnapshotMetadata, SnapshotFormatVersion};
@@ -38,7 +38,7 @@ pub(crate) async fn run_tests(
         .await
         .unwrap();
 
-    let key_range = partition_store.partition_key_range().clone();
+    let key_range = partition_store.partition_key_range();
     let snapshot_meta = PartitionSnapshotMetadata {
         version: SnapshotFormatVersion::V1,
         cluster_name: "cluster_name".to_string(),
@@ -47,7 +47,7 @@ pub(crate) async fn run_tests(
         node_name: "node".to_string(),
         created_at: MillisSinceEpoch::new(0).into_timestamp(),
         snapshot_id: SnapshotId::from_parts(0, 0),
-        key_range: key_range.clone(),
+        key_range,
         log_id: LogId::from(partition_id),
         min_applied_lsn: snapshot.min_applied_lsn,
         db_comparator_name: snapshot.db_comparator_name.clone(),
@@ -73,7 +73,7 @@ pub(crate) async fn run_tests(
 
     let mut new_partition_store = manager
         .open_from_snapshot(
-            &Partition::new(partition_id, RangeInclusive::new(0, PartitionKey::MAX - 1)),
+            &Partition::new(partition_id, KeyRange::new(0, PartitionKey::MAX - 1)),
             snapshot,
         )
         .await

--- a/crates/partition-store/src/vqueue_table/mod.rs
+++ b/crates/partition-store/src/vqueue_table/mod.rs
@@ -70,7 +70,7 @@ impl ScanVQueueTable for PartitionDb {
             // of it.
             let mut key_buf = key_buf.as_mut();
             ActiveKey::serialize_key_kind(&mut key_buf);
-            crate::keys::serialize(self.partition().key_range.start(), &mut key_buf);
+            crate::keys::serialize(&self.partition().key_range.start(), &mut key_buf);
         }
 
         // setting iterator bounds.
@@ -84,7 +84,7 @@ impl ScanVQueueTable for PartitionDb {
             // of it.
             let mut key_buf = key_buf.as_mut();
             ActiveKey::serialize_key_kind(&mut key_buf);
-            crate::keys::serialize(self.partition().key_range.end(), &mut key_buf);
+            crate::keys::serialize(&self.partition().key_range.end(), &mut key_buf);
         }
         let _success = crate::convert_to_upper_bound(&mut key_buf);
         debug_assert!(_success);

--- a/crates/sharding/Cargo.toml
+++ b/crates/sharding/Cargo.toml
@@ -16,6 +16,7 @@ bilrost = ["dep:bilrost"]
 restate-workspace-hack = { workspace = true }
 
 bilrost = { workspace = true, optional = true }
+derive_more = { workspace = true, features = ["deref", "from", "into", "add", "display", "debug", "from_str"] }
 serde = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/sharding/Cargo.toml
+++ b/crates/sharding/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "restate-sharding"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[features]
+default = []
+serde = ["dep:serde"]
+bilrost = ["dep:bilrost"]
+
+[dependencies]
+restate-workspace-hack = { workspace = true }
+
+bilrost = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+
+[dev-dependencies]
+restate-sharding = { path = ".", default-features = false, features = ["serde", "bilrost"] }
+
+flexbuffers = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/sharding/src/key_range.rs
+++ b/crates/sharding/src/key_range.rs
@@ -1,0 +1,441 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt;
+use std::ops::{Bound, RangeBounds};
+use std::range::RangeInclusiveIter;
+
+/// An inclusive range of partition keys `[start, end]`.
+///
+/// This is a compact, `Copy` representation of an inclusive key range backed by
+/// [`std::range::RangeInclusive<u64>`]. Compared to [`std::ops::RangeInclusive<u64>`]:
+///
+/// Wire-format compatible with `std::ops::RangeInclusive<u64>` for both serde and bilrost.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct KeyRange(std::range::RangeInclusive<u64>);
+
+impl KeyRange {
+    /// The full key space `[0, u64::MAX]`.
+    pub const FULL: Self = Self::new(u64::MIN, u64::MAX);
+
+    /// Creates a new inclusive key range `[start, end]`.
+    pub const fn new(start: u64, end: u64) -> Self {
+        Self(std::range::RangeInclusive { start, last: end })
+    }
+
+    /// The inclusive lower bound.
+    #[inline]
+    pub const fn start(&self) -> u64 {
+        self.0.start
+    }
+
+    /// The inclusive upper bound.
+    #[inline]
+    pub const fn end(&self) -> u64 {
+        self.0.last
+    }
+
+    /// Returns an iterator over all keys in this range.
+    #[inline]
+    pub fn iter(&self) -> RangeInclusiveIter<u64> {
+        self.0.iter()
+    }
+
+    /// Returns `true` if `self` and `other` share at least one key.
+    #[inline]
+    pub const fn is_overlapping(&self, other: &KeyRange) -> bool {
+        self.start() <= other.end() && other.start() <= self.end()
+    }
+
+    /// Splits this range into two roughly equal halves at the midpoint.
+    ///
+    /// Returns `None` if the range contains a single key (cannot be split).
+    /// Otherwise returns `(left, right)` where `left.end() + 1 == right.start()`.
+    pub const fn split(&self) -> Option<(KeyRange, KeyRange)> {
+        if self.start() == self.end() {
+            return None;
+        }
+        let mid = self.start() + (self.end() - self.start()) / 2;
+        Some((
+            KeyRange::new(self.start(), mid),
+            KeyRange::new(mid + 1, self.end()),
+        ))
+    }
+}
+
+impl RangeBounds<u64> for KeyRange {
+    #[inline]
+    fn start_bound(&self) -> Bound<&u64> {
+        self.0.start_bound()
+    }
+
+    #[inline]
+    fn end_bound(&self) -> Bound<&u64> {
+        self.0.end_bound()
+    }
+}
+
+impl From<std::ops::RangeInclusive<u64>> for KeyRange {
+    #[inline]
+    fn from(range: std::ops::RangeInclusive<u64>) -> Self {
+        Self::new(*range.start(), *range.end())
+    }
+}
+
+impl From<KeyRange> for std::ops::RangeInclusive<u64> {
+    #[inline]
+    fn from(range: KeyRange) -> Self {
+        range.start()..=range.end()
+    }
+}
+
+impl From<std::range::RangeInclusive<u64>> for KeyRange {
+    #[inline]
+    fn from(range: std::range::RangeInclusive<u64>) -> Self {
+        Self(range)
+    }
+}
+
+impl From<KeyRange> for std::range::RangeInclusive<u64> {
+    #[inline]
+    fn from(range: KeyRange) -> Self {
+        range.0
+    }
+}
+
+impl fmt::Display for KeyRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[{}, {}]", self.start(), self.end())
+    }
+}
+
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use super::KeyRange;
+
+    use serde::ser::SerializeStruct;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    /// Serializes as `{"start": <u64>, "end": <u64>}` to match `std::ops::RangeInclusive`'s
+    /// serde format.
+    impl Serialize for KeyRange {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            let mut state = serializer.serialize_struct("KeyRange", 2)?;
+            state.serialize_field("start", &self.start())?;
+            state.serialize_field("end", &self.end())?;
+            state.end()
+        }
+    }
+
+    /// Deserializes from `{"start": <u64>, "end": <u64>}` to match `std::ops::RangeInclusive`'s
+    /// serde format.
+    impl<'de> Deserialize<'de> for KeyRange {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+            #[derive(Deserialize)]
+            #[serde(deny_unknown_fields)]
+            struct Raw {
+                start: u64,
+                end: u64,
+            }
+            let raw = Raw::deserialize(deserializer)?;
+            Ok(KeyRange::new(raw.start, raw.end))
+        }
+    }
+}
+
+#[cfg(feature = "bilrost")]
+mod bilrost_impl {
+    use super::KeyRange;
+
+    use bilrost::DecodeErrorKind;
+    use bilrost::encoding::{EmptyState, ForOverwrite, Proxiable};
+
+    impl Proxiable for KeyRange {
+        type Proxy = (u64, u64);
+
+        fn encode_proxy(&self) -> Self::Proxy {
+            (self.start(), self.end())
+        }
+
+        fn decode_proxy(&mut self, proxy: Self::Proxy) -> Result<(), DecodeErrorKind> {
+            *self = KeyRange::new(proxy.0, proxy.1);
+            Ok(())
+        }
+    }
+
+    impl ForOverwrite<(), KeyRange> for () {
+        fn for_overwrite() -> KeyRange {
+            KeyRange::new(0, 0)
+        }
+    }
+
+    impl EmptyState<(), KeyRange> for () {
+        fn empty() -> KeyRange {
+            KeyRange::new(0, 0)
+        }
+
+        fn is_empty(val: &KeyRange) -> bool {
+            val.start() == 0 && val.end() == 0
+        }
+
+        fn clear(val: &mut KeyRange) {
+            *val = <() as EmptyState<(), KeyRange>>::empty();
+        }
+    }
+
+    bilrost::delegate_proxied_encoding!(
+        use encoding (bilrost::encoding::General)
+        to encode proxied type (KeyRange)
+        with general encodings
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basics() {
+        let r = KeyRange::new(10, 20);
+        assert_eq!(r.start(), 10);
+        assert_eq!(r.end(), 20);
+        assert!(r.contains(&10));
+        assert!(r.contains(&15));
+        assert!(r.contains(&20));
+        assert!(!r.contains(&9));
+        assert!(!r.contains(&21));
+
+        // Copy
+        let r2 = r;
+        assert_eq!(r, r2);
+
+        // Display
+        assert_eq!(format!("{r}"), "[10, 20]");
+    }
+
+    #[test]
+    fn full_range() {
+        assert_eq!(KeyRange::FULL.start(), u64::MIN);
+        assert_eq!(KeyRange::FULL.end(), u64::MAX);
+        assert!(KeyRange::FULL.contains(&0));
+        assert!(KeyRange::FULL.contains(&u64::MAX));
+    }
+
+    #[test]
+    fn from_ops_range_inclusive() {
+        let ops_range: std::ops::RangeInclusive<u64> = 5..=10;
+        let kr = KeyRange::from(ops_range.clone());
+        assert_eq!(kr.start(), 5);
+        assert_eq!(kr.end(), 10);
+
+        let back: std::ops::RangeInclusive<u64> = kr.into();
+        assert_eq!(back, ops_range);
+    }
+
+    #[test]
+    fn from_range_inclusive() {
+        let range = std::range::RangeInclusive { start: 3, last: 7 };
+        let kr = KeyRange::from(range);
+        assert_eq!(kr.start(), 3);
+        assert_eq!(kr.end(), 7);
+
+        let back: std::range::RangeInclusive<u64> = kr.into();
+        assert_eq!(back, range);
+    }
+
+    #[test]
+    fn size_and_copy() {
+        assert_eq!(size_of::<KeyRange>(), 16);
+        assert_eq!(
+            size_of::<KeyRange>(),
+            size_of::<std::range::RangeInclusive<u64>>()
+        );
+        // Old type is larger due to exhausted flag + padding
+        assert!(size_of::<std::ops::RangeInclusive<u64>>() > size_of::<KeyRange>());
+    }
+
+    #[test]
+    fn bilrost_roundtrip() {
+        use bilrost::{Message, OwnedMessage};
+
+        #[derive(Debug, PartialEq, bilrost::Message)]
+        struct TestMsg {
+            #[bilrost(1)]
+            range: KeyRange,
+        }
+
+        let msg = TestMsg {
+            range: KeyRange::new(100, 200),
+        };
+        let encoded = msg.encode_to_vec();
+        let decoded = TestMsg::decode(&*encoded).unwrap();
+        assert_eq!(msg, decoded);
+    }
+
+    #[test]
+    fn iter() {
+        let r = KeyRange::new(5, 9);
+        let keys: Vec<u64> = r.iter().collect();
+        assert_eq!(keys, vec![5, 6, 7, 8, 9]);
+
+        let single = KeyRange::new(42, 42);
+        let keys: Vec<u64> = single.iter().collect();
+        assert_eq!(keys, vec![42]);
+    }
+
+    #[test]
+    fn is_overlapping() {
+        let a = KeyRange::new(0, 10);
+        let b = KeyRange::new(5, 15);
+        assert!(a.is_overlapping(&b));
+        assert!(b.is_overlapping(&a));
+
+        // Adjacent ranges don't overlap
+        let c = KeyRange::new(11, 20);
+        assert!(!a.is_overlapping(&c));
+
+        // Touching at boundary
+        let d = KeyRange::new(10, 20);
+        assert!(a.is_overlapping(&d));
+
+        // Contained
+        let e = KeyRange::new(2, 8);
+        assert!(a.is_overlapping(&e));
+
+        // Same range
+        assert!(a.is_overlapping(&a));
+
+        // Disjoint
+        let f = KeyRange::new(100, 200);
+        assert!(!a.is_overlapping(&f));
+    }
+
+    #[test]
+    fn split() {
+        // Even range [0, 9] → [0, 4] and [5, 9]
+        let r = KeyRange::new(0, 9);
+        let (left, right) = r.split().unwrap();
+        assert_eq!(left, KeyRange::new(0, 4));
+        assert_eq!(right, KeyRange::new(5, 9));
+
+        // Odd range [0, 10] → [0, 5] and [6, 10]
+        let r = KeyRange::new(0, 10);
+        let (left, right) = r.split().unwrap();
+        assert_eq!(left, KeyRange::new(0, 5));
+        assert_eq!(right, KeyRange::new(6, 10));
+
+        // Two-element range [5, 6] → [5, 5] and [6, 6]
+        let r = KeyRange::new(5, 6);
+        let (left, right) = r.split().unwrap();
+        assert_eq!(left, KeyRange::new(5, 5));
+        assert_eq!(right, KeyRange::new(6, 6));
+
+        // Single element cannot be split
+        assert!(KeyRange::new(42, 42).split().is_none());
+
+        // Full range
+        let (left, right) = KeyRange::FULL.split().unwrap();
+        assert_eq!(left.start(), 0);
+        assert_eq!(right.end(), u64::MAX);
+        assert_eq!(left.end() + 1, right.start());
+    }
+
+    #[test]
+    fn json_wire_compat_with_ops_range_inclusive() {
+        // KeyRange must be wire-compatible with std::ops::RangeInclusive<u64> in JSON.
+        let kr = KeyRange::new(100, 200);
+        let ops = std::ops::RangeInclusive::new(100u64, 200u64);
+
+        let kr_json = serde_json::to_string(&kr).unwrap();
+        let ops_json = serde_json::to_string(&ops).unwrap();
+        assert_eq!(kr_json, ops_json, "serialized forms must be identical");
+
+        // Cross-deserialize in both directions
+        let kr_from_ops: KeyRange = serde_json::from_str(&ops_json).unwrap();
+        assert_eq!(kr_from_ops, kr);
+
+        let ops_from_kr: std::ops::RangeInclusive<u64> = serde_json::from_str(&kr_json).unwrap();
+        assert_eq!(ops_from_kr, ops);
+    }
+
+    #[test]
+    fn json_wire_compat_boundary_values() {
+        // Verify wire compat at boundary values (0, u64::MAX)
+        for (start, end) in [(0u64, 0u64), (0, u64::MAX), (u64::MAX, u64::MAX)] {
+            let kr = KeyRange::new(start, end);
+            let ops = std::ops::RangeInclusive::new(start, end);
+
+            let kr_json = serde_json::to_string(&kr).unwrap();
+            let ops_json = serde_json::to_string(&ops).unwrap();
+            assert_eq!(kr_json, ops_json, "mismatch at ({start}, {end})");
+
+            let roundtrip: KeyRange = serde_json::from_str(&ops_json).unwrap();
+            assert_eq!(roundtrip, kr);
+        }
+    }
+
+    #[test]
+    fn flexbuffers_wire_compat_with_ops_range_inclusive() {
+        // KeyRange must be wire-compatible with std::ops::RangeInclusive<u64> in flexbuffers.
+        let kr = KeyRange::new(100, 200);
+        let ops = std::ops::RangeInclusive::new(100u64, 200u64);
+
+        let kr_buf = flexbuffers::to_vec(kr).unwrap();
+        let ops_buf = flexbuffers::to_vec(&ops).unwrap();
+        assert_eq!(kr_buf, ops_buf, "serialized forms must be identical");
+
+        // Cross-deserialize in both directions
+        let kr_from_ops: KeyRange = flexbuffers::from_slice(&ops_buf).unwrap();
+        assert_eq!(kr_from_ops, kr);
+
+        let ops_from_kr: std::ops::RangeInclusive<u64> = flexbuffers::from_slice(&kr_buf).unwrap();
+        assert_eq!(ops_from_kr, ops);
+    }
+
+    #[test]
+    fn flexbuffers_wire_compat_boundary_values() {
+        for (start, end) in [(0u64, 0u64), (0, u64::MAX), (u64::MAX, u64::MAX)] {
+            let kr = KeyRange::new(start, end);
+            let ops = std::ops::RangeInclusive::new(start, end);
+
+            let kr_buf = flexbuffers::to_vec(kr).unwrap();
+            let ops_buf = flexbuffers::to_vec(&ops).unwrap();
+            assert_eq!(kr_buf, ops_buf, "mismatch at ({start}, {end})");
+
+            let roundtrip: KeyRange = flexbuffers::from_slice(&ops_buf).unwrap();
+            assert_eq!(roundtrip, kr);
+        }
+    }
+
+    #[test]
+    fn bilrost_compat_with_ops_range() {
+        use bilrost::{Message, OwnedMessage};
+
+        // The bilrost crate's existing encoding for RangeInclusive<u64> uses RestateEncoding
+        // which is defined in restate-encoding. We can't test cross-type bilrost compat here
+        // since RestateEncoding is not available in this crate. That test belongs in
+        // restate-encoding's test suite.
+        //
+        // Here we verify that KeyRange's bilrost encoding is self-consistent.
+        #[derive(Debug, PartialEq, bilrost::Message)]
+        struct Msg {
+            #[bilrost(1)]
+            range: KeyRange,
+        }
+
+        let msg = Msg {
+            range: KeyRange::new(u64::MIN, u64::MAX),
+        };
+        let encoded = msg.encode_to_vec();
+        let decoded = Msg::decode(&*encoded).unwrap();
+        assert_eq!(msg, decoded);
+    }
+}

--- a/crates/sharding/src/lib.rs
+++ b/crates/sharding/src/lib.rs
@@ -1,0 +1,43 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod key_range;
+
+use std::sync::Arc;
+
+pub use key_range::KeyRange;
+
+/// Identifying to which partition a key belongs. This is unlike the [`PartitionId`]
+/// which identifies a consecutive range of partition keys.
+pub type PartitionKey = u64;
+
+/// Trait for data structures that have a partition key
+pub trait WithPartitionKey {
+    /// Returns the partition key
+    fn partition_key(&self) -> PartitionKey;
+}
+
+impl<T> WithPartitionKey for &T
+where
+    T: WithPartitionKey,
+{
+    fn partition_key(&self) -> PartitionKey {
+        (*self).partition_key()
+    }
+}
+
+impl<T> WithPartitionKey for Arc<T>
+where
+    T: WithPartitionKey,
+{
+    fn partition_key(&self) -> PartitionKey {
+        self.as_ref().partition_key()
+    }
+}

--- a/crates/sharding/src/lib.rs
+++ b/crates/sharding/src/lib.rs
@@ -9,10 +9,14 @@
 // by the Apache License, Version 2.0.
 
 mod key_range;
+mod partition_id;
+mod partitioner;
 
 use std::sync::Arc;
 
 pub use key_range::KeyRange;
+pub use partition_id::PartitionId;
+pub use partitioner::EqualSizedPartitionPartitioner;
 
 /// Identifying to which partition a key belongs. This is unlike the [`PartitionId`]
 /// which identifies a consecutive range of partition keys.

--- a/crates/sharding/src/partition_id.rs
+++ b/crates/sharding/src/partition_id.rs
@@ -1,0 +1,107 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/// Identifying the partition
+#[derive(
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    derive_more::Deref,
+    derive_more::From,
+    derive_more::Into,
+    derive_more::Add,
+    derive_more::Display,
+    derive_more::Debug,
+    derive_more::FromStr,
+)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[repr(transparent)]
+#[debug("{}", _0)]
+pub struct PartitionId(u16);
+
+impl From<PartitionId> for u32 {
+    fn from(value: PartitionId) -> Self {
+        u32::from(value.0)
+    }
+}
+
+impl From<PartitionId> for u64 {
+    fn from(value: PartitionId) -> Self {
+        u64::from(value.0)
+    }
+}
+
+impl PartitionId {
+    /// It's your responsibility to ensure the value is within the valid range.
+    pub const fn new_unchecked(v: u16) -> Self {
+        Self(v)
+    }
+
+    pub const MIN: Self = Self(u16::MIN);
+    // 65535 partitions.
+    pub const MAX: Self = Self(u16::MAX);
+
+    #[inline]
+    pub fn next(self) -> Self {
+        Self(std::cmp::min(*Self::MAX, self.0.saturating_add(1)))
+    }
+}
+
+#[cfg(feature = "bilrost")]
+mod bilrost_impl {
+    use super::PartitionId;
+
+    use bilrost::DecodeErrorKind;
+    use bilrost::encoding::{EmptyState, ForOverwrite, Proxiable};
+
+    impl Proxiable for PartitionId {
+        type Proxy = u16;
+
+        fn encode_proxy(&self) -> Self::Proxy {
+            self.0
+        }
+
+        fn decode_proxy(&mut self, proxy: Self::Proxy) -> Result<(), DecodeErrorKind> {
+            self.0 = proxy;
+            Ok(())
+        }
+    }
+
+    impl ForOverwrite<(), PartitionId> for () {
+        fn for_overwrite() -> PartitionId {
+            PartitionId(0)
+        }
+    }
+
+    impl EmptyState<(), PartitionId> for () {
+        fn empty() -> PartitionId {
+            PartitionId(0)
+        }
+
+        fn is_empty(val: &PartitionId) -> bool {
+            val.0 == 0
+        }
+
+        fn clear(val: &mut PartitionId) {
+            val.0 = 0;
+        }
+    }
+
+    bilrost::delegate_proxied_encoding!(
+        use encoding (bilrost::encoding::Varint)
+        to encode proxied type (PartitionId)
+        with general encodings
+    );
+}

--- a/crates/sharding/src/partitioner.rs
+++ b/crates/sharding/src/partitioner.rs
@@ -1,0 +1,104 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::{KeyRange, PartitionId};
+
+#[derive(Debug)]
+pub struct EqualSizedPartitionPartitioner {
+    num_partitions: u16,
+    next_partition_id: PartitionId,
+}
+
+impl EqualSizedPartitionPartitioner {
+    const PARTITION_KEY_RANGE_END: u128 = 1 << 64;
+
+    pub fn new(num_partitions: u16) -> Self {
+        Self {
+            num_partitions,
+            next_partition_id: PartitionId::MIN,
+        }
+    }
+
+    pub fn partition_id_to_partition_range(
+        num_partitions: u16,
+        partition_id: PartitionId,
+    ) -> KeyRange {
+        let num_partitions = u128::from(num_partitions);
+        let partition_id = u128::from(*partition_id);
+
+        assert!(
+            partition_id < num_partitions,
+            "There cannot be a partition id which is larger than the number of partitions \
+                '{num_partitions}', when using the fixed consecutive partitioning scheme."
+        );
+
+        // adding num_partitions - 1 to dividend is equivalent to applying ceil function to result
+        let start = (partition_id * Self::PARTITION_KEY_RANGE_END).div_ceil(num_partitions);
+        let end = ((partition_id + 1) * Self::PARTITION_KEY_RANGE_END).div_ceil(num_partitions) - 1;
+
+        let start = u64::try_from(start)
+            .expect("Resulting partition start '{start}' should be <= u64::MAX.");
+        let end =
+            u64::try_from(end).expect("Resulting partition end '{end}' should be <= u64::MAX.");
+
+        KeyRange::new(start, end)
+    }
+}
+
+impl Iterator for EqualSizedPartitionPartitioner {
+    type Item = (PartitionId, KeyRange);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if *self.next_partition_id < self.num_partitions {
+            let partition_id = self.next_partition_id;
+            self.next_partition_id = self.next_partition_id.next();
+
+            let partition_range =
+                Self::partition_id_to_partition_range(self.num_partitions, partition_id);
+
+            Some((partition_id, partition_range))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::PartitionKey;
+
+    #[test]
+    fn partitioner_produces_consecutive_ranges() {
+        let partitioner = EqualSizedPartitionPartitioner::new(10);
+        let mut previous_end = None;
+        let mut previous_length = None::<PartitionKey>;
+
+        for (_id, range) in partitioner {
+            let current_length = range.end() - range.start();
+
+            if let Some(previous_length) = previous_length {
+                let length_diff = previous_length.abs_diff(current_length);
+                assert!(length_diff <= 1);
+            } else {
+                assert_eq!(range.start(), 0);
+            }
+
+            if let Some(previous_end) = previous_end {
+                assert_eq!(previous_end + 1, range.start());
+            }
+
+            previous_end = Some(range.end());
+            previous_length = Some(current_length);
+        }
+
+        assert_eq!(previous_end, Some(PartitionKey::MAX));
+    }
+}

--- a/crates/storage-api/src/idempotency_table/mod.rs
+++ b/crates/storage-api/src/idempotency_table/mod.rs
@@ -9,9 +9,9 @@
 // by the Apache License, Version 2.0.
 
 use std::future::Future;
-use std::ops::RangeInclusive;
 
-use restate_types::identifiers::{IdempotencyId, InvocationId, PartitionKey};
+use restate_types::identifiers::{IdempotencyId, InvocationId};
+use restate_types::sharding::KeyRange;
 
 use super::Result;
 use crate::protobuf_types::PartitionStoreProtobufValue;
@@ -40,7 +40,7 @@ pub trait ScanIdempotencyTable {
             + 'static,
     >(
         &self,
-        range: RangeInclusive<PartitionKey>,
+        range: KeyRange,
         f: F,
     ) -> Result<impl Future<Output = Result<()>> + Send>;
 }

--- a/crates/storage-api/src/inbox_table/mod.rs
+++ b/crates/storage-api/src/inbox_table/mod.rs
@@ -8,12 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::ops::RangeInclusive;
-
 use futures::Stream;
 
 use restate_types::identifiers::{InvocationId, PartitionKey, ServiceId, WithPartitionKey};
 use restate_types::message::MessageIndex;
+use restate_types::sharding::KeyRange;
 use restate_types::state_mut::ExternalStateMutation;
 
 use crate::Result;
@@ -101,7 +100,7 @@ pub trait ScanInboxTable {
         F: FnMut(SequenceNumberInboxEntry) -> std::ops::ControlFlow<()> + Send + Sync + 'static,
     >(
         &self,
-        range: RangeInclusive<PartitionKey>,
+        range: KeyRange,
         f: F,
     ) -> Result<impl Future<Output = Result<()>> + Send>;
 }

--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -19,12 +19,13 @@ use futures::Stream;
 
 use restate_types::RestateVersion;
 use restate_types::deployment::PinnedDeployment;
-use restate_types::identifiers::{InvocationId, PartitionKey};
+use restate_types::identifiers::InvocationId;
 use restate_types::invocation::{
     Header, InvocationInput, InvocationTarget, ResponseResult, ServiceInvocation,
     ServiceInvocationResponseSink, ServiceInvocationSpanContext, Source,
 };
 use restate_types::journal_v2::NotificationId;
+use restate_types::sharding::KeyRange;
 use restate_types::time::MillisSinceEpoch;
 
 use crate::Result;
@@ -793,7 +794,7 @@ pub trait ReadInvocationStatusTable {
 
 #[derive(Debug, Clone)]
 pub enum ScanInvocationStatusTableRange {
-    PartitionKey(RangeInclusive<PartitionKey>),
+    PartitionKey(KeyRange),
     InvocationId(RangeInclusive<InvocationId>),
 }
 

--- a/crates/storage-api/src/journal_events/mod.rs
+++ b/crates/storage-api/src/journal_events/mod.rs
@@ -8,12 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use futures::Stream;
 use std::ops::RangeInclusive;
 
+use futures::Stream;
+
 use crate::Result;
-use restate_types::identifiers::{EntryIndex, InvocationId, PartitionKey};
+use restate_types::identifiers::{EntryIndex, InvocationId};
 use restate_types::journal_events::raw::RawEvent;
+use restate_types::sharding::KeyRange;
 use restate_types::time::MillisSinceEpoch;
 
 pub trait ReadJournalEventsTable {
@@ -25,7 +27,7 @@ pub trait ReadJournalEventsTable {
 
 #[derive(Debug, Clone)]
 pub enum ScanJournalEventsTableRange {
-    PartitionKey(RangeInclusive<PartitionKey>),
+    PartitionKey(KeyRange),
     InvocationId(RangeInclusive<InvocationId>),
 }
 

--- a/crates/storage-api/src/journal_table/mod.rs
+++ b/crates/storage-api/src/journal_table/mod.rs
@@ -13,9 +13,10 @@ use std::ops::RangeInclusive;
 use futures::Stream;
 
 use restate_memory::{LocalMemoryLease, LocalMemoryPool};
-use restate_types::identifiers::{EntryIndex, InvocationId, JournalEntryId, PartitionKey};
+use restate_types::identifiers::{EntryIndex, InvocationId, JournalEntryId};
 use restate_types::journal::enriched::EnrichedRawEntry;
 use restate_types::journal::{CompletionResult, EntryType};
+use restate_types::sharding::KeyRange;
 
 use crate::protobuf_types::PartitionStoreProtobufValue;
 use crate::{BudgetedReadError, Result};
@@ -107,7 +108,7 @@ pub trait ReadJournalTable {
 
 #[derive(Debug, Clone)]
 pub enum ScanJournalTableRange {
-    PartitionKey(RangeInclusive<PartitionKey>),
+    PartitionKey(KeyRange),
     InvocationId(RangeInclusive<InvocationId>),
 }
 

--- a/crates/storage-api/src/journal_table_v2/mod.rs
+++ b/crates/storage-api/src/journal_table_v2/mod.rs
@@ -14,9 +14,10 @@ use std::ops::RangeInclusive;
 use futures::Stream;
 
 use restate_memory::{LocalMemoryLease, LocalMemoryPool};
-use restate_types::identifiers::{EntryIndex, InvocationId, PartitionKey};
+use restate_types::identifiers::{EntryIndex, InvocationId};
 use restate_types::journal_v2::raw::RawCommand;
 use restate_types::journal_v2::{CompletionId, NotificationId};
+use restate_types::sharding::KeyRange;
 use restate_types::storage::{StoredRawEntry, StoredRawEntryHeader};
 
 use crate::protobuf_types::PartitionStoreProtobufValue;
@@ -89,7 +90,7 @@ pub trait ReadJournalTable {
 
 #[derive(Debug, Clone)]
 pub enum ScanJournalTableRange {
-    PartitionKey(RangeInclusive<PartitionKey>),
+    PartitionKey(KeyRange),
     InvocationId(RangeInclusive<InvocationId>),
 }
 

--- a/crates/storage-api/src/lock_table/mod.rs
+++ b/crates/storage-api/src/lock_table/mod.rs
@@ -8,10 +8,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::ops::RangeInclusive;
-
 use restate_clock::UniqueTimestamp;
 use restate_types::identifiers::{InvocationId, PartitionKey, StateMutationId};
+use restate_types::sharding::KeyRange;
 use restate_types::vqueues::{EntryId, EntryKind};
 use restate_types::{LockName, Scope};
 use restate_util_string::ReString;
@@ -68,7 +67,7 @@ pub trait ScanLocksTable {
             + 'static,
     >(
         &self,
-        range: RangeInclusive<PartitionKey>,
+        range: KeyRange,
         f: F,
     ) -> Result<impl Future<Output = Result<()>> + Send>;
 }

--- a/crates/storage-api/src/promise_table/mod.rs
+++ b/crates/storage-api/src/promise_table/mod.rs
@@ -9,18 +9,18 @@
 // by the Apache License, Version 2.0.
 
 use std::future::Future;
-use std::ops::RangeInclusive;
 
 use bytes::Bytes;
 use bytestring::ByteString;
 
 use restate_types::errors::InvocationErrorCode;
-use restate_types::identifiers::{PartitionKey, ServiceId};
+use restate_types::identifiers::ServiceId;
 use restate_types::invocation::JournalCompletionTarget;
 use restate_types::journal::{CompletionResult, EntryResult};
 use restate_types::journal_v2::{
     CompletePromiseValue, Failure, FailureMetadata, GetPromiseResult, PeekPromiseResult,
 };
+use restate_types::sharding::KeyRange;
 
 use super::Result;
 use crate::protobuf_types::PartitionStoreProtobufValue;
@@ -132,7 +132,7 @@ pub trait ScanPromiseTable {
         F: FnMut(OwnedPromiseRow) -> std::ops::ControlFlow<()> + Send + Sync + 'static,
     >(
         &self,
-        range: RangeInclusive<PartitionKey>,
+        range: KeyRange,
         f: F,
     ) -> Result<impl Future<Output = Result<()>> + Send>;
 }

--- a/crates/storage-api/src/service_status_table/mod.rs
+++ b/crates/storage-api/src/service_status_table/mod.rs
@@ -9,9 +9,9 @@
 // by the Apache License, Version 2.0.
 
 use std::future::Future;
-use std::ops::RangeInclusive;
 
-use restate_types::identifiers::{InvocationId, PartitionKey, ServiceId};
+use restate_types::identifiers::{InvocationId, ServiceId};
+use restate_types::sharding::KeyRange;
 
 use crate::Result;
 use crate::protobuf_types::PartitionStoreProtobufValue;
@@ -42,7 +42,7 @@ pub trait ScanVirtualObjectStatusTable {
             + 'static,
     >(
         &self,
-        range: RangeInclusive<PartitionKey>,
+        range: KeyRange,
         f: F,
     ) -> Result<impl Future<Output = Result<()>> + Send>;
 }

--- a/crates/storage-api/src/state_table/mod.rs
+++ b/crates/storage-api/src/state_table/mod.rs
@@ -8,13 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::ops::RangeInclusive;
-
 use bytes::Bytes;
 use futures::Stream;
 
 use restate_memory::{LocalMemoryLease, LocalMemoryPool, PinnableMemoryStream};
-use restate_types::identifiers::{PartitionKey, ServiceId};
+use restate_types::identifiers::ServiceId;
+use restate_types::sharding::KeyRange;
 
 use crate::{BudgetedReadError, Result};
 
@@ -54,7 +53,7 @@ pub trait ScanStateTable {
         F: FnMut((ServiceId, Bytes, &[u8])) -> std::ops::ControlFlow<()> + Send + Sync + 'static,
     >(
         &self,
-        range: RangeInclusive<PartitionKey>,
+        range: KeyRange,
         f: F,
     ) -> Result<impl Future<Output = Result<()>> + Send>;
 }

--- a/crates/storage-query-datafusion/src/empty_invoker_status_handle.rs
+++ b/crates/storage-query-datafusion/src/empty_invoker_status_handle.rs
@@ -8,11 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use restate_invoker_api::{InvocationStatusReport, StatusHandle};
-use restate_types::identifiers::PartitionKey;
-use std::future::Future;
-use std::ops::RangeInclusive;
 use std::{future, iter};
+
+use restate_invoker_api::{InvocationStatusReport, StatusHandle};
+use restate_types::sharding::KeyRange;
 
 #[derive(Clone, Debug)]
 pub struct EmptyInvokerStatusHandle;
@@ -20,10 +19,7 @@ pub struct EmptyInvokerStatusHandle;
 impl StatusHandle for EmptyInvokerStatusHandle {
     type Iterator = iter::Empty<InvocationStatusReport>;
 
-    fn read_status(
-        &self,
-        _keys: RangeInclusive<PartitionKey>,
-    ) -> impl Future<Output = Self::Iterator> + Send {
+    fn read_status(&self, _keys: KeyRange) -> impl Future<Output = Self::Iterator> + Send {
         future::ready(iter::empty())
     }
 }

--- a/crates/storage-query-datafusion/src/filter.rs
+++ b/crates/storage-query-datafusion/src/filter.rs
@@ -10,7 +10,7 @@
 
 use std::collections::{BTreeSet, HashSet};
 use std::fmt::{Debug, Formatter};
-use std::ops::RangeInclusive;
+use std::ops::{RangeBounds, RangeInclusive};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -24,6 +24,7 @@ use datafusion::physical_plan::expressions::{BinaryExpr, Column, InListExpr, Lit
 
 use restate_types::identifiers::partitioner::HashPartitioner;
 use restate_types::identifiers::{InvocationId, PartitionKey, WithPartitionKey};
+use restate_types::sharding::KeyRange;
 
 use crate::partition_store_scanner::ScanLocalPartitionFilter;
 
@@ -243,19 +244,17 @@ fn extract_column_literal<'a>(
 
 #[derive(Debug, Clone)]
 pub struct InvocationIdFilter {
-    pub partition_keys: RangeInclusive<PartitionKey>,
+    pub partition_keys: KeyRange,
     pub invocation_ids: Option<RangeInclusive<InvocationId>>,
 }
 
 impl ScanLocalPartitionFilter for InvocationIdFilter {
-    fn new(range: RangeInclusive<PartitionKey>, predicate: Option<Arc<dyn PhysicalExpr>>) -> Self {
+    fn new(range: KeyRange, predicate: Option<Arc<dyn PhysicalExpr>>) -> Self {
         if let Some(predicate) = predicate
             && let Ok(predicate) = snapshot_physical_expr(predicate)
         {
             for conjunct in split_conjunction(&predicate) {
-                if let Some(invocation_ids) =
-                    parse_invocation_id_range("id", range.clone(), conjunct)
-                {
+                if let Some(invocation_ids) = parse_invocation_id_range("id", range, conjunct) {
                     return Self {
                         partition_keys: range,
                         invocation_ids: Some(invocation_ids),
@@ -273,7 +272,7 @@ impl ScanLocalPartitionFilter for InvocationIdFilter {
 
 fn parse_invocation_id_range(
     column_name: &str,
-    range: RangeInclusive<PartitionKey>,
+    range: KeyRange,
     predicate: &Arc<dyn PhysicalExpr>,
 ) -> Option<RangeInclusive<InvocationId>> {
     let in_list = InList::parse(predicate, 5)?;
@@ -308,8 +307,9 @@ mod tests {
     use datafusion::physical_plan::PhysicalExpr;
     use datafusion::physical_plan::expressions::{BinaryExpr, Column, InListExpr, Literal};
 
-    use restate_types::identifiers::{InvocationId, PartitionKey, ServiceId, WithPartitionKey};
+    use restate_types::identifiers::{InvocationId, ServiceId, WithPartitionKey};
     use restate_types::invocation::{InvocationTarget, VirtualObjectHandlerType};
+    use restate_types::sharding::KeyRange;
 
     use crate::filter::{
         FirstMatchingPartitionKeyExtractor, InvocationIdFilter, PartitionKeyExtractor,
@@ -354,7 +354,7 @@ mod tests {
         ))
     }
 
-    const FULL_RANGE: std::ops::RangeInclusive<PartitionKey> = 0..=PartitionKey::MAX;
+    const FULL_RANGE: KeyRange = KeyRange::FULL;
 
     fn make_invocation_id(key: &str) -> InvocationId {
         let target = InvocationTarget::virtual_object(
@@ -582,7 +582,11 @@ mod tests {
     fn invocation_id_filter_excludes_out_of_range() {
         let id = make_invocation_id("key-1");
         let pk = id.partition_key();
-        let narrow_range = if pk > 0 { 0..=(pk - 1) } else { 1..=1 };
+        let narrow_range = if pk > 0 {
+            KeyRange::new(0, pk - 1)
+        } else {
+            KeyRange::new(1, 1)
+        };
 
         let predicate = eq(col("id"), utf8_lit(id.to_string()));
         let filter = InvocationIdFilter::new(narrow_range, Some(predicate));

--- a/crates/storage-query-datafusion/src/idempotency/table.rs
+++ b/crates/storage-query-datafusion/src/idempotency/table.rs
@@ -9,13 +9,14 @@
 // by the Apache License, Version 2.0.
 
 use std::fmt::Debug;
-use std::ops::{ControlFlow, RangeInclusive};
+use std::ops::ControlFlow;
 use std::sync::Arc;
 
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_api::StorageError;
 use restate_storage_api::idempotency_table::{IdempotencyMetadata, ScanIdempotencyTable};
-use restate_types::identifiers::{IdempotencyId, PartitionKey};
+use restate_types::identifiers::IdempotencyId;
+use restate_types::sharding::KeyRange;
 
 use super::row::append_idempotency_row;
 use super::schema::{SysIdempotencyBuilder, sys_idempotency_sort_order};
@@ -57,7 +58,7 @@ impl ScanLocalPartition for IdempotencyScanner {
     type Builder = SysIdempotencyBuilder;
     type Item<'a> = (IdempotencyId, IdempotencyMetadata);
     type ConversionError = std::convert::Infallible;
-    type Filter = RangeInclusive<PartitionKey>;
+    type Filter = KeyRange;
 
     fn for_each_row<
         F: for<'a> FnMut(Self::Item<'a>) -> ControlFlow<Result<(), Self::ConversionError>>
@@ -66,7 +67,7 @@ impl ScanLocalPartition for IdempotencyScanner {
             + 'static,
     >(
         partition_store: &PartitionStore,
-        range: RangeInclusive<PartitionKey>,
+        range: KeyRange,
         mut f: F,
     ) -> Result<impl Future<Output = Result<(), StorageError>> + Send, StorageError> {
         partition_store

--- a/crates/storage-query-datafusion/src/inbox/table.rs
+++ b/crates/storage-query-datafusion/src/inbox/table.rs
@@ -9,13 +9,12 @@
 // by the Apache License, Version 2.0.
 
 use std::fmt::Debug;
-use std::ops::RangeInclusive;
 use std::sync::Arc;
 
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_api::StorageError;
 use restate_storage_api::inbox_table::{ScanInboxTable, SequenceNumberInboxEntry};
-use restate_types::identifiers::PartitionKey;
+use restate_types::sharding::KeyRange;
 
 use crate::context::{QueryContext, SelectPartitions};
 use crate::filter::FirstMatchingPartitionKeyExtractor;
@@ -57,7 +56,7 @@ impl ScanLocalPartition for InboxScanner {
     type Builder = SysInboxBuilder;
     type Item<'a> = SequenceNumberInboxEntry;
     type ConversionError = std::convert::Infallible;
-    type Filter = RangeInclusive<PartitionKey>;
+    type Filter = KeyRange;
 
     fn for_each_row<
         F: for<'a> FnMut(
@@ -68,7 +67,7 @@ impl ScanLocalPartition for InboxScanner {
             + 'static,
     >(
         partition_store: &PartitionStore,
-        range: RangeInclusive<PartitionKey>,
+        range: KeyRange,
         mut f: F,
     ) -> Result<impl Future<Output = restate_storage_api::Result<()>> + Send, StorageError> {
         partition_store.for_each_inbox(range, move |item| f(item).map_break(Result::unwrap))

--- a/crates/storage-query-datafusion/src/invocation_state/table.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/table.rs
@@ -9,7 +9,6 @@
 // by the Apache License, Version 2.0.
 
 use std::fmt::Debug;
-use std::ops::RangeInclusive;
 use std::sync::Arc;
 
 use anyhow::anyhow;
@@ -23,7 +22,8 @@ use tokio::sync::mpsc::Sender;
 
 use restate_invoker_api::{InvocationStatusReport, StatusHandle};
 use restate_partition_store::PartitionStoreManager;
-use restate_types::identifiers::{PartitionId, PartitionKey};
+use restate_types::identifiers::PartitionId;
+use restate_types::sharding::KeyRange;
 
 use crate::context::{QueryContext, SelectPartitions};
 use crate::filter::FirstMatchingPartitionKeyExtractor;
@@ -74,7 +74,7 @@ pub(crate) fn register_self(
 async fn partition_key_range(
     partition_store_manager: &PartitionStoreManager,
     partition_id: PartitionId,
-) -> datafusion::common::Result<RangeInclusive<PartitionKey>> {
+) -> datafusion::common::Result<KeyRange> {
     partition_store_manager
         .get_partition_store(partition_id)
         .await
@@ -82,7 +82,7 @@ async fn partition_key_range(
             let err = anyhow!("expecting a partition store");
             DataFusionError::External(err.into())
         })
-        .map(|store| store.partition_key_range().clone())
+        .map(|store| store.partition_key_range())
 }
 
 #[derive(derive_more::Debug, Clone)]
@@ -96,7 +96,7 @@ impl<S: StatusHandle + Send + Sync + Debug + Clone + 'static> ScanPartition for 
     fn scan_partition(
         &self,
         partition_id: PartitionId,
-        _range: RangeInclusive<PartitionKey>,
+        _range: KeyRange,
         projection: SchemaRef,
         _predicate: Option<Arc<dyn PhysicalExpr>>,
         batch_size: usize,

--- a/crates/storage-query-datafusion/src/keyed_service_status/table.rs
+++ b/crates/storage-query-datafusion/src/keyed_service_status/table.rs
@@ -9,7 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use std::fmt::Debug;
-use std::ops::{ControlFlow, RangeInclusive};
+use std::ops::ControlFlow;
 use std::sync::Arc;
 
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
@@ -17,7 +17,8 @@ use restate_storage_api::StorageError;
 use restate_storage_api::service_status_table::{
     ScanVirtualObjectStatusTable, VirtualObjectStatus,
 };
-use restate_types::identifiers::{PartitionKey, ServiceId};
+use restate_types::identifiers::ServiceId;
+use restate_types::sharding::KeyRange;
 
 use crate::context::{QueryContext, SelectPartitions};
 use crate::filter::FirstMatchingPartitionKeyExtractor;
@@ -61,7 +62,7 @@ impl ScanLocalPartition for VirtualObjectStatusScanner {
     type Builder = SysKeyedServiceStatusBuilder;
     type Item<'a> = (ServiceId, VirtualObjectStatus);
     type ConversionError = std::convert::Infallible;
-    type Filter = RangeInclusive<PartitionKey>;
+    type Filter = KeyRange;
 
     fn for_each_row<
         F: for<'a> FnMut(Self::Item<'a>) -> ControlFlow<Result<(), Self::ConversionError>>
@@ -70,7 +71,7 @@ impl ScanLocalPartition for VirtualObjectStatusScanner {
             + 'static,
     >(
         partition_store: &PartitionStore,
-        range: RangeInclusive<PartitionKey>,
+        range: KeyRange,
         mut f: F,
     ) -> Result<impl Future<Output = restate_storage_api::Result<()>> + Send, StorageError> {
         partition_store

--- a/crates/storage-query-datafusion/src/locks/table.rs
+++ b/crates/storage-query-datafusion/src/locks/table.rs
@@ -9,13 +9,14 @@
 // by the Apache License, Version 2.0.
 
 use std::fmt::Debug;
-use std::ops::{ControlFlow, RangeInclusive};
+use std::ops::ControlFlow;
 use std::sync::Arc;
 
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_api::StorageError;
 use restate_storage_api::lock_table::{LockState, ScanLocksTable};
 use restate_types::identifiers::PartitionKey;
+use restate_types::sharding::KeyRange;
 use restate_types::{LockName, Scope};
 
 use crate::context::{QueryContext, SelectPartitions};
@@ -58,7 +59,7 @@ impl ScanLocalPartition for LocksScanner {
     type Builder = SysLocksBuilder;
     type Item<'a> = (PartitionKey, Option<Scope>, LockName, LockState);
     type ConversionError = std::convert::Infallible;
-    type Filter = RangeInclusive<PartitionKey>;
+    type Filter = KeyRange;
 
     fn for_each_row<
         F: for<'a> FnMut(Self::Item<'a>) -> ControlFlow<Result<(), Self::ConversionError>>
@@ -67,7 +68,7 @@ impl ScanLocalPartition for LocksScanner {
             + 'static,
     >(
         partition_store: &PartitionStore,
-        range: RangeInclusive<PartitionKey>,
+        range: KeyRange,
         mut f: F,
     ) -> Result<impl Future<Output = restate_storage_api::Result<()>> + Send, StorageError> {
         partition_store.for_each_lock(range, move |item| f(item).map_break(Result::unwrap))

--- a/crates/storage-query-datafusion/src/mocks.rs
+++ b/crates/storage-query-datafusion/src/mocks.rs
@@ -28,7 +28,7 @@ use restate_types::NodeId;
 use restate_types::config::QueryEngineOptions;
 use restate_types::deployment::{DeploymentAddress, Headers};
 use restate_types::errors::GenericError;
-use restate_types::identifiers::{DeploymentId, PartitionId, PartitionKey, ServiceRevision};
+use restate_types::identifiers::{DeploymentId, PartitionId, ServiceRevision};
 use restate_types::live::Live;
 use restate_types::net::address::{AdvertisedAddress, HttpIngressPort};
 use restate_types::net::remote_query_scanner::RemoteQueryScannerOpen;
@@ -37,6 +37,7 @@ use restate_types::schema::deployment::test_util::MockDeploymentMetadataRegistry
 use restate_types::schema::deployment::{Deployment, DeploymentResolver};
 use restate_types::schema::service::test_util::MockServiceMetadataResolver;
 use restate_types::schema::service::{ServiceMetadata, ServiceMetadataResolver};
+use restate_types::sharding::KeyRange;
 
 use super::context::QueryContext;
 use crate::context::SelectPartitions;
@@ -113,8 +114,7 @@ struct MockPartitionSelector;
 impl SelectPartitions for MockPartitionSelector {
     async fn get_live_partitions(&self) -> Result<Vec<(PartitionId, Partition)>, GenericError> {
         let id = PartitionId::MIN;
-        let partition_range = 0..=PartitionKey::MAX;
-        let partition = Partition::new(id, partition_range);
+        let partition = Partition::new(id, KeyRange::FULL);
         Ok(vec![(id, partition)])
     }
 }
@@ -164,10 +164,7 @@ impl MockQueryEngine {
             .await
             .expect("DB creation succeeds");
         let partition_store = manager
-            .open(
-                &Partition::new(PartitionId::MIN, PartitionKey::MIN..=PartitionKey::MAX),
-                None,
-            )
+            .open(&Partition::new(PartitionId::MIN, KeyRange::FULL), None)
             .await
             .unwrap();
 

--- a/crates/storage-query-datafusion/src/node_fan_out.rs
+++ b/crates/storage-query-datafusion/src/node_fan_out.rs
@@ -22,7 +22,6 @@
 
 use std::any::Any;
 use std::fmt::{self, Debug, Display, Formatter};
-use std::ops::RangeInclusive;
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -45,8 +44,9 @@ use datafusion::physical_plan::{
 use futures::{Stream, StreamExt};
 
 use restate_core::Metadata;
-use restate_types::identifiers::{PartitionId, PartitionKey};
+use restate_types::identifiers::PartitionId;
 use restate_types::nodes_config::Role;
+use restate_types::sharding::KeyRange;
 use restate_types::{NodeId, PlainNodeId};
 
 use crate::remote_query_scanner_client::{RemoteScannerService, remote_scan_as_datafusion_stream};
@@ -425,7 +425,7 @@ impl ExecutionPlan for NodeFanOutExecutionPlan {
                 self.remote_scanner.clone(),
                 target.node_id,
                 PartitionId::MIN,
-                RangeInclusive::new(PartitionKey::MIN, PartitionKey::MAX),
+                KeyRange::FULL,
                 self.table_name.clone(),
                 self.projected_schema.clone(),
                 None, // predicate is applied locally after combining

--- a/crates/storage-query-datafusion/src/partition/row.rs
+++ b/crates/storage-query-datafusion/src/partition/row.rs
@@ -22,8 +22,8 @@ pub(crate) fn append_partition_row(
     let mut row = builder.row();
     row.log_id(partition.log_id().into());
     row.partition_id(partition.partition_id.into());
-    row.start_key(*partition.key_range.start());
-    row.end_key(*partition.key_range.end());
+    row.start_key(partition.key_range.start());
+    row.end_key(partition.key_range.end());
     row.cf_name(partition.cf_name());
     row.db_name(partition.db_name());
     let leadership = membership.current_leader();

--- a/crates/storage-query-datafusion/src/partition_store_scanner.rs
+++ b/crates/storage-query-datafusion/src/partition_store_scanner.rs
@@ -8,7 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::ops::RangeInclusive;
 use std::sync::Arc;
 use std::time::Instant;
 use std::{fmt::Debug, ops::ControlFlow};
@@ -23,17 +22,18 @@ use datafusion::physical_plan::stream::RecordBatchReceiverStream;
 
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_api::StorageError;
-use restate_types::identifiers::{PartitionId, PartitionKey};
+use restate_types::identifiers::PartitionId;
+use restate_types::sharding::KeyRange;
 
 use crate::table_providers::ScanPartition;
 use crate::table_util::BatchSender;
 
 pub trait ScanLocalPartitionFilter {
-    fn new(range: RangeInclusive<PartitionKey>, predicate: Option<Arc<dyn PhysicalExpr>>) -> Self;
+    fn new(range: KeyRange, predicate: Option<Arc<dyn PhysicalExpr>>) -> Self;
 }
 
-impl ScanLocalPartitionFilter for RangeInclusive<PartitionKey> {
-    fn new(range: RangeInclusive<PartitionKey>, _predicate: Option<Arc<dyn PhysicalExpr>>) -> Self {
+impl ScanLocalPartitionFilter for KeyRange {
+    fn new(range: KeyRange, _predicate: Option<Arc<dyn PhysicalExpr>>) -> Self {
         range
     }
 }
@@ -89,7 +89,7 @@ where
     fn scan_partition(
         &self,
         partition_id: PartitionId,
-        range: RangeInclusive<PartitionKey>,
+        range: KeyRange,
         projection: SchemaRef,
         predicate: Option<Arc<dyn PhysicalExpr>>,
         batch_size: usize,
@@ -117,7 +117,7 @@ where
 
             S::for_each_row(
                 &partition_store,
-                S::Filter::new(range.clone(), predicate),
+                S::Filter::new(range, predicate),
                 move |row| {
                     elapsed_compute.start();
                     match S::append_row(batch_sender.builder_mut(), row) {
@@ -146,7 +146,7 @@ where
     fn scan_partition(
         &self,
         partition_id: PartitionId,
-        range: RangeInclusive<PartitionKey>,
+        range: KeyRange,
         projection: SchemaRef,
         predicate: Option<Arc<dyn PhysicalExpr>>,
         batch_size: usize,

--- a/crates/storage-query-datafusion/src/promise/table.rs
+++ b/crates/storage-query-datafusion/src/promise/table.rs
@@ -9,13 +9,12 @@
 // by the Apache License, Version 2.0.
 
 use std::fmt::Debug;
-use std::ops::RangeInclusive;
 use std::sync::Arc;
 
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_api::StorageError;
 use restate_storage_api::promise_table::{OwnedPromiseRow, ScanPromiseTable};
-use restate_types::identifiers::PartitionKey;
+use restate_types::sharding::KeyRange;
 
 use super::row::append_promise_row;
 use super::schema::{SysPromiseBuilder, sys_promise_sort_order};
@@ -55,7 +54,7 @@ impl ScanLocalPartition for PromiseScanner {
     type Builder = SysPromiseBuilder;
     type Item<'a> = OwnedPromiseRow;
     type ConversionError = std::convert::Infallible;
-    type Filter = RangeInclusive<PartitionKey>;
+    type Filter = KeyRange;
 
     fn for_each_row<
         F: for<'a> FnMut(
@@ -66,7 +65,7 @@ impl ScanLocalPartition for PromiseScanner {
             + 'static,
     >(
         partition_store: &PartitionStore,
-        range: RangeInclusive<PartitionKey>,
+        range: KeyRange,
         mut f: F,
     ) -> Result<impl Future<Output = restate_storage_api::Result<()>> + Send, StorageError> {
         partition_store.for_each_promise(range, move |item| f(item).map_break(Result::unwrap))

--- a/crates/storage-query-datafusion/src/remote_query_scanner_client.rs
+++ b/crates/storage-query-datafusion/src/remote_query_scanner_client.rs
@@ -9,7 +9,6 @@
 // by the Apache License, Version 2.0.
 
 use std::fmt::{Debug, Formatter};
-use std::ops::RangeInclusive;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -24,12 +23,13 @@ use tracing::debug;
 use restate_core::network::{Connection, NetworkSender, Networking, Swimlane, TransportConnect};
 use restate_core::{TaskCenter, TaskCenterFutureExt, TaskKind, task_center};
 use restate_types::NodeId;
-use restate_types::identifiers::{PartitionId, PartitionKey};
+use restate_types::identifiers::PartitionId;
 use restate_types::net::remote_query_scanner::{
     RemoteQueryScannerClose, RemoteQueryScannerNext, RemoteQueryScannerNextResult,
     RemoteQueryScannerOpen, RemoteQueryScannerOpened, RemoteQueryScannerPredicate, ScannerBatch,
     ScannerFailure, ScannerId,
 };
+use restate_types::sharding::KeyRange;
 
 use crate::{decode_record_batch, encode_expr, encode_schema};
 
@@ -143,7 +143,7 @@ pub fn remote_scan_as_datafusion_stream(
     service: Arc<dyn RemoteScannerService>,
     target_node_id: NodeId,
     partition_id: PartitionId,
-    range: RangeInclusive<PartitionKey>,
+    range: KeyRange,
     table_name: String,
     projection_schema: SchemaRef,
     predicate: Option<Arc<dyn PhysicalExpr>>,

--- a/crates/storage-query-datafusion/src/remote_query_scanner_manager.rs
+++ b/crates/storage-query-datafusion/src/remote_query_scanner_manager.rs
@@ -10,7 +10,6 @@
 
 use std::collections::BTreeMap;
 use std::fmt::{Debug, Formatter};
-use std::ops::RangeInclusive;
 use std::sync::Arc;
 
 use anyhow::{anyhow, bail};
@@ -23,7 +22,8 @@ use parking_lot::Mutex;
 use restate_core::Metadata;
 use restate_core::partitions::PartitionRouting;
 use restate_types::NodeId;
-use restate_types::identifiers::{PartitionId, PartitionKey};
+use restate_types::identifiers::PartitionId;
+use restate_types::sharding::KeyRange;
 
 use crate::remote_query_scanner_client::{RemoteScannerService, remote_scan_as_datafusion_stream};
 use crate::table_providers::{Scan, ScanPartition};
@@ -194,7 +194,7 @@ impl ScanPartition for ScanToScanPartitionAdapter {
     fn scan_partition(
         &self,
         _partition_id: PartitionId,
-        _range: RangeInclusive<PartitionKey>,
+        _range: KeyRange,
         projection: SchemaRef,
         _predicate: Option<Arc<dyn PhysicalExpr>>,
         batch_size: usize,
@@ -210,7 +210,7 @@ impl ScanPartition for RemotePartitionsScanner {
     fn scan_partition(
         &self,
         partition_id: PartitionId,
-        range: RangeInclusive<PartitionKey>,
+        range: KeyRange,
         projection: SchemaRef,
         predicate: Option<Arc<dyn PhysicalExpr>>,
         batch_size: usize,

--- a/crates/storage-query-datafusion/src/scanner_task.rs
+++ b/crates/storage-query-datafusion/src/scanner_task.rs
@@ -84,7 +84,7 @@ impl ScannerTask {
 
         let stream = scanner.scan_partition(
             request.partition_id,
-            request.range.clone(),
+            request.range,
             schema.clone(),
             dynamic_filter
                 .as_ref()

--- a/crates/storage-query-datafusion/src/state/table.rs
+++ b/crates/storage-query-datafusion/src/state/table.rs
@@ -9,7 +9,6 @@
 // by the Apache License, Version 2.0.
 
 use std::fmt::Debug;
-use std::ops::RangeInclusive;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -17,7 +16,8 @@ use bytes::Bytes;
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
 use restate_storage_api::StorageError;
 use restate_storage_api::state_table::ScanStateTable;
-use restate_types::identifiers::{PartitionKey, ServiceId};
+use restate_types::identifiers::ServiceId;
+use restate_types::sharding::KeyRange;
 
 use crate::context::{QueryContext, SelectPartitions};
 use crate::filter::FirstMatchingPartitionKeyExtractor;
@@ -57,7 +57,7 @@ impl ScanLocalPartition for StateScanner {
     type Builder = StateBuilder;
     type Item<'a> = (ServiceId, Bytes, &'a [u8]);
     type ConversionError = std::convert::Infallible;
-    type Filter = RangeInclusive<PartitionKey>;
+    type Filter = KeyRange;
 
     fn for_each_row<
         F: for<'a> FnMut(
@@ -68,7 +68,7 @@ impl ScanLocalPartition for StateScanner {
             + 'static,
     >(
         partition_store: &PartitionStore,
-        range: RangeInclusive<PartitionKey>,
+        range: KeyRange,
         mut f: F,
     ) -> Result<impl Future<Output = restate_storage_api::Result<()>> + Send, StorageError> {
         partition_store.for_each_user_state(range, move |item| f(item).map_break(Result::unwrap))

--- a/crates/storage-query-datafusion/src/table_providers.rs
+++ b/crates/storage-query-datafusion/src/table_providers.rs
@@ -9,7 +9,6 @@
 // by the Apache License, Version 2.0.
 use std::any::Any;
 use std::fmt::{self, Debug, Display, Formatter};
-use std::ops::RangeInclusive;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -35,8 +34,9 @@ use datafusion::physical_plan::{
 };
 use futures::stream::{self, Stream, StreamExt, TryStreamExt};
 
-use restate_types::identifiers::{PartitionId, PartitionKey};
+use restate_types::identifiers::PartitionId;
 use restate_types::partition_table::Partition;
+use restate_types::sharding::KeyRange;
 
 use crate::context::SelectPartitions;
 use crate::filter::{FirstMatchingPartitionKeyExtractor, PartitionKeyExtractor};
@@ -47,7 +47,7 @@ pub trait ScanPartition: Send + Sync + Debug + 'static {
     fn scan_partition(
         &self,
         partition_id: PartitionId,
-        range: RangeInclusive<PartitionKey>,
+        range: KeyRange,
         projection: SchemaRef,
         predicate: Option<Arc<dyn PhysicalExpr>>,
         batch_size: usize,
@@ -212,7 +212,10 @@ where
                                     // in parallel efficiently.
                                     (
                                         partition_id,
-                                        Partition::new(partition_id, partition_key..=partition_key),
+                                        Partition::new(
+                                            partition_id,
+                                            KeyRange::new(partition_key, partition_key),
+                                        ),
                                     )
                                 }),
                         )

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -30,6 +30,7 @@ restate-memory = { workspace = true }
 restate-serde-util = { workspace = true }
 restate-test-util = { workspace = true, optional = true }
 restate-time-util = { workspace = true, features = ["serde", "serde_with"] }
+restate-sharding = { workspace = true, features = ["serde", "bilrost"] }
 restate-util-string = { workspace = true, features = ["serde", "bilrost"] }
 restate-utoipa = { workspace = true }
 

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -13,6 +13,7 @@
 mod partitioned;
 
 pub use partitioned::PartitionedResourceId;
+pub use restate_sharding::{PartitionKey, WithPartitionKey};
 
 use std::cell::RefCell;
 use std::fmt::{self, Display, Formatter};
@@ -155,10 +156,6 @@ pub type PartitionLeaderEpoch = (PartitionId, LeaderEpoch);
 // Just an alias
 pub type EntryIndex = u32;
 
-/// Identifying to which partition a key belongs. This is unlike the [`PartitionId`]
-/// which identifies a consecutive range of partition keys.
-pub type PartitionKey = u64;
-
 /// Returns the partition key computed from either the service_key, or idempotency_key, if possible
 fn deterministic_partition_key(
     service_key: Option<&str>,
@@ -203,13 +200,6 @@ fn random_unscoped_service_partition_key(service_name: &str) -> PartitionKey {
     let bucket = rand::rng().random_range(0..UNSCOPED_SERVICE_PARTITION_KEY_FANOUT);
     unscoped_service_partition_key(service_name, bucket)
 }
-
-/// Trait for data structures that have a partition key
-pub trait WithPartitionKey {
-    /// Returns the partition key
-    fn partition_key(&self) -> PartitionKey;
-}
-
 /// A family of resource identifiers that tracks the timestamp of its creation.
 pub trait TimestampAwareId {
     /// The timestamp when this ID was created.
@@ -656,12 +646,6 @@ impl WithPartitionKey for InvocationId {
     }
 }
 
-impl<T: WithInvocationId> WithPartitionKey for T {
-    fn partition_key(&self) -> PartitionKey {
-        self.invocation_id().partition_key
-    }
-}
-
 impl Display for InvocationId {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         // encode the id such that it is possible to do a string prefix search for a
@@ -813,6 +797,12 @@ impl JournalEntryId {
 impl From<(InvocationId, EntryIndex)> for JournalEntryId {
     fn from(value: (InvocationId, EntryIndex)) -> Self {
         Self::from_parts(value.0, value.1)
+    }
+}
+
+impl WithPartitionKey for JournalEntryId {
+    fn partition_key(&self) -> PartitionKey {
+        self.invocation_id.partition_key()
     }
 }
 

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -96,59 +96,7 @@ impl From<LeaderEpoch> for crate::protobuf::common::LeaderEpoch {
     }
 }
 
-/// Identifying the partition
-#[derive(
-    Copy,
-    Clone,
-    PartialEq,
-    Eq,
-    Hash,
-    PartialOrd,
-    Ord,
-    derive_more::Deref,
-    derive_more::From,
-    derive_more::Into,
-    derive_more::Add,
-    derive_more::Display,
-    derive_more::Debug,
-    derive_more::FromStr,
-    serde::Serialize,
-    serde::Deserialize,
-    BilrostNewType,
-    NetSerde,
-)]
-#[repr(transparent)]
-#[serde(transparent)]
-#[debug("{}", _0)]
-pub struct PartitionId(u16);
-
-impl From<PartitionId> for u32 {
-    fn from(value: PartitionId) -> Self {
-        u32::from(value.0)
-    }
-}
-
-impl From<PartitionId> for u64 {
-    fn from(value: PartitionId) -> Self {
-        u64::from(value.0)
-    }
-}
-
-impl PartitionId {
-    /// It's your responsibility to ensure the value is within the valid range.
-    pub const fn new_unchecked(v: u16) -> Self {
-        Self(v)
-    }
-
-    pub const MIN: Self = Self(u16::MIN);
-    // 65535 partitions.
-    pub const MAX: Self = Self(u16::MAX);
-
-    #[inline]
-    pub fn next(self) -> Self {
-        Self(std::cmp::min(*Self::MAX, self.0.saturating_add(1)))
-    }
-}
+pub use crate::sharding::PartitionId;
 
 /// The leader epoch of a given partition
 pub type PartitionLeaderEpoch = (PartitionId, LeaderEpoch);

--- a/crates/types/src/invocation/mod.rs
+++ b/crates/types/src/invocation/mod.rs
@@ -427,6 +427,12 @@ impl InvocationRequest {
     }
 }
 
+impl WithPartitionKey for InvocationRequest {
+    fn partition_key(&self) -> PartitionKey {
+        self.header.invocation_id().partition_key()
+    }
+}
+
 impl WithInvocationId for InvocationRequest {
     fn invocation_id(&self) -> InvocationId {
         self.header.invocation_id()
@@ -590,6 +596,12 @@ impl JournalCompletionTarget {
     }
 }
 
+impl WithPartitionKey for JournalCompletionTarget {
+    fn partition_key(&self) -> PartitionKey {
+        self.caller_id.partition_key()
+    }
+}
+
 impl WithInvocationId for JournalCompletionTarget {
     fn invocation_id(&self) -> InvocationId {
         self.caller_id
@@ -605,6 +617,12 @@ impl WithInvocationId for JournalCompletionTarget {
 pub struct InvocationResponse {
     pub target: JournalCompletionTarget,
     pub result: ResponseResult,
+}
+
+impl WithPartitionKey for InvocationResponse {
+    fn partition_key(&self) -> PartitionKey {
+        self.target.invocation_id().partition_key()
+    }
 }
 
 impl WithInvocationId for InvocationResponse {
@@ -1359,6 +1377,12 @@ impl WithPartitionKey for AttachInvocationRequest {
 pub struct NotifySignalRequest {
     pub invocation_id: InvocationId,
     pub signal: Signal,
+}
+
+impl WithPartitionKey for NotifySignalRequest {
+    fn partition_key(&self) -> PartitionKey {
+        self.invocation_id.partition_key()
+    }
 }
 
 impl WithInvocationId for NotifySignalRequest {

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -81,6 +81,11 @@ pub mod memory {
     pub use restate_memory::*;
 }
 
+// Re-export restate-sharding crate for key range utilities.
+pub mod sharding {
+    pub use restate_sharding::*;
+}
+
 // Re-export metrics' SharedString (Space-efficient Cow + RefCounted variant)
 pub type SharedString = metrics::SharedString;
 

--- a/crates/types/src/net/remote_query_scanner.rs
+++ b/crates/types/src/net/remote_query_scanner.rs
@@ -9,13 +9,10 @@
 // by the Apache License, Version 2.0.
 
 use std::fmt::{Display, Formatter};
-use std::ops::RangeInclusive;
-
-use restate_encoding::RestateEncoding;
 
 use super::ServiceTag;
 use crate::GenerationalNodeId;
-use crate::identifiers::{PartitionId, PartitionKey};
+use crate::identifiers::PartitionId;
 use crate::net::{bilrost_wire_codec, define_rpc, define_service};
 
 pub struct RemoteDataFusionService;
@@ -41,8 +38,8 @@ impl Display for ScannerId {
 pub struct RemoteQueryScannerOpen {
     #[bilrost(1)]
     pub partition_id: PartitionId,
-    #[bilrost(tag(2), encoding(RestateEncoding))]
-    pub range: RangeInclusive<PartitionKey>,
+    #[bilrost(2)]
+    pub range: crate::sharding::KeyRange,
     #[bilrost(3)]
     pub table: String,
     #[bilrost(tag(4), encoding(plainbytes))]

--- a/crates/types/src/partition_table.rs
+++ b/crates/types/src/partition_table.rs
@@ -10,7 +10,6 @@
 
 use std::collections::BTreeMap;
 use std::hash::Hash;
-use std::ops::RangeInclusive;
 use std::sync::Arc;
 
 use serde_with::serde_as;
@@ -36,18 +35,6 @@ pub trait FindPartition {
         &self,
         partition_key: PartitionKey,
     ) -> Result<PartitionId, PartitionTableError>;
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct KeyRange {
-    pub from: PartitionKey,
-    pub to: PartitionKey,
-}
-
-impl From<KeyRange> for RangeInclusive<PartitionKey> {
-    fn from(val: KeyRange) -> Self {
-        RangeInclusive::new(val.from, val.to)
-    }
 }
 
 /// Specified how partitions are replicated across the cluster.
@@ -204,7 +191,7 @@ impl FindPartition for PartitionTable {
         self.partitions
             .get(&candidate)
             .and_then(|partition| {
-                if partition.key_range.start() <= &partition_key {
+                if partition.key_range.start() <= partition_key {
                     Some(candidate)
                 } else {
                     None
@@ -272,14 +259,14 @@ impl AsRef<str> for CfName {
 #[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Partition {
     pub partition_id: PartitionId,
-    pub key_range: RangeInclusive<PartitionKey>,
+    pub key_range: crate::sharding::KeyRange,
     log_id: Option<LogId>,
     db_name: Option<DbName>,
     cf_name: Option<CfName>,
 }
 
 impl Partition {
-    pub const fn new(partition_id: PartitionId, key_range: RangeInclusive<PartitionKey>) -> Self {
+    pub const fn new(partition_id: PartitionId, key_range: crate::sharding::KeyRange) -> Self {
         Self {
             partition_id,
             key_range,
@@ -392,8 +379,8 @@ impl PartitionTableBuilder {
             return Err(BuilderError::LimitReached);
         }
 
-        let start = *partition.key_range.start();
-        let end = *partition.key_range.end();
+        let start = partition.key_range.start();
+        let end = partition.key_range.end();
 
         if let Some((_, partition_id)) = self.inner.partition_key_index.range(end..).next() {
             let partition = self
@@ -401,7 +388,7 @@ impl PartitionTableBuilder {
                 .partitions
                 .get(partition_id)
                 .expect("partition should be present");
-            if *partition.key_range.start() <= end {
+            if partition.key_range.start() <= end {
                 return Err(BuilderError::Overlap(*partition_id));
             }
         }
@@ -422,7 +409,7 @@ impl PartitionTableBuilder {
         if let Some(partition) = self.inner.partitions.remove(partition_id) {
             self.inner
                 .partition_key_index
-                .remove(partition.key_range.end());
+                .remove(&partition.key_range.end());
         }
     }
 
@@ -458,7 +445,7 @@ impl From<PartitionTable> for PartitionTableBuilder {
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct PartitionShadow {
     pub log_id: Option<LogId>,
-    pub key_range: RangeInclusive<PartitionKey>,
+    pub key_range: crate::sharding::KeyRange,
     #[serde(default)]
     pub db_name: Option<DbName>,
     pub cf_name: Option<CfName>,
@@ -541,105 +528,18 @@ impl TryFrom<PartitionTableShadow> for PartitionTable {
     }
 }
 
-#[derive(Debug)]
-pub struct EqualSizedPartitionPartitioner {
-    num_partitions: u16,
-    next_partition_id: PartitionId,
-}
-
-impl EqualSizedPartitionPartitioner {
-    const PARTITION_KEY_RANGE_END: u128 = 1 << 64;
-
-    fn new(num_partitions: u16) -> Self {
-        Self {
-            num_partitions,
-            next_partition_id: PartitionId::MIN,
-        }
-    }
-
-    fn partition_id_to_partition_range(
-        num_partitions: u16,
-        partition_id: PartitionId,
-    ) -> RangeInclusive<PartitionKey> {
-        let num_partitions = u128::from(num_partitions);
-        let partition_id = u128::from(*partition_id);
-
-        assert!(
-            partition_id < num_partitions,
-            "There cannot be a partition id which is larger than the number of partitions \
-                '{num_partitions}', when using the fixed consecutive partitioning scheme."
-        );
-
-        // adding num_partitions - 1 to dividend is equivalent to applying ceil function to result
-        let start = (partition_id * Self::PARTITION_KEY_RANGE_END).div_ceil(num_partitions);
-        let end = ((partition_id + 1) * Self::PARTITION_KEY_RANGE_END).div_ceil(num_partitions) - 1;
-
-        let start = u64::try_from(start)
-            .expect("Resulting partition start '{start}' should be <= u64::MAX.");
-        let end =
-            u64::try_from(end).expect("Resulting partition end '{end}' should be <= u64::MAX.");
-
-        start..=end
-    }
-}
-
-impl Iterator for EqualSizedPartitionPartitioner {
-    type Item = (PartitionId, RangeInclusive<PartitionKey>);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if *self.next_partition_id < self.num_partitions {
-            let partition_id = self.next_partition_id;
-            self.next_partition_id = self.next_partition_id.next();
-
-            let partition_range =
-                Self::partition_id_to_partition_range(self.num_partitions, partition_id);
-
-            Some((partition_id, partition_range))
-        } else {
-            None
-        }
-    }
-}
+pub use crate::sharding::EqualSizedPartitionPartitioner;
 
 #[cfg(test)]
 mod tests {
     use bytes::BytesMut;
     use test_log::test;
 
-    use crate::identifiers::{PartitionId, PartitionKey};
-    use crate::partition_table::{
-        EqualSizedPartitionPartitioner, FindPartition, Partition, PartitionTable,
-        PartitionTableBuilder,
-    };
+    use crate::identifiers::PartitionId;
+    use crate::partition_table::{FindPartition, Partition, PartitionTable, PartitionTableBuilder};
+    use crate::sharding::KeyRange;
     use crate::storage::StorageCodec;
     use crate::{Version, flexbuffers_storage_encode_decode};
-
-    #[test]
-    fn partitioner_produces_consecutive_ranges() {
-        let partitioner = EqualSizedPartitionPartitioner::new(10);
-        let mut previous_end = None;
-        let mut previous_length = None::<PartitionKey>;
-
-        for (_id, range) in partitioner {
-            let current_length = *range.end() - *range.start();
-
-            if let Some(previous_length) = previous_length {
-                let length_diff = previous_length.abs_diff(current_length);
-                assert!(length_diff <= 1);
-            } else {
-                assert_eq!(*range.start(), 0);
-            }
-
-            if let Some(previous_end) = previous_end {
-                assert_eq!(previous_end + 1, *range.start());
-            }
-
-            previous_end = Some(*range.end());
-            previous_length = Some(current_length);
-        }
-
-        assert_eq!(previous_end, Some(PartitionKey::MAX));
-    }
 
     #[test(tokio::test)]
     async fn partition_table_resolves_partition_keys() {
@@ -651,13 +551,13 @@ mod tests {
         for (partition_id, partition) in partitioner {
             assert_eq!(
                 partition_table
-                    .find_partition_id(*partition.key_range.start())
+                    .find_partition_id(partition.key_range.start())
                     .expect("partition should exist"),
                 *partition_id
             );
             assert_eq!(
                 partition_table
-                    .find_partition_id(*partition.key_range.end())
+                    .find_partition_id(partition.key_range.end())
                     .expect("partition should exist"),
                 *partition_id
             );
@@ -707,8 +607,11 @@ mod tests {
     #[test]
     fn detect_holes_in_partition_table() -> googletest::Result<()> {
         let mut builder = PartitionTableBuilder::new(Version::INVALID);
-        builder.add_partition(Partition::new(PartitionId::from(0), 0..=1024))?;
-        builder.add_partition(Partition::new(PartitionId::from(1), 2048..=4096))?;
+        builder.add_partition(Partition::new(PartitionId::from(0), KeyRange::new(0, 1024)))?;
+        builder.add_partition(Partition::new(
+            PartitionId::from(1),
+            KeyRange::new(2048, 4096),
+        ))?;
 
         let partition_table = builder.build();
 

--- a/crates/vqueues/src/scheduler/drr.rs
+++ b/crates/vqueues/src/scheduler/drr.rs
@@ -434,7 +434,6 @@ impl<S: VQueueStore> DRRScheduler<S> {
 #[cfg(test)]
 mod tests {
     use std::num::{NonZeroU16, NonZeroUsize};
-    use std::ops::RangeInclusive;
     use std::pin::pin;
     use std::task::Poll;
 
@@ -456,6 +455,7 @@ mod tests {
     use restate_types::clock::UniqueTimestamp;
     use restate_types::identifiers::{PartitionId, PartitionKey};
     use restate_types::partitions::Partition;
+    use restate_types::sharding::KeyRange;
     use restate_types::vqueues::VQueueId;
     use restate_types::vqueues::{EntryId, EntryKind};
 
@@ -482,10 +482,7 @@ mod tests {
             .expect("DB storage creation succeeds");
         manager
             .open(
-                &Partition::new(
-                    PartitionId::MIN,
-                    RangeInclusive::new(0, PartitionKey::MAX - 1),
-                ),
+                &Partition::new(PartitionId::MIN, KeyRange::new(0, PartitionKey::MAX - 1)),
                 None,
             )
             .await

--- a/crates/vqueues/src/scheduler/queue.rs
+++ b/crates/vqueues/src/scheduler/queue.rs
@@ -322,8 +322,6 @@ impl<S: VQueueStore> Queue<S> {
 mod tests {
     use super::*;
 
-    use std::ops::RangeInclusive;
-
     use restate_clock::RoughTimestamp;
     use restate_clock::time::MillisSinceEpoch;
     use restate_core::TaskCenter;
@@ -337,6 +335,7 @@ mod tests {
     use restate_types::clock::UniqueTimestamp;
     use restate_types::identifiers::{PartitionId, PartitionKey};
     use restate_types::partitions::Partition;
+    use restate_types::sharding::KeyRange;
     use restate_types::vqueues::VQueueId;
 
     const BASE_RUN_AT_MS: u64 = 1_744_000_000_000;
@@ -387,10 +386,7 @@ mod tests {
             .expect("DB storage creation succeeds");
         manager
             .open(
-                &Partition::new(
-                    PartitionId::MIN,
-                    RangeInclusive::new(0, PartitionKey::MAX - 1),
-                ),
+                &Partition::new(PartitionId::MIN, KeyRange::new(0, PartitionKey::MAX - 1)),
                 None,
             )
             .await

--- a/crates/wal-protocol/src/control.rs
+++ b/crates/wal-protocol/src/control.rs
@@ -8,15 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::ops::RangeInclusive;
-
 use restate_storage_api::fsm_table::{CurrentReplicaSetState, NextReplicaSetState};
-use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionKey};
+use restate_types::identifiers::{LeaderEpoch, PartitionId};
 use restate_types::logs::{Keys, Lsn, SequenceNumber};
 use restate_types::partitions::PartitionConfiguration;
 use restate_types::partitions::state::{MemberState, ReplicaSetState};
 use restate_types::replication::{NodeSet, ReplicationProperty};
 use restate_types::schema::Schema;
+use restate_types::sharding::KeyRange;
 use restate_types::time::MillisSinceEpoch;
 use restate_types::{GenerationalNodeId, SemanticRestateVersion, Version, Versioned};
 
@@ -30,7 +29,7 @@ pub struct AnnounceLeader {
     /// it's safe to assume that it's always set.
     pub node_id: GenerationalNodeId,
     pub leader_epoch: LeaderEpoch,
-    pub partition_key_range: RangeInclusive<PartitionKey>,
+    pub partition_key_range: KeyRange,
 
     /// Associated epoch metadata version
     ///

--- a/crates/wal-protocol/src/lib.rs
+++ b/crates/wal-protocol/src/lib.rs
@@ -239,15 +239,17 @@ impl HasRecordKeys for Envelope {
             Command::TruncateOutbox(_) => Keys::Single(self.partition_key()),
             Command::ProxyThrough(_) => Keys::Single(self.partition_key()),
             Command::AttachInvocation(_) => Keys::Single(self.partition_key()),
-            Command::ResumeInvocation(req) => Keys::Single(req.partition_key()),
-            Command::RestartAsNewInvocation(req) => Keys::Single(req.partition_key()),
+            Command::ResumeInvocation(req) => Keys::Single(req.invocation_id.partition_key()),
+            Command::RestartAsNewInvocation(req) => Keys::Single(req.invocation_id.partition_key()),
             // todo: Handle journal entries that request cross-partition invocations
             Command::InvokerEffect(effect) => Keys::Single(effect.invocation_id.partition_key()),
             Command::Timer(timer) => Keys::Single(timer.invocation_id().partition_key()),
             Command::ScheduleTimer(timer) => Keys::Single(timer.invocation_id().partition_key()),
             Command::InvocationResponse(response) => Keys::Single(response.partition_key()),
             Command::NotifySignal(sig) => Keys::Single(sig.partition_key()),
-            Command::NotifyGetInvocationOutputResponse(res) => Keys::Single(res.partition_key()),
+            Command::NotifyGetInvocationOutputResponse(res) => {
+                Keys::Single(res.target.partition_key())
+            }
             Command::UpsertSchema(schema) => schema.partition_key_range.clone(),
             Command::VQSchedulerDecisions(_) => Keys::Single(self.partition_key()),
         }

--- a/crates/wal-protocol/src/lib.rs
+++ b/crates/wal-protocol/src/lib.rs
@@ -225,7 +225,7 @@ impl HasRecordKeys for Envelope {
             Command::UpdatePartitionDurability(_) => Keys::Single(self.partition_key()),
             Command::VersionBarrier(barrier) => barrier.partition_key_range.clone(),
             Command::AnnounceLeader(announce) => {
-                Keys::RangeInclusive(announce.partition_key_range.clone())
+                Keys::RangeInclusive(announce.partition_key_range.into())
             }
             Command::PatchState(mutation) => Keys::Single(mutation.service_id.partition_key()),
             Command::TerminateInvocation(terminate) => {

--- a/crates/worker/src/partition/leadership/leader_state.rs
+++ b/crates/worker/src/partition/leadership/leader_state.rs
@@ -11,7 +11,6 @@
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::future::Future;
-use std::ops::RangeInclusive;
 use std::pin::Pin;
 use std::task::{Context, Poll, ready};
 
@@ -39,6 +38,7 @@ use restate_types::net::ingest::IngestRecord;
 use restate_types::net::partition_processor::{
     PartitionProcessorRpcError, PartitionProcessorRpcResponse,
 };
+use restate_types::sharding::KeyRange;
 use restate_types::{RESTATE_VERSION_1_7_0, SemanticRestateVersion, Version, Versioned, vqueues};
 use restate_vqueues::SchedulerService;
 use restate_vqueues::VQueueEvent;
@@ -66,7 +66,7 @@ pub struct LeaderState {
     pub(crate) partition_id: PartitionId,
     pub leader_epoch: LeaderEpoch,
     // only needed for proposing TruncateOutbox to ourselves
-    partition_key_range: RangeInclusive<PartitionKey>,
+    partition_key_range: KeyRange,
 
     pub shuffle_hint_tx: HintSender,
     // It's illegal to await the shuffle task handle once it has
@@ -93,7 +93,7 @@ impl LeaderState {
     pub fn new(
         partition_id: PartitionId,
         leader_epoch: LeaderEpoch,
-        partition_key_range: RangeInclusive<PartitionKey>,
+        partition_key_range: KeyRange,
         shuffle_task_handle: TaskHandle<anyhow::Result<()>>,
         cleaner_handle: CleanerHandle,
         trimmer_task_id: TaskId,
@@ -316,7 +316,7 @@ impl LeaderState {
                     // the replica-set as a sufficient source of durability, or only snapshots.
                     self.self_proposer
                         .self_propose(
-                            *self.partition_key_range.start(),
+                            self.partition_key_range.start(),
                             Command::UpdatePartitionDurability(partition_durability),
                         )
                         .await?;
@@ -334,7 +334,7 @@ impl LeaderState {
                     //  specific destination messages that are identified by a partition_id
                     self.self_proposer
                         .self_propose(
-                            *self.partition_key_range.start(),
+                            self.partition_key_range.start(),
                             Command::TruncateOutbox(outbox_truncation.index()),
                         )
                         .await?;
@@ -372,10 +372,10 @@ impl LeaderState {
                     {
                         self.self_proposer
                             .self_propose(
-                                *self.partition_key_range.start(),
+                                self.partition_key_range.start(),
                                 Command::UpsertSchema(UpsertSchema {
                                     partition_key_range: Keys::RangeInclusive(
-                                        self.partition_key_range.clone(),
+                                        self.partition_key_range.into(),
                                     ),
                                     schema,
                                 }),

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -251,7 +251,7 @@ where
             node_id: my_node_id(),
             leader_epoch,
             epoch_version: Some(leadership_info.version),
-            partition_key_range: self.partition.key_range.clone(),
+            partition_key_range: self.partition.key_range,
             current_config: Some(leadership_info.current_config),
             next_config: leadership_info.next_config,
         }));
@@ -263,7 +263,7 @@ where
         )?;
 
         self_proposer
-            .self_propose(*self.partition.key_range.start(), announce_leader)
+            .self_propose(self.partition.key_range.start(), announce_leader)
             .await?;
 
         self.state = State::Candidate {
@@ -396,7 +396,7 @@ where
             self.invoker_tx
                 .register_partition(
                     (self.partition.partition_id, *leader_epoch),
-                    self.partition.key_range.clone(),
+                    self.partition.key_range,
                     InvokerStorageReader::new(partition_store.clone()),
                     invoker_tx,
                 )
@@ -480,11 +480,11 @@ where
             {
                 self_proposer
                     .self_propose(
-                        *self.partition.key_range.start(),
+                        self.partition.key_range.start(),
                         Command::VersionBarrier(VersionBarrier {
                             version: forced_min_restate_version.clone(),
                             partition_key_range: Keys::RangeInclusive(
-                                self.partition.key_range.clone(),
+                                self.partition.key_range.into(),
                             ),
                             human_reason: Some("Force min Restate version".to_owned()),
                         }),
@@ -500,11 +500,11 @@ where
             {
                 self_proposer
                     .self_propose(
-                        *self.partition.key_range.start(),
+                        self.partition.key_range.start(),
                         Command::VersionBarrier(VersionBarrier {
                             version: RESTATE_VERSION_1_6_0.clone(),
                             partition_key_range: Keys::RangeInclusive(
-                                self.partition.key_range.clone(),
+                                self.partition.key_range.into(),
                             ),
                             human_reason: Some("Enable journal v2 by default".to_owned()),
                         }),
@@ -528,7 +528,7 @@ where
             self.state = State::Leader(Box::new(LeaderState::new(
                 self.partition.partition_id,
                 *leader_epoch,
-                self.partition.key_range.clone(),
+                self.partition.key_range,
                 shuffle_task_handle,
                 cleaner_handle,
                 trimmer_task_id,
@@ -785,23 +785,23 @@ mod tests {
     use restate_partition_store::PartitionStoreManager;
     use restate_rocksdb::RocksDbManager;
     use restate_types::config::Configuration;
-    use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionKey};
+    use restate_types::identifiers::{LeaderEpoch, PartitionId};
     use restate_types::logs::{KeyFilter, Lsn, SequenceNumber};
     use restate_types::partitions::state::PartitionReplicaSetStates;
     use restate_types::partitions::{Partition, PartitionConfiguration};
+    use restate_types::sharding::KeyRange;
     use restate_types::{GenerationalNodeId, Version};
     use restate_vqueues::VQueuesMetaCache;
     use restate_wal_protocol::Command;
     use restate_wal_protocol::Envelope;
     use std::num::NonZeroUsize;
-    use std::ops::RangeInclusive;
     use std::sync::Arc;
     use test_log::test;
     use tokio_stream::StreamExt;
 
     const PARTITION_ID: PartitionId = PartitionId::MIN;
     const NODE_ID: GenerationalNodeId = GenerationalNodeId::new(0, 0);
-    const PARTITION_KEY_RANGE: RangeInclusive<PartitionKey> = PartitionKey::MIN..=PartitionKey::MAX;
+    const PARTITION_KEY_RANGE: KeyRange = KeyRange::FULL;
     const PARTITION: Partition = Partition::new(PARTITION_ID, PARTITION_KEY_RANGE);
 
     #[test(restate_core::test)]

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -17,6 +17,7 @@ mod state_machine;
 pub mod types;
 
 use std::fmt::Debug;
+use std::ops::RangeBounds;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -254,7 +255,7 @@ where
             inbox_seq_number,
             outbox_seq_number,
             outbox_head_seq_number,
-            partition_store.partition_key_range().clone(),
+            partition_store.partition_key_range(),
             min_restate_version,
             schema,
         );
@@ -491,7 +492,7 @@ where
 
         let mut record_stream = self.bifrost.create_reader(
             log_id,
-            KeyFilter::Within(self.partition_store.partition_key_range().clone()),
+            KeyFilter::Within(self.partition_store.partition_key_range().into()),
             last_applied_lsn.next(),
             Lsn::MAX,
         )?;

--- a/crates/worker/src/partition/state_machine/lifecycle/version_barrier.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/version_barrier.rs
@@ -51,6 +51,7 @@ mod tests {
     use restate_types::SemanticRestateVersion;
     use restate_types::identifiers::PartitionKey;
     use restate_types::logs::Keys;
+    use restate_types::sharding::KeyRange;
     use restate_wal_protocol::Command;
     use restate_wal_protocol::control::VersionBarrier;
 
@@ -64,7 +65,7 @@ mod tests {
             0,    /* inbox_seq_number */
             0,    /* outbox_seq_number */
             None, /* outbox_head_seq_number */
-            PartitionKey::MIN..=PartitionKey::MAX,
+            KeyRange::FULL,
             SemanticRestateVersion::unknown().clone(),
             Default::default(),
         );
@@ -106,7 +107,7 @@ mod tests {
             0,    /* inbox_seq_number */
             0,    /* outbox_seq_number */
             None, /* outbox_head_seq_number */
-            PartitionKey::MIN..=PartitionKey::MAX,
+            KeyRange::FULL,
             SemanticRestateVersion::unknown().clone(),
             Default::default(),
         );

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -19,7 +19,7 @@ use std::borrow::Cow;
 use std::collections::HashSet;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
-use std::ops::RangeInclusive;
+use std::ops::{RangeBounds, RangeInclusive};
 use std::str::FromStr;
 use std::time::Instant;
 
@@ -71,7 +71,7 @@ use restate_types::errors::{
     NOT_READY_INVOCATION_ERROR, WORKFLOW_ALREADY_INVOKED_INVOCATION_ERROR,
 };
 use restate_types::identifiers::{
-    AwakeableIdentifier, EntryIndex, ExternalSignalIdentifier, InvocationId, PartitionKey,
+    AwakeableIdentifier, EntryIndex, ExternalSignalIdentifier, InvocationId,
     PartitionProcessorRpcRequestId, ServiceId, StateMutationId,
 };
 use restate_types::identifiers::{IdempotencyId, WithPartitionKey};
@@ -105,6 +105,7 @@ use restate_types::logs::Lsn;
 use restate_types::message::MessageIndex;
 use restate_types::schema::Schema;
 use restate_types::service_protocol::ServiceProtocolVersion;
+use restate_types::sharding::KeyRange;
 use restate_types::state_mut::ExternalStateMutation;
 use restate_types::state_mut::StateMutationVersion;
 use restate_types::storage::{StoredRawEntry, StoredRawEntryHeader};
@@ -152,7 +153,7 @@ pub struct StateMachine {
     /// Consistent schema
     pub(crate) schema: Option<Schema>,
 
-    pub(crate) partition_key_range: RangeInclusive<PartitionKey>,
+    pub(crate) partition_key_range: KeyRange,
 }
 
 impl Debug for StateMachine {
@@ -235,7 +236,7 @@ impl StateMachine {
         inbox_seq_number: MessageIndex,
         outbox_seq_number: MessageIndex,
         outbox_head_seq_number: Option<MessageIndex>,
-        partition_key_range: RangeInclusive<PartitionKey>,
+        partition_key_range: KeyRange,
         min_restate_version: SemanticRestateVersion,
         schema: Option<Schema>,
     ) -> Self {
@@ -261,7 +262,7 @@ pub(crate) struct StateMachineApplyContext<'a, S> {
     outbox_head_seq_number: &'a mut Option<MessageIndex>,
     min_restate_version: &'a mut SemanticRestateVersion,
     schema: &'a mut Option<Schema>,
-    partition_key_range: RangeInclusive<PartitionKey>,
+    partition_key_range: KeyRange,
     is_leader: bool,
 }
 
@@ -301,7 +302,7 @@ impl StateMachine {
                 min_restate_version: &mut self.min_restate_version,
                 vqueues_cache,
                 schema: &mut self.schema,
-                partition_key_range: self.partition_key_range.clone(),
+                partition_key_range: self.partition_key_range,
                 is_leader,
             }
             .on_apply(command)

--- a/crates/worker/src/partition/state_machine/tests/mod.rs
+++ b/crates/worker/src/partition/state_machine/tests/mod.rs
@@ -51,8 +51,7 @@ use restate_test_util::matchers::*;
 use restate_types::config::StorageOptions;
 use restate_types::errors::{InvocationError, KILLED_INVOCATION_ERROR, codes};
 use restate_types::identifiers::{
-    AwakeableIdentifier, InvocationId, PartitionId, PartitionKey, PartitionProcessorRpcRequestId,
-    ServiceId,
+    AwakeableIdentifier, InvocationId, PartitionId, PartitionProcessorRpcRequestId, ServiceId,
 };
 use restate_types::invocation::client::InvocationOutputResponse;
 use restate_types::invocation::{
@@ -95,7 +94,7 @@ impl TestEnv {
             0,    /* inbox_seq_number */
             0,    /* outbox_seq_number */
             None, /* outbox_head_seq_number */
-            PartitionKey::MIN..=PartitionKey::MAX,
+            KeyRange::FULL,
             min_restate_version,
             None,
         ))
@@ -133,13 +132,7 @@ impl TestEnv {
         );
         let manager = PartitionStoreManager::create().await.unwrap();
         let rocksdb_storage = manager
-            .open(
-                &Partition::new(
-                    PartitionId::MIN,
-                    RangeInclusive::new(PartitionKey::MIN, PartitionKey::MAX),
-                ),
-                None,
-            )
+            .open(&Partition::new(PartitionId::MIN, KeyRange::FULL), None)
             .await
             .unwrap();
 
@@ -1061,7 +1054,7 @@ async fn truncate_outbox_with_gap() -> Result<(), Error> {
         0,
         outbox_tail_index,
         Some(outbox_head_index),
-        PartitionKey::MIN..=PartitionKey::MAX,
+        KeyRange::FULL,
         SemanticRestateVersion::unknown().clone(),
         None,
     ))

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -13,7 +13,7 @@ mod spawn_processor_task;
 
 use std::collections::BTreeMap;
 use std::collections::hash_map::Entry;
-use std::ops::{Add, RangeInclusive};
+use std::ops::Add;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
@@ -62,8 +62,8 @@ use restate_types::cluster::cluster_state::{PartitionProcessorStatus, RunMode};
 use restate_types::config::Configuration;
 use restate_types::epoch::EpochMetadata;
 use restate_types::health::HealthStatus;
+use restate_types::identifiers::PartitionId;
 use restate_types::identifiers::SnapshotId;
-use restate_types::identifiers::{PartitionId, PartitionKey};
 use restate_types::live::Live;
 use restate_types::logs::{Lsn, SequenceNumber};
 use restate_types::metadata_store::keys::partition_processor_epoch_key;
@@ -80,6 +80,7 @@ use restate_types::partitions::Partition;
 use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::protobuf::common::WorkerStatus;
 use restate_types::retries::with_jitter;
+use restate_types::sharding::KeyRange;
 use restate_types::{GenerationalNodeId, SharedString};
 use restate_wal_protocol::Envelope;
 
@@ -189,7 +190,7 @@ impl std::fmt::Display for RestartDelay {
     }
 }
 
-type ChannelStatusReaderList = Vec<(RangeInclusive<PartitionKey>, ChannelStatusReader)>;
+type ChannelStatusReaderList = Vec<(KeyRange, ChannelStatusReader)>;
 
 #[derive(Debug, Clone, Default)]
 pub struct MultiplexedInvokerStatusReader {
@@ -197,12 +198,12 @@ pub struct MultiplexedInvokerStatusReader {
 }
 
 impl MultiplexedInvokerStatusReader {
-    fn push(&mut self, key_range: RangeInclusive<PartitionKey>, reader: ChannelStatusReader) {
+    fn push(&mut self, key_range: KeyRange, reader: ChannelStatusReader) {
         self.readers.write().push((key_range, reader));
     }
 
-    fn remove(&mut self, key_range: &RangeInclusive<PartitionKey>) {
-        self.readers.write().retain(|elem| &elem.0 != key_range);
+    fn remove(&mut self, key_range: KeyRange) {
+        self.readers.write().retain(|elem| elem.0 != key_range);
     }
 }
 
@@ -210,7 +211,7 @@ impl StatusHandle for MultiplexedInvokerStatusReader {
     type Iterator =
         std::iter::Flatten<std::vec::IntoIter<<ChannelStatusReader as StatusHandle>::Iterator>>;
 
-    async fn read_status(&self, keys: RangeInclusive<PartitionKey>) -> Self::Iterator {
+    async fn read_status(&self, keys: KeyRange) -> Self::Iterator {
         let mut overlapping_partitions = Vec::new();
 
         // first clone the readers while holding the lock, then release the lock before reading the
@@ -218,18 +219,18 @@ impl StatusHandle for MultiplexedInvokerStatusReader {
         for (range, reader) in self.readers.read().iter() {
             if keys.start() <= range.end() && keys.end() >= range.start() {
                 // if this partition is actually overlapping with the search range
-                overlapping_partitions.push((range.clone(), reader.clone()))
+                overlapping_partitions.push((*range, reader.clone()))
             }
         }
         // although we never have a single scans that cross partitions (thus overlapping_partitions.len() == 1),
         // we can make this code path a bit more future resilient cheaply, by ordering the partitions by their start key.
         // (this uniquely defines the order between the partitions)
-        overlapping_partitions.sort_by(|(a, _), (b, _)| a.start().cmp(b.start()));
+        overlapping_partitions.sort_by_key(|(a, _)| a.start());
 
         let mut result = Vec::with_capacity(overlapping_partitions.len());
 
         for (_, reader) in overlapping_partitions {
-            result.push(reader.read_status(keys.clone()).await);
+            result.push(reader.read_status(keys).await);
         }
 
         result.into_iter().flatten()
@@ -523,7 +524,7 @@ where
                                 } => {
                                     debug!(%target_run_mode, "Partition processor was successfully created.");
                                     self.invokers_status_reader.push(
-                                        started_processor.key_range().clone(),
+                                        started_processor.key_range(),
                                         started_processor.invoker_status_reader().clone(),
                                     );
 

--- a/crates/worker/src/partition_processor_manager/processor_state.rs
+++ b/crates/worker/src/partition_processor_manager/processor_state.rs
@@ -8,7 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::ops::RangeInclusive;
 use std::time::{Duration, Instant};
 
 use tokio::sync::watch;
@@ -19,8 +18,9 @@ use ulid::Ulid;
 use restate_core::network::ShardSender;
 use restate_invoker_impl::ChannelStatusReader;
 use restate_types::cluster::cluster_state::{PartitionProcessorStatus, ReplayStatus, RunMode};
-use restate_types::identifiers::{LeaderEpoch, PartitionKey};
+use restate_types::identifiers::LeaderEpoch;
 use restate_types::net::partition_processor::PartitionLeaderService;
+use restate_types::sharding::KeyRange;
 
 use crate::partition::{LeadershipInfo, TargetLeaderState};
 
@@ -325,7 +325,7 @@ impl ProcessorState {
 #[derive(Debug)]
 pub struct StartedProcessor {
     cancellation_token: CancellationToken,
-    key_range: RangeInclusive<PartitionKey>,
+    key_range: KeyRange,
     control_tx: watch::Sender<TargetLeaderState>,
     status_reader: ChannelStatusReader,
     rpc_shard_tx: ShardSender<PartitionLeaderService>,
@@ -335,7 +335,7 @@ pub struct StartedProcessor {
 impl StartedProcessor {
     pub fn new(
         cancellation_token: CancellationToken,
-        key_range: RangeInclusive<PartitionKey>,
+        key_range: KeyRange,
         control_tx: watch::Sender<TargetLeaderState>,
         status_reader: ChannelStatusReader,
         rpc_shard_tx: ShardSender<PartitionLeaderService>,
@@ -389,8 +389,8 @@ impl StartedProcessor {
     }
 
     #[inline]
-    pub fn key_range(&self) -> &RangeInclusive<PartitionKey> {
-        &self.key_range
+    pub fn key_range(&self) -> KeyRange {
+        self.key_range
     }
 
     #[inline]

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -143,7 +143,7 @@ where
 
         let invoker_name = Arc::from(format!("invoker-{}", partition.partition_id));
         let invoker_config = configuration.clone().map(|c| &c.worker.invoker);
-        let key_range = partition.key_range.clone();
+        let key_range = partition.key_range;
 
         let root_task_handle = TaskCenter::current().start_runtime(
             TaskKind::PartitionProcessor,

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -25,7 +25,7 @@ arrow-ipc = { version = "57", features = ["lz4"] }
 arrow-schema = { version = "57", default-features = false, features = ["canonical_extension_types"] }
 aws-credential-types = { version = "1", default-features = false, features = ["test-util"] }
 aws-lc-rs = { version = "1", features = ["prebuilt-nasm"] }
-aws-lc-sys = { version = "0.39", default-features = false, features = ["prebuilt-nasm"] }
+aws-lc-sys = { version = "0.40", default-features = false, features = ["prebuilt-nasm"] }
 aws-runtime = { version = "1", default-features = false, features = ["event-stream"] }
 aws-sdk-sts = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio"] }
 aws-sigv4 = { version = "1", features = ["http0-compat", "sign-eventstream"] }
@@ -65,7 +65,6 @@ hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-
 hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16" }
 hdrhistogram = { version = "7" }
 hex = { version = "0.4" }
-hmac = { version = "0.12", default-features = false, features = ["reset"] }
 hyper = { version = "1", features = ["full"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "logging", "native-tokio", "ring", "tls12"] }
 hyper-util = { version = "0.1", features = ["full"] }
@@ -139,7 +138,6 @@ uuid = { version = "1", features = ["js", "serde", "v4", "v7"] }
 winnow = { version = "1" }
 xxhash-rust = { version = "0.8", default-features = false, features = ["std", "xxh3"] }
 zerocopy = { version = "0.8", default-features = false, features = ["derive", "simd"] }
-zeroize = { version = "1", features = ["zeroize_derive"] }
 zstd = { version = "0.13" }
 zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
 zstd-sys = { version = "2", features = ["experimental", "std"] }
@@ -154,7 +152,7 @@ arrow-ipc = { version = "57", features = ["lz4"] }
 arrow-schema = { version = "57", default-features = false, features = ["canonical_extension_types"] }
 aws-credential-types = { version = "1", default-features = false, features = ["test-util"] }
 aws-lc-rs = { version = "1", features = ["prebuilt-nasm"] }
-aws-lc-sys = { version = "0.39", default-features = false, features = ["prebuilt-nasm"] }
+aws-lc-sys = { version = "0.40", default-features = false, features = ["prebuilt-nasm"] }
 aws-runtime = { version = "1", default-features = false, features = ["event-stream"] }
 aws-sdk-sts = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client", "rt-tokio"] }
 aws-sigv4 = { version = "1", features = ["http0-compat", "sign-eventstream"] }
@@ -196,7 +194,6 @@ hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-
 hashbrown-986da7b5efc2b80e = { package = "hashbrown", version = "0.16" }
 hdrhistogram = { version = "7" }
 hex = { version = "0.4" }
-hmac = { version = "0.12", default-features = false, features = ["reset"] }
 hyper = { version = "1", features = ["full"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "logging", "native-tokio", "ring", "tls12"] }
 hyper-util = { version = "0.1", features = ["full"] }
@@ -272,7 +269,6 @@ uuid = { version = "1", features = ["js", "serde", "v4", "v7"] }
 winnow = { version = "1" }
 xxhash-rust = { version = "0.8", default-features = false, features = ["std", "xxh3"] }
 zerocopy = { version = "0.8", default-features = false, features = ["derive", "simd"] }
-zeroize = { version = "1", features = ["zeroize_derive"] }
 zstd = { version = "0.13" }
 zstd-safe = { version = "7", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
 zstd-sys = { version = "2", features = ["experimental", "std"] }
@@ -281,7 +277,7 @@ zstd-sys = { version = "2", features = ["experimental", "std"] }
 bitflags = { version = "2", default-features = false, features = ["std"] }
 clap = { version = "4" }
 crossterm = { version = "0.29" }
-getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std"] }
+getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-tokio"] }
 jemalloc_pprof = { version = "0.8", default-features = false, features = ["flamegraph", "symbolize"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
@@ -291,6 +287,7 @@ num = { version = "0.4" }
 object = { version = "0.37", default-features = false, features = ["read", "std"] }
 pprof_util = { version = "0.8", default-features = false, features = ["flamegraph"] }
 prost = { version = "0.14", default-features = false, features = ["no-recursion-limit"] }
+quick-xml = { version = "0.39", features = ["overlapped-lists", "serialize"] }
 rustix = { version = "1", features = ["fs", "stdio", "termios"] }
 signal-hook = { version = "0.3" }
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats", "use_std"] }
@@ -300,7 +297,7 @@ tikv-jemalloc-sys = { version = "0.6", features = ["profiling", "stats", "unpref
 bitflags = { version = "2", default-features = false, features = ["std"] }
 clap = { version = "4" }
 crossterm = { version = "0.29" }
-getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std"] }
+getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-tokio"] }
 jemalloc_pprof = { version = "0.8", default-features = false, features = ["flamegraph", "symbolize"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
@@ -310,6 +307,7 @@ num = { version = "0.4" }
 object = { version = "0.37", default-features = false, features = ["read", "std"] }
 pprof_util = { version = "0.8", default-features = false, features = ["flamegraph"] }
 prost = { version = "0.14", default-features = false, features = ["no-recursion-limit"] }
+quick-xml = { version = "0.39", features = ["overlapped-lists", "serialize"] }
 rustix = { version = "1", features = ["fs", "stdio", "termios"] }
 signal-hook = { version = "0.3" }
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats", "use_std"] }
@@ -320,7 +318,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clap = { version = "4" }
 crossterm = { version = "0.29" }
 errno = { version = "0.3" }
-getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std"] }
+getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-tokio"] }
 jemalloc_pprof = { version = "0.8", default-features = false, features = ["flamegraph", "symbolize"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
@@ -329,6 +327,7 @@ num = { version = "0.4" }
 object = { version = "0.37", default-features = false, features = ["read", "std"] }
 pprof_util = { version = "0.8", default-features = false, features = ["flamegraph"] }
 prost = { version = "0.14", default-features = false, features = ["no-recursion-limit"] }
+quick-xml = { version = "0.39", features = ["overlapped-lists", "serialize"] }
 rustix = { version = "1", features = ["fs", "stdio", "termios"] }
 signal-hook = { version = "0.3" }
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats", "use_std"] }
@@ -339,7 +338,7 @@ bitflags = { version = "2", default-features = false, features = ["std"] }
 clap = { version = "4" }
 crossterm = { version = "0.29" }
 errno = { version = "0.3" }
-getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std"] }
+getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["webpki-tokio"] }
 jemalloc_pprof = { version = "0.8", default-features = false, features = ["flamegraph", "symbolize"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
@@ -348,6 +347,7 @@ num = { version = "0.4" }
 object = { version = "0.37", default-features = false, features = ["read", "std"] }
 pprof_util = { version = "0.8", default-features = false, features = ["flamegraph"] }
 prost = { version = "0.14", default-features = false, features = ["no-recursion-limit"] }
+quick-xml = { version = "0.39", features = ["overlapped-lists", "serialize"] }
 rustix = { version = "1", features = ["fs", "stdio", "termios"] }
 signal-hook = { version = "0.3" }
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats", "use_std"] }


### PR DESCRIPTION

Part of the effort to break the restate-types monolith into composable,
focused utility crates.

Replace all ~85 uses of std::ops::RangeInclusive<PartitionKey> with the new
KeyRange type from restate-util-sharding. Move PartitionId and
EqualSizedPartitionPartitioner into restate-util-sharding alongside KeyRange,
re-exporting from restate-types for backwards compatibility.

The migration is mechanical: .start()/.end() now return u64 by value instead
of &u64, .clone() calls are removed (KeyRange is Copy), and construction
switches from a..=b syntax to KeyRange::new(a, b).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4624).
* #4627
* #4626
* __->__ #4624
* #4623