### PR TITLE
[Restate UI] Update to v0.1.56

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8524,8 +8524,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.55"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.55#87dfb0008c5137b1ce8ceed733ce2a801de20286"
+version = "0.1.56"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.56#03ecafd2feaab6d90f5c9a2534945a455ef3e420"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -36,7 +36,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.55", tag = "v0.1.55" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.56", tag = "v0.1.56" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.56
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.56/ui-v0.1.56.zip