### PR TITLE
More plumbing for exposing scopes in our public API and updating service protocol V7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7077,6 +7077,7 @@ dependencies = [
  "restate-storage-query-datafusion",
  "restate-time-util",
  "restate-types",
+ "restate-util-string",
  "restate-wal-protocol",
  "restate-web-ui",
  "restate-workspace-hack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8298,6 +8298,7 @@ dependencies = [
  "restate-service-client",
  "restate-test-util",
  "restate-types",
+ "restate-util-string",
  "restate-workspace-hack",
  "serde_json",
  "strum",

--- a/cli/src/commands/state/util.rs
+++ b/cli/src/commands/state/util.rs
@@ -93,10 +93,12 @@ pub(crate) async fn update_state(
     service_key: &str,
     new_state: HashMap<String, Bytes>,
 ) -> anyhow::Result<()> {
+    // TODO(tillrohrmann): allow CLI state commands to specify scope
     let req = ModifyServiceStateRequest {
         version: expected_version,
         new_state,
         object_key: service_key.to_string(),
+        scope: None,
     };
 
     let client = AdminClient::new(env).await?;

--- a/crates/admin-rest-model/src/services.rs
+++ b/crates/admin-rest-model/src/services.rs
@@ -107,6 +107,13 @@ pub struct ModifyServiceStateRequest {
     /// To what virtual object key to apply this change
     pub object_key: String,
 
+    /// # Scope
+    ///
+    /// Optional scope for the virtual object instance. When set, targets the scoped
+    /// instance instead of the unscoped one. Since v1.7.0.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+
     /// # New State
     ///
     /// The new state to replace the previous state with

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -35,6 +35,7 @@ restate-service-protocol-v4 = { workspace = true, features = ["discovery", "serd
 restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
+restate-util-string = { workspace = true }
 restate-wal-protocol = { workspace = true }
 restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.58", tag = "v0.1.58" }
 

--- a/crates/admin/src/rest_api/error.rs
+++ b/crates/admin/src/rest_api/error.rs
@@ -16,6 +16,7 @@ use restate_core::ShutdownError;
 use restate_types::identifiers::{DeploymentId, SubscriptionId};
 use restate_types::invocation::ServiceType;
 use restate_types::schema::registry::SchemaRegistryError;
+use restate_util_string::RestrictedValueError;
 use serde::Serialize;
 use std::ops::RangeInclusive;
 // --- Few helpers to define Admin API errors.
@@ -288,6 +289,8 @@ pub enum MetaApiError {
     Conflict(String),
     #[error("PUT deployment is deprecated, use PATCH instead")]
     DeprecatedPutDeployment,
+    #[error("bad scope: {0}")]
+    BadScope(RestrictedValueError),
 }
 
 /// # Error description response

--- a/crates/admin/src/rest_api/services.rs
+++ b/crates/admin/src/rest_api/services.rs
@@ -22,10 +22,11 @@ use restate_core::network::TransportConnect;
 use restate_errors::warn_it;
 use restate_types::config::Configuration;
 use restate_types::identifiers::{ServiceId, WithPartitionKey};
-use restate_types::schema;
 use restate_types::schema::registry::MetadataService;
 use restate_types::schema::service::ServiceMetadata;
 use restate_types::state_mut::ExternalStateMutation;
+use restate_types::{Scope, schema};
+use restate_util_string::RestrictedValue;
 use restate_wal_protocol::{Command, Envelope};
 
 use super::create_envelope_header;
@@ -208,6 +209,7 @@ pub async fn modify_service_state<Metadata, Discovery, Telemetry, Invocations, T
     Json(ModifyServiceStateRequest {
         version,
         object_key,
+        scope,
         new_state,
     }): Json<ModifyServiceStateRequest>,
 ) -> Result<StatusCode, MetaApiError>
@@ -229,8 +231,17 @@ where
         return Err(MetaApiError::ServiceNotFound(service_name));
     }
 
-    // todo(tillrohrmann) allow modify service state to specify scope
-    let service_id = ServiceId::new(None, service_name, object_key);
+    let scope = if let Some(scope) = scope {
+        Some(Scope::new(
+            RestrictedValue::new(scope)
+                .map_err(MetaApiError::BadScope)?
+                .as_str(),
+        ))
+    } else {
+        None
+    };
+
+    let service_id = ServiceId::new(scope, service_name, object_key);
 
     let new_state = new_state
         .into_iter()

--- a/crates/ingress-http/src/handler/invocation.rs
+++ b/crates/ingress-http/src/handler/invocation.rs
@@ -74,6 +74,7 @@ where
                 },
                 handler.into(),
                 idempotency_id.into(),
+                None,
             ))),
         }
     }

--- a/crates/ingress-http/src/handler/path_parsing.rs
+++ b/crates/ingress-http/src/handler/path_parsing.rs
@@ -13,12 +13,13 @@ use super::HandlerError;
 use http::Uri;
 use restate_types::ServiceName;
 use restate_types::schema::invocation_target::InvocationTargetResolver;
