### PR TITLE
[VQueues] Introduce sys_vqueues datafusion table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8401,6 +8401,7 @@ dependencies = [
  "restate-workspace-hack",
  "schemars 1.2.1",
  "serde_json",
+ "strum",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",

--- a/crates/partition-store/src/tests/vqueue_table_test/mod.rs
+++ b/crates/partition-store/src/tests/vqueue_table_test/mod.rs
@@ -27,12 +27,14 @@
 
 use restate_clock::time::MillisSinceEpoch;
 use restate_storage_api::Transaction;
+use restate_storage_api::vqueue_table::ScanVQueueEntries;
 use restate_storage_api::vqueue_table::{
     EntryKey, EntryMetadata, EntryValue, Options, Stage, Status, VQueueCursor, VQueueRunningCursor,
     VQueueStore, WriteVQueueTable, stats::EntryStatistics,
 };
 use restate_types::clock::UniqueTimestamp;
 use restate_types::identifiers::PartitionKey;
+use restate_types::sharding::KeyRange;
 use restate_types::vqueues::{EntryId, EntryKind, VQueueId};
 
 use crate::PartitionStore;
@@ -527,6 +529,67 @@ async fn existing_reader_does_not_see_post_snapshot_writes(rocksdb: &mut Partiti
     assert_eq!(collect_ids(&items), vec![entry_id(1), entry_id(2)]);
 }
 
+/// Test: Stage scan reads only the requested stage key kind.
+///
+/// This validates the datafusion-oriented scan API and ensures stage-specific
+/// scans do not leak rows from adjacent stage key kinds or partition keys.
+async fn stage_scan_is_filtered_by_stage(rocksdb: &mut PartitionStore) {
+    let target_partition_key = PartitionKey::from(9_300u64);
+    let other_partition_key = PartitionKey::from(9_301u64);
+    let target_qid = VQueueId::custom(target_partition_key, "scan-target");
+    let other_qid = VQueueId::custom(other_partition_key, "scan-target");
+
+    let stages = [
+        Stage::Inbox,
+        Stage::Running,
+        Stage::Suspended,
+        Stage::Paused,
+        Stage::Finished,
+    ];
+
+    {
+        let mut txn = rocksdb.transaction();
+        for (index, stage) in stages.into_iter().enumerate() {
+            let entry_id = 100 + index as u8;
+            let target_entry = default_entry(entry_id);
+            let other_entry = default_entry(entry_id + 10);
+
+            txn.put_vqueue_inbox(&target_qid, stage, &target_entry.0, &target_entry.1);
+            txn.put_vqueue_inbox(&other_qid, stage, &other_entry.0, &other_entry.1);
+        }
+        txn.commit().await.expect("commit should succeed");
+    }
+
+    let range = KeyRange::from(target_partition_key..=target_partition_key);
+
+    for (index, stage) in stages.into_iter().enumerate() {
+        let expected_key = default_entry(100 + index as u8).0;
+        let rows = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let rows_for_scan = rows.clone();
+
+        rocksdb
+            .for_each_vqueue_entry(range, vec![stage], move |(qid, got_stage, key, _)| {
+                rows_for_scan
+                    .lock()
+                    .expect("stage scan lock should not be poisoned")
+                    .push((qid.clone(), got_stage, *key));
+                std::ops::ControlFlow::Continue(())
+            })
+            .expect("stage scan setup should succeed")
+            .await
+            .expect("stage scan should succeed");
+
+        let rows = rows
+            .lock()
+            .expect("stage scan lock should not be poisoned")
+            .clone();
+        assert_eq!(rows.len(), 1, "stage {stage} should return one row");
+        assert_eq!(rows[0].0, target_qid, "stage {stage} returned wrong qid");
+        assert_eq!(rows[0].1, stage, "stage {stage} returned wrong stage");
+        assert_eq!(rows[0].2, expected_key, "stage {stage} returned wrong key");
+    }
+}
+
 pub(crate) async fn run_tests(mut rocksdb: PartitionStore) {
     let mut txn = rocksdb.transaction();
 
@@ -553,6 +616,7 @@ pub(crate) async fn run_tests(mut rocksdb: PartitionStore) {
     verify_waiting_cursor_boundary_is_respected(db);
     verify_waiting_cursor_partition_prefix_boundary_is_respected(db);
 
+    stage_scan_is_filtered_by_stage(&mut rocksdb).await;
     // Snapshot-iterator tests — exercise the contract that a fresh reader
     // sees current storage and that an existing reader holds a fixed view.
     fresh_reader_sees_current_state(&mut rocksdb).await;

--- a/crates/partition-store/src/vqueue_table/mod.rs
+++ b/crates/partition-store/src/vqueue_table/mod.rs
@@ -18,6 +18,7 @@ mod reader;
 mod running_reader;
 
 use std::io::Cursor;
+use std::pin::Pin;
 
 pub use entry::{EntryStatusKey, EntryStatusKeyRef, StatusHeaderRaw};
 pub use inbox::InboxKey;
@@ -28,16 +29,17 @@ use anyhow::Context;
 use bilrost::{BorrowedMessage, Message, OwnedMessage};
 use bytes::BytesMut;
 use rocksdb::{DBRawIteratorWithThreadMode, ReadOptions};
+use strum::EnumCount;
 use tracing::error;
 
 use restate_rocksdb::Priority;
 use restate_storage_api::StorageError;
-use restate_storage_api::vqueue_table::ScanVQueueMetaTable;
 use restate_storage_api::vqueue_table::metadata::{VQueueMeta, VQueueMetaRef, VQueueMetaUpdates};
 use restate_storage_api::vqueue_table::{
     EntryKey, EntryMetadata, EntryStatusHeader, EntryValue, LazyEntryStatus, ReadVQueueTable,
     ScanVQueueTable, Stage, Status, WriteVQueueTable, stats::EntryStatistics,
 };
+use restate_storage_api::vqueue_table::{ScanVQueueEntries, ScanVQueueMetaTable};
 use restate_types::sharding::{KeyRange, PartitionKey};
 use restate_types::vqueues::{EntryId, Seq, VQueueId};
 
@@ -471,6 +473,168 @@ impl ScanVQueueMetaTable for PartitionStore {
             },
         )
         .map_err(|_| StorageError::OperationalError)
+    }
+}
+
+/// Default scan order when no stages are explicitly requested. Skips
+/// `Stage::Unknown` which has no on-disk representation.
+const ALL_SCANNABLE_STAGES: [Stage; Stage::COUNT - 1] = [
+    Stage::Inbox,
+    Stage::Running,
+    Stage::Suspended,
+    Stage::Paused,
+    Stage::Finished,
+];
+
+fn scan_single_stage<'store, K, F>(
+    partition_store: &'store PartitionStore,
+    scanner_name: &'static str,
+    range: KeyRange,
+    stage: Stage,
+    f: std::sync::Arc<tokio::sync::Mutex<F>>,
+) -> Result<Pin<Box<dyn Future<Output = Result<()>> + Send + 'store>>>
+where
+    K: EncodeTableKeyPrefix + 'store,
+    F: for<'a> FnMut(
+            (&'a VQueueId, Stage, &'a EntryKey, &'a EntryValue),
+        ) -> std::ops::ControlFlow<()>
+        + Send
+        + 'static,
+{
+    // Each stage holds its own Arc clone exclusively inside the iterator
+    // closure. Once iteration acquires the first row, the closure takes the
+    // Arc and converts it to an owned mutex guard that it holds for the rest
+    // of the scan; the guard (and thus the Arc) is dropped on the iterator's
+    // background thread. This keeps the wrapped callback off the tokio
+    // runtime, which is required because data-fusion's `BatchSender` performs
+    // blocking I/O during `Drop`.
+    let mut f_arc = Some(f);
+    let mut f_guard: Option<tokio::sync::OwnedMutexGuard<F>> = None;
+
+    let future = partition_store
+        .iterator_for_each(
+            scanner_name,
+            Priority::Low,
+            TableScan::FullScanPartitionKeyRange::<K>(range),
+            move |(mut key, mut value)| {
+                // Skip the key-kind byte; the iterator was opened with a stage-specific
+                // prefix so every row belongs to `stage`.
+                break_on_err(KeyKind::deserialize(&mut key))?;
+                let qid: VQueueId = break_on_err(crate::keys::deserialize(&mut key))?;
+                let entry_key: EntryKey = break_on_err(crate::keys::deserialize(&mut key))?;
+                let entry = break_on_err(
+                    EntryValue::decode(&mut value).map_err(StorageError::BilrostDecode),
+                )?;
+
+                let f = f_guard.get_or_insert_with(|| {
+                    f_arc
+                        .take()
+                        .expect("Arc is taken at most once per iterator")
+                        .blocking_lock_owned()
+                });
+                f((&qid, stage, &entry_key, &entry)).map_break(Ok)
+            },
+        )
+        .map_err(|_| StorageError::OperationalError)?;
+
+    Ok(Box::pin(future))
+}
+
+fn scanner_for_stage<'store, F>(
+    partition_store: &'store PartitionStore,
+    range: KeyRange,
+    stage: Stage,
+    f: std::sync::Arc<tokio::sync::Mutex<F>>,
+) -> Result<Pin<Box<dyn Future<Output = Result<()>> + Send + 'store>>>
+where
+    F: for<'a> FnMut(
+            (&'a VQueueId, Stage, &'a EntryKey, &'a EntryValue),
+        ) -> std::ops::ControlFlow<()>
+        + Send
+        + 'static,
+{
+    match stage {
+        Stage::Unknown => Err(StorageError::Generic(anyhow::anyhow!(
+            "Unknown stage can't be scanned"
+        ))),
+        Stage::Inbox => scan_single_stage::<inbox::InboxKey, _>(
+            partition_store,
+            "df-vqueue-inbox",
+            range,
+            stage,
+            f,
+        ),
+        Stage::Running => scan_single_stage::<inbox::RunningKey, _>(
+            partition_store,
+            "df-vqueue-running",
+            range,
+            stage,
+            f,
+        ),
+        Stage::Suspended => scan_single_stage::<inbox::SuspendedKey, _>(
+            partition_store,
+            "df-vqueue-suspended",
+            range,
+            stage,
+            f,
+        ),
+        Stage::Paused => scan_single_stage::<inbox::PausedKey, _>(
+            partition_store,
+            "df-vqueue-paused",
+            range,
+            stage,
+            f,
+        ),
+        Stage::Finished => scan_single_stage::<inbox::FinishedKey, _>(
+            partition_store,
+            "df-vqueue-finished",
+            range,
+            stage,
+            f,
+        ),
+    }
+}
+
+impl ScanVQueueEntries for PartitionStore {
+    fn for_each_vqueue_entry<F, S>(
+        &self,
+        range: KeyRange,
+        stages: S,
+        f: F,
+    ) -> Result<impl Future<Output = Result<()>> + Send>
+    where
+        F: for<'a> FnMut(
+                (&'a VQueueId, Stage, &'a EntryKey, &'a EntryValue),
+            ) -> std::ops::ControlFlow<()>
+            + Send
+            + Sync
+            + 'static,
+        S: IntoIterator<Item = Stage>,
+    {
+        // The Arc is built here, cloned once per stage into each iterator closure,
+        // and immediately dropped from this scope. The async block below has *no*
+        // reference to it, so the wrapped callback never returns to the tokio
+        // runtime — see the comment in `scan_single_stage` for why that matters.
+        let scans: Vec<_> = {
+            let f = std::sync::Arc::new(tokio::sync::Mutex::new(f));
+            let mut stages = stages.into_iter().peekable();
+            let build = |stage| scanner_for_stage(self, range, stage, f.clone());
+            if stages.peek().is_some() {
+                stages.map(build).collect::<Result<Vec<_>>>()?
+            } else {
+                ALL_SCANNABLE_STAGES
+                    .into_iter()
+                    .map(build)
+                    .collect::<Result<Vec<_>>>()?
+            }
+        };
+
+        Ok(async move {
+            for scan in scans {
+                scan.await?;
+            }
+            Ok(())
+        })
     }
 }
 

