### PR TITLE
[connection-pool] Cap per-connection max-concurrent-streams

### DIFF
--- a/crates/service-client/src/http.rs
+++ b/crates/service-client/src/http.rs
@@ -133,6 +133,7 @@ impl HttpClient {
             let builder = pool::PoolBuilder::default()
                 .max_connections(options.max_http2_connections)
                 .keep_alive_interval(keep_alive_interval)
+                .streams_per_connection_limit(options.streams_per_connection_limit)
                 .keep_alive_timeout(options.http_keep_alive_options.timeout.into())
                 .idle_authority_timeout(options.idle_pool_timeout.map(Into::into));
 

--- a/crates/service-client/src/pool/authority.rs
+++ b/crates/service-client/src/pool/authority.rs
@@ -29,7 +29,7 @@ use tower::Service;
 use tracing::trace;
 
 use crate::pool::PoolConfig;
-use crate::pool::conn::ConnectionConfigBuilder;
+use crate::pool::conn::{ConnectionConfig, ConnectionConfigBuilder};
 
 use super::Error;
 use super::conn::{Connection, ResponseFuture};
@@ -51,6 +51,7 @@ struct AuthorityPoolInner<C> {
 pub struct AuthorityPool<C> {
     connector: C,
     config: PoolConfig,
+    connection_config: ConnectionConfig,
     inner: Arc<RwLock<AuthorityPoolInner<C>>>,
     /// Timestamp of the last request routed through this pool. Updated
     /// atomically without holding the inner lock.
@@ -67,7 +68,8 @@ impl<C: Clone> Clone for AuthorityPool<C> {
     fn clone(&self) -> Self {
         Self {
             connector: self.connector.clone(),
-            config: self.config.clone(),
+            config: self.config,
+            connection_config: self.connection_config,
             inner: Arc::clone(&self.inner),
             last_used: Arc::clone(&self.last_used),
             ready: None,
@@ -111,9 +113,18 @@ where
     C::Error: Into<Error>,
 {
     pub fn new(connector: C, config: PoolConfig) -> Self {
+        let connection_config = ConnectionConfigBuilder::default()
+            .initial_max_send_streams(config.initial_max_send_streams.get())
+            .streams_per_connection_limit(config.streams_per_connection_limit.get())
+            .keep_alive_interval(config.keep_alive_interval)
+            .keep_alive_timeout(config.keep_alive_timeout)
+            .build()
+            .unwrap();
+
         Self {
             connector,
             config,
+            connection_config,
             inner: Arc::new(RwLock::new(AuthorityPoolInner {
                 epoch: 0,
                 connections: Vec::new(),
@@ -194,8 +205,8 @@ where
             let mut has_some_closed = false;
             let mut candidates_expanded = false;
 
-            let mut total_available_streams = 0;
-            let mut total_max_concurrent_streams = 0;
+            let mut total_available_streams = 0usize;
+            let mut total_max_concurrent_streams = 0usize;
 
             for candidate in &inner.connections {
                 if candidate.is_closed() {
@@ -203,8 +214,10 @@ where
                     continue;
                 }
 
-                total_available_streams += candidate.available_streams();
-                total_max_concurrent_streams += candidate.max_concurrent_streams();
+                total_available_streams =
+                    total_available_streams.saturating_add(candidate.available_streams());
+                total_max_concurrent_streams =
+                    total_max_concurrent_streams.saturating_add(candidate.max_concurrent_streams());
 
                 if current_ids.contains(&candidate.id()) {
                     continue;
@@ -338,15 +351,7 @@ where
 
                 inner.epoch = inner.epoch.wrapping_add(1);
 
-                let candidate = Connection::new(
-                    self.connector.clone(),
-                    ConnectionConfigBuilder::default()
-                        .initial_max_send_streams(self.config.initial_max_send_streams.get())
-                        .keep_alive_interval(self.config.keep_alive_interval)
-                        .keep_alive_timeout(self.config.keep_alive_timeout)
-                        .build()
-                        .unwrap(),
-                );
+                let candidate = Connection::new(self.connector.clone(), self.connection_config);
                 inner.connections.push(candidate.clone());
 
                 Some(candidate)

--- a/crates/service-client/src/pool/config.rs
+++ b/crates/service-client/src/pool/config.rs
@@ -12,7 +12,7 @@ use std::num::{NonZeroU32, NonZeroUsize};
 use std::time::Duration;
 
 /// Configuration for an [`AuthorityPool`].
-#[derive(Debug, Clone, derive_builder::Builder)]
+#[derive(Debug, Clone, Copy, derive_builder::Builder)]
 #[builder(
     pattern = "owned",
     build_fn(name = "build_inner", private),
@@ -43,8 +43,25 @@ pub struct PoolConfig {
     /// limiting the number of requests queued behind a single pending connection.
     /// Once the connection is established, it discovers the remote peer's actual
     /// max-concurrent-streams and adjusts accordingly.
+    ///
+    /// This value is also capped by [`Self::streams_per_connection_limit`]
+    ///
+    /// Default: 50
     #[builder(default = NonZeroU32::new(50).unwrap())]
     pub(crate) initial_max_send_streams: NonZeroU32,
+
+    /// Upper bound on the per-connection max-send-streams.
+    ///
+    /// Caps the remote server's advertised `max_concurrent_streams`.
+    ///
+    /// A high number of concurrent streams per connection works
+    /// poorly with L4 load balancers because streams are not balanced across
+    /// backends.
+    ///
+    /// Default: 128
+    #[builder(default = NonZeroUsize::new(128).unwrap())]
+    pub(crate) streams_per_connection_limit: NonZeroUsize,
+
     /// Maximum time to wait for an HTTP/2 PING response before declaring the
     /// connection dead and returning [`ConnectionError::KeepAliveTimeout`].
     /// Only meaningful when `keep_alive_interval` is `Some`. Defaults to 20 s.
@@ -63,6 +80,7 @@ impl Default for PoolConfig {
             max_connections: NonZeroUsize::new(1).unwrap(),
             connection_saturation_threshold: Some(0.7f64),
             initial_max_send_streams: NonZeroU32::new(50).unwrap(),
+            streams_per_connection_limit: NonZeroUsize::new(128).unwrap(),
             keep_alive_interval: None,
             keep_alive_timeout: Duration::from_secs(20),
             idle_authority_timeout: Some(Duration::from_secs(300)),

--- a/crates/service-client/src/pool/conn.rs
+++ b/crates/service-client/src/pool/conn.rs
@@ -85,7 +85,12 @@ struct ConnectionShared {
 
 impl ConnectionShared {
     fn new(config: ConnectionConfig) -> Self {
-        let concurrency = Concurrency::new(config.initial_max_send_streams as usize);
+        let concurrency = Concurrency::new(
+            config
+                .streams_per_connection_limit
+                .min(config.initial_max_send_streams as usize),
+        );
+
         Self {
             id: next_connection_id(),
             config,
@@ -117,6 +122,8 @@ impl Drop for ConnectionShared {
 #[builder(pattern = "owned", default)]
 pub struct ConnectionConfig {
     initial_max_send_streams: u32,
+    // upper bound applied to the peer's advertised max-concurrent-streams
+    streams_per_connection_limit: usize,
     keep_alive_timeout: Duration,
     keep_alive_interval: Option<Duration>,
 }
@@ -125,6 +132,7 @@ impl Default for ConnectionConfig {
     fn default() -> Self {
         Self {
             initial_max_send_streams: 50,
+            streams_per_connection_limit: 128,
             keep_alive_timeout: Duration::from_secs(20),
             keep_alive_interval: None,
         }
@@ -262,9 +270,12 @@ where
 
                 // this is a good synchronization point to update the permits
                 // to the last known size known by the send_request object.
-                self.shared
-                    .concurrency
-                    .resize(h2.send_request.current_max_send_streams());
+                self.shared.concurrency.resize(
+                    self.shared
+                        .config
+                        .streams_per_connection_limit
+                        .min(h2.send_request.current_max_send_streams()),
+                );
             }
             STATE_CONNECTING => {}
             _ => unreachable!(),
@@ -564,6 +575,26 @@ where
                             continue;
                         }
                     };
+
+                    // Sync the semaphore to the peer's advertised limit, clamped
+                    // by the configured cap.
+                    //
+                    // If the peer's SETTINGS frame hasn't arrived yet,
+                    // `current_max_send_streams()` still reflects the initial
+                    // value which is fine, every later `poll_ready()` re-runs
+                    // this resize.
+                    //
+                    // If the new size is smaller than what's currently in use,
+                    // permits are reclaimed: waiters drop their permits and retry again
+                    // (can land on different connection). That's wasted work, but preferable
+                    // to blocking them waiting on streams on this connection to free
+                    // up.
+                    this.shared.concurrency.resize(
+                        this.shared
+                            .config
+                            .streams_per_connection_limit
+                            .min(send_request.current_max_send_streams()),
+                    );
 
                     this.state = ResponseFutureState::PreFlight {
                         send_request: send_request.clone(),
@@ -882,6 +913,44 @@ mod test {
         );
 
         // Drop all held bodies, permits are released
+        drop(held_bodies);
+    }
+
+    /// Server advertises max_concurrent_streams=50, but the connection is
+    /// configured with cap_max_send_streams=3. After the handshake, the
+    /// semaphore must be clamped to the cap (not the server-advertised value)
+    /// so the pool keeps opening new connections instead of funneling every
+    /// request through this one.
+    #[tokio::test]
+    async fn permits_clamped_to_cap_max_send_streams() {
+        let connection = Connection::new(
+            TestConnector::new(50),
+            ConnectionConfigBuilder::default()
+                .initial_max_send_streams(10)
+                .streams_per_connection_limit(3)
+                .build()
+                .unwrap(),
+        );
+
+        // Hold exactly 3 response bodies to exhaust the cap.
+        let mut held_bodies = Vec::new();
+        for _ in 0..3 {
+            let mut c = connection.clone();
+            held_bodies.push(send_request(&mut c).await);
+        }
+
+        // 4th try_ready must fail — the cap is the active limit even though
+        // the server would happily accept up to 50 concurrent streams.
+        let mut c4 = connection.clone();
+        assert!(
+            c4.try_ready().is_none(),
+            "expected try_ready to return None at cap"
+        );
+
+        // Releasing one held body frees a permit under the cap.
+        drop(held_bodies.pop());
+        c4.ready().await.unwrap();
+
         drop(held_bodies);
     }
 

--- a/crates/service-client/src/pool/mod.rs
+++ b/crates/service-client/src/pool/mod.rs
@@ -104,7 +104,7 @@ where
         let mut authority_pool = self
             .authorities
             .entry(key)
-            .or_insert_with(|| AuthorityPool::new(self.connector.clone(), self.config.clone()))
+            .or_insert_with(|| AuthorityPool::new(self.connector.clone(), self.config))
             .value()
             .clone();
         authority_pool.touch();

--- a/crates/types/src/config/http.rs
+++ b/crates/types/src/config/http.rs
@@ -56,11 +56,26 @@ pub struct HttpOptions {
     /// This value will be overwritten by the value included in the initial
     /// SETTINGS frame received from the peer as part of a [connection preface].
     ///
+    /// Note: This value is capped by [`Self::streams_per_connection_limit`]
+    ///
     /// Default: None
     ///
     /// **NOTE**: Setting this value to None (default) users the default
     /// recommended value from HTTP2 specs
     pub initial_max_send_streams: Option<NonZeroU32>,
+
+    /// Upper bound on the per-connection max-send-streams.
+    ///
+    /// Caps the remote server's advertised `max_concurrent_streams`.
+    ///
+    /// A high number of concurrent streams per connection works
+    /// poorly with L4 load balancers because streams are not balanced across
+    /// backends.
+    ///
+    /// Since v1.7.0
+    ///
+    /// Default: 128
+    pub streams_per_connection_limit: NonZeroUsize,
 
     /// # Max HTTP2 Connections
     ///
@@ -87,6 +102,7 @@ impl Default for HttpOptions {
             no_proxy: None,
             connect_timeout: NonZeroFriendlyDuration::from_secs_unchecked(10),
             initial_max_send_streams: None,
+            streams_per_connection_limit: NonZeroUsize::new(128).unwrap(),
             max_http2_connections: NonZeroUsize::new(20).unwrap(),
             idle_pool_timeout: Some(NonZeroFriendlyDuration::from_secs_unchecked(300)),
         }


### PR DESCRIPTION
[connection-pool] Cap per-connection max-concurrent-streams

Summary:
Currently the per-connection concurrent-streams limit is whatever the peer
advertises in its SETTINGS frame, falling back to usize::MAX when no value is
sent. With an effectively unbounded limit, the pool's saturation threshold is
never crossed, so:

  * every request funnels through the first established connection,
  * the pool never opens additional connections, and
  * any load balancer in front of the deployment sees a single long-lived
    HTTP/2 connection and cannot spread requests across backends.

This change introduces `cap_max_send_streams` (default 128) and clamps the
effective per-connection limit to:

    min(peer.max_concurrent_streams, cap_max_send_streams)

That bound is low enough that connections saturate under realistic load,
which lets the existing saturation logic in `AuthorityPool` spawn new
connections, restoring fan-out across LB-balanced backends, including the
end-to-end HTTP/2 path.

Secondary cleanups in the same change:
  * `PoolConfig` is now `Copy` (all fields are stack-sized) and cloning the
    authority pool no longer allocates.
  * `ConnectionConfig` is built once per `AuthorityPool` instead of
    re-derived on every new connection.
  * Stream-count aggregation in the saturation check uses `saturating_add`.

Fixes #4650

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4654).
* #4666
* __->__ #4654