+use restate_util_string::{ReString, ToReString};
 
 pub(crate) enum WorkflowRequestType {
     /// (name, key, scope)
-    Attach(String, String, Option<String>),
+    Attach(ReString, ReString, Option<ReString>),
     /// (name, key, scope)
-    GetOutput(String, String, Option<String>),
+    GetOutput(ReString, ReString, Option<ReString>),
 }
 
 impl WorkflowRequestType {
@@ -26,14 +27,12 @@ impl WorkflowRequestType {
     fn from_path_chunks<'a>(
         mut path_parts: impl Iterator<Item = &'a str>,
     ) -> Result<Self, HandlerError> {
-        let workflow_name = path_parts
-            .next()
-            .ok_or(HandlerError::BadWorkflowPath)?
-            .to_owned();
-        let workflow_key =
+        let workflow_name =
+            ReString::new_owned(path_parts.next().ok_or(HandlerError::BadWorkflowPath)?);
+        let workflow_key = ReString::new_owned(
             urlencoding::decode(path_parts.next().ok_or(HandlerError::BadWorkflowPath)?)
-                .map_err(HandlerError::UrlDecodingError)?
-                .into_owned();
+                .map_err(HandlerError::UrlDecodingError)?,
+        );
 
         match path_parts.next().ok_or(HandlerError::BadWorkflowPath)? {
             "output" => Ok(WorkflowRequestType::GetOutput(
@@ -54,16 +53,14 @@ impl WorkflowRequestType {
     /// Expects: `{name}/{key}/attach|output`
     fn from_v1_path_chunks<'a>(
         mut path_parts: impl Iterator<Item = &'a str>,
-        scope: Option<String>,
+        scope: Option<ReString>,
     ) -> Result<Self, HandlerError> {
-        let workflow_name = path_parts
-            .next()
-            .ok_or(HandlerError::BadApiV1Path)?
-            .to_owned();
-        let workflow_key =
+        let workflow_name =
+            ReString::new_owned(path_parts.next().ok_or(HandlerError::BadApiV1Path)?);
+        let workflow_key = ReString::new_owned(
             urlencoding::decode(path_parts.next().ok_or(HandlerError::BadApiV1Path)?)
-                .map_err(HandlerError::UrlDecodingError)?
-                .into_owned();
+                .map_err(HandlerError::UrlDecodingError)?,
+        );
 
         let action = path_parts.next().ok_or(HandlerError::BadApiV1Path)?;
 
@@ -206,7 +203,7 @@ pub(crate) struct ServiceRequestType {
     pub(crate) target: TargetType,
     pub(crate) invoke_ty: InvokeType,
     /// Scope from the `/api/v1/scope/{scopeKey}/...` path prefix.
-    pub(crate) scope: Option<String>,
+    pub(crate) scope: Option<ReString>,
 }
 
 impl ServiceRequestType {
@@ -295,7 +292,7 @@ where
             let scope_key =
                 urlencoding::decode(path_parts.next().ok_or(HandlerError::BadApiV1Path)?)
                     .map_err(HandlerError::UrlDecodingError)?
-                    .into_owned();
+                    .to_restring();
             let verb = path_parts.next().ok_or(HandlerError::BadApiV1Path)?;
             parse_api_v1_verb(verb, Some(scope_key), path_parts, schemas)
         }
@@ -306,7 +303,7 @@ where
 /// Dispatch a v1 API verb (`call`, `send`, or `workflow`) with an optional scope.
 fn parse_api_v1_verb<'a, Schemas>(
     verb: &str,
-    scope: Option<String>,
+    scope: Option<ReString>,
     mut path_parts: impl Iterator<Item = &'a str>,
     schemas: &Schemas,
 ) -> Result<RequestType, HandlerError>
@@ -316,7 +313,7 @@ where
     // Workflow verb returns a WorkflowRequestType instead of ServiceRequestType
     if verb == "workflow" {
         return Ok(RequestType::Workflow(
-            WorkflowRequestType::from_v1_path_chunks(path_parts, scope)?,
+            WorkflowRequestType::from_v1_path_chunks(path_parts, scope.map(ReString::new_owned))?,
         ));
     }
 

--- a/crates/ingress-http/src/handler/path_parsing.rs
+++ b/crates/ingress-http/src/handler/path_parsing.rs
@@ -15,15 +15,17 @@ use restate_types::ServiceName;
 use restate_types::schema::invocation_target::InvocationTargetResolver;
 
 pub(crate) enum WorkflowRequestType {
-    Attach(String, String),
-    GetOutput(String, String),
+    /// (name, key, scope)
+    Attach(String, String, Option<String>),
+    /// (name, key, scope)
+    GetOutput(String, String, Option<String>),
 }
 
 impl WorkflowRequestType {
+    /// Parse workflow request from unversioned path: `/restate/workflow/{name}/{key}/attach|output`
     fn from_path_chunks<'a>(
         mut path_parts: impl Iterator<Item = &'a str>,
     ) -> Result<Self, HandlerError> {
-        // Parse invocation id
         let workflow_name = path_parts
             .next()
             .ok_or(HandlerError::BadWorkflowPath)?
@@ -33,11 +35,54 @@ impl WorkflowRequestType {
                 .map_err(HandlerError::UrlDecodingError)?
                 .into_owned();
 
-        // Resolve or reject
         match path_parts.next().ok_or(HandlerError::BadWorkflowPath)? {
-            "output" => Ok(WorkflowRequestType::GetOutput(workflow_name, workflow_key)),
-            "attach" => Ok(WorkflowRequestType::Attach(workflow_name, workflow_key)),
+            "output" => Ok(WorkflowRequestType::GetOutput(
+                workflow_name,
+                workflow_key,
+                None,
+            )),
+            "attach" => Ok(WorkflowRequestType::Attach(
+                workflow_name,
+                workflow_key,
+                None,
+            )),
             _ => Err(HandlerError::NotFound),
+        }
+    }
+
+    /// Parse workflow request from versioned path segments (after `workflow` keyword).
+    /// Expects: `{name}/{key}/attach|output`
+    fn from_v1_path_chunks<'a>(
+        mut path_parts: impl Iterator<Item = &'a str>,
+        scope: Option<String>,
+    ) -> Result<Self, HandlerError> {
+        let workflow_name = path_parts
+            .next()
+            .ok_or(HandlerError::BadApiV1Path)?
+            .to_owned();
+        let workflow_key =
+            urlencoding::decode(path_parts.next().ok_or(HandlerError::BadApiV1Path)?)
+                .map_err(HandlerError::UrlDecodingError)?
+                .into_owned();
+
+        let action = path_parts.next().ok_or(HandlerError::BadApiV1Path)?;
+
+        if path_parts.next().is_some() {
+            return Err(HandlerError::BadApiV1Path);
+        }
+
+        match action {
+            "output" => Ok(WorkflowRequestType::GetOutput(
+                workflow_name,
+                workflow_key,
+                scope,
+            )),
+            "attach" => Ok(WorkflowRequestType::Attach(
+                workflow_name,
+                workflow_key,
+                scope,
+            )),
+            _ => Err(HandlerError::BadApiV1Path),
         }
     }
 }
@@ -244,22 +289,40 @@ where
 {
     let segment = path_parts.next().ok_or(HandlerError::NotFound)?;
 
-    let (invoke_ty, scope) = match segment {
-        "call" => (InvokeType::Call, None),
-        "send" => (InvokeType::Send, None),
+    match segment {
+        "call" | "send" | "workflow" => parse_api_v1_verb(segment, None, path_parts, schemas),
         "scope" => {
             let scope_key =
                 urlencoding::decode(path_parts.next().ok_or(HandlerError::BadApiV1Path)?)
                     .map_err(HandlerError::UrlDecodingError)?
                     .into_owned();
             let verb = path_parts.next().ok_or(HandlerError::BadApiV1Path)?;
-            let invoke_ty = match verb {
-                "call" => InvokeType::Call,
-                "send" => InvokeType::Send,
-                _ => return Err(HandlerError::BadApiV1Path),
-            };
-            (invoke_ty, Some(scope_key))
+            parse_api_v1_verb(verb, Some(scope_key), path_parts, schemas)
         }
+        _ => Err(HandlerError::BadApiV1Path),
+    }
+}
+
+/// Dispatch a v1 API verb (`call`, `send`, or `workflow`) with an optional scope.
+fn parse_api_v1_verb<'a, Schemas>(
+    verb: &str,
+    scope: Option<String>,
+    mut path_parts: impl Iterator<Item = &'a str>,
+    schemas: &Schemas,
+) -> Result<RequestType, HandlerError>
+where
+    Schemas: InvocationTargetResolver + Clone + Send + Sync + 'static,
+{
+    // Workflow verb returns a WorkflowRequestType instead of ServiceRequestType
+    if verb == "workflow" {
+        return Ok(RequestType::Workflow(
+            WorkflowRequestType::from_v1_path_chunks(path_parts, scope)?,
+        ));
+    }
+
+    let invoke_ty = match verb {
+        "call" => InvokeType::Call,
+        "send" => InvokeType::Send,
         _ => return Err(HandlerError::BadApiV1Path),
     };
 

--- a/crates/ingress-http/src/handler/tests.rs
+++ b/crates/ingress-http/src/handler/tests.rs
@@ -623,7 +623,8 @@ async fn attach_with_idempotency_id_to_unkeyed_service() {
                     "greeter.Greeter".into(),
                     None,
                     "greet".into(),
-                    "myid".into()
+                    "myid".into(),
+                    None,
                 )),
                 actual_invocation_query
             );
@@ -681,7 +682,8 @@ async fn attach_with_idempotency_id_to_keyed_service() {
                     "greeter.Greeter".into(),
                     Some("mygreet".into()),
                     "greet".into(),
-                    "myid".into()
+                    "myid".into(),
+                    None,
                 )),
                 actual_invocation_query
             );

--- a/crates/ingress-http/src/handler/workflow.rs
+++ b/crates/ingress-http/src/handler/workflow.rs
@@ -35,14 +35,15 @@ where
     where
         <B as http_body::Body>::Error: std::error::Error + Send + Sync + 'static,
     {
-        // todo(tillrohrmann) plumb through scope value
         match workflow_request_type {
-            WorkflowRequestType::Attach(name, key) => {
-                self.handle_workflow_attach(req, ServiceId::new(None, name, key))
+            WorkflowRequestType::Attach(name, key, scope) => {
+                let scope = scope.map(|s| restate_types::Scope::new(&s));
+                self.handle_workflow_attach(req, ServiceId::new(scope, name, key))
                     .await
             }
-            WorkflowRequestType::GetOutput(name, key) => {
-                self.handle_workflow_get_output(req, ServiceId::new(None, name, key))
+            WorkflowRequestType::GetOutput(name, key, scope) => {
+                let scope = scope.map(|s| restate_types::Scope::new(&s));
+                self.handle_workflow_get_output(req, ServiceId::new(scope, name, key))
                     .await
             }
         }

--- a/crates/ingress-http/src/handler/workflow.rs
+++ b/crates/ingress-http/src/handler/workflow.rs
@@ -14,6 +14,7 @@ use super::path_parsing::WorkflowRequestType;
 
 use crate::RequestDispatcher;
 use bytes::Bytes;
+use bytestring::ByteString;
 use http::{Method, Request, Response};
 use http_body_util::Full;
 use restate_types::identifiers::ServiceId;
@@ -37,14 +38,28 @@ where
     {
         match workflow_request_type {
             WorkflowRequestType::Attach(name, key, scope) => {
-                let scope = scope.map(|s| restate_types::Scope::new(&s));
-                self.handle_workflow_attach(req, ServiceId::new(scope, name, key))
-                    .await
+                let scope = scope.map(|s| restate_types::Scope::new(s.as_str()));
+                self.handle_workflow_attach(
+                    req,
+                    ServiceId::new(
+                        scope,
+                        ByteString::from(name.as_str()),
+                        ByteString::from(key.as_str()),
+                    ),
+                )
+                .await
             }
             WorkflowRequestType::GetOutput(name, key, scope) => {
-                let scope = scope.map(|s| restate_types::Scope::new(&s));
-                self.handle_workflow_get_output(req, ServiceId::new(scope, name, key))
-                    .await
+                let scope = scope.map(|s| restate_types::Scope::new(s.as_str()));
+                self.handle_workflow_get_output(
+                    req,
+                    ServiceId::new(
+                        scope,
+                        ByteString::from(name.as_str()),
+                        ByteString::from(key.as_str()),
+                    ),
+                )
+                .await
             }
         }
     }

--- a/crates/ingress-kafka/src/builder.rs
+++ b/crates/ingress-kafka/src/builder.rs
@@ -246,6 +246,20 @@ impl InvocationBuilder {
         }
         .with_scope(scope);
 
+        // Validate: scoped invocations require vqueues to be enabled
+        if invocation_target.scope().is_some()
+            && !restate_types::config::Configuration::pinned()
+                .common
+                .experimental_enable_vqueues
+        {
+            bail!("Scoped invocations require experimental vqueues to be enabled");
+        }
+
+        // Validate: limit_key requires scope
+        if !limit_key.is_empty() && invocation_target.scope().is_none() {
+            bail!("limit-key requires a scope to be set");
+        }
+
         // Compute the retention values
         let target = schema
             .resolve_latest_invocation_target(

--- a/crates/invoker-impl/src/error.rs
+++ b/crates/invoker-impl/src/error.rs
@@ -391,9 +391,6 @@ pub(crate) enum CommandPreconditionError {
     InvalidScope(RestrictedValueError),
     #[error("invalid invocation id {0}: {1}")]
     InvalidInvocationId(String, IdDecodeError),
-    #[error("workflow {0} not found")]
-    #[code(restate_errors::RT0018)]
-    WorkflowNotFound(String),
 }
 
 #[derive(Debug)]

--- a/crates/invoker-impl/src/error.rs
+++ b/crates/invoker-impl/src/error.rs
@@ -22,7 +22,7 @@ use restate_serde_util::NonZeroByteCount;
 use restate_service_client::ServiceClientError;
 use restate_service_protocol::message::{EncodingError, MessageType};
 use restate_time_util::FriendlyDuration;
-use restate_types::errors::{InvocationError, InvocationErrorCode, codes};
+use restate_types::errors::{IdDecodeError, InvocationError, InvocationErrorCode, codes};
 use restate_types::identifiers::DeploymentId;
 use restate_types::journal::raw::RawEntryCodecError;
 use restate_types::journal::{EntryIndex, EntryType};
@@ -389,6 +389,11 @@ pub(crate) enum CommandPreconditionError {
     LimitKeyWithoutScope,
     #[error("invalid scope: {0}")]
     InvalidScope(RestrictedValueError),
+    #[error("invalid invocation id {0}: {1}")]
+    InvalidInvocationId(String, IdDecodeError),
+    #[error("workflow {0} not found")]
+    #[code(restate_errors::RT0018)]
+    WorkflowNotFound(String),
 }
 
 #[derive(Debug)]

--- a/crates/invoker-impl/src/input_command.rs
+++ b/crates/invoker-impl/src/input_command.rs
@@ -11,11 +11,13 @@
 use tokio::sync::mpsc;
 
 use restate_errors::NotRunningError;
+use restate_types::LimitKey;
 use restate_types::identifiers::{EntryIndex, InvocationId};
 use restate_types::invocation::InvocationTarget;
 use restate_types::journal_v2::{CommandIndex, NotificationId};
 use restate_types::sharding::KeyRange;
 use restate_types::vqueues::VQueueId;
+use restate_util_string::ReString;
 use restate_worker_api::invoker::{InvocationStatusReport, StatusHandle};
 use restate_worker_api::resources::ReservedResources;
 // -- Input messages
@@ -33,6 +35,8 @@ pub(crate) struct VQueueInvokeCommand {
     pub(super) permit: ReservedResources,
     pub(super) invocation_id: InvocationId,
     pub(super) invocation_target: InvocationTarget,
+    pub(super) limit_key: LimitKey<ReString>,
+    pub(super) idempotency_key: Option<ReString>,
 }
 
 #[derive(Debug)]
@@ -101,6 +105,8 @@ impl restate_worker_api::invoker::InvokerHandle for InvokerHandle {
         permit: ReservedResources,
         invocation_id: InvocationId,
         invocation_target: InvocationTarget,
+        limit_key: LimitKey<ReString>,
+        idempotency_key: Option<ReString>,
     ) -> Result<(), NotRunningError> {
         self.input
             .send(InputCommand::VQInvoke(Box::new(VQueueInvokeCommand {
@@ -108,6 +114,8 @@ impl restate_worker_api::invoker::InvokerHandle for InvokerHandle {
                 permit,
                 invocation_id,
                 invocation_target,
+                limit_key,
+                idempotency_key,
             })))
             .map_err(|_| NotRunningError)
     }

--- a/crates/invoker-impl/src/invocation_state_machine.rs
+++ b/crates/invoker-impl/src/invocation_state_machine.rs
@@ -45,6 +45,8 @@ pub(super) struct InvocationStateMachine<K: TimerKey = tokio_util::time::delay_q
     #[debug(skip)]
     pub(super) _permit: ReservedResources,
     pub(super) invocation_target: InvocationTarget,
+    pub(super) limit_key: LimitKey<ReString>,
+    pub(super) idempotency_key: Option<ReString>,
     pub(super) last_transient_error_event: Option<TransientErrorEvent>,
     invocation_state: AttemptState<K>,
     retry_policy_state: RetryPolicyState,
@@ -202,10 +204,13 @@ struct RetryPolicyState {
 }
 
 impl<K: TimerKey> InvocationStateMachine<K> {
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn create(
         qid: Option<VQueueId>,
         permit: ReservedResources,
         invocation_target: InvocationTarget,
+        limit_key: LimitKey<ReString>,
+        idempotency_key: Option<ReString>,
         retry_iter: retries::RetryIter<'static>,
         on_max_attempts: OnMaxAttempts,
         concurrency_slot: ConcurrencySlot,
@@ -214,6 +219,8 @@ impl<K: TimerKey> InvocationStateMachine<K> {
             qid,
             _permit: permit,
             invocation_target,
+            limit_key,
+            idempotency_key,
             last_transient_error_event: None,
             invocation_state: AttemptState::New,
             retry_policy_state: RetryPolicyState {
@@ -625,6 +632,8 @@ mod tests {
             None,
             ReservedResources::new_empty(),
             InvocationTarget::mock_virtual_object(),
+            LimitKey::None,
+            None,
             RetryPolicy::fixed_delay(Duration::from_secs(1), Some(10)).into_iter(),
             OnMaxAttempts::Kill,
             ConcurrencySlot::empty(),

--- a/crates/invoker-impl/src/invocation_task/mod.rs
+++ b/crates/invoker-impl/src/invocation_task/mod.rs
@@ -35,6 +35,7 @@ use tracing::{debug, instrument};
 use restate_memory::{LocalMemoryLease, LocalMemoryPool};
 use restate_serde_util::{ByteCount, NonZeroByteCount};
 use restate_service_client::{Request, ResponseBody, ServiceClient, ServiceClientError};
+use restate_types::LimitKey;
 use restate_types::deployment::PinnedDeployment;
 use restate_types::identifiers::InvocationId;
 use restate_types::invocation::InvocationTarget;
@@ -46,6 +47,7 @@ use restate_types::live::Live;
 use restate_types::schema::deployment::DeploymentResolver;
 use restate_types::schema::invocation_target::InvocationTargetResolver;
 use restate_types::service_protocol::ServiceProtocolVersion;
+use restate_util_string::ReString;
 use restate_worker_api::invoker::invocation_reader::{
     EagerState, InvocationReader, InvocationReaderTransaction, JournalKind,
 };
@@ -247,6 +249,8 @@ pub(super) struct InvocationTask<EE, DMR> {
     // Connection params
     invocation_id: InvocationId,
     invocation_target: InvocationTarget,
+    limit_key: LimitKey<ReString>,
+    idempotency_key: Option<ReString>,
     inactivity_timeout: Duration,
     abort_timeout: Duration,
     eager_state_size_limit: usize,
@@ -340,6 +344,8 @@ where
         invoker_tx: mpsc::UnboundedSender<InvocationTaskOutput>,
         invoker_rx: mpsc::UnboundedReceiver<Notification>,
         action_token_bucket: Option<TokenBucket>,
+        limit_key: LimitKey<ReString>,
+        idempotency_key: Option<ReString>,
         allow_protocol_v7: bool,
     ) -> Self {
         Self {
@@ -358,6 +364,8 @@ where
             retry_count_since_last_stored_entry,
             action_token_bucket,
             allow_protocol_v7,
+            limit_key,
+            idempotency_key,
         }
     }
 

--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
@@ -33,9 +33,7 @@ use restate_service_protocol_v4::entry_codec::ServiceProtocolV4Codec;
 use restate_service_protocol_v4::message_codec::{
     Decoder, Encoder, Message, MessageHeader, MessageType, StateEntry, proto,
 };
-use restate_service_protocol_v4::proto::{
-    attach_invocation_command_message, get_invocation_output_command_message,
-};
+use restate_service_protocol_v4::proto_lite;
 use restate_types::Scope;
 use restate_types::errors::{GenericError, InvocationError};
 use restate_types::identifiers::InvocationId;
@@ -925,22 +923,21 @@ where
             }
             Message::GetInvocationOutputCommand(cmd) => {
                 // The macro registers `GetInvocationOutput Command` as `noparse`, so `cmd` is
-                // the raw bytes from the wire. We decode it once to validate the target, then
-                // forward the original bytes to avoid a re-encode round trip.
+                // the raw bytes from the wire. We decode a lite shadow type that only
+                // covers the fields we actually validate (target/scope) and forward the
+                // original bytes downstream to avoid a re-encode round trip.
                 let parsed = crate::shortcircuit!(
-                    proto::GetInvocationOutputCommandMessage::decode(cmd.clone())
+                    proto_lite::GetInvocationOutputCommandMessageLite::decode(cmd.as_ref())
                         .map_err(|err| InvokerError::EncodingV2(GenericError::from(err).into()))
                 );
                 if let Some(target) = parsed.target.as_ref() {
-                    crate::shortcircuit!(
-                        Self::validate_get_invocation_output_target(target).map_err(|err| {
-                            InvokerError::CommandPrecondition(
-                                self.command_index,
-                                EntryType::Command(CommandType::GetInvocationOutput),
-                                err,
-                            )
-                        })
-                    );
+                    crate::shortcircuit!(Self::validate_target(target).map_err(|err| {
+                        InvokerError::CommandPrecondition(
+                            self.command_index,
+                            EntryType::Command(CommandType::GetInvocationOutput),
+                            err,
+                        )
+                    }));
                 }
                 self.handle_new_command(mh, RawCommand::new(CommandType::GetInvocationOutput, cmd));
                 TerminalLoopState::Continue(())
@@ -948,19 +945,17 @@ where
             Message::AttachInvocationCommand(cmd) => {
                 // See `Message::GetInvocationOutputCommand` above for why we decode-then-forward.
                 let parsed = crate::shortcircuit!(
-                    proto::AttachInvocationCommandMessage::decode(cmd.clone())
+                    proto_lite::AttachInvocationCommandMessageLite::decode(cmd.as_ref())
                         .map_err(|err| InvokerError::EncodingV2(GenericError::from(err).into()))
                 );
                 if let Some(target) = parsed.target.as_ref() {
-                    crate::shortcircuit!(Self::validate_attach_invocation_target(target).map_err(
-                        |err| {
-                            InvokerError::CommandPrecondition(
-                                self.command_index,
-                                EntryType::Command(CommandType::AttachInvocation),
-                                err,
-                            )
-                        }
-                    ));
+                    crate::shortcircuit!(Self::validate_target(target).map_err(|err| {
+                        InvokerError::CommandPrecondition(
+                            self.command_index,
+                            EntryType::Command(CommandType::AttachInvocation),
+                            err,
+                        )
+                    }));
                 }
                 self.handle_new_command(mh, RawCommand::new(CommandType::AttachInvocation, cmd));
                 TerminalLoopState::Continue(())
@@ -1308,54 +1303,20 @@ where
     /// valid `RestrictedValue`). We do not check that the service/handler/workflow currently
     /// exists in the schema, because the user may legitimately query the output of an invocation
     /// whose service has since been removed from the registry.
-    fn validate_get_invocation_output_target(
-        target: &get_invocation_output_command_message::Target,
-    ) -> Result<(), CommandPreconditionError> {
+    fn validate_target(target: &proto_lite::TargetLite) -> Result<(), CommandPreconditionError> {
         match target {
-            get_invocation_output_command_message::Target::InvocationId(invocation_id) => {
+            proto_lite::TargetLite::InvocationId(invocation_id) => {
                 invocation_id.parse::<InvocationId>().map_err(|err| {
                     CommandPreconditionError::InvalidInvocationId(invocation_id.clone(), err)
                 })?;
             }
-            get_invocation_output_command_message::Target::IdempotentRequestTarget(
-                idempotent_request_target,
-            ) => {
+            proto_lite::TargetLite::IdempotentRequestTarget(idempotent_request_target) => {
                 if let Some(scope) = idempotent_request_target.scope.as_ref() {
                     let _ = RestrictedValue::new(scope.as_str())
                         .map_err(CommandPreconditionError::InvalidScope)?;
                 }
             }
-            get_invocation_output_command_message::Target::WorkflowTarget(workflow_target) => {
-                if let Some(scope) = workflow_target.scope.as_ref() {
-                    let _ = RestrictedValue::new(scope.as_str())
-                        .map_err(CommandPreconditionError::InvalidScope)?;
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Validates the target of an `AttachInvocation` command. See
-    /// [`Self::validate_get_invocation_output_target`] for the validation contract.
-    fn validate_attach_invocation_target(
-        target: &attach_invocation_command_message::Target,
-    ) -> Result<(), CommandPreconditionError> {
-        match target {
-            attach_invocation_command_message::Target::InvocationId(invocation_id) => {
-                invocation_id.parse::<InvocationId>().map_err(|err| {
-                    CommandPreconditionError::InvalidInvocationId(invocation_id.clone(), err)
-                })?;
-            }
-            attach_invocation_command_message::Target::IdempotentRequestTarget(
-                idempotent_request_target,
-            ) => {
-                if let Some(scope) = idempotent_request_target.scope.as_ref() {
-                    let _ = RestrictedValue::new(scope.as_str())
-                        .map_err(CommandPreconditionError::InvalidScope)?;
-                }
-            }
-            attach_invocation_command_message::Target::WorkflowTarget(workflow_target) => {
+            proto_lite::TargetLite::WorkflowTarget(workflow_target) => {
                 if let Some(scope) = workflow_target.scope.as_ref() {
                     let _ = RestrictedValue::new(scope.as_str())
                         .map_err(CommandPreconditionError::InvalidScope)?;

--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
@@ -667,9 +667,7 @@ where
         )
         .await?;
 
-        // Send the invoke frame with the merged state lease
-        self.write_with_lease(
-            http_stream_tx,
+        let start_message = if self.service_protocol_version >= ServiceProtocolVersion::V7 {
             Message::new_start_message(
                 Bytes::copy_from_slice(&self.invocation_task.invocation_id.to_bytes()),
                 self.invocation_task.invocation_id.to_string(),
@@ -683,9 +681,33 @@ where
                 retry_count_since_last_stored_entry,
                 duration_since_last_stored_entry,
                 random_seed,
-            ),
-            state_lease,
-        )
+                self.invocation_task.invocation_target.scope(),
+                &self.invocation_task.limit_key,
+                self.invocation_task.idempotency_key.as_ref(),
+            )
+        } else {
+            Message::new_start_message(
+                Bytes::copy_from_slice(&self.invocation_task.invocation_id.to_bytes()),
+                self.invocation_task.invocation_id.to_string(),
+                self.invocation_task
+                    .invocation_target
+                    .key()
+                    .map(|bs| bs.as_bytes().clone()),
+                journal_size,
+                partial_state,
+                state_map,
+                retry_count_since_last_stored_entry,
+                duration_since_last_stored_entry,
+                random_seed,
+                // those fields were only introduced with service protocol V7
+                None,
+                &LimitKey::None,
+                None,
+            )
+        };
+
+        // Send the invoke frame with the merged state lease
+        self.write_with_lease(http_stream_tx, start_message, state_lease)
     }
 
     fn write_entry_with_lease(

--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
@@ -21,6 +21,7 @@ use gardal::futures::StreamExt as GardalStreamExt;
 use http::uri::PathAndQuery;
 use http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
 use opentelemetry::trace::TraceFlags;
+use prost::Message as ProstMessage;
 use tokio::sync::mpsc;
 use tracing::{debug, trace, warn};
 
@@ -31,6 +32,9 @@ use restate_service_protocol::codec::ProtobufRawEntryCodec;
 use restate_service_protocol_v4::entry_codec::ServiceProtocolV4Codec;
 use restate_service_protocol_v4::message_codec::{
     Decoder, Encoder, Message, MessageHeader, MessageType, StateEntry, proto,
+};
+use restate_service_protocol_v4::proto::{
+    attach_invocation_command_message, get_invocation_output_command_message,
 };
 use restate_types::Scope;
 use restate_types::errors::{GenericError, InvocationError};
@@ -898,21 +902,43 @@ where
                 TerminalLoopState::Continue(())
             }
             Message::GetInvocationOutputCommand(cmd) => {
-                // Verify the provided InvocationId is valid
-                let _: Entry = crate::shortcircuit!(
-                    RawCommand::new(CommandType::GetInvocationOutput, cmd.clone())
-                        .decode::<ServiceProtocolV4Codec, _>()
+                if let Some(target) = &cmd.target {
+                    crate::shortcircuit!(
+                        Self::validate_get_invocation_output_target(
+                            self.invocation_task.schemas.live_load(),
+                            target
+                        )
+                        .map_err(|err| InvokerError::CommandPrecondition(
+                            self.command_index,
+                            EntryType::Command(CommandType::GetInvocationOutput),
+                            err
+                        ))
+                    );
+                }
+                self.handle_new_command(
+                    mh,
+                    RawCommand::new(CommandType::GetInvocationOutput, cmd.encode_to_vec()),
                 );
-                self.handle_new_command(mh, RawCommand::new(CommandType::GetInvocationOutput, cmd));
                 TerminalLoopState::Continue(())
             }
             Message::AttachInvocationCommand(cmd) => {
-                // Verify the provided InvocationId is valid
-                let _: Entry = crate::shortcircuit!(
-                    RawCommand::new(CommandType::AttachInvocation, cmd.clone())
-                        .decode::<ServiceProtocolV4Codec, _>()
+                if let Some(target) = &cmd.target {
+                    crate::shortcircuit!(
+                        Self::validate_attach_invocation_target(
+                            self.invocation_task.schemas.live_load(),
+                            target
+                        )
+                        .map_err(|err| InvokerError::CommandPrecondition(
+                            self.command_index,
+                            EntryType::Command(CommandType::AttachInvocation),
+                            err
+                        ))
+                    );
+                }
+                self.handle_new_command(
+                    mh,
+                    RawCommand::new(CommandType::AttachInvocation, cmd.encode_to_vec()),
                 );
-                self.handle_new_command(mh, RawCommand::new(CommandType::AttachInvocation, cmd));
                 TerminalLoopState::Continue(())
             }
             Message::RunCommand(cmd) => {
@@ -1250,6 +1276,110 @@ where
             next_retry_interval_override: error.next_retry_delay.map(Duration::from_millis),
             error: InvocationError::from(error).into(),
         }))
+    }
+
+    fn validate_get_invocation_output_target(
+        invocation_target_resolver: &impl InvocationTargetResolver,
+        target: &get_invocation_output_command_message::Target,
+    ) -> Result<(), CommandPreconditionError> {
+        match target {
+            get_invocation_output_command_message::Target::InvocationId(invocation_id) => {
+                invocation_id.parse::<InvocationId>().map_err(|err| {
+                    CommandPreconditionError::InvalidInvocationId(invocation_id.clone(), err)
+                })?;
+            }
+            get_invocation_output_command_message::Target::IdempotentRequestTarget(
+                idempotent_request_target,
+            ) => {
+                // check whether we know the service/handler
+                invocation_target_resolver
+                    .resolve_latest_invocation_target(
+                        &idempotent_request_target.service_name,
+                        &idempotent_request_target.handler_name,
+                    )
+                    .ok_or_else(|| {
+                        CommandPreconditionError::ServiceHandlerNotFound(
+                            idempotent_request_target.service_name.clone(),
+                            idempotent_request_target.handler_name.clone(),
+                        )
+                    })?;
+                if let Some(scope) = idempotent_request_target.scope.as_ref() {
+                    // check whether the scope value is restricted
+                    let _ = RestrictedValue::new(scope.as_str())
+                        .map_err(CommandPreconditionError::InvalidScope)?;
+                }
+            }
+            get_invocation_output_command_message::Target::WorkflowTarget(workflow_target) => {
+                // check whether we know the workflow
+                invocation_target_resolver
+                    // the "run" handler must always be present for a workflow
+                    .resolve_latest_invocation_target(&workflow_target.workflow_name, "run")
+                    .ok_or_else(|| {
+                        CommandPreconditionError::WorkflowNotFound(
+                            workflow_target.workflow_name.clone(),
+                        )
+                    })?;
+                if let Some(scope) = workflow_target.scope.as_ref() {
+                    // check whether the scope value is restricted
+                    let _ = RestrictedValue::new(scope.as_str())
+                        .map_err(CommandPreconditionError::InvalidScope)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn validate_attach_invocation_target(
+        invocation_target_resolver: &impl InvocationTargetResolver,
+        target: &attach_invocation_command_message::Target,
+    ) -> Result<(), CommandPreconditionError> {
+        match target {
+            attach_invocation_command_message::Target::InvocationId(invocation_id) => {
+                invocation_id.parse::<InvocationId>().map_err(|err| {
+                    CommandPreconditionError::InvalidInvocationId(invocation_id.clone(), err)
+                })?;
+            }
+            attach_invocation_command_message::Target::IdempotentRequestTarget(
+                idempotent_request_target,
+            ) => {
+                // check whether we know the service/handler
+                invocation_target_resolver
+                    .resolve_latest_invocation_target(
+                        &idempotent_request_target.service_name,
+                        &idempotent_request_target.handler_name,
+                    )
+                    .ok_or_else(|| {
+                        CommandPreconditionError::ServiceHandlerNotFound(
+                            idempotent_request_target.service_name.clone(),
+                            idempotent_request_target.handler_name.clone(),
+                        )
+                    })?;
+                if let Some(scope) = idempotent_request_target.scope.as_ref() {
+                    // check whether the scope value is restricted
+                    let _ = RestrictedValue::new(scope.as_str())
+                        .map_err(CommandPreconditionError::InvalidScope)?;
+                }
+            }
+            attach_invocation_command_message::Target::WorkflowTarget(workflow_target) => {
+                // check whether we know the workflow
+                invocation_target_resolver
+                    // the "run" handler must always be present for a workflow
+                    .resolve_latest_invocation_target(&workflow_target.workflow_name, "run")
+                    .ok_or_else(|| {
+                        CommandPreconditionError::WorkflowNotFound(
+                            workflow_target.workflow_name.clone(),
+                        )
+                    })?;
+                if let Some(scope) = workflow_target.scope.as_ref() {
+                    // check whether the scope value is restricted
+                    let _ = RestrictedValue::new(scope.as_str())
+                        .map_err(CommandPreconditionError::InvalidScope)?;
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
@@ -924,43 +924,45 @@ where
                 TerminalLoopState::Continue(())
             }
             Message::GetInvocationOutputCommand(cmd) => {
-                if let Some(target) = &cmd.target {
+                // The macro registers `GetInvocationOutput Command` as `noparse`, so `cmd` is
+                // the raw bytes from the wire. We decode it once to validate the target, then
+                // forward the original bytes to avoid a re-encode round trip.
+                let parsed = crate::shortcircuit!(
+                    proto::GetInvocationOutputCommandMessage::decode(cmd.clone())
+                        .map_err(|err| InvokerError::EncodingV2(GenericError::from(err).into()))
+                );
+                if let Some(target) = parsed.target.as_ref() {
                     crate::shortcircuit!(
-                        Self::validate_get_invocation_output_target(
-                            self.invocation_task.schemas.live_load(),
-                            target
-                        )
-                        .map_err(|err| InvokerError::CommandPrecondition(
-                            self.command_index,
-                            EntryType::Command(CommandType::GetInvocationOutput),
-                            err
-                        ))
+                        Self::validate_get_invocation_output_target(target).map_err(|err| {
+                            InvokerError::CommandPrecondition(
+                                self.command_index,
+                                EntryType::Command(CommandType::GetInvocationOutput),
+                                err,
+                            )
+                        })
                     );
                 }
-                self.handle_new_command(
-                    mh,
-                    RawCommand::new(CommandType::GetInvocationOutput, cmd.encode_to_vec()),
-                );
+                self.handle_new_command(mh, RawCommand::new(CommandType::GetInvocationOutput, cmd));
                 TerminalLoopState::Continue(())
             }
             Message::AttachInvocationCommand(cmd) => {
-                if let Some(target) = &cmd.target {
-                    crate::shortcircuit!(
-                        Self::validate_attach_invocation_target(
-                            self.invocation_task.schemas.live_load(),
-                            target
-                        )
-                        .map_err(|err| InvokerError::CommandPrecondition(
-                            self.command_index,
-                            EntryType::Command(CommandType::AttachInvocation),
-                            err
-                        ))
-                    );
-                }
-                self.handle_new_command(
-                    mh,
-                    RawCommand::new(CommandType::AttachInvocation, cmd.encode_to_vec()),
+                // See `Message::GetInvocationOutputCommand` above for why we decode-then-forward.
+                let parsed = crate::shortcircuit!(
+                    proto::AttachInvocationCommandMessage::decode(cmd.clone())
+                        .map_err(|err| InvokerError::EncodingV2(GenericError::from(err).into()))
                 );
+                if let Some(target) = parsed.target.as_ref() {
+                    crate::shortcircuit!(Self::validate_attach_invocation_target(target).map_err(
+                        |err| {
+                            InvokerError::CommandPrecondition(
+                                self.command_index,
+                                EntryType::Command(CommandType::AttachInvocation),
+                                err,
+                            )
+                        }
+                    ));
+                }
+                self.handle_new_command(mh, RawCommand::new(CommandType::AttachInvocation, cmd));
                 TerminalLoopState::Continue(())
             }
             Message::RunCommand(cmd) => {
@@ -1300,8 +1302,13 @@ where
         }))
     }
 
+    /// Validates the target of a `GetInvocationOutput` command.
+    ///
+    /// We only validate the syntactic shape of the target (invocation id parses, scope is a
+    /// valid `RestrictedValue`). We do not check that the service/handler/workflow currently
+    /// exists in the schema, because the user may legitimately query the output of an invocation
+    /// whose service has since been removed from the registry.
     fn validate_get_invocation_output_target(
-        invocation_target_resolver: &impl InvocationTargetResolver,
         target: &get_invocation_output_command_message::Target,
     ) -> Result<(), CommandPreconditionError> {
         match target {
@@ -1313,36 +1320,13 @@ where
             get_invocation_output_command_message::Target::IdempotentRequestTarget(
                 idempotent_request_target,
             ) => {
-                // check whether we know the service/handler
-                invocation_target_resolver
-                    .resolve_latest_invocation_target(
-                        &idempotent_request_target.service_name,
-                        &idempotent_request_target.handler_name,
-                    )
-                    .ok_or_else(|| {
-                        CommandPreconditionError::ServiceHandlerNotFound(
-                            idempotent_request_target.service_name.clone(),
-                            idempotent_request_target.handler_name.clone(),
-                        )
-                    })?;
                 if let Some(scope) = idempotent_request_target.scope.as_ref() {
-                    // check whether the scope value is restricted
                     let _ = RestrictedValue::new(scope.as_str())
                         .map_err(CommandPreconditionError::InvalidScope)?;
                 }
             }
             get_invocation_output_command_message::Target::WorkflowTarget(workflow_target) => {
-                // check whether we know the workflow
-                invocation_target_resolver
-                    // the "run" handler must always be present for a workflow
-                    .resolve_latest_invocation_target(&workflow_target.workflow_name, "run")
-                    .ok_or_else(|| {
-                        CommandPreconditionError::WorkflowNotFound(
-                            workflow_target.workflow_name.clone(),
-                        )
-                    })?;
                 if let Some(scope) = workflow_target.scope.as_ref() {
-                    // check whether the scope value is restricted
                     let _ = RestrictedValue::new(scope.as_str())
                         .map_err(CommandPreconditionError::InvalidScope)?;
                 }
@@ -1352,8 +1336,9 @@ where
         Ok(())
     }
 
+    /// Validates the target of an `AttachInvocation` command. See
+    /// [`Self::validate_get_invocation_output_target`] for the validation contract.
     fn validate_attach_invocation_target(
-        invocation_target_resolver: &impl InvocationTargetResolver,
         target: &attach_invocation_command_message::Target,
     ) -> Result<(), CommandPreconditionError> {
         match target {
@@ -1365,36 +1350,13 @@ where
             attach_invocation_command_message::Target::IdempotentRequestTarget(
                 idempotent_request_target,
             ) => {
-                // check whether we know the service/handler
-                invocation_target_resolver
-                    .resolve_latest_invocation_target(
-                        &idempotent_request_target.service_name,
-                        &idempotent_request_target.handler_name,
-                    )
-                    .ok_or_else(|| {
-                        CommandPreconditionError::ServiceHandlerNotFound(
-                            idempotent_request_target.service_name.clone(),
-                            idempotent_request_target.handler_name.clone(),
-                        )
-                    })?;
                 if let Some(scope) = idempotent_request_target.scope.as_ref() {
-                    // check whether the scope value is restricted
                     let _ = RestrictedValue::new(scope.as_str())
                         .map_err(CommandPreconditionError::InvalidScope)?;
                 }
             }
             attach_invocation_command_message::Target::WorkflowTarget(workflow_target) => {
-                // check whether we know the workflow
-                invocation_target_resolver
-                    // the "run" handler must always be present for a workflow
-                    .resolve_latest_invocation_target(&workflow_target.workflow_name, "run")
-                    .ok_or_else(|| {
-                        CommandPreconditionError::WorkflowNotFound(
-                            workflow_target.workflow_name.clone(),
-                        )
-                    })?;
                 if let Some(scope) = workflow_target.scope.as_ref() {
-                    // check whether the scope value is restricted
                     let _ = RestrictedValue::new(scope.as_str())
                         .map_err(CommandPreconditionError::InvalidScope)?;
                 }

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -79,11 +79,12 @@ use crate::metric_definitions::{
 };
 use crate::status_store::InvocationStatusStore;
 
-pub use input_command::ChannelStatusReader;
-pub use input_command::InvokerHandle;
-
 use self::input_command::VQueueInvokeCommand;
 use self::state_machine_manager::InvocationStateMachineManager;
+pub use input_command::ChannelStatusReader;
+pub use input_command::InvokerHandle;
+use restate_types::LimitKey;
+use restate_util_string::ReString;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Notification {
@@ -104,6 +105,8 @@ trait InvocationTaskRunner<SR> {
         options: &InvokerOptions,
         invocation_id: InvocationId,
         invocation_target: InvocationTarget,
+        limit_key: LimitKey<ReString>,
+        idempotency_key: Option<ReString>,
         retry_count_since_last_stored_entry: u32,
         storage_reader: SR,
         invoker_tx: mpsc::UnboundedSender<InvocationTaskOutput>,
@@ -132,6 +135,8 @@ where
         opts: &InvokerOptions,
         invocation_id: InvocationId,
         invocation_target: InvocationTarget,
+        limit_key: LimitKey<ReString>,
+        idempotency_key: Option<ReString>,
         retry_count_since_last_stored_entry: u32,
         storage_reader: IR,
         invoker_tx: mpsc::UnboundedSender<InvocationTaskOutput>,
@@ -158,6 +163,8 @@ where
                     invoker_tx,
                     invoker_rx,
                     self.action_token_bucket.clone(),
+                    limit_key,
+                    idempotency_key,
                     self.allow_protocol_v7,
                 )
                 .run(storage_reader, budget),
@@ -647,6 +654,8 @@ where
                 Some(command.qid),
                 command.permit,
                 command.invocation_target,
+                command.limit_key,
+                command.idempotency_key,
                 retry_iter,
                 on_max_attempts,
                 concurrency_slot,
@@ -690,6 +699,8 @@ where
                 None,
                 fake_permit,
                 invocation_target,
+                LimitKey::None,
+                None,
                 retry_iter,
                 on_max_attempts,
                 concurrency_slot,
@@ -1675,6 +1686,8 @@ where
             options,
             invocation_id,
             ism.invocation_target.clone(),
+            ism.limit_key.clone(),
+            ism.idempotency_key.clone(),
             ism.start_message_retry_count_since_last_stored_command,
             storage_reader,
             self.invocation_tasks_tx.clone(),
@@ -1895,6 +1908,8 @@ mod tests {
             _options: &InvokerOptions,
             invocation_id: InvocationId,
             invocation_target: InvocationTarget,
+            _limit_key: LimitKey<ReString>,
+            _idempotency_key: Option<ReString>,
             _retry_count_since_last_stored_entry: u32,
             storage_reader: IR,
             invoker_tx: mpsc::UnboundedSender<InvocationTaskOutput>,
@@ -1926,6 +1941,8 @@ mod tests {
             _options: &InvokerOptions,
             _invocation_id: InvocationId,
             _invocation_target: InvocationTarget,
+            _limit_key: LimitKey<ReString>,
+            _idempotency_key: Option<ReString>,
             _retry_count_since_last_stored_entry: u32,
             _storage_reader: SR,
             _invoker_tx: mpsc::UnboundedSender<InvocationTaskOutput>,
@@ -1946,6 +1963,8 @@ mod tests {
             _options: &InvokerOptions,
             _invocation_id: InvocationId,
             _invocation_target: InvocationTarget,
+            _limit_key: LimitKey<ReString>,
+            _idempotency_key: Option<ReString>,
             _retry_count_since_last_stored_entry: u32,
             _storage_reader: SR,
             _invoker_tx: mpsc::UnboundedSender<InvocationTaskOutput>,
@@ -2309,6 +2328,8 @@ mod tests {
             )),
             ReservedResources::new_empty(),
             invocation_target.clone(),
+            LimitKey::None,
+            None,
             RetryPolicy::fixed_delay(Duration::from_millis(100), None).into_iter(),
             OnMaxAttempts::Kill,
             ConcurrencySlot::empty(),

--- a/crates/invoker-impl/src/test_util.rs
+++ b/crates/invoker-impl/src/test_util.rs
@@ -14,6 +14,7 @@ use bytes::Bytes;
 
 use restate_errors::NotRunningError;
 use restate_memory::{IgnorePinnableMemoryStream, LocalMemoryLease, LocalMemoryPool};
+use restate_types::LimitKey;
 use restate_types::errors::InvocationError;
 use restate_types::identifiers::{EntryIndex, InvocationId, InvocationUuid, ServiceId};
 use restate_types::invocation::{InvocationTarget, ServiceInvocationSpanContext};
@@ -24,6 +25,7 @@ use restate_types::journal::raw::{PlainEntryHeader, PlainRawEntry, RawEntry};
 use restate_types::journal_v2::CommandIndex;
 use restate_types::time::MillisSinceEpoch;
 use restate_types::vqueues::VQueueId;
+use restate_util_string::ReString;
 use restate_worker_api::invoker::invocation_reader::{
     EagerState, InvocationReader, InvocationReaderTransaction, JournalEntry, JournalKind,
 };
@@ -142,6 +144,8 @@ impl InvokerHandle for MockInvokerHandle {
         _permit: ReservedResources,
         _invocation_id: InvocationId,
         _invocation_target: InvocationTarget,
+        _limit_key: LimitKey<ReString>,
+        _idempotency_key: Option<ReString>,
     ) -> Result<(), NotRunningError> {
         Ok(())
     }

--- a/crates/service-protocol-v4/Cargo.toml
+++ b/crates/service-protocol-v4/Cargo.toml
@@ -20,6 +20,7 @@ restate-workspace-hack = { workspace = true }
 restate-errors = { workspace = true, optional = true }
 restate-serde-util = { workspace = true }
 restate-service-client = { workspace = true, optional = true }
+restate-util-string = { workspace = true }
 restate-types = { workspace = true }
 
 assert2 = { workspace = true, optional = true }

--- a/crates/service-protocol-v4/src/entry_codec.rs
+++ b/crates/service-protocol-v4/src/entry_codec.rs
@@ -1649,6 +1649,8 @@ impl TryFrom<proto::attach_invocation_command_message::Target> for AttachInvocat
                 idempotent_request.service_key.map(Into::into),
                 idempotent_request.handler_name.into(),
                 idempotent_request.idempotency_key.into(),
+                // TODO(tillrohrmann): IdempotentRequestTarget proto doesn't carry scope yet
+                None,
             )),
             proto::attach_invocation_command_message::Target::WorkflowTarget(workflow_target) => {
                 Self::Workflow(ServiceId::new(
@@ -1698,6 +1700,8 @@ impl TryFrom<proto::get_invocation_output_command_message::Target> for AttachInv
                 idempotent_request.service_key.map(Into::into),
                 idempotent_request.handler_name.into(),
                 idempotent_request.idempotency_key.into(),
+                // TODO(tillrohrmann): IdempotentRequestTarget proto doesn't carry scope yet
+                None,
             )),
             proto::get_invocation_output_command_message::Target::WorkflowTarget(
                 workflow_target,

--- a/crates/service-protocol-v4/src/entry_codec.rs
+++ b/crates/service-protocol-v4/src/entry_codec.rs
@@ -36,7 +36,7 @@ use restate_types::journal_v2::raw::{
     CallOrSendMetadata, RawCommand, RawCommandSpecificMetadata, RawEntry, RawNotification,
     RawNotificationResultVariant,
 };
-use restate_types::{LimitKey, journal_v2::*};
+use restate_types::{LimitKey, Scope, journal_v2::*};
 
 use crate::proto;
 use crate::proto::{
@@ -1622,11 +1622,13 @@ impl From<AttachInvocationTarget> for proto::attach_invocation_command_message::
                     service_key: id.service_key.map(Into::into),
                     handler_name: id.service_handler.into(),
                     idempotency_key: id.idempotency_key.into(),
+                    scope: id.scope.map(|s| s.to_string()),
                 })
             }
             AttachInvocationTarget::Workflow(id) => Self::WorkflowTarget(proto::WorkflowTarget {
                 workflow_name: id.service_name.into(),
                 workflow_key: id.key.into(),
+                scope: id.scope.map(|s| s.to_string()),
             }),
         }
     }
@@ -1640,21 +1642,36 @@ impl TryFrom<proto::attach_invocation_command_message::Target> for AttachInvocat
     ) -> Result<Self, Self::Error> {
         Ok(match value {
             proto::attach_invocation_command_message::Target::InvocationId(invocation_id) => {
+                // Before we accept an idempotent request we validate in
+                // ServiceProtocolRunner::handle_message that the invocation_id value is valid.
                 Self::InvocationId(to_invocation_id_or_bail!(invocation_id))
             }
             proto::attach_invocation_command_message::Target::IdempotentRequestTarget(
                 idempotent_request,
-            ) => Self::IdempotentRequest(IdempotencyId::new(
-                idempotent_request.service_name.into(),
-                idempotent_request.service_key.map(Into::into),
-                idempotent_request.handler_name.into(),
-                idempotent_request.idempotency_key.into(),
-                // TODO(tillrohrmann): IdempotentRequestTarget proto doesn't carry scope yet
-                None,
-            )),
+            ) => {
+                // Before we accept an idempotent request we validate in
+                // ServiceProtocolRunner::handle_message that the scope value is valid.
+                let scope = idempotent_request
+                    .scope
+                    .as_ref()
+                    .map(|scope| Scope::new(scope));
+                Self::IdempotentRequest(IdempotencyId::new(
+                    idempotent_request.service_name.into(),
+                    idempotent_request.service_key.map(Into::into),
+                    idempotent_request.handler_name.into(),
+                    idempotent_request.idempotency_key.into(),
+                    scope,
+                ))
+            }
             proto::attach_invocation_command_message::Target::WorkflowTarget(workflow_target) => {
+                // Before we accept a workflow target we validate in
+                // ServiceProtocolRunner::handle_message that the scope value is valid.
+                let scope = workflow_target
+                    .scope
+                    .as_ref()
+                    .map(|scope| Scope::new(scope));
                 Self::Workflow(ServiceId::new(
-                    None,
+                    scope,
                     workflow_target.workflow_name,
                     workflow_target.workflow_key,
                 ))
@@ -1673,11 +1690,13 @@ impl From<AttachInvocationTarget> for proto::get_invocation_output_command_messa
                     service_key: id.service_key.map(Into::into),
                     handler_name: id.service_handler.into(),
                     idempotency_key: id.idempotency_key.into(),
+                    scope: id.scope.map(|s| s.to_string()),
                 })
             }
             AttachInvocationTarget::Workflow(id) => Self::WorkflowTarget(proto::WorkflowTarget {
                 workflow_name: id.service_name.into(),
                 workflow_key: id.key.into(),
+                scope: id.scope.map(|s| s.to_string()),
             }),
         }
     }
@@ -1691,25 +1710,42 @@ impl TryFrom<proto::get_invocation_output_command_message::Target> for AttachInv
     ) -> Result<Self, Self::Error> {
         Ok(match value {
             proto::get_invocation_output_command_message::Target::InvocationId(invocation_id) => {
+                // Before we accept an idempotent request we validate in
+                // ServiceProtocolRunner::handle_message that the invocation_id value is valid.
                 Self::InvocationId(to_invocation_id_or_bail!(invocation_id))
             }
             proto::get_invocation_output_command_message::Target::IdempotentRequestTarget(
                 idempotent_request,
-            ) => Self::IdempotentRequest(IdempotencyId::new(
-                idempotent_request.service_name.into(),
-                idempotent_request.service_key.map(Into::into),
-                idempotent_request.handler_name.into(),
-                idempotent_request.idempotency_key.into(),
-                // TODO(tillrohrmann): IdempotentRequestTarget proto doesn't carry scope yet
-                None,
-            )),
+            ) => {
+                // Before we accept an idempotent request we validate in
+                // ServiceProtocolRunner::handle_message that the scope value is valid.
+                let scope = idempotent_request
+                    .scope
+                    .as_ref()
+                    .map(|scope| Scope::new(scope));
+                Self::IdempotentRequest(IdempotencyId::new(
+                    idempotent_request.service_name.into(),
+                    idempotent_request.service_key.map(Into::into),
+                    idempotent_request.handler_name.into(),
+                    idempotent_request.idempotency_key.into(),
+                    scope,
+                ))
+            }
             proto::get_invocation_output_command_message::Target::WorkflowTarget(
                 workflow_target,
-            ) => Self::Workflow(ServiceId::new(
-                None,
-                workflow_target.workflow_name,
-                workflow_target.workflow_key,
-            )),
+            ) => {
+                // Before we accept a workflow target we validate in
+                // ServiceProtocolRunner::handle_message that the scope value is valid.
+                let scope = workflow_target
+                    .scope
+                    .as_ref()
+                    .map(|scope| Scope::new(scope));
+                Self::Workflow(ServiceId::new(
+                    scope,
+                    workflow_target.workflow_name,
+                    workflow_target.workflow_key,
+                ))
+            }
         })
     }
 }

--- a/crates/service-protocol-v4/src/lib.rs
+++ b/crates/service-protocol-v4/src/lib.rs
@@ -148,6 +148,175 @@ mod legacy {
     include!(concat!(env!("OUT_DIR"), "/dev.restate.service.legacy.rs"));
 }
 
+/// Shadow types matching a subset of the wire format of the full `proto`
+/// messages, used for partial deserialization on the validation hot path.
+/// Each type only declares the field tags relevant to validation; prost
+/// silently skips the remaining wire bytes during decoding.
+///
+/// # Important
+/// These messages need to be kept in sync with the protobuf messages from
+/// [`super::proto`]. Whenever the service protocol messages change, check
+/// these shadow types.
+pub mod proto_lite {
+    /// Shadow of [`super::proto::AttachInvocationCommandMessage`] that only
+    /// decodes the `target` oneof.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct AttachInvocationCommandMessageLite {
+        #[prost(oneof = "TargetLite", tags = "1, 3, 4")]
+        pub target: Option<TargetLite>,
+    }
+
+    /// Shadow of [`super::proto::get_invocation_output_command_message::Target`] and
+    /// [`super::proto::attach_invocation_command_message::Target`] that only decodes the target
+    /// parts that need validation.
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum TargetLite {
+        #[prost(string, tag = "1")]
+        InvocationId(String),
+        #[prost(message, tag = "3")]
+        IdempotentRequestTarget(IdempotentRequestTargetScopeLite),
+        #[prost(message, tag = "4")]
+        WorkflowTarget(WorkflowTargetScopeLite),
+    }
+
+    /// Shadow of [`super::proto::GetInvocationOutputCommandMessage`] that only
+    /// decodes the `target` oneof.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct GetInvocationOutputCommandMessageLite {
+        #[prost(oneof = "TargetLite", tags = "1, 3, 4")]
+        pub target: Option<TargetLite>,
+    }
+
+    /// Shadow of [`super::proto::WorkflowTarget`]. Only the `scope` field is
+    /// decoded since it is the only field validated at the invoker boundary.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct WorkflowTargetScopeLite {
+        #[prost(string, optional, tag = "3")]
+        pub scope: Option<String>,
+    }
+
+    /// Shadow of [`super::proto::IdempotentRequestTarget`]. Only the `scope`
+    /// field is decoded since it is the only field validated at the invoker
+    /// boundary.
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct IdempotentRequestTargetScopeLite {
+        #[prost(string, optional, tag = "5")]
+        pub scope: Option<String>,
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use prost::Message as _;
+
+        use super::{
+            AttachInvocationCommandMessageLite, GetInvocationOutputCommandMessageLite, TargetLite,
+        };
+        use crate::proto::{
+            AttachInvocationCommandMessage, GetInvocationOutputCommandMessage,
+            IdempotentRequestTarget, WorkflowTarget, attach_invocation_command_message,
+            get_invocation_output_command_message,
+        };
+
+        #[test]
+        fn attach_invocation_lite_decodes_invocation_id() {
+            let full = AttachInvocationCommandMessage {
+                target: Some(attach_invocation_command_message::Target::InvocationId(
+                    "inv_test".into(),
+                )),
+                result_completion_id: 42,
+                name: "ignored".into(),
+            };
+
+            let bytes = full.encode_to_vec();
+            let lite = AttachInvocationCommandMessageLite::decode(bytes.as_slice()).unwrap();
+
+            assert_eq!(
+                lite.target,
+                Some(TargetLite::InvocationId("inv_test".into()))
+            );
+        }
+
+        #[test]
+        fn attach_invocation_lite_decodes_idempotent_request_scope() {
+            let full = AttachInvocationCommandMessage {
+                target: Some(
+                    attach_invocation_command_message::Target::IdempotentRequestTarget(
+                        IdempotentRequestTarget {
+                            service_name: "svc".into(),
+                            service_key: Some("key".into()),
+                            handler_name: "handler".into(),
+                            idempotency_key: "idem".into(),
+                            scope: Some("scope-1".into()),
+                        },
+                    ),
+                ),
+                result_completion_id: 7,
+                name: "ignored".into(),
+            };
+
+            let bytes = full.encode_to_vec();
+            let lite = AttachInvocationCommandMessageLite::decode(bytes.as_slice()).unwrap();
+
+            match lite.target {
+                Some(TargetLite::IdempotentRequestTarget(inner)) => {
+                    assert_eq!(inner.scope.as_deref(), Some("scope-1"))
+                }
+                other => panic!("unexpected target: {other:?}"),
+            }
+        }
+
+        #[test]
+        fn get_invocation_output_lite_decodes_workflow_target_scope() {
+            let full = GetInvocationOutputCommandMessage {
+                target: Some(
+                    get_invocation_output_command_message::Target::WorkflowTarget(WorkflowTarget {
+                        workflow_name: "wf".into(),
+                        workflow_key: "key".into(),
+                        scope: Some("scope-2".into()),
+                    }),
+                ),
+                result_completion_id: 11,
+                name: "ignored".into(),
+            };
+
+            let bytes = full.encode_to_vec();
+            let lite = GetInvocationOutputCommandMessageLite::decode(bytes.as_slice()).unwrap();
+
+            match lite.target {
+                Some(TargetLite::WorkflowTarget(inner)) => {
+                    assert_eq!(inner.scope.as_deref(), Some("scope-2"))
+                }
+                other => panic!("unexpected target: {other:?}"),
+            }
+        }
+
+        #[test]
+        fn get_invocation_output_lite_decodes_workflow_target_without_scope() {
+            let full = GetInvocationOutputCommandMessage {
+                target: Some(
+                    get_invocation_output_command_message::Target::WorkflowTarget(WorkflowTarget {
+                        workflow_name: "wf".into(),
+                        workflow_key: "key".into(),
+                        scope: None,
+                    }),
+                ),
+                result_completion_id: 11,
+                name: "ignored".into(),
+            };
+
+            let bytes = full.encode_to_vec();
+            let lite = GetInvocationOutputCommandMessageLite::decode(bytes.as_slice()).unwrap();
+
+            match lite.target {
+                Some(TargetLite::WorkflowTarget(inner)) => {
+                    assert_eq!(inner.scope, None)
+                }
+                other => panic!("unexpected target: {other:?}"),
+            }
+        }
+    }
+}
+
 #[cfg(feature = "message-codec")]
 mod dto {
     use prost::Message;

--- a/crates/service-protocol-v4/src/lib.rs
+++ b/crates/service-protocol-v4/src/lib.rs
@@ -36,7 +36,9 @@ pub mod proto {
         ProposeRunCompletionMessage,
         CallCommandMessage,
         OneWayCallCommandMessage,
-        AwaitingOnMessage
+        AwaitingOnMessage,
+        AttachInvocationCommandMessage,
+        GetInvocationOutputCommandMessage
     );
 
     mod pb_conversion {

--- a/crates/service-protocol-v4/src/message_codec/encoding.rs
+++ b/crates/service-protocol-v4/src/message_codec/encoding.rs
@@ -329,6 +329,9 @@ mod tests {
             10,
             Duration::ZERO,
             10,
+            None,
+            &LimitKey::None,
+            None,
         );
 
         let expected_msg_1 = Message::InputCommand(Bytes::from_static(b"123"));

--- a/crates/service-protocol-v4/src/message_codec/mod.rs
+++ b/crates/service-protocol-v4/src/message_codec/mod.rs
@@ -368,9 +368,9 @@ gen_message!(
     Run Command noparse allows_ack = 0x0411,
     Run CompletionNotification noparse = 0x8011,
 
-    AttachInvocation Command noparse allows_ack = 0x0412,
+    AttachInvocation Command allows_ack = 0x0412,
     AttachInvocation CompletionNotification noparse = 0x8012,
-    GetInvocationOutput Command noparse allows_ack = 0x0413,
+    GetInvocationOutput Command allows_ack = 0x0413,
     GetInvocationOutput CompletionNotification noparse = 0x8013,
 
     CompleteAwakeable Command noparse allows_ack = 0x0414,

--- a/crates/service-protocol-v4/src/message_codec/mod.rs
+++ b/crates/service-protocol-v4/src/message_codec/mod.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 mod encoding;
 mod header;
 
+pub use crate::proto;
 pub(crate) use encoding::default_encode_decode;
 pub use encoding::{
     Decoder, Encoder, EncodingError, MessageEncodingError, ServiceWireDecoder, ServiceWireEncoder,
@@ -26,8 +27,8 @@ pub use proto::start_message::StateEntry;
 use restate_types::journal_v2::{
     CommandIndex, CommandType, CompletionType, EntryType, NotificationType,
 };
-
-pub use crate::proto;
+use restate_types::{LimitKey, Scope};
+use restate_util_string::ReString;
 
 const CUSTOM_MESSAGE_MASK: u16 = 0xFC00;
 
@@ -390,6 +391,9 @@ impl Message {
         retry_count_since_last_stored_entry: u32,
         duration_since_last_stored_entry: Duration,
         random_seed: u64,
+        scope: Option<&Scope>,
+        limit_key: &LimitKey<ReString>,
+        idempotency_key: Option<&ReString>,
     ) -> Self {
         Self::Start(proto::StartMessage {
             id,
@@ -403,6 +407,13 @@ impl Message {
             retry_count_since_last_stored_entry,
             duration_since_last_stored_entry: duration_since_last_stored_entry.as_millis() as u64,
             random_seed,
+            scope: scope.map(|scope| scope.to_string()),
+            limit_key: if limit_key == &LimitKey::None {
+                None
+            } else {
+                Some(limit_key.to_string())
+            },
+            idempotency_key: idempotency_key.map(|value| value.to_string()),
         })
     }
 

--- a/crates/service-protocol-v4/src/message_codec/mod.rs
+++ b/crates/service-protocol-v4/src/message_codec/mod.rs
@@ -369,9 +369,9 @@ gen_message!(
     Run Command noparse allows_ack = 0x0411,
     Run CompletionNotification noparse = 0x8011,
 
-    AttachInvocation Command allows_ack = 0x0412,
+    AttachInvocation Command noparse allows_ack = 0x0412,
     AttachInvocation CompletionNotification noparse = 0x8012,
-    GetInvocationOutput Command allows_ack = 0x0413,
+    GetInvocationOutput Command noparse allows_ack = 0x0413,
     GetInvocationOutput CompletionNotification noparse = 0x8013,
 
     CompleteAwakeable Command noparse allows_ack = 0x0414,

--- a/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
@@ -30,6 +30,8 @@ message InvocationTarget {
 message ServiceId {
   bytes service_name = 1;
   bytes service_key = 2;
+  // Since v1.7.0 — scope for vqueue partitioning. Empty string means no scope.
+  optional string scope = 3;
 }
 
 message IdempotencyId {

--- a/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
@@ -39,6 +39,8 @@ message IdempotencyId {
   optional string service_key = 2;
   string handler_name = 3;
   string idempotency_key = 4;
+  // Since v1.7.0 — scope for vqueue partitioning. Empty string means no scope.
+  optional string scope = 5;
 }
 
 message GenerationalNodeId {

--- a/crates/storage-api/src/protobuf_types.rs
+++ b/crates/storage-api/src/protobuf_types.rs
@@ -2016,8 +2016,9 @@ pub mod v1 {
             type Error = ConversionError;
 
             fn try_from(service_id: ServiceId) -> Result<Self, ConversionError> {
+                let scope = service_id.scope.as_ref().map(|scope| Scope::new(scope));
                 Ok(restate_types::identifiers::ServiceId::new(
-                    None,
+                    scope,
                     ByteString::try_from(service_id.service_name)
                         .map_err(ConversionError::invalid_data)?,
                     ByteString::try_from(service_id.service_key)
@@ -2031,6 +2032,7 @@ pub mod v1 {
                 ServiceId {
                     service_key: service_id.key.into_bytes(),
                     service_name: service_id.service_name.into_bytes(),
+                    scope: service_id.scope.map(|s| s.to_string()),
                 }
             }
         }

--- a/crates/storage-api/src/protobuf_types.rs
+++ b/crates/storage-api/src/protobuf_types.rs
@@ -223,6 +223,7 @@ pub mod v1 {
                     service_key: value.service_key.map(Into::into),
                     handler_name: value.service_handler.into(),
                     idempotency_key: value.idempotency_key.into(),
+                    scope: value.scope.map(|s| s.to_string()),
                 }
             }
         }
@@ -231,11 +232,13 @@ pub mod v1 {
             type Error = ConversionError;
 
             fn try_from(value: IdempotencyId) -> Result<Self, ConversionError> {
+                let scope = value.scope.as_ref().map(|scope| Scope::new(scope));
                 Ok(restate_types::identifiers::IdempotencyId::new(
                     value.service_name.into(),
                     value.service_key.map(Into::into),
                     value.handler_name.into(),
                     value.idempotency_key.into(),
+                    scope,
                 ))
             }
         }

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -674,6 +674,8 @@ pub struct IdempotencyId {
     pub service_handler: ByteString,
     /// The user supplied idempotency_key
     pub idempotency_key: ByteString,
+    /// Optional scope for vqueue partitioning
+    pub scope: Option<Scope>,
 
     partition_key: PartitionKey,
 }
@@ -684,23 +686,29 @@ impl IdempotencyId {
         service_key: Option<ByteString>,
         service_handler: ByteString,
         idempotency_key: ByteString,
+        scope: Option<Scope>,
     ) -> Self {
-        // The ownership model for idempotent invocations is the following:
-        //
+        // When scoped, the partition key comes from the scope.
+        // Otherwise:
         // * For services without key, the partition key is the hash(idempotency key).
-        //   This makes sure that for a given idempotency key and its scope, we always land in the same partition.
-        // * For services with key, the partition key is the hash(service key), this due to the virtual object locking requirement.
-        let partition_key = deterministic_partition_key(
-            service_key.as_ref().map(|bs| bs.as_ref()),
-            Some(&idempotency_key),
-        )
-        .expect("A deterministic partition key can always be generated for idempotency id");
+        // * For services with key, the partition key is the hash(service key).
+        let partition_key = scope
+            .as_ref()
+            .map(|s| s.partition_key())
+            .or_else(|| {
+                deterministic_partition_key(
+                    service_key.as_ref().map(|bs| bs.as_ref()),
+                    Some(&idempotency_key),
+                )
+            })
+            .expect("A deterministic partition key can always be generated for idempotency id");
 
         Self {
             service_name,
             service_key,
             service_handler,
             idempotency_key,
+            scope,
             partition_key,
         }
     }
@@ -715,6 +723,7 @@ impl IdempotencyId {
             service_key: invocation_target.key().cloned(),
             service_handler: invocation_target.handler_name().clone(),
             idempotency_key,
+            scope: invocation_target.scope().cloned(),
             partition_key: invocation_id.partition_key(),
         }
     }
@@ -1383,6 +1392,7 @@ mod mocks {
                 service_key: None,
                 service_handler: ByteString::from_static(service_handler),
                 idempotency_key: ByteString::from_static(idempotency_key),
+                scope: None,
                 partition_key,
             }
         }
@@ -1393,6 +1403,7 @@ mod mocks {
                 Some(Alphanumeric.sample_string(&mut rand::rng(), 16).into()),
                 Alphanumeric.sample_string(&mut rand::rng(), 8).into(),
                 Alphanumeric.sample_string(&mut rand::rng(), 8).into(),
+                None,
             )
         }
     }

--- a/crates/types/src/invocation/mod.rs
+++ b/crates/types/src/invocation/mod.rs
@@ -1400,7 +1400,7 @@ impl InvocationQuery {
                     handler: Default::default(),
                     // Must be the workflow handler type
                     handler_ty: WorkflowHandlerType::Workflow,
-                    scope: None,
+                    scope: wfid.scope.clone(),
                 },
                 None,
             ),

--- a/crates/types/src/invocation/mod.rs
+++ b/crates/types/src/invocation/mod.rs
@@ -1409,6 +1409,7 @@ impl InvocationQuery {
                 service_key,
                 service_handler,
                 idempotency_key,
+                scope,
                 ..
             }) => {
                 let target = match service_key {
@@ -1422,7 +1423,8 @@ impl InvocationQuery {
                         // Doesn't really matter
                         VirtualObjectHandlerType::Exclusive,
                     ),
-                };
+                }
+                .with_scope(scope.clone());
                 InvocationId::generate(&target, Some(idempotency_key.deref()))
             }
         }

--- a/crates/types/src/service_protocol.rs
+++ b/crates/types/src/service_protocol.rs
@@ -474,11 +474,13 @@ mod pb_into {
                 idempotency_key,
             }: IdempotentRequestTarget,
         ) -> Self {
+            // TODO(tillrohrmann): IdempotentRequestTarget doesn't carry scope yet
             IdempotencyId::new(
                 service_name.into(),
                 service_key.map(Into::into),
                 handler_name.into(),
                 idempotency_key.into(),
+                None,
             )
         }
     }

--- a/crates/types/src/service_protocol.rs
+++ b/crates/types/src/service_protocol.rs
@@ -474,7 +474,7 @@ mod pb_into {
                 idempotency_key,
             }: IdempotentRequestTarget,
         ) -> Self {
-            // TODO(tillrohrmann): IdempotentRequestTarget doesn't carry scope yet
+            // V3 protocol types don't carry scope
             IdempotencyId::new(
                 service_name.into(),
                 service_key.map(Into::into),
@@ -492,7 +492,7 @@ mod pb_into {
                 workflow_key,
             }: WorkflowTarget,
         ) -> Self {
-            // todo(tillrohrmann) teach the service protocol to select a scoped workflow target
+            // V3 protocol types don't carry scope
             ServiceId::new(None, workflow_name, workflow_key)
         }
     }

--- a/crates/vqueues/src/cache.rs
+++ b/crates/vqueues/src/cache.rs
@@ -106,6 +106,10 @@ impl VQueuesMetaCache {
         VQueuesMeta::new(self)
     }
 
+    pub fn get(&self, key: VQueueCacheKey) -> Option<&Slot> {
+        self.slab.get(key)
+    }
+
     pub fn get_mut(&mut self, key: VQueueCacheKey) -> Option<&mut Slot> {
         self.slab.get_mut(key)
     }

--- a/crates/vqueues/src/lib.rs
+++ b/crates/vqueues/src/lib.rs
@@ -117,6 +117,10 @@ where
     A: From<VQueueEvent> + 'static,
     S: WriteVQueueTable + ReadVQueueTable + WriteLockTable,
 {
+    pub fn meta(&self) -> &VQueueMeta {
+        self.cache.get(self.cache_key).unwrap().meta()
+    }
+
     /// The entry has completed execution and it needs to be removed from the vqueue.
     ///
     /// Does nothing if the entry was not found in the previous stage.

--- a/crates/worker-api/src/invoker/handle.rs
+++ b/crates/worker-api/src/invoker/handle.rs
@@ -8,13 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use crate::resources::ReservedResources;
 use restate_errors::NotRunningError;
+use restate_types::LimitKey;
 use restate_types::identifiers::{EntryIndex, InvocationId};
 use restate_types::invocation::InvocationTarget;
 use restate_types::journal_v2::{CommandIndex, NotificationId};
 use restate_types::vqueues::VQueueId;
-
-use crate::resources::ReservedResources;
+use restate_util_string::ReString;
 
 pub trait InvokerHandle {
     fn invoke(
@@ -29,6 +30,8 @@ pub trait InvokerHandle {
         permit: ReservedResources,
         invocation_id: InvocationId,
         invocation_target: InvocationTarget,
+        limit_key: LimitKey<ReString>,
+        idempotency_key: Option<ReString>,
     ) -> Result<(), NotRunningError>;
 
     fn notify_completion(

--- a/crates/worker/src/partition/leadership/leader_state.rs
+++ b/crates/worker/src/partition/leadership/leader_state.rs
@@ -690,6 +690,8 @@ impl LeaderState {
                 qid,
                 key,
                 invocation_target,
+                limit_key,
+                idempotency_key,
             } => {
                 // state mutations should not create Invoke actions. At least for now.
                 assert!(matches!(key.kind(), vqueues::EntryKind::Invocation));
@@ -707,7 +709,14 @@ impl LeaderState {
                     ReservedResources::new_empty()
                 });
                 self.invoker_handle
-                    .vqueue_invoke(qid, run_permit, invocation_id, invocation_target)
+                    .vqueue_invoke(
+                        qid,
+                        run_permit,
+                        invocation_id,
+                        invocation_target,
+                        limit_key,
+                        idempotency_key,
+                    )
                     .map_err(Error::Invoker)?
             }
         }

--- a/crates/worker/src/partition/state_machine/actions.rs
+++ b/crates/worker/src/partition/state_machine/actions.rs
@@ -11,6 +11,7 @@
 use restate_storage_api::outbox_table::OutboxMessage;
 use restate_storage_api::timer_table::TimerKey;
 use restate_storage_api::vqueue_table::EntryKey;
+use restate_types::LimitKey;
 use restate_types::identifiers::{EntryIndex, InvocationId, PartitionProcessorRpcRequestId};
 use restate_types::invocation::InvocationTarget;
 use restate_types::invocation::client::{
@@ -21,6 +22,7 @@ use restate_types::journal_v2::{CommandIndex, NotificationId};
 use restate_types::message::MessageIndex;
 use restate_types::time::MillisSinceEpoch;
 use restate_types::vqueues::VQueueId;
+use restate_util_string::ReString;
 use restate_vqueues::VQueueEvent;
 use restate_wal_protocol::timer::TimerKeyValue;
 
@@ -35,6 +37,8 @@ pub enum Action {
         qid: VQueueId,
         key: EntryKey,
         invocation_target: InvocationTarget,
+        limit_key: LimitKey<ReString>,
+        idempotency_key: Option<ReString>,
     },
     Invoke {
         invocation_id: InvocationId,

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -1229,6 +1229,7 @@ impl<S> StateMachineApplyContext<'_, S> {
         invocation_id: InvocationId,
         mut in_flight_invocation_metadata: InFlightInvocationMetadata,
         invocation_input: Option<InvocationInput>,
+        limit_key: LimitKey<ReString>,
     ) -> Result<(), Error>
     where
         S: WriteJournalTable + WriteInvocationStatusTable + journal_table_v2::WriteJournalTable,
@@ -1252,7 +1253,13 @@ impl<S> StateMachineApplyContext<'_, S> {
             )?;
         }
 
-        self.vqueue_invoke(qid, key, invocation_id, in_flight_invocation_metadata)
+        self.vqueue_invoke(
+            qid,
+            key,
+            invocation_id,
+            in_flight_invocation_metadata,
+            limit_key,
+        )
     }
 
     /// Inits the journal if invocation_input is `Some` and invokes the invocation. If
@@ -1365,6 +1372,7 @@ impl<S> StateMachineApplyContext<'_, S> {
         key: &EntryKey,
         invocation_id: InvocationId,
         in_flight_invocation_metadata: InFlightInvocationMetadata,
+        limit_key: LimitKey<ReString>,
     ) -> Result<(), Error>
     where
         S: WriteInvocationStatusTable,
@@ -1378,11 +1386,14 @@ impl<S> StateMachineApplyContext<'_, S> {
             .map_err(Error::Storage)?;
 
         if self.is_leader {
-            let invocation_target = status.into_invocation_metadata().unwrap().invocation_target;
+            let invocation_metadata = status.into_invocation_metadata().unwrap();
+            let invocation_target = invocation_metadata.invocation_target;
             self.action_collector.push(Action::VQInvoke {
                 qid: qid.clone(),
                 key: *key,
                 invocation_target,
+                limit_key,
+                idempotency_key: invocation_metadata.idempotency_key.map(ReString::new_owned),
             });
         }
 
@@ -3014,21 +3025,30 @@ impl<S> StateMachineApplyContext<'_, S> {
             info!("Resuming invocation {invocation_id}, scheduler stats: {wait_stats:?}");
 
             let status = self.get_invocation_status(&invocation_id).await?;
-            VQueue::get(
+            let mut vqueue = VQueue::get(
                 qid,
                 self.storage,
                 self.vqueues_cache,
                 self.is_leader.then_some(self.action_collector),
             )
             .await?
-            .unwrap()
-            .run_entry(record_unique_ts, &header, wait_stats);
+            .unwrap();
+
+            vqueue.run_entry(record_unique_ts, &header, wait_stats);
+
+            let limit_key = vqueue.meta().limit_key().clone();
 
             if self.is_leader {
                 self.action_collector.push(Action::VQInvoke {
                     qid: qid.clone(),
                     key: *entry_key,
                     invocation_target: status.invocation_target().unwrap().clone(),
+                    limit_key,
+                    // todo(tillrohrmann) avoid the transformation from ByteString to ReString by
+                    //  storing the idempotency key as ReString in the first place
+                    idempotency_key: status
+                        .idempotency_key()
+                        .map(|value| ReString::new_shared(value.as_ref())),
                 });
             }
             return Ok(());
@@ -3081,15 +3101,18 @@ impl<S> StateMachineApplyContext<'_, S> {
                     );
 
                 info!("Starting invocation {invocation_id}, scheduler stats: {wait_stats:?}");
-                VQueue::get(
+                let mut vqueue = VQueue::get(
                     qid,
                     self.storage,
                     self.vqueues_cache,
                     self.is_leader.then_some(self.action_collector),
                 )
                 .await?
-                .unwrap()
-                .run_entry(record_unique_ts, &header, wait_stats);
+                .unwrap();
+
+                vqueue.run_entry(record_unique_ts, &header, wait_stats);
+
+                let limit_key = vqueue.meta().limit_key().clone();
 
                 self.init_journal_and_vqueue_invoke(
                     qid,
@@ -3097,6 +3120,7 @@ impl<S> StateMachineApplyContext<'_, S> {
                     invocation_id,
                     metadata,
                     invocation_input,
+                    limit_key,
                 )?;
             }
             _ => {

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -798,6 +798,16 @@ impl<S> StateMachineApplyContext<'_, S> {
     {
         // A pre-flight invocation has been already deduplicated
 
+        // Invariant: limit_key requires scope (defense-in-depth, ingress should also validate)
+        debug_assert!(
+            limit_key.is_empty()
+                || pre_flight_invocation_metadata
+                    .invocation_target
+                    .scope()
+                    .is_some(),
+            "limit_key set without scope — this should have been rejected at the ingress"
+        );
+
         // 0. Prepare the journal table v2. This ensures that all newly created invocations will
         // have a journal v2 created. To handle already existing invocations for which we didn't
         // create the journal yet, there is a separate path in init_journal to create the journal

--- a/service-protocol/dev/restate/service/protocol.proto
+++ b/service-protocol/dev/restate/service/protocol.proto
@@ -43,6 +43,8 @@ enum ServiceProtocolVersion {
   // * CallCommandMessage.limit_key
   // * OneWayCallCommandMessage.scope
   // * OneWayCallCommandMessage.limit_key
+  // * WorkflowTarget.scope
+  // * IdempotentRequestTarget.scope
   V7 = 7;
 }
 
@@ -731,6 +733,9 @@ message Header {
 message WorkflowTarget {
   string workflow_name = 1;
   string workflow_key = 2;
+  // Scope for the invocation target. Empty string means no scope (unscoped invocation).
+  // Since V7.
+  optional string scope = 3;
 }
 
 message IdempotentRequestTarget {
@@ -738,6 +743,9 @@ message IdempotentRequestTarget {
   optional string service_key = 2;
   string handler_name = 3;
   string idempotency_key = 4;
+  // Scope for the invocation target. Empty string means no scope (unscoped invocation).
+  // Since V7.
+  optional string scope = 5;
 }
 
 message Void {

--- a/service-protocol/dev/restate/service/protocol.proto
+++ b/service-protocol/dev/restate/service/protocol.proto
@@ -39,12 +39,11 @@ enum ServiceProtocolVersion {
   V6 = 6;
   // Added:
   // * Future & AwaitingOnMessage + Changed the SuspensionMessage
-  // * CallCommandMessage.scope
-  // * CallCommandMessage.limit_key
-  // * OneWayCallCommandMessage.scope
-  // * OneWayCallCommandMessage.limit_key
+  // * CallCommandMessage.scope and CallCommandMessage.limit_key
+  // * OneWayCallCommandMessage.scope and OneWayCallCommandMessage.limit_key
   // * WorkflowTarget.scope
   // * IdempotentRequestTarget.scope
+  // * StartMessage.scope, StartMessage.limit_key and StartMessage.idempotency_key
   V7 = 7;
 }
 
@@ -91,6 +90,18 @@ message StartMessage {
   // Random seed to use to seed the deterministic RNG exposed in the context API.
   // This will be stable across restarts.
   uint64 random_seed = 9;
+
+  // If this invocation was called within a scope, returns the scope
+  // Since V7
+  optional string scope = 10;
+
+  // If this invocation was called with a limit key, returns the limit key
+  // Since V7
+  optional string limit_key = 11;
+
+  // If this invocation was called with an idempotency key, returns the idempotency key
+  // Since V7
+  optional string idempotency_key = 12;
 }
 
 // Defines how a set of child futures are combined.


### PR DESCRIPTION
This PR adds the scope field to a few persisted data structures like `ServiceId` and `IdempotencyId`. Moreover, it exposes scopes to workflows and state mutations. Last but not least, it extends the service protocol V7 such that the StartMessage carries the scope, limit and idempotency information.