--- a/crates/storage-api/src/vqueue_table/entry.rs
+++ b/crates/storage-api/src/vqueue_table/entry.rs
@@ -205,7 +205,7 @@ impl<'a> From<&'a EntryMetadata> for EntryMetadataRef<'a> {
 pub struct EntryMetadata {
     // todo: This is temporary placeholder, type and name _will_ change.
     #[bilrost(tag(1))]
-    deployment: Option<String>,
+    pub deployment: Option<String>,
 }
 
 #[cfg(test)]

--- a/crates/storage-api/src/vqueue_table/tables.rs
+++ b/crates/storage-api/src/vqueue_table/tables.rs
@@ -29,6 +29,7 @@ use crate::Result;
     PartialOrd,
     Ord,
     bilrost::Enumeration,
+    strum::EnumCount,
     strum::FromRepr,
     strum::Display,
 )]
@@ -220,4 +221,28 @@ pub trait ScanVQueueMetaTable {
         range: KeyRange,
         f: F,
     ) -> Result<impl Future<Output = Result<()>> + Send>;
+}
+
+pub trait ScanVQueueEntries {
+    /// Iterate entries across one or more stages within a partition-key range.
+    ///
+    /// Stages are scanned sequentially in the order given. An empty `stages`
+    /// iterator scans all stages except [`Stage::Unknown`]. The callback
+    /// receives the originating stage along with each item.
+    ///
+    /// Used for data-fusion queries.
+    fn for_each_vqueue_entry<F, S>(
+        &self,
+        range: KeyRange,
+        stages: S,
+        f: F,
+    ) -> Result<impl Future<Output = Result<()>> + Send>
+    where
+        F: for<'a> FnMut(
+                (&'a VQueueId, Stage, &'a EntryKey, &'a EntryValue),
+            ) -> std::ops::ControlFlow<()>
+            + Send
+            + Sync
+            + 'static,
+        S: IntoIterator<Item = Stage>;
 }

