### PR TITLE
[Snapshots] Graduate retained snapshots out of experimental

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "bifrost-benchpress"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1674,7 +1674,7 @@ checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "codederror"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "codederror-derive",
  "restate-workspace-hack",
@@ -4989,7 +4989,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logserver-bench"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "anyhow",
  "axum",
@@ -5256,7 +5256,7 @@ checksum = "f2b8f3a258db515d5e91a904ce4ae3f73e091149b90cadbdb93d210bee07f63b"
 
 [[package]]
 name = "mock-service-endpoint"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "assert2",
  "async-stream",
@@ -6115,7 +6115,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "pp-bench"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "anyhow",
  "axum",
@@ -7040,7 +7040,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "restate-admin"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "ahash",
  "anyhow",
@@ -7096,7 +7096,7 @@ dependencies = [
 
 [[package]]
 name = "restate-admin-rest-model"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "bytes",
  "derive_more",
@@ -7115,7 +7115,7 @@ dependencies = [
 
 [[package]]
 name = "restate-base64-util"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "base64 0.22.1",
  "restate-workspace-hack",
@@ -7123,7 +7123,7 @@ dependencies = [
 
 [[package]]
 name = "restate-benchmarks"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "anyhow",
  "criterion",
@@ -7150,7 +7150,7 @@ dependencies = [
 
 [[package]]
 name = "restate-bifrost"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "adaptive-timeout",
  "ahash",
@@ -7206,7 +7206,7 @@ dependencies = [
 
 [[package]]
 name = "restate-cli"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7275,7 +7275,7 @@ dependencies = [
 
 [[package]]
 name = "restate-cli-util"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7304,7 +7304,7 @@ dependencies = [
 
 [[package]]
 name = "restate-clock"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "bilrost",
  "criterion",
@@ -7323,7 +7323,7 @@ dependencies = [
 
 [[package]]
 name = "restate-cloud-tunnel-client"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "anyhow",
  "bs58",
@@ -7343,7 +7343,7 @@ dependencies = [
 
 [[package]]
 name = "restate-core"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "ahash",
  "anyhow",
@@ -7411,7 +7411,7 @@ dependencies = [
 
 [[package]]
 name = "restate-doctor"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "anyhow",
  "bilrost",
@@ -7447,7 +7447,7 @@ dependencies = [
 
 [[package]]
 name = "restate-encoding"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "bilrost",
  "bytes",
@@ -7468,7 +7468,7 @@ dependencies = [
 
 [[package]]
 name = "restate-errors"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "codederror",
  "paste",
@@ -7480,7 +7480,7 @@ dependencies = [
 
 [[package]]
 name = "restate-fs-util"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "restate-workspace-hack",
  "tokio",
@@ -7490,7 +7490,7 @@ dependencies = [
 
 [[package]]
 name = "restate-futures-util"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -7510,7 +7510,7 @@ dependencies = [
 
 [[package]]
 name = "restate-hyper-uds"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "http 1.4.0",
  "hyper-util",
@@ -7522,7 +7522,7 @@ dependencies = [
 
 [[package]]
 name = "restate-ingestion-client"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "bytes",
  "dashmap",
@@ -7542,7 +7542,7 @@ dependencies = [
 
 [[package]]
 name = "restate-ingress-http"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7587,7 +7587,7 @@ dependencies = [
 
 [[package]]
 name = "restate-ingress-kafka"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -7618,7 +7618,7 @@ dependencies = [
 
 [[package]]
 name = "restate-invoker-impl"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7667,7 +7667,7 @@ dependencies = [
 
 [[package]]
 name = "restate-limiter"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "bilrost",
  "restate-limiter",
@@ -7680,7 +7680,7 @@ dependencies = [
 
 [[package]]
 name = "restate-lite"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "anyhow",
  "http 1.4.0",
@@ -7709,7 +7709,7 @@ dependencies = [
 
 [[package]]
 name = "restate-local-cluster-runner"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7746,7 +7746,7 @@ dependencies = [
 
 [[package]]
 name = "restate-log-server"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "ahash",
  "anyhow",
@@ -7788,7 +7788,7 @@ dependencies = [
 
 [[package]]
 name = "restate-log-server-grpc"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "prost",
  "restate-types",
@@ -7800,7 +7800,7 @@ dependencies = [
 
 [[package]]
 name = "restate-memory"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "bytes",
  "futures",
@@ -7816,7 +7816,7 @@ dependencies = [
 
 [[package]]
 name = "restate-metadata-providers"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7852,7 +7852,7 @@ dependencies = [
 
 [[package]]
 name = "restate-metadata-server"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7897,7 +7897,7 @@ dependencies = [
 
 [[package]]
 name = "restate-metadata-server-grpc"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "bytes",
  "bytestring",
@@ -7918,7 +7918,7 @@ dependencies = [
 
 [[package]]
 name = "restate-metadata-store"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7940,7 +7940,7 @@ dependencies = [
 
 [[package]]
 name = "restate-node"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8002,7 +8002,7 @@ dependencies = [
 
 [[package]]
 name = "restate-object-store-util"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -8020,7 +8020,7 @@ dependencies = [
 
 [[package]]
 name = "restate-partition-store"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8075,7 +8075,7 @@ dependencies = [
 
 [[package]]
 name = "restate-platform"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "bilrost",
  "bytes",
@@ -8091,7 +8091,7 @@ dependencies = [
 
 [[package]]
 name = "restate-queue"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "bincode",
  "criterion",
@@ -8106,7 +8106,7 @@ dependencies = [
 
 [[package]]
 name = "restate-rocksdb"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "anyhow",
  "bytes",
@@ -8136,7 +8136,7 @@ dependencies = [
 
 [[package]]
 name = "restate-serde-util"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "bytes",
  "bytesize",
@@ -8153,7 +8153,7 @@ dependencies = [
 
 [[package]]
 name = "restate-server"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "anyhow",
  "bytestring",
@@ -8203,7 +8203,7 @@ dependencies = [
 
 [[package]]
 name = "restate-service-client"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "arc-swap",
  "aws-config",
@@ -8254,7 +8254,7 @@ dependencies = [
 
 [[package]]
 name = "restate-service-protocol"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "bytes",
  "bytes-utils",
@@ -8275,7 +8275,7 @@ dependencies = [
 
 [[package]]
 name = "restate-service-protocol-v4"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "assert2",
  "bytes",
@@ -8309,7 +8309,7 @@ dependencies = [
 
 [[package]]
 name = "restate-sharding"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "bilrost",
  "derive_more",
@@ -8323,7 +8323,7 @@ dependencies = [
 
 [[package]]
 name = "restate-storage-api"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8351,7 +8351,7 @@ dependencies = [
 
 [[package]]
 name = "restate-storage-query-datafusion"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8392,7 +8392,7 @@ dependencies = [
 
 [[package]]
 name = "restate-test-util"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "assert2",
  "bytes",
@@ -8407,7 +8407,7 @@ dependencies = [
 
 [[package]]
 name = "restate-time-util"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "jiff",
  "restate-workspace-hack",
@@ -8420,7 +8420,7 @@ dependencies = [
 
 [[package]]
 name = "restate-timer"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "ahash",
  "futures-util",
@@ -8437,7 +8437,7 @@ dependencies = [
 
 [[package]]
 name = "restate-timer-queue"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "futures",
  "restate-workspace-hack",
@@ -8446,7 +8446,7 @@ dependencies = [
 
 [[package]]
 name = "restate-tracing-instrumentation"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "console-subscriber",
  "criterion",
@@ -8476,7 +8476,7 @@ dependencies = [
 
 [[package]]
 name = "restate-types"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "adaptive-timeout",
  "ahash",
@@ -8575,7 +8575,7 @@ dependencies = [
 
 [[package]]
 name = "restate-util-string"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "ahash",
  "bilrost",
@@ -8589,7 +8589,7 @@ dependencies = [
 
 [[package]]
 name = "restate-utoipa"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "indexmap 2.14.0",
  "restate-utoipa",
@@ -8600,7 +8600,7 @@ dependencies = [
 
 [[package]]
 name = "restate-vqueues"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "arrayvec",
  "bilrost",
@@ -8634,7 +8634,7 @@ dependencies = [
 
 [[package]]
 name = "restate-wal-protocol"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "bilrost",
  "bytes",
@@ -8661,7 +8661,7 @@ dependencies = [
 
 [[package]]
 name = "restate-worker"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "ahash",
  "anyhow",
@@ -8727,7 +8727,7 @@ dependencies = [
 
 [[package]]
 name = "restate-worker-api"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "bytes",
  "codederror",
@@ -8903,7 +8903,7 @@ dependencies = [
 
 [[package]]
 name = "restatectl"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "anyhow",
  "arrow",
@@ -9431,7 +9431,7 @@ dependencies = [
 
 [[package]]
 name = "service-protocol-wireshark-dissector"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "bytes",
  "mlua",
@@ -11644,7 +11644,7 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xtask"
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 dependencies = [
  "anyhow",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.6.3-dev"
+version = "1.7.0-dev"
 authors = ["restate.dev"]
 edition = "2024"
 rust-version = "1.95.0"

--- a/charts/restate-helm/Chart.yaml
+++ b/charts/restate-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: restate-helm
 description: Deploy a Restate cluster on Kubernetes
 type: application
-version: "1.6.3-dev"
+version: "1.7.0-dev"
 home: https://restate.dev
 sources:
   - https://github.com/restatedev/restate

--- a/crates/partition-store/src/snapshots/repository.rs
+++ b/crates/partition-store/src/snapshots/repository.rs
@@ -37,7 +37,6 @@ use restate_types::identifiers::{PartitionId, SnapshotId};
 use restate_types::logs::{LogId, Lsn};
 use restate_types::nodes_config::ClusterFingerprint;
 use restate_types::time::MillisSinceEpoch;
-use restate_types::{RESTATE_VERSION_1_7_0, SemanticRestateVersion};
 
 use super::{LocalPartitionSnapshot, PartitionSnapshotMetadata, SnapshotFormatVersion};
 
@@ -61,7 +60,7 @@ pub struct SnapshotRepository {
     destination: Url,
     prefix: ObjectPath,
     staging_dir: PathBuf,
-    num_retained: Option<std::num::NonZeroU8>,
+    num_retained: std::num::NonZeroU8,
     #[cfg(any(test, feature = "test-util"))]
     enable_cleanup: bool,
 }
@@ -75,9 +74,9 @@ const DOWNLOAD_CONCURRENCY_LIMIT: usize = 8;
 
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum LatestSnapshotVersion {
-    #[default]
     V1,
     /// V2 adds support for retained snapshots. Introduced in v1.6.
+    #[default]
     V2,
 }
 
@@ -141,22 +140,6 @@ impl SnapshotReference {
 }
 
 impl LatestSnapshot {
-    pub fn from_snapshot(snapshot: &PartitionSnapshotMetadata) -> Self {
-        LatestSnapshot {
-            version: LatestSnapshotVersion::V1,
-            cluster_name: snapshot.cluster_name.clone(),
-            cluster_fingerprint: snapshot.cluster_fingerprint,
-            node_name: snapshot.node_name.clone(),
-            partition_id: snapshot.partition_id,
-            log_id: Some(snapshot.log_id),
-            snapshot_id: snapshot.snapshot_id,
-            created_at: snapshot.created_at,
-            min_applied_lsn: snapshot.min_applied_lsn,
-            path: UniqueSnapshotKey::from_metadata(snapshot).padded_key(),
-            retained_snapshots: vec![],
-        }
-    }
-
     /// We ensure that retained snapshots is in descending order of archived LSN, most recent snapshot first.
     fn effective_retained_snapshots(&self) -> Vec<SnapshotReference> {
         if self.retained_snapshots.is_empty() {
@@ -344,7 +327,7 @@ impl SnapshotRepository {
             destination,
             prefix: ObjectPath::from(prefix),
             staging_dir,
-            num_retained: snapshots_options.experimental_num_retained,
+            num_retained: snapshots_options.num_retained,
             #[cfg(any(test, feature = "test-util"))]
             enable_cleanup: snapshots_options.enable_cleanup,
         }))
@@ -419,41 +402,9 @@ impl SnapshotRepository {
         );
 
         let mut progress = SnapshotUploadProgress::with_snapshot_path(snapshot_prefix);
-        let mut buf = BytesMut::new();
-        for file in &snapshot.files {
-            let filename = strip_leading_slash(&file.name);
-            let key = self.snapshot_file_path(snapshot, filename);
 
-            let put_result = put_snapshot_object(
-                local_snapshot_path.join(filename).as_path(),
-                &key,
-                &self.object_store,
-                &mut buf,
-            )
-            .await
-            .map_err(|e| PutSnapshotError::from(e, progress.clone()))?;
-
-            debug!(etag = %put_result.e_tag.unwrap_or_default(), %key, "Put snapshot object completed");
-            progress.push(file.name.clone());
-        }
-
-        let metadata_key = self.snapshot_file_path(snapshot, "metadata.json");
-        let metadata_json_payload = PutPayload::from(
-            serde_json::to_string_pretty(snapshot).expect("Can always serialize JSON"),
-        );
-
-        let put_result = self
-            .object_store
-            .put(&metadata_key, metadata_json_payload)
-            .await
-            .map_err(|e| PutSnapshotError::from(e, progress.clone()))?;
-        progress.push("/metadata.json".to_owned());
-
-        debug!(
-            key = %metadata_key,
-            etag = %put_result.e_tag.unwrap_or_default(),
-            "Successfully published snapshot metadata",
-        );
+        self.upload_snapshot(snapshot, local_snapshot_path, &mut progress)
+            .await?;
 
         let latest_path = self.latest_snapshot_pointer_path(snapshot.partition_id);
 
@@ -490,13 +441,9 @@ impl SnapshotRepository {
                 .map_err(|e| PutSnapshotError::from(e, progress.clone()));
         }
 
-        let format_version = self.determine_format_version(maybe_stored.as_ref().map(|(l, _)| l));
-        let (new_latest, evicted_snapshots) = match format_version {
-            LatestSnapshotVersion::V1 => (self.build_latest_v1(snapshot), vec![]),
-            LatestSnapshotVersion::V2 => self
-                .build_latest_v2(snapshot, maybe_stored.as_ref().map(|(l, _)| l))
-                .map_err(|e| PutSnapshotError::from(e, progress.clone()))?,
-        };
+        let (new_latest, evicted_snapshots) = self
+            .build_latest_v2(snapshot, maybe_stored.as_ref().map(|(l, _)| l))
+            .map_err(|e| PutSnapshotError::from(e, progress.clone()))?;
 
         let latest_payload = PutPayload::from(
             serde_json::to_string_pretty(&new_latest)
@@ -531,26 +478,49 @@ impl SnapshotRepository {
             .map_err(|e| PutSnapshotError::from(e, progress.clone()))
     }
 
-    fn determine_format_version(&self, current: Option<&LatestSnapshot>) -> LatestSnapshotVersion {
-        // V2 is the default from 1.7.0, including pre-releases
-        if SemanticRestateVersion::current().is_equal_or_newer_than(&RESTATE_VERSION_1_7_0)
-            || self.num_retained.is_some()
-        {
-            if let Some(latest) = current
-                && latest.version == LatestSnapshotVersion::V1
-            {
-                debug!("Upgrading latest snapshot format from V1 to V2");
-            }
-            LatestSnapshotVersion::V2
-        } else {
-            current
-                .map(|l| l.version)
-                .unwrap_or(LatestSnapshotVersion::V1)
-        }
-    }
+    async fn upload_snapshot(
+        &self,
+        snapshot: &PartitionSnapshotMetadata,
+        local_snapshot_path: &Path,
+        progress: &mut SnapshotUploadProgress,
+    ) -> Result<(), PutSnapshotError> {
+        let mut buf = BytesMut::new();
+        for file in &snapshot.files {
+            let filename = strip_leading_slash(&file.name);
+            let key = self.snapshot_file_path(snapshot, filename);
 
-    fn build_latest_v1(&self, snapshot: &PartitionSnapshotMetadata) -> LatestSnapshot {
-        LatestSnapshot::from_snapshot(snapshot)
+            let put_result = put_snapshot_object(
+                local_snapshot_path.join(filename).as_path(),
+                &key,
+                &self.object_store,
+                &mut buf,
+            )
+            .await
+            .map_err(|e| PutSnapshotError::from(e, progress.clone()))?;
+
+            debug!(etag = %put_result.e_tag.unwrap_or_default(), %key, "Put snapshot object completed");
+            progress.push(file.name.clone());
+        }
+
+        let metadata_key = self.snapshot_file_path(snapshot, "metadata.json");
+        let metadata_json_payload = PutPayload::from(
+            serde_json::to_string_pretty(snapshot).expect("Can always serialize JSON"),
+        );
+
+        let put_result = self
+            .object_store
+            .put(&metadata_key, metadata_json_payload)
+            .await
+            .map_err(|e| PutSnapshotError::from(e, progress.clone()))?;
+        progress.push("/metadata.json".to_owned());
+
+        debug!(
+            key = %metadata_key,
+            etag = %put_result.e_tag.unwrap_or_default(),
+            "Successfully published snapshot metadata",
+        );
+
+        Ok(())
     }
 
     /// Builds V2 latest snapshot metadata.
@@ -565,22 +535,15 @@ impl SnapshotRepository {
     ) -> anyhow::Result<(LatestSnapshot, Vec<SnapshotReference>)> {
         let new_snapshot_ref = SnapshotReference::from_metadata(snapshot);
 
-        let (retained_snapshots, evicted_snapshots) = match self.num_retained {
-            None => (vec![], vec![]), // tracking is only enabled if num-retained is set
-            Some(num_retained) => {
-                let mut retained_snapshots = current
-                    .map(|l| l.effective_retained_snapshots())
-                    .unwrap_or_default();
+        let mut retained_snapshots = current
+            .map(|l| l.effective_retained_snapshots())
+            .unwrap_or_default();
 
-                // List will be in correct descending order if we insert the newest snapshot first
-                retained_snapshots.insert(0, new_snapshot_ref.clone());
+        // List will be in correct descending order if we insert the newest snapshot first
+        retained_snapshots.insert(0, new_snapshot_ref.clone());
 
-                let evicted_snapshots = retained_snapshots
-                    .split_off((num_retained.get() as usize).min(retained_snapshots.len()));
-
-                (retained_snapshots, evicted_snapshots)
-            }
-        };
+        let evicted_snapshots = retained_snapshots
+            .split_off((self.num_retained.get() as usize).min(retained_snapshots.len()));
 
         let latest = LatestSnapshot {
             version: LatestSnapshotVersion::V2,
@@ -1034,6 +997,8 @@ impl SnapshotUploadProgress {
     }
 }
 
+#[derive(Debug, thiserror::Error)]
+#[error("failed to upload snapshot to {full_snapshot_path}: {error}")]
 struct PutSnapshotError {
     pub full_snapshot_path: ObjectPath,
     pub uploaded_files: Vec<String>,
@@ -1124,8 +1089,8 @@ mod tests {
     use bytes::Bytes;
     use futures::TryStreamExt;
     use jiff::Timestamp;
-    use object_store::ObjectStoreExt;
     use object_store::path::Path as ObjectPath;
+    use object_store::{ObjectStoreExt, PutPayload};
     use tempfile::TempDir;
     use tokio::io::AsyncWriteExt;
     use tracing::info;
@@ -1140,7 +1105,7 @@ mod tests {
     use restate_types::retries::RetryPolicy;
     use restate_types::sharding::KeyRange;
 
-    use crate::snapshots::repository::LatestSnapshotVersion;
+    use crate::snapshots::repository::{LatestSnapshotVersion, SnapshotUploadProgress};
 
     use super::{LatestSnapshot, SnapshotReference, SnapshotRepository, UniqueSnapshotKey};
     use super::{PartitionSnapshotMetadata, SnapshotFormatVersion};
@@ -1283,7 +1248,8 @@ mod tests {
             .get(&partition_prefix.clone().join("latest.json"))
             .await?;
         let latest: LatestSnapshot = serde_json::from_slice(&latest.bytes().await?)?;
-        assert_eq!(LatestSnapshot::from_snapshot(&snapshot1), latest);
+        let (expected_latest, _) = repository.build_latest_v2(&snapshot1, None)?;
+        assert_eq!(expected_latest, latest);
 
         let snapshot_source = TempDir::new()?;
         let source_dir = snapshot_source.path().to_path_buf();
@@ -1306,7 +1272,8 @@ mod tests {
             .get(&partition_prefix.join("latest.json"))
             .await?;
         let latest: LatestSnapshot = serde_json::from_slice(&latest.bytes().await?)?;
-        assert_eq!(LatestSnapshot::from_snapshot(&snapshot2,), latest);
+        let (expected_latest2, _) = repository.build_latest_v2(&snapshot2, None)?;
+        assert_eq!(expected_latest2, latest);
 
         let latest = repository.get_latest(PartitionId::MIN).await?.unwrap();
         assert_eq!(latest.min_applied_lsn, snapshot2.min_applied_lsn);
@@ -1388,7 +1355,7 @@ mod tests {
 
         let opts = SnapshotsOptions {
             destination: Some(destination.clone()),
-            experimental_num_retained: Some(std::num::NonZeroU8::new(3).unwrap()),
+            num_retained: std::num::NonZeroU8::new(3).unwrap(),
             ..SnapshotsOptions::default()
         };
 
@@ -1449,17 +1416,6 @@ mod tests {
             .unwrap()
             .to_string();
 
-        let opts_v1 = SnapshotsOptions {
-            destination: Some(destination.clone()),
-            experimental_num_retained: None,
-            ..SnapshotsOptions::default()
-        };
-
-        let repository_v1 =
-            SnapshotRepository::new_from_config(&opts_v1, TempDir::new().unwrap().keep())
-                .await?
-                .unwrap();
-
         let snapshot_source = TempDir::new()?;
         let source_dir = snapshot_source.path().to_path_buf();
         let data = b"snapshot-data-v1";
@@ -1467,14 +1423,12 @@ mod tests {
         data_file.write_all(data).await?;
         data_file.shutdown().await?;
 
-        let mut snapshot_v1 = mock_snapshot_metadata(
+        let mut snapshot = mock_snapshot_metadata(
             "/data.sst".to_owned(),
             source_dir.to_string_lossy().to_string(),
             data.len(),
         );
-        snapshot_v1.min_applied_lsn = Lsn::new(1000);
-
-        repository_v1.put(&snapshot_v1, source_dir.clone()).await?;
+        snapshot.min_applied_lsn = Lsn::new(1000);
 
         let object_store = create_object_store_client(
             Url::parse(&destination)?,
@@ -1483,24 +1437,45 @@ mod tests {
         )
         .await?;
 
-        let latest_path = ObjectPath::from(Url::parse(&destination)?.path().to_string())
-            .join(PartitionId::MIN.to_string())
-            .join("latest.json");
-
-        let latest_data = object_store.get(&latest_path).await?;
-        let latest: LatestSnapshot = serde_json::from_slice(&latest_data.bytes().await?)?;
-        assert_eq!(latest.version, LatestSnapshotVersion::V1);
-
-        let opts_v2 = SnapshotsOptions {
+        let opts = SnapshotsOptions {
             destination: Some(destination.clone()),
-            experimental_num_retained: Some(std::num::NonZeroU8::new(2).unwrap()),
+            num_retained: std::num::NonZeroU8::new(2).unwrap(),
             ..SnapshotsOptions::default()
         };
 
-        let repository_v2 =
-            SnapshotRepository::new_from_config(&opts_v2, TempDir::new().unwrap().keep())
-                .await?
-                .unwrap();
+        let repository = SnapshotRepository::new_from_config(&opts, TempDir::new().unwrap().keep())
+            .await?
+            .unwrap();
+
+        let mut progress =
+            SnapshotUploadProgress::with_snapshot_path(repository.base_prefix(&snapshot));
+        // upload the snapshot data
+        repository
+            .upload_snapshot(&snapshot, source_dir.as_path(), &mut progress)
+            .await?;
+
+        // store v1 latest snapshot pointer
+        let latest_snapshot_v1 = LatestSnapshot {
+            version: LatestSnapshotVersion::V1,
+            cluster_name: snapshot.cluster_name.clone(),
+            cluster_fingerprint: snapshot.cluster_fingerprint,
+            node_name: snapshot.node_name.clone(),
+            partition_id: snapshot.partition_id,
+            log_id: Some(snapshot.log_id),
+            snapshot_id: snapshot.snapshot_id,
+            created_at: snapshot.created_at,
+            min_applied_lsn: snapshot.min_applied_lsn,
+            path: UniqueSnapshotKey::from_metadata(&snapshot).padded_key(),
+            retained_snapshots: vec![],
+        };
+
+        let latest_path = repository.latest_snapshot_pointer_path(snapshot.partition_id);
+        object_store
+            .put(
+                &latest_path,
+                PutPayload::from(serde_json::to_string(&latest_snapshot_v1)?),
+            )
+            .await?;
 
         let snapshot_source_2 = TempDir::new()?;
         let source_dir_2 = snapshot_source_2.path().to_path_buf();
@@ -1516,7 +1491,7 @@ mod tests {
         );
         snapshot_v2.min_applied_lsn = Lsn::new(2000);
 
-        repository_v2.put(&snapshot_v2, source_dir_2).await?;
+        repository.put(&snapshot_v2, source_dir_2).await?;
 
         let latest_data = object_store.get(&latest_path).await?;
         let latest: LatestSnapshot = serde_json::from_slice(&latest_data.bytes().await?)?;
@@ -1537,7 +1512,7 @@ mod tests {
 
         let opts = SnapshotsOptions {
             destination: Some(destination.clone()),
-            experimental_num_retained: Some(std::num::NonZeroU8::new(3).unwrap()),
+            num_retained: std::num::NonZeroU8::new(3).unwrap(),
             ..SnapshotsOptions::default()
         };
 
@@ -1587,7 +1562,7 @@ mod tests {
 
         let opts = SnapshotsOptions {
             destination: Some(destination.clone()),
-            experimental_num_retained: Some(std::num::NonZeroU8::new(3).unwrap()),
+            num_retained: std::num::NonZeroU8::new(3).unwrap(),
             enable_cleanup: true,
             ..SnapshotsOptions::default()
         };

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::num::{NonZeroU8, NonZeroU32, NonZeroU64, NonZeroUsize};
+use std::num::{NonZero, NonZeroU8, NonZeroU32, NonZeroU64, NonZeroUsize};
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -793,9 +793,9 @@ pub struct SnapshotsOptions {
     /// A retry policy for dealing with retryable object store errors.
     pub object_store_retry_policy: RetryPolicy,
 
-    /// # Experimental: Snapshot retention count
+    /// # Snapshot retention count
     ///
-    /// EXPERIMENTAL (v1.6): Number of most recent snapshots to retain. Older snapshots will be
+    /// Number of most recent snapshots to retain. Older snapshots will be
     /// deleted automatically. Only snapshots created after this setting is enabled will
     /// be considered for pruning.
     ///
@@ -803,15 +803,12 @@ pub struct SnapshotsOptions {
     /// oldest retained snapshot. Therefore, retaining multiple snapshots will cause increased disk
     /// usage on log-server nodes.
     ///
-    /// WARNING: Enabling this feature upgrades the snapshot tracking format. Only enable if all
-    /// cluster nodes run a compatible version. Downgrading will forget the tracked snapshots and
-    /// revert to v1.5.x behavior.
+    /// Default: `1`
     ///
-    /// Default: `None` (feature is disabled, older snapshots will accumulate in repository)
-    // todo(v1.7): Drop the experimental prefix; make it non-optional with default value `1`
+    /// Since v1.7.0
     #[cfg_attr(feature = "schemars", schemars(skip))]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub experimental_num_retained: Option<NonZeroU8>,
+    #[serde(default = "default_num_retained")]
+    pub num_retained: NonZeroU8,
 
     /// # Export concurrency limit
     ///
@@ -827,6 +824,10 @@ pub struct SnapshotsOptions {
     pub enable_cleanup: bool,
 }
 
+fn default_num_retained() -> NonZero<u8> {
+    NonZeroU8::new(1).unwrap()
+}
+
 impl Default for SnapshotsOptions {
     fn default() -> Self {
         Self {
@@ -835,7 +836,7 @@ impl Default for SnapshotsOptions {
             snapshot_interval_num_records: None,
             object_store: Default::default(),
             object_store_retry_policy: Self::default_retry_policy(),
-            experimental_num_retained: None,
+            num_retained: default_num_retained(),
             export_concurrency_limit: None,
             #[cfg(any(test, feature = "test-util"))]
             enable_cleanup: true,

--- a/release-notes/unreleased/4155-snapshot-retention-graduation.md
+++ b/release-notes/unreleased/4155-snapshot-retention-graduation.md
@@ -1,0 +1,62 @@
+# Release Notes for Issue #4155: Graduate snapshot retention out of experimental
+
+## Behavioral Change / Breaking Change
+
+### What Changed
+
+The opt-in snapshot retention feature introduced in v1.6 is now a stable, always-on
+part of the snapshot repository:
+
+1. **Config option renamed and made non-optional.** The `worker.snapshots.experimental-num-retained`
+   option (an optional integer, disabled by default) has been replaced by
+   `worker.snapshots.num-retained`, a non-optional integer with a default of `1`.
+2. **`latest.json` is always written in V2 format.** Restate no longer gates the
+   on-disk format on the running version or on whether retention was opted in.
+   Every snapshot upload writes a V2 `latest.json` pointer.
+3. **Legacy V1 pointers continue to be readable** and are upgraded to V2 the next
+   time a snapshot is uploaded for that partition — no action is required from
+   operators on existing repositories.
+
+### Why This Matters
+
+Restate is now responsible for cleaning up snapshots that are no longer used
+for bootstrapping partition processors because the log has been trimmed beyond
+their archived lsn. Users can configure how many snapshots should be retained
+before deleting them. This will also prevent unbounded snapshot storage growth
+as only `num-retained` snapshots per partition are stored.
+
+### Impact on Users
+
+- **Existing repositories**: no migration required. The first upload after the
+  upgrade rewrites `latest.json` from V1 to V2 in place. Snapshot data files
+  themselves are unchanged.
+- **Existing configurations**: any deployment that explicitly set
+  `experimental-num-retained` in its `restate.toml` (or via the
+  `RESTATE_WORKER__SNAPSHOTS__EXPERIMENTAL_NUM_RETAINED` env var) **must rename
+  the key to `num-retained`** before upgrading. Restate will ignore the old key.
+- **Default behavior**: `num-retained = 1` keeps exactly one snapshot per partition 
+  and cleans up older snapshots which are no longer usable due to log trimming.
+- **Downgrade**: rolling back to a binary older than v1.6 is not supported once
+  V2 pointers have been written. Rolling back to v1.6.x is safe.
+
+### Migration Guidance
+
+If your config sets the experimental key:
+
+```toml
+[worker.snapshots]
+experimental-num-retained = 3
+```
+
+rename it to:
+
+```toml
+[worker.snapshots]
+num-retained = 3
+```
+
+If your config does not set the key, no action is needed.
+
+### Related Issues
+
+- #3942 — original experimental introduction in v1.6


### PR DESCRIPTION
Renames `experimental_num_retained` to `num_retained` (non-optional,
default `1`) and always writes `LatestSnapshot` V2. The V1 writer
(`determine_format_version`, `build_latest_v1`,
`LatestSnapshot::from_snapshot`) is removed; the V1 enum variant stays
so legacy `latest.json` blobs continue to deserialize and migrate on
next put. `test_v1_to_v2_migration` now seeds a V1 pointer directly
through the object store instead of going through the deleted writer.

This fixes https://github.com/restatedev/restate/issues/4155.