--- a/crates/storage-query-datafusion/Cargo.toml
+++ b/crates/storage-query-datafusion/Cargo.toml
@@ -46,6 +46,7 @@ paste = { workspace = true }
 prost = { workspace = true }
 schemars = { workspace = true, optional = true }
 serde_json = { workspace = true }
+strum = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }

--- a/crates/storage-query-datafusion/src/context.rs
+++ b/crates/storage-query-datafusion/src/context.rs
@@ -297,6 +297,12 @@ where
             self.partition_store_manager.clone(),
             &self.remote_scanner_manager,
         )?;
+        crate::vqueues::register_self(
+            ctx,
+            self.partition_selector.clone(),
+            self.partition_store_manager.clone(),
+            &self.remote_scanner_manager,
+        )?;
 
         ctx.datafusion_context.sql(SYS_INVOCATION_VIEW).await?;
 

--- a/crates/storage-query-datafusion/src/filter.rs
+++ b/crates/storage-query-datafusion/src/filter.rs
@@ -21,7 +21,9 @@ use datafusion::physical_expr::split_conjunction;
 use datafusion::physical_expr_common::physical_expr::snapshot_physical_expr;
 use datafusion::physical_plan::PhysicalExpr;
 use datafusion::physical_plan::expressions::{BinaryExpr, Column, InListExpr, Literal};
+use strum::EnumCount;
 
+use restate_storage_api::vqueue_table::Stage;
 use restate_types::PartitionedResourceId;
 use restate_types::identifiers::partitioner::HashPartitioner;
 use restate_types::identifiers::{
@@ -283,6 +285,81 @@ fn extract_column_literal<'a>(
 }
 
 #[derive(Debug, Clone)]
+pub struct VQueueFilter {
+    pub partition_keys: KeyRange,
+    pub stages: Option<BTreeSet<Stage>>,
+}
+
+impl ScanLocalPartitionFilter for VQueueFilter {
+    fn new(range: KeyRange, predicate: Option<Arc<dyn PhysicalExpr>>) -> Self {
+        let mut stages: Option<BTreeSet<Stage>> = None;
+
+        if let Some(predicate) = predicate
+            && let Ok(predicate) = snapshot_physical_expr(predicate)
+        {
+            for conjunct in split_conjunction(&predicate) {
+                let Some(conjunct_stages) = parse_vqueue_stages("stage", conjunct) else {
+                    continue;
+                };
+
+                stages = Some(match stages {
+                    Some(current) => current.intersection(&conjunct_stages).copied().collect(),
+                    None => conjunct_stages,
+                });
+            }
+        }
+
+        Self {
+            partition_keys: range,
+            stages,
+        }
+    }
+}
+
+fn parse_vqueue_stages(
+    column_name: &str,
+    predicate: &Arc<dyn PhysicalExpr>,
+) -> Option<BTreeSet<Stage>> {
+    // OR-chain recursion depth budget. Each `Or` node consumes one unit and the
+    // leaf check requires the remaining budget to be > 1, so an N-leaf chain
+    // needs depth >= N + 1. `Stage::COUNT` covers every variant (incl. `Unknown`)
+    // and the `+ 1` satisfies the leaf threshold.
+    let in_list = InList::parse(predicate, Stage::COUNT + 1)?;
+
+    if in_list.col.name() != column_name || in_list.negated {
+        return None;
+    }
+
+    let mut stages = BTreeSet::new();
+    for literal in in_list.list {
+        let Some(Some(stage_str)) = literal.try_as_str() else {
+            continue;
+        };
+
+        if let Some(stage) = parse_stage_literal(stage_str) {
+            stages.insert(stage);
+        }
+    }
+
+    if stages.is_empty() {
+        None
+    } else {
+        Some(stages)
+    }
+}
+
+fn parse_stage_literal(value: &str) -> Option<Stage> {
+    match value.to_ascii_lowercase().as_str() {
+        "inbox" => Some(Stage::Inbox),
+        "run" | "running" => Some(Stage::Running),
+        "suspended" => Some(Stage::Suspended),
+        "paused" => Some(Stage::Paused),
+        "finished" => Some(Stage::Finished),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct InvocationIdFilter {
     pub partition_keys: KeyRange,
     pub invocation_ids: Option<RangeInclusive<InvocationId>>,
@@ -347,12 +424,13 @@ mod tests {
     use datafusion::physical_plan::PhysicalExpr;
     use datafusion::physical_plan::expressions::{BinaryExpr, Column, InListExpr, Literal};
 
+    use restate_storage_api::vqueue_table::Stage;
     use restate_types::identifiers::{InvocationId, ServiceId, StateMutationId, WithPartitionKey};
     use restate_types::invocation::{InvocationTarget, VirtualObjectHandlerType};
     use restate_types::sharding::KeyRange;
 
     use crate::filter::{
-        FirstMatchingPartitionKeyExtractor, InvocationIdFilter, PartitionKeyExtractor,
+        FirstMatchingPartitionKeyExtractor, InvocationIdFilter, PartitionKeyExtractor, VQueueFilter,
     };
     use crate::partition_store_scanner::ScanLocalPartitionFilter;
 
@@ -715,5 +793,81 @@ mod tests {
 
         let filter = InvocationIdFilter::new(FULL_RANGE, Some(predicate));
         assert!(filter.invocation_ids.is_none());
+    }
+
+    #[test]
+    fn vqueue_filter_single_stage_eq() {
+        let predicate = eq(col("stage"), utf8_lit("running"));
+
+        let filter = VQueueFilter::new(FULL_RANGE, Some(predicate));
+        assert_eq!(
+            filter.stages,
+            Some(std::collections::BTreeSet::from([Stage::Running]))
+        );
+    }
+
+    #[test]
+    fn vqueue_filter_in_list() {
+        let predicate = in_list("stage", vec![utf8_lit("running"), utf8_lit("paused")]);
+
+        let filter = VQueueFilter::new(FULL_RANGE, Some(predicate));
+        assert_eq!(
+            filter.stages,
+            Some(std::collections::BTreeSet::from([
+                Stage::Running,
+                Stage::Paused,
+            ]))
+        );
+    }
+
+    #[test]
+    fn vqueue_filter_or_expression() {
+        let predicate = or(
+            eq(col("stage"), utf8_lit("finished")),
+            eq(col("stage"), utf8_lit("inbox")),
+        );
+
+        let filter = VQueueFilter::new(FULL_RANGE, Some(predicate));
+        assert_eq!(
+            filter.stages,
+            Some(std::collections::BTreeSet::from([
+                Stage::Finished,
+                Stage::Inbox,
+            ]))
+        );
+    }
+
+    #[test]
+    fn vqueue_filter_conjunction_intersection() {
+        let predicate = and(
+            in_list(
+                "stage",
+                vec![utf8_lit("running"), utf8_lit("paused"), utf8_lit("inbox")],
+            ),
+            eq(col("stage"), utf8_lit("paused")),
+        );
+
+        let filter = VQueueFilter::new(FULL_RANGE, Some(predicate));
+        assert_eq!(
+            filter.stages,
+            Some(std::collections::BTreeSet::from([Stage::Paused]))
+        );
+    }
+
+    #[test]
+    fn vqueue_filter_invalid_stage_falls_back() {
+        let predicate = eq(col("stage"), utf8_lit("not-a-stage"));
+
+        let filter = VQueueFilter::new(FULL_RANGE, Some(predicate));
+        assert!(filter.stages.is_none());
+        assert_eq!(filter.partition_keys, FULL_RANGE);
+    }
+
+    #[test]
+    fn vqueue_filter_no_predicate() {
+        let filter = VQueueFilter::new(FULL_RANGE, None);
+
+        assert!(filter.stages.is_none());
+        assert_eq!(filter.partition_keys, FULL_RANGE);
     }
 }

--- a/crates/storage-query-datafusion/src/lib.rs
+++ b/crates/storage-query-datafusion/src/lib.rs
@@ -42,6 +42,7 @@ mod table_macro;
 mod table_providers;
 mod user_limits;
 mod vqueue_meta;
+mod vqueues;
 pub use table_providers::Scan;
 pub mod table_util;
 

--- a/crates/storage-query-datafusion/src/table_docs.rs
+++ b/crates/storage-query-datafusion/src/table_docs.rs
@@ -10,7 +10,7 @@
 
 use crate::{
     deployment, inbox, invocation_state, invocation_status, journal, journal_events,
-    keyed_service_status, promise, scheduler_status, service, state, vqueue_meta,
+    keyed_service_status, promise, scheduler_status, service, state, vqueue_meta, vqueues,
 };
 use std::borrow::Cow;
 
@@ -28,6 +28,7 @@ pub const ALL_TABLE_DOCS: &[StaticTableDocs] = &[
     service::schema::TABLE_DOCS,
     state::schema::TABLE_DOCS,
     vqueue_meta::schema::TABLE_DOCS,
+    vqueues::schema::TABLE_DOCS,
 ];
 
 pub trait TableDocs {

--- a/crates/storage-query-datafusion/src/vqueues/mod.rs
+++ b/crates/storage-query-datafusion/src/vqueues/mod.rs
@@ -1,0 +1,18 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod row;
+pub(crate) mod schema;
+mod table;
+
+pub(crate) use table::register_self;
+
+#[cfg(test)]
+mod tests;

--- a/crates/storage-query-datafusion/src/vqueues/row.rs
+++ b/crates/storage-query-datafusion/src/vqueues/row.rs
@@ -1,0 +1,101 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use restate_storage_api::vqueue_table::{EntryKey, EntryKind, EntryValue, Stage};
+use restate_types::vqueues::VQueueId;
+
+use super::schema::SysVqueuesBuilder;
+
+#[inline]
+pub(crate) fn append_vqueues_row<'a>(
+    builder: &mut SysVqueuesBuilder,
+    qid: &'a VQueueId,
+    stage: Stage,
+    entry_key: &'a EntryKey,
+    entry: &'a EntryValue,
+) {
+    let mut row = builder.row();
+
+    row.partition_key(qid.partition_key());
+    if row.is_id_defined() {
+        row.fmt_id(qid);
+    }
+    if row.is_stage_defined() {
+        row.fmt_stage(stage);
+    }
+    if row.is_status_defined() {
+        row.fmt_status(entry.status);
+    }
+
+    if row.is_has_lock_defined() {
+        row.has_lock(entry_key.has_lock());
+    }
+    if matches!(stage, Stage::Inbox) && row.is_run_at_defined() {
+        row.run_at(entry_key.run_at().as_unix_millis().as_u64() as i64);
+    }
+    if row.is_sequence_number_defined() {
+        row.sequence_number(entry_key.seq().as_u64());
+    }
+
+    if row.is_entry_id_defined() {
+        row.fmt_entry_id(entry_key.entry_id().display(qid.partition_key()));
+    }
+
+    if row.is_entry_kind_defined() {
+        row.entry_kind(match entry_key.kind() {
+            EntryKind::Invocation => "invocation",
+            EntryKind::StateMutation => "state-mutation",
+            EntryKind::Unknown => "unknown",
+        });
+    }
+
+    if row.is_created_at_defined() {
+        row.created_at(entry.stats.created_at.to_unix_millis().as_u64() as i64);
+    }
+
+    if row.is_transitioned_at_defined() {
+        row.transitioned_at(entry.stats.transitioned_at.to_unix_millis().as_u64() as i64);
+    }
+
+    if row.is_num_attempts_defined() {
+        row.num_attempts(entry.stats.num_attempts);
+    }
+    if row.is_num_pauses_defined() {
+        row.num_pauses(entry.stats.num_paused);
+    }
+    if row.is_num_suspensions_defined() {
+        row.num_suspensions(entry.stats.num_suspensions);
+    }
+    if row.is_num_yields_defined() {
+        row.num_yields(entry.stats.num_yields);
+    }
+
+    if row.is_first_attempt_at_defined()
+        && let Some(first_attempt_at) = entry.stats.first_attempt_at
+    {
+        row.first_attempt_at(first_attempt_at.to_unix_millis().as_u64() as i64);
+    }
+
+    if row.is_latest_attempt_at_defined()
+        && let Some(latest_attempt_at) = entry.stats.latest_attempt_at
+    {
+        row.latest_attempt_at(latest_attempt_at.to_unix_millis().as_u64() as i64);
+    }
+
+    if row.is_first_runnable_at_defined() {
+        row.first_runnable_at(entry.stats.first_runnable_at.as_u64() as i64);
+    }
+
+    if row.is_deployment_defined()
+        && let Some(deployment) = &entry.metadata.deployment
+    {
+        row.fmt_deployment(deployment);
+    }
+}

--- a/crates/storage-query-datafusion/src/vqueues/schema.rs
+++ b/crates/storage-query-datafusion/src/vqueues/schema.rs
@@ -1,0 +1,84 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::table_macro::*;
+
+use datafusion::arrow::datatypes::DataType;
+
+// Stage scans run concurrently and merge into a shared builder, so only
+// `partition_key` is monotone within a single partition's output stream.
+define_sort_order!(sys_vqueues(partition_key));
+
+define_table!(sys_vqueues(
+    /// Internal column that is used for partitioning. Can be ignored.
+    partition_key: DataType::UInt64,
+
+    /// The VQueue Identifier (vq_...).
+    id: DataType::Utf8,
+
+    /// The stage this entry currently belongs to. Choices are 'inbox', 'running', 'paused',
+    /// 'suspended', and 'finished'.
+    stage: DataType::Utf8,
+
+    /// The entry processing status. Examples are `new`, `scheduled`, `started`,
+    /// `backing-off`, `yielded`, `killed`, `cancelled`, `failed`, and `succeeded`.
+    ///
+    /// Note that in stages some cases, the status will reflect the old status prior
+    /// to transitioning into the current stage. We preserve the last known status
+    /// because it will be useful to know when the entry transitions out of the
+    /// current stage.
+    status: DataType::Utf8,
+
+    /// Whether this entry currently holds a lock.
+    has_lock: DataType::Boolean,
+
+    /// The entry will be eligible to run after this timestamp. Only present for entries
+    /// that are in the stage=inbox.
+    run_at: TimestampMillisecond,
+
+    /// Sequence number encoded in the queue ordering key.
+    sequence_number: DataType::UInt64,
+
+    /// Identifier of the entry.
+    entry_id: DataType::Utf8,
+
+    /// Entry kind (`invocation` or `state-mutation`).
+    entry_kind: DataType::Utf8,
+
+    /// Creation timestamp of the entry.
+    created_at: TimestampMillisecond,
+
+    /// Timestamp of the latest stage transition.
+    transitioned_at: TimestampMillisecond,
+
+    /// Number of times this entry has been moved to the run queue.
+    num_attempts: DataType::UInt32,
+
+    /// Number of times this entry has been moved to the paused stage.
+    num_pauses: DataType::UInt32,
+
+    /// Number of times this entry has been moved to the suspended stage.
+    num_suspensions: DataType::UInt32,
+
+    /// Number of times this entry has yielded execution.
+    num_yields: DataType::UInt32,
+
+    /// Timestamp of the first attempt to run this entry.
+    first_attempt_at: TimestampMillisecond,
+
+    /// Timestamp of the latest attempt to run this entry.
+    latest_attempt_at: TimestampMillisecond,
+
+    /// The realistic earliest time at which this entry can run its first attempt.
+    first_runnable_at: TimestampMillisecond,
+
+    /// If set, the entry's pinned deployment identifier.
+    deployment: DataType::Utf8,
+));

--- a/crates/storage-query-datafusion/src/vqueues/table.rs
+++ b/crates/storage-query-datafusion/src/vqueues/table.rs
@@ -1,0 +1,88 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt::Debug;
+use std::ops::ControlFlow;
+use std::sync::Arc;
+
+use restate_partition_store::{PartitionStore, PartitionStoreManager};
+use restate_storage_api::StorageError;
+use restate_storage_api::vqueue_table::{EntryKey, EntryValue, ScanVQueueEntries, Stage};
+use restate_types::vqueues::VQueueId;
+
+use crate::context::{QueryContext, SelectPartitions};
+use crate::filter::{FirstMatchingPartitionKeyExtractor, VQueueFilter};
+use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
+use crate::remote_query_scanner_manager::RemoteScannerManager;
+use crate::table_providers::{PartitionedTableProvider, ScanPartition};
+use crate::vqueues::row::append_vqueues_row;
+use crate::vqueues::schema::{SysVqueuesBuilder, sys_vqueues_sort_order};
+
+const NAME: &str = "sys_vqueues";
+
+pub(crate) fn register_self(
+    ctx: &QueryContext,
+    partition_selector: impl SelectPartitions,
+    partition_store_manager: Arc<PartitionStoreManager>,
+    remote_scanner_manager: &RemoteScannerManager,
+) -> datafusion::common::Result<()> {
+    let local_scanner = Arc::new(LocalPartitionsScanner::new(
+        partition_store_manager,
+        VQueuesScanner,
+    )) as Arc<dyn ScanPartition>;
+
+    let table = PartitionedTableProvider::new(
+        partition_selector,
+        SysVqueuesBuilder::schema(),
+        sys_vqueues_sort_order(),
+        remote_scanner_manager.create_distributed_scanner(NAME, local_scanner),
+        FirstMatchingPartitionKeyExtractor::default()
+            .with_partitioned_resource_id::<VQueueId>("id")
+            .with_vqueue_entry_id("entry_id"),
+    );
+
+    ctx.register_partitioned_table(NAME, Arc::new(table))
+}
+
+#[derive(Debug, Clone)]
+struct VQueuesScanner;
+
+impl ScanLocalPartition for VQueuesScanner {
+    type Builder = SysVqueuesBuilder;
+    type Item<'a> = (&'a VQueueId, Stage, &'a EntryKey, &'a EntryValue);
+    type ConversionError = std::convert::Infallible;
+    type Filter = VQueueFilter;
+
+    fn for_each_row<
+        F: for<'a> FnMut(Self::Item<'a>) -> ControlFlow<Result<(), Self::ConversionError>>
+            + Send
+            + Sync
+            + 'static,
+    >(
+        partition_store: &PartitionStore,
+        filter: VQueueFilter,
+        mut f: F,
+    ) -> Result<impl Future<Output = restate_storage_api::Result<()>> + Send, StorageError> {
+        partition_store.for_each_vqueue_entry(
+            filter.partition_keys,
+            filter.stages.unwrap_or_default(),
+            move |item| f(item).map_break(Result::unwrap),
+        )
+    }
+
+    fn append_row<'a>(
+        row_builder: &mut Self::Builder,
+        value: Self::Item<'a>,
+    ) -> Result<(), Self::ConversionError> {
+        let (qid, stage, entry_key, entry) = value;
+        append_vqueues_row(row_builder, qid, stage, entry_key, entry);
+        Ok(())
+    }
+}

--- a/crates/storage-query-datafusion/src/vqueues/tests.rs
+++ b/crates/storage-query-datafusion/src/vqueues/tests.rs
@@ -1,0 +1,192 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::mocks::*;
+use crate::row;
+
+use datafusion::arrow::array::{StringArray, TimestampMillisecondArray, UInt32Array};
+use datafusion::arrow::record_batch::RecordBatch;
+use futures::StreamExt;
+use googletest::all;
+use googletest::prelude::{assert_that, eq};
+
+use restate_storage_api::Transaction;
+use restate_storage_api::vqueue_table::{
+    EntryId, EntryKey, EntryKind, EntryMetadata, EntryValue, Stage, Status, WriteVQueueTable,
+    stats::EntryStatistics,
+};
+use restate_types::clock::UniqueTimestamp;
+use restate_types::time::MillisSinceEpoch;
+use restate_types::vqueues::VQueueId;
+
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_vqueue_entry_value_fields() {
+    let mut engine = MockQueryEngine::create().await;
+
+    let qid = VQueueId::custom(1337, "df-vqueue");
+    let key = EntryKey::new(
+        true,
+        MillisSinceEpoch::new(1_744_000_001_000),
+        7,
+        EntryId::new(EntryKind::Invocation, [7; 16]),
+    );
+
+    let created_at =
+        UniqueTimestamp::try_from_unix_millis(MillisSinceEpoch::new(1_744_000_000_100)).unwrap();
+    let transitioned_at =
+        UniqueTimestamp::try_from_unix_millis(MillisSinceEpoch::new(1_744_000_000_300)).unwrap();
+    let first_attempt_at =
+        UniqueTimestamp::try_from_unix_millis(MillisSinceEpoch::new(1_744_000_000_400)).unwrap();
+    let latest_attempt_at =
+        UniqueTimestamp::try_from_unix_millis(MillisSinceEpoch::new(1_744_000_000_500)).unwrap();
+
+    let mut stats = EntryStatistics::new(created_at, key.run_at().to_owned());
+    stats.transitioned_at = transitioned_at;
+    stats.num_attempts = 3;
+    stats.num_paused = 2;
+    stats.num_suspensions = 4;
+    stats.num_yields = 5;
+    stats.first_attempt_at = Some(first_attempt_at);
+    stats.latest_attempt_at = Some(latest_attempt_at);
+
+    let value = EntryValue {
+        status: Status::BackingOff,
+        metadata: EntryMetadata {
+            deployment: Some("dp_123".to_string()),
+        },
+        stats,
+    };
+
+    // This row should be returned.
+    let mut tx = engine.partition_store().transaction();
+    tx.put_vqueue_inbox(&qid, Stage::Inbox, &key, &value);
+
+    // This row should only be returned when stage filtering selects it.
+    tx.put_vqueue_inbox(&qid, Stage::Running, &key, &value);
+    tx.commit().await.unwrap();
+
+    let records = engine
+        .execute(
+            "SELECT stage, status, num_attempts, num_pauses, num_suspensions, num_yields, \
+            created_at, transitioned_at, first_attempt_at, latest_attempt_at, first_runnable_at, \
+            run_at, deployment FROM sys_vqueues WHERE stage = 'inbox' ORDER BY sequence_number",
+        )
+        .await
+        .unwrap()
+        .stream
+        .collect::<Vec<datafusion::common::Result<RecordBatch>>>()
+        .await
+        .remove(0)
+        .unwrap();
+
+    assert_eq!(records.num_rows(), 1);
+
+    assert_that!(
+        records,
+        all!(row!(
+            0,
+            {
+                "stage" => StringArray: eq("inbox"),
+                "status" => StringArray: eq("backing_off"),
+                "num_attempts" => UInt32Array: eq(3),
+                "num_pauses" => UInt32Array: eq(2),
+                "num_suspensions" => UInt32Array: eq(4),
+                "num_yields" => UInt32Array: eq(5),
+                "created_at" => TimestampMillisecondArray: eq(created_at.to_unix_millis().as_u64() as i64),
+                "transitioned_at" => TimestampMillisecondArray: eq(transitioned_at.to_unix_millis().as_u64() as i64),
+                "first_attempt_at" => TimestampMillisecondArray: eq(first_attempt_at.to_unix_millis().as_u64() as i64),
+                "latest_attempt_at" => TimestampMillisecondArray: eq(latest_attempt_at.to_unix_millis().as_u64() as i64),
+                "first_runnable_at" => TimestampMillisecondArray: eq(value.stats.first_runnable_at.as_u64() as i64),
+                "run_at" => TimestampMillisecondArray: eq(key.run_at().as_unix_millis().as_u64() as i64),
+                "deployment" => StringArray: eq("dp_123"),
+            }
+        ))
+    );
+}
+
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
+async fn vqueue_stage_filter_and_unfiltered_scan() {
+    let mut engine = MockQueryEngine::create().await;
+
+    let qid = VQueueId::custom(2337, "df-vqueue-stages");
+
+    let mut tx = engine.partition_store().transaction();
+    let stages = [
+        Stage::Inbox,
+        Stage::Running,
+        Stage::Suspended,
+        Stage::Paused,
+        Stage::Finished,
+    ];
+    for (index, stage) in stages.into_iter().enumerate() {
+        let key = EntryKey::new(
+            false,
+            MillisSinceEpoch::new(1_744_001_000_000 + index as u64),
+            (index + 1) as u64,
+            EntryId::new(EntryKind::Invocation, [index as u8 + 1; 16]),
+        );
+        let value = EntryValue {
+            status: Status::Started,
+            metadata: EntryMetadata::default(),
+            stats: EntryStatistics::new(
+                UniqueTimestamp::try_from_unix_millis(MillisSinceEpoch::new(
+                    1_744_001_000_100 + index as u64,
+                ))
+                .unwrap(),
+                key.run_at().to_owned(),
+            ),
+        };
+        tx.put_vqueue_inbox(&qid, stage, &key, &value);
+    }
+    tx.commit().await.unwrap();
+
+    let all_stages = engine
+        .execute("SELECT stage FROM sys_vqueues ORDER BY stage")
+        .await
+        .unwrap()
+        .stream
+        .collect::<Vec<datafusion::common::Result<RecordBatch>>>()
+        .await
+        .remove(0)
+        .unwrap();
+
+    assert_eq!(all_stages.num_rows(), 5);
+    assert_that!(
+        all_stages,
+        all!(
+            row!(0, { "stage" => StringArray: eq("finished") }),
+            row!(1, { "stage" => StringArray: eq("inbox") }),
+            row!(2, { "stage" => StringArray: eq("paused") }),
+            row!(3, { "stage" => StringArray: eq("running") }),
+            row!(4, { "stage" => StringArray: eq("suspended") })
+        )
+    );
+
+    let filtered_stages = engine
+        .execute(
+            "SELECT stage FROM sys_vqueues WHERE stage IN ('running', 'paused') ORDER BY stage",
+        )
+        .await
+        .unwrap()
+        .stream
+        .collect::<Vec<datafusion::common::Result<RecordBatch>>>()
+        .await
+        .remove(0)
+        .unwrap();
+
+    assert_eq!(filtered_stages.num_rows(), 2);
+    assert_that!(
+        filtered_stages,
+        all!(
+            row!(0, { "stage" => StringArray: eq("paused") }),
+            row!(1, { "stage" => StringArray: eq("running") })
+        )
+    );
+}


### PR DESCRIPTION

Expose vqueue entries as a single DataFusion table with stage-aware scanning.
When the query filters `stage`, only matching stage key kinds are scanned;
without a stage filter, all inbox stages are scanned and merged.

Also project the latest entry metadata for observability (status plus
EntryStatistics timestamps and counters), and add targeted tests for stage
predicate extraction and sys_vqueues stage filtering behavior.
