### PR TITLE
[Limiter] Add RuleBook persistent data model and writer/diff logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3626,9 +3626,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "1.3.5"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf57c49a95fd1fe24b90b3033bee6dc7e8f1288d51494cb44e627c295e38542"
+checksum = "dab9e9188e97a93276e1fe7b56401b851e2b45a46d045ca658100c1303ada649"
 dependencies = [
  "rustversion",
  "typenum",
@@ -7669,6 +7669,9 @@ name = "restate-limiter"
 version = "1.7.0-dev"
 dependencies = [
  "bilrost",
+ "bytes",
+ "restate-clock",
+ "restate-encoding",
  "restate-limiter",
  "restate-types",
  "restate-util-string",
@@ -8506,7 +8509,7 @@ dependencies = [
  "flexbuffers",
  "futures",
  "gardal",
- "generic-array 1.3.5",
+ "generic-array 1.4.1",
  "googletest",
  "hostname",
  "http 1.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,6 +165,7 @@ futures = "0.3.31"
 futures-sink = "0.3.31"
 futures-util = "0.3.31"
 gardal = { version = "0.0.1-alpha.9" }
+generic-array = { version = "1.4.1" }
 googletest = { version = "0.10", features = ["anyhow"] }
 hashbrown = { version = "0.16" }
 slotmap = { version = "1" }

--- a/crates/limiter/Cargo.toml
+++ b/crates/limiter/Cargo.toml
@@ -10,17 +10,31 @@ description = "Hierarchical concurrency limiter with 3-level rule matching"
 
 [features]
 default = []
+# Enables bilrost encoding for limiter types that contain ReString
+# (LimitKey, RulePattern). Lets external crates put those into bilrost
+# messages without pulling in the rule book.
 bilrost = ["dep:bilrost", "restate-util-string/bilrost"]
+# Enables the persistent rule book (RuleBook, PersistedRule,
+# diff/apply_change machinery). Implies `bilrost`.
+rule-book = [
+    "bilrost",
+    "dep:bytes",
+    "dep:restate-clock",
+    "dep:restate-encoding",
+]
 
 [dependencies]
 restate-workspace-hack = { workspace = true }
 
+restate-clock = { workspace = true, optional = true }
+restate-encoding = { workspace = true, optional = true }
 restate-types = { workspace = true }
 restate-util-string = { workspace = true }
 
 bilrost = { workspace = true, optional = true }
+bytes = { workspace = true, optional = true }
 slotmap = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-restate-limiter = { path = ".", default-features = false, features = ["bilrost"] }
+restate-limiter = { path = ".", default-features = false, features = ["rule-book"] }

--- a/crates/limiter/src/lib.rs
+++ b/crates/limiter/src/lib.rs
@@ -41,12 +41,18 @@
 
 mod key;
 mod rule;
+#[cfg(feature = "rule-book")]
+pub mod rule_book;
 mod rule_store;
+mod user_limits;
 
 // Re-exports
 pub use key::LimitKey;
 pub use rule::{Pattern, RuleHandle, RulePattern};
+#[cfg(feature = "rule-book")]
+pub use rule_book::{PersistedRule, Precondition, RuleBook, RuleBookError, RuleChange, RuleUpsert};
 pub use rule_store::{Limit, Rules, StructuredLimits};
+pub use user_limits::{RuleUpdate, UserLimits};
 
 /// Represents the hierarchy level of counters or rules
 ///

--- a/crates/limiter/src/rule.rs
+++ b/crates/limiter/src/rule.rs
@@ -54,7 +54,7 @@ pub enum ParseError {
 ///
 /// The wildcard character is `*`. Component values must be valid restricted values
 /// (only `[a-zA-Z0-9_.-]`, non-empty, max 36 bytes).
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub enum RulePattern<S: StringLike> {
     /// A rule that defines a limit for the scope level
     Scope(Pattern<S>),
@@ -164,7 +164,7 @@ impl<S: StringLike> std::fmt::Display for RulePattern<S> {
 }
 
 /// A pattern component that matches either an exact value or any value (wildcard).
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
 pub enum Pattern<S: StringLike> {
     /// Match a specific value.
     Exact(RestrictedValue<S>),

--- a/crates/limiter/src/rule_book.rs
+++ b/crates/limiter/src/rule_book.rs
@@ -1,0 +1,988 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Persistent, versioned rule book that backs the in-memory [`crate::Rules`] store.
+
+use std::collections::{HashMap, HashSet};
+
+use restate_clock::time::MillisSinceEpoch;
+use restate_types::{Version, Versioned};
+use restate_util_string::ReString;
+
+use crate::{RulePattern, RuleUpdate, UserLimits};
+
+/// Hard cap on the number of rules a single rule book may carry.
+///
+/// Prevents an admin from accidentally producing a book that exceeds the
+/// metadata-store value-size limit (~32 MB). A configurable knob will
+/// replace this constant once the user-facing API stabilizes.
+pub const MAX_RULES_PER_BOOK: usize = 10_000;
+
+/// One persisted rule entry. Keyed by its [`RulePattern`] in the
+/// owning [`RuleBook`].
+#[derive(Debug, Clone, PartialEq, Eq, bilrost::Message)]
+pub struct PersistedRule {
+    /// Per-rule version. Advances on runtime-relevant changes
+    /// (`limits`, `disabled`); reason-only edits leave it alone. See
+    /// [`RuleBook::apply_changes`] for the full bump contract.
+    #[bilrost(tag(1))]
+    pub version: Version,
+    #[bilrost(tag(3))]
+    pub limits: UserLimits,
+    /// Operator-supplied note explaining why the rule was created or
+    /// modified.
+    #[bilrost(tag(4))]
+    pub reason: Option<String>,
+    /// Soft tombstone. `true` parks the rule so the runtime treats it
+    /// as absent without removing the persisted entry.
+    #[bilrost(tag(5))]
+    pub disabled: bool,
+    /// Wall-clock time of the last write that touched this entry.
+    /// Informational only — runtime semantics depend on `version`.
+    #[bilrost(tag(6))]
+    pub last_modified: MillisSinceEpoch,
+}
+
+/// The cluster-wide rule book.
+///
+/// Lives under a single key in the metadata store. The
+/// [`crate::rule_store::Rules`] runtime store is materialized from this.
+///
+/// Rules are keyed by their [`RulePattern`] so the pattern is the single
+/// source of truth for a rule's identity.
+#[derive(Debug, Clone, PartialEq, Eq, bilrost::Message)]
+pub struct RuleBook {
+    #[bilrost(tag(1))]
+    version: Version,
+    #[bilrost(tag(2), encoding(map<general, general>))]
+    rules: HashMap<RulePattern<ReString>, PersistedRule>,
+}
+
+impl RuleBook {
+    /// Empty book at [`Version::INVALID`]. The first successful write bumps
+    /// it to [`Version::MIN`].
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&RulePattern<ReString>, &PersistedRule)> {
+        self.rules.iter()
+    }
+
+    pub fn get(&self, pattern: &RulePattern<ReString>) -> Option<&PersistedRule> {
+        self.rules.get(pattern)
+    }
+
+    pub fn len(&self) -> usize {
+        self.rules.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+
+    /// Apply a batch of CRUD-style changes to the rule book atomically.
+    ///
+    /// Changes are processed in iteration order. The batch is
+    /// all-or-nothing: every precondition and the [`MAX_RULES_PER_BOOK`]
+    /// cap are checked against the *evolving* state of the batch (so a
+    /// rule deleted earlier in the batch counts as absent for later
+    /// steps). On error nothing is mutated; on success all changes are
+    /// committed in one go.
+    ///
+    /// The book version is bumped by exactly one if the batch produces
+    /// any state change, and is unchanged otherwise. Per-rule versions
+    /// are bumped only on runtime-relevant changes (`limits`,
+    /// `disabled`); reason-only edits leave the per-rule version alone.
+    /// Pure no-op upserts and deletes of already-absent rules don't move
+    /// anything.
+    pub fn apply_changes<I>(&mut self, changes: I) -> Result<(), RuleBookError>
+    where
+        I: IntoIterator<Item = (RulePattern<ReString>, RuleChange)>,
+    {
+        // Per-touched-pattern post-batch state. Some(rule) = insert/replace
+        // in self.rules; None = remove from self.rules. Patterns absent
+        // from this map are read straight from self.rules during the walk
+        // (so memory cost is O(touched), not O(book)).
+        let mut staged: HashMap<RulePattern<ReString>, Option<PersistedRule>> = HashMap::new();
+        let mut sim_count = self.rules.len();
+        let new_book_version = self.version.next();
+        let now = MillisSinceEpoch::now();
+
+        for (pattern, change) in changes {
+            let resolved: Option<&PersistedRule> = match staged.get(&pattern) {
+                Some(slot) => slot.as_ref(),
+                None => self.rules.get(&pattern),
+            };
+            let actual_version = resolved.map(|r| r.version);
+
+            match change {
+                RuleChange::Upsert(upsert) => {
+                    if !check_precondition(upsert.precondition, actual_version) {
+                        return Err(RuleBookError::PreconditionFailed {
+                            pattern,
+                            precondition: upsert.precondition,
+                            actual: actual_version,
+                        });
+                    }
+                    match resolved {
+                        None => {
+                            if sim_count >= MAX_RULES_PER_BOOK {
+                                return Err(RuleBookError::CapExceeded {
+                                    cap: MAX_RULES_PER_BOOK,
+                                });
+                            }
+                            sim_count += 1;
+                            staged.insert(
+                                pattern,
+                                Some(PersistedRule {
+                                    version: new_book_version,
+                                    limits: upsert.limits,
+                                    reason: upsert.reason,
+                                    disabled: upsert.disabled,
+                                    last_modified: now,
+                                }),
+                            );
+                        }
+                        Some(existing) => {
+                            let runtime_changed = existing.limits != upsert.limits
+                                || existing.disabled != upsert.disabled;
+                            let anything_changed =
+                                runtime_changed || existing.reason != upsert.reason;
+                            if anything_changed {
+                                let (new_version, last_modified) = if runtime_changed {
+                                    (existing.version.next(), now)
+                                } else {
+                                    (existing.version, existing.last_modified)
+                                };
+                                staged.insert(
+                                    pattern,
+                                    Some(PersistedRule {
+                                        version: new_version,
+                                        limits: upsert.limits,
+                                        reason: upsert.reason,
+                                        disabled: upsert.disabled,
+                                        last_modified,
+                                    }),
+                                );
+                            }
+                        }
+                    }
+                }
+                RuleChange::Delete { precondition } => {
+                    if !check_precondition(precondition, actual_version) {
+                        return Err(RuleBookError::PreconditionFailed {
+                            pattern,
+                            precondition,
+                            actual: actual_version,
+                        });
+                    }
+                    if resolved.is_some() {
+                        sim_count -= 1;
+                        staged.insert(pattern, None);
+                    }
+                }
+            }
+        }
+
+        if staged.is_empty() {
+            return Ok(());
+        }
+
+        for (pattern, rule) in staged {
+            match rule {
+                Some(rule) => {
+                    self.rules.insert(pattern, rule);
+                }
+                None => {
+                    self.rules.remove(&pattern);
+                }
+            }
+        }
+        self.version = new_book_version;
+
+        Ok(())
+    }
+
+    /// Convenience wrapper around [`Self::apply_changes`] for a single
+    /// change.
+    pub fn apply_change(
+        &mut self,
+        pattern: RulePattern<ReString>,
+        change: RuleChange,
+    ) -> Result<(), RuleBookError> {
+        self.apply_changes(std::iter::once((pattern, change)))
+    }
+
+    /// Compute the runtime-relevant diff against `previous`. Returns the
+    /// list of [`RuleUpdate`]s that should be forwarded to the per-PP
+    /// `UserLimiter`.
+    ///
+    /// Projection rules:
+    /// - A rule is *visible* in the projection iff it is present and
+    ///   `disabled == false`.
+    /// - A rule transitioning from invisible → visible emits `Upsert`.
+    /// - Visible → invisible (disabled or deleted) emits `Remove`.
+    /// - Visible in both with a different per-rule `version` emits
+    ///   `Upsert` (the per-rule version is the single source of truth for
+    ///   "anything runtime-relevant changed").
+    /// - Visible in both with equal per-rule `version` emits nothing.
+    ///
+    /// `last_modified` and `reason` never produce updates on their own.
+    pub fn diff(&self, previous: &Self) -> Vec<RuleUpdate> {
+        let mut updates = Vec::new();
+
+        let mut removals: HashSet<_> = previous.rules.keys().collect();
+
+        for (pattern, current) in &self.rules {
+            // pattern hasn't been removed from self
+            removals.remove(&pattern);
+
+            let current_visible = !current.disabled;
+            let prev_visible_version = previous
+                .rules
+                .get(pattern)
+                .filter(|r| !r.disabled)
+                .map(|r| r.version);
+
+            match (prev_visible_version, current_visible) {
+                // Was visible, still visible — only emit if version changed.
+                (Some(prev_version), true) if prev_version != current.version => {
+                    updates.push(RuleUpdate::Upsert {
+                        pattern: pattern.clone(),
+                        limit: current.limits.clone(),
+                    });
+                }
+                (Some(_), true) => {
+                    // No version bump → no runtime change.
+                }
+                // Was visible, now invisible.
+                (Some(_), false) => {
+                    updates.push(RuleUpdate::Remove {
+                        pattern: pattern.clone(),
+                    });
+                }
+                // Was invisible, now visible.
+                (None, true) => {
+                    updates.push(RuleUpdate::Upsert {
+                        pattern: pattern.clone(),
+                        limit: current.limits.clone(),
+                    });
+                }
+                // Was invisible, still invisible.
+                (None, false) => {}
+            }
+        }
+
+        // Removals: patterns that were visible in `previous` but absent from `self`.
+        for pattern in removals {
+            if let Some(rule) = previous.rules.get(pattern)
+                && !rule.disabled
+            {
+                updates.push(RuleUpdate::Remove {
+                    pattern: pattern.clone(),
+                })
+            }
+        }
+
+        updates
+    }
+
+    /// Produce the diff as if `self` were applied on top of an empty book.
+    /// Used by consumers that need to seed their runtime state on bootstrap.
+    pub fn diff_from_empty(&self) -> Vec<RuleUpdate> {
+        self.diff(&Self::empty())
+    }
+
+    /// Test/internal helper.
+    #[cfg(test)]
+    pub fn from_parts(
+        version: Version,
+        rules: HashMap<RulePattern<ReString>, PersistedRule>,
+    ) -> Self {
+        Self { version, rules }
+    }
+}
+
+/// Body of [`RuleChange::Upsert`]. Carries a fully-specified rule body
+/// plus an optional optimistic-concurrency [`Precondition`].
+#[derive(Debug, Clone)]
+pub struct RuleUpsert {
+    pub limits: UserLimits,
+    pub reason: Option<String>,
+    /// Default `false` (rule is active). Set to `true` to write a parked
+    /// rule that is invisible to the runtime until later toggled.
+    pub disabled: bool,
+    pub precondition: Precondition,
+}
+
+/// CRUD-style change applied to a [`RuleBook`].
+#[derive(Debug, Clone)]
+pub enum RuleChange {
+    Upsert(RuleUpsert),
+    Delete { precondition: Precondition },
+}
+
+/// Optimistic-concurrency guard for a [`RuleChange`].
+///
+/// - [`Precondition::None`] applies the change unconditionally.
+/// - [`Precondition::Matches`] requires the rule to be present at the
+///   given version; otherwise the change is rejected with
+///   [`RuleBookError::PreconditionFailed`].
+/// - [`Precondition::DoesNotExist`] requires the rule to be absent.
+///   Combined with `Upsert` this is a pure insert.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum Precondition {
+    #[default]
+    None,
+    Matches(Version),
+    DoesNotExist,
+}
+
+fn check_precondition(precondition: Precondition, actual: Option<Version>) -> bool {
+    match precondition {
+        Precondition::None => true,
+        Precondition::Matches(v) => actual == Some(v),
+        Precondition::DoesNotExist => actual.is_none(),
+    }
+}
+
+/// Errors returned from [`RuleBook::apply_change`].
+#[derive(Debug, thiserror::Error)]
+pub enum RuleBookError {
+    /// Inserting the rule would exceed [`MAX_RULES_PER_BOOK`].
+    #[error("rule book is full ({cap} rules)")]
+    CapExceeded { cap: usize },
+    /// The supplied [`Precondition`] did not hold against the rule's
+    /// actual state. `actual = None` means the rule was absent.
+    #[error(
+        "rule precondition {precondition:?} for pattern {pattern} failed (actual version: {actual:?})"
+    )]
+    PreconditionFailed {
+        pattern: RulePattern<ReString>,
+        precondition: Precondition,
+        actual: Option<Version>,
+    },
+}
+
+impl Default for RuleBook {
+    fn default() -> Self {
+        Self {
+            version: Version::INVALID,
+            rules: HashMap::new(),
+        }
+    }
+}
+
+impl Versioned for RuleBook {
+    fn version(&self) -> Version {
+        self.version
+    }
+}
+
+// `RulePattern<ReString>` rides through bilrost via its `Display`/`FromStr`
+// round-trip — same trick as `InvocationId`. This avoids spreading bilrost
+// glue across `Pattern`/`RestrictedValue` and keeps the wire form
+// human-readable.
+restate_encoding::bilrost_as_display_from_str!(RulePattern<ReString>);
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU64;
+
+    use bilrost::{Message, OwnedMessage};
+
+    use super::*;
+
+    fn pat(s: &str) -> RulePattern<ReString> {
+        s.parse().unwrap()
+    }
+
+    fn upsert(concurrency: u64) -> RuleUpsert {
+        RuleUpsert {
+            limits: UserLimits {
+                action_concurrency: NonZeroU64::new(concurrency),
+            },
+            reason: None,
+            disabled: false,
+            precondition: Precondition::None,
+        }
+    }
+
+    /// Helper for diff assertions: extract pattern strings and tag.
+    fn updates_summary(updates: &[RuleUpdate]) -> Vec<(String, &'static str)> {
+        updates
+            .iter()
+            .map(|u| match u {
+                RuleUpdate::Upsert { pattern, .. } => (pattern.to_string(), "upsert"),
+                RuleUpdate::Remove { pattern } => (pattern.to_string(), "remove"),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn empty_rule_book_is_at_invalid_version() {
+        let book = RuleBook::empty();
+        assert_eq!(book.version(), Version::INVALID);
+        assert_eq!(book.iter().next(), None);
+    }
+
+    #[test]
+    fn rule_book_bilrost_roundtrip() {
+        let mut rules = HashMap::new();
+        rules.insert(
+            pat("*"),
+            PersistedRule {
+                limits: UserLimits {
+                    action_concurrency: NonZeroU64::new(1000),
+                },
+                reason: Some("global default".to_owned()),
+                disabled: false,
+                last_modified: MillisSinceEpoch::new(42),
+                version: Version::from(1),
+            },
+        );
+        rules.insert(
+            pat("scope1/*/tenant1"),
+            PersistedRule {
+                limits: UserLimits {
+                    action_concurrency: NonZeroU64::new(10),
+                },
+                reason: None,
+                disabled: true,
+                last_modified: MillisSinceEpoch::new(43),
+                version: Version::from(2),
+            },
+        );
+        let book = RuleBook::from_parts(Version::from(2), rules);
+
+        let bytes = book.encode_to_bytes();
+        let decoded = RuleBook::decode(bytes).unwrap();
+        assert_eq!(book, decoded);
+    }
+
+    // -- apply_change(Upsert) -----------------------------------------------
+
+    #[test]
+    fn upsert_inserts_at_book_version() {
+        let mut book = RuleBook::empty();
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(1000)))
+            .unwrap();
+        assert_eq!(book.version(), Version::from(1));
+        let r = book.get(&pat("*")).unwrap();
+        assert_eq!(r.version, Version::from(1));
+        assert!(!r.disabled);
+        assert_eq!(r.limits.action_concurrency, NonZeroU64::new(1000));
+    }
+
+    #[test]
+    fn upsert_runtime_change_bumps_per_rule_and_book_versions() {
+        let mut book = RuleBook::empty();
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(1000)))
+            .unwrap();
+        let v_before_book = book.version();
+        let v_before_rule = book.get(&pat("*")).unwrap().version;
+
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(500)))
+            .unwrap();
+        let r = book.get(&pat("*")).unwrap();
+        assert_eq!(r.limits.action_concurrency, NonZeroU64::new(500));
+        assert_eq!(r.version, v_before_rule.next());
+        assert_eq!(book.version(), v_before_book.next());
+    }
+
+    #[test]
+    fn upsert_reason_only_change_bumps_book_but_not_rule_version() {
+        let mut book = RuleBook::empty();
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(1000)))
+            .unwrap();
+        let v_before_book = book.version();
+        let v_before_rule = book.get(&pat("*")).unwrap().version;
+
+        book.apply_change(
+            pat("*"),
+            RuleChange::Upsert(RuleUpsert {
+                reason: Some("vendor X paused".to_owned()),
+                ..upsert(1000)
+            }),
+        )
+        .unwrap();
+        let r = book.get(&pat("*")).unwrap();
+        assert_eq!(r.reason.as_deref(), Some("vendor X paused"));
+        assert_eq!(r.version, v_before_rule, "per-rule version must NOT bump");
+        assert_eq!(
+            book.version(),
+            v_before_book.next(),
+            "book version must bump"
+        );
+    }
+
+    #[test]
+    fn upsert_full_noop_does_not_bump_anything() {
+        let mut book = RuleBook::empty();
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(1000)))
+            .unwrap();
+        let v_before_book = book.version();
+        let v_before_rule = book.get(&pat("*")).unwrap().version;
+
+        // Re-asserting the same values is a no-op.
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(1000)))
+            .unwrap();
+        let r = book.get(&pat("*")).unwrap();
+        assert_eq!(r.version, v_before_rule);
+        assert_eq!(book.version(), v_before_book);
+    }
+
+    #[test]
+    fn upsert_disabled_toggle_is_runtime_relevant() {
+        let mut book = RuleBook::empty();
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(1000)))
+            .unwrap();
+        let v_before_rule = book.get(&pat("*")).unwrap().version;
+
+        book.apply_change(
+            pat("*"),
+            RuleChange::Upsert(RuleUpsert {
+                disabled: true,
+                ..upsert(1000)
+            }),
+        )
+        .unwrap();
+        let r = book.get(&pat("*")).unwrap();
+        assert!(r.disabled);
+        assert_eq!(r.version, v_before_rule.next());
+    }
+
+    // -- apply_change(Upsert) with Precondition -----------------------------
+
+    #[test]
+    fn upsert_does_not_exist_inserts_when_absent() {
+        let mut book = RuleBook::empty();
+        book.apply_change(
+            pat("*"),
+            RuleChange::Upsert(RuleUpsert {
+                precondition: Precondition::DoesNotExist,
+                ..upsert(1000)
+            }),
+        )
+        .unwrap();
+        assert!(book.get(&pat("*")).is_some());
+    }
+
+    #[test]
+    fn upsert_does_not_exist_rejects_when_present() {
+        let mut book = RuleBook::empty();
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(1000)))
+            .unwrap();
+        let actual = book.get(&pat("*")).unwrap().version;
+        let err = book
+            .apply_change(
+                pat("*"),
+                RuleChange::Upsert(RuleUpsert {
+                    precondition: Precondition::DoesNotExist,
+                    ..upsert(2000)
+                }),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            RuleBookError::PreconditionFailed {
+                pattern,
+                precondition: Precondition::DoesNotExist,
+                actual: Some(a),
+            } if a == actual && pattern == pat("*")
+        ));
+    }
+
+    #[test]
+    fn upsert_matches_succeeds_when_version_matches() {
+        let mut book = RuleBook::empty();
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(1000)))
+            .unwrap();
+        let v = book.get(&pat("*")).unwrap().version;
+        book.apply_change(
+            pat("*"),
+            RuleChange::Upsert(RuleUpsert {
+                precondition: Precondition::Matches(v),
+                ..upsert(500)
+            }),
+        )
+        .unwrap();
+        assert_eq!(
+            book.get(&pat("*")).unwrap().limits.action_concurrency,
+            NonZeroU64::new(500)
+        );
+    }
+
+    #[test]
+    fn upsert_matches_rejects_when_version_differs() {
+        let mut book = RuleBook::empty();
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(1000)))
+            .unwrap();
+        let actual = book.get(&pat("*")).unwrap().version;
+        let stale = Version::from(u32::from(actual) + 7);
+        let err = book
+            .apply_change(
+                pat("*"),
+                RuleChange::Upsert(RuleUpsert {
+                    precondition: Precondition::Matches(stale),
+                    ..upsert(500)
+                }),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            RuleBookError::PreconditionFailed {
+                pattern,
+                precondition: Precondition::Matches(e),
+                actual: Some(a),
+            } if e == stale && a == actual && pattern == pat("*")
+        ));
+    }
+
+    #[test]
+    fn upsert_matches_on_absent_rule_rejects() {
+        let mut book = RuleBook::empty();
+        let err = book
+            .apply_change(
+                pat("*"),
+                RuleChange::Upsert(RuleUpsert {
+                    precondition: Precondition::Matches(Version::from(1)),
+                    ..upsert(1000)
+                }),
+            )
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            RuleBookError::PreconditionFailed {
+                precondition: Precondition::Matches(_),
+                actual: None,
+                pattern: _pattern,
+            }
+        ));
+    }
+
+    // -- apply_change(Delete) ----------------------------------------------
+
+    #[test]
+    fn delete_then_recreate_assigns_strictly_greater_version() {
+        let mut book = RuleBook::empty();
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(1000)))
+            .unwrap();
+        // bump the rule a few times
+        for i in 1u64..=3 {
+            book.apply_change(pat("*"), RuleChange::Upsert(upsert(1000 + i)))
+                .unwrap();
+        }
+        let v_before_delete = book.get(&pat("*")).unwrap().version;
+
+        book.apply_change(
+            pat("*"),
+            RuleChange::Delete {
+                precondition: Precondition::None,
+            },
+        )
+        .unwrap();
+        assert!(book.get(&pat("*")).is_none());
+
+        // Recreate.
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(1000)))
+            .unwrap();
+        let v_after_create = book.get(&pat("*")).unwrap().version;
+        assert!(
+            v_after_create > v_before_delete,
+            "recreated rule's version {v_after_create:?} must exceed pre-delete version {v_before_delete:?}",
+        );
+    }
+
+    #[test]
+    fn delete_matches_succeeds_when_version_matches() {
+        let mut book = RuleBook::empty();
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(1000)))
+            .unwrap();
+        let v = book.get(&pat("*")).unwrap().version;
+        book.apply_change(
+            pat("*"),
+            RuleChange::Delete {
+                precondition: Precondition::Matches(v),
+            },
+        )
+        .unwrap();
+        assert!(book.get(&pat("*")).is_none());
+    }
+
+    #[test]
+    fn delete_matches_rejects_when_version_differs() {
+        let mut book = RuleBook::empty();
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(1000)))
+            .unwrap();
+        let actual = book.get(&pat("*")).unwrap().version;
+        let stale = Version::from(u32::from(actual) + 7);
+        let err = book
+            .apply_change(
+                pat("*"),
+                RuleChange::Delete {
+                    precondition: Precondition::Matches(stale),
+                },
+            )
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            RuleBookError::PreconditionFailed {
+                pattern,
+                precondition: Precondition::Matches(e),
+                actual: Some(a),
+            } if e == stale && a == actual && pattern == pat("*")
+        ));
+        // Rule must still be present because the precondition guarded the delete.
+        assert!(book.get(&pat("*")).is_some());
+    }
+
+    #[test]
+    fn delete_matches_on_absent_rule_rejects() {
+        let mut book = RuleBook::empty();
+        let err = book
+            .apply_change(
+                pat("*"),
+                RuleChange::Delete {
+                    precondition: Precondition::Matches(Version::from(1)),
+                },
+            )
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            RuleBookError::PreconditionFailed {
+                precondition: Precondition::Matches(_),
+                actual: None,
+                pattern: _pattern,
+            }
+        ));
+    }
+
+    #[test]
+    fn delete_does_not_exist_rejects_when_present() {
+        let mut book = RuleBook::empty();
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(1000)))
+            .unwrap();
+        let actual = book.get(&pat("*")).unwrap().version;
+        let err = book
+            .apply_change(
+                pat("*"),
+                RuleChange::Delete {
+                    precondition: Precondition::DoesNotExist,
+                },
+            )
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            RuleBookError::PreconditionFailed {
+                pattern,
+                precondition: Precondition::DoesNotExist,
+                actual: Some(a),
+            } if a == actual && pattern == pat("*")
+        ));
+        // Rule untouched.
+        assert!(book.get(&pat("*")).is_some());
+    }
+
+    // -- apply_changes (batch) ----------------------------------------------
+
+    #[test]
+    fn batch_applies_independent_changes() {
+        let mut book = RuleBook::empty();
+        let v_before = book.version();
+        book.apply_changes([
+            (pat("a"), RuleChange::Upsert(upsert(1))),
+            (pat("b"), RuleChange::Upsert(upsert(2))),
+            (pat("c"), RuleChange::Upsert(upsert(3))),
+        ])
+        .unwrap();
+        // Three inserts but only one book version bump.
+        assert_eq!(book.version(), v_before.next());
+        assert_eq!(book.len(), 3);
+        // All inserts share the post-batch book version.
+        let post = book.version();
+        for p in ["a", "b", "c"] {
+            assert_eq!(book.get(&pat(p)).unwrap().version, post);
+        }
+    }
+
+    #[test]
+    fn batch_aborts_atomically_on_precondition_failure() {
+        let mut book = RuleBook::empty();
+        book.apply_change(pat("a"), RuleChange::Upsert(upsert(1)))
+            .unwrap();
+        let snapshot = book.clone();
+
+        // Second change should fail (DoesNotExist on present rule).
+        let err = book
+            .apply_changes([
+                (pat("b"), RuleChange::Upsert(upsert(2))),
+                (
+                    pat("a"),
+                    RuleChange::Upsert(RuleUpsert {
+                        precondition: Precondition::DoesNotExist,
+                        ..upsert(99)
+                    }),
+                ),
+            ])
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            RuleBookError::PreconditionFailed {
+                precondition: Precondition::DoesNotExist,
+                ..
+            }
+        ));
+        // Book is byte-identical to the snapshot — first upsert was rolled back.
+        assert_eq!(book, snapshot);
+    }
+
+    // -- diff() tests -------------------------------------------------------
+
+    #[test]
+    fn diff_identical_books_is_empty() {
+        let mut book = RuleBook::empty();
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(1000)))
+            .unwrap();
+        let snapshot = book.clone();
+        assert!(book.diff(&snapshot).is_empty());
+    }
+
+    #[test]
+    fn diff_addition_emits_upsert() {
+        let prev = RuleBook::empty();
+        let mut next = prev.clone();
+        next.apply_change(pat("*"), RuleChange::Upsert(upsert(1000)))
+            .unwrap();
+        let updates = next.diff(&prev);
+        assert_eq!(updates_summary(&updates), vec![("*".to_owned(), "upsert")]);
+    }
+
+    #[test]
+    fn diff_modification_emits_upsert() {
+        let mut book = RuleBook::empty();
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(1000)))
+            .unwrap();
+        let prev = book.clone();
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(500)))
+            .unwrap();
+        let updates = book.diff(&prev);
+        assert_eq!(updates_summary(&updates), vec![("*".to_owned(), "upsert")]);
+        if let RuleUpdate::Upsert { limit, .. } = &updates[0] {
+            assert_eq!(limit.action_concurrency, NonZeroU64::new(500));
+        }
+    }
+
+    #[test]
+    fn diff_deletion_emits_remove() {
+        let mut book = RuleBook::empty();
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(1000)))
+            .unwrap();
+        let prev = book.clone();
+        book.apply_change(
+            pat("*"),
+            RuleChange::Delete {
+                precondition: Precondition::None,
+            },
+        )
+        .unwrap();
+        let updates = book.diff(&prev);
+        assert_eq!(updates_summary(&updates), vec![("*".to_owned(), "remove")]);
+    }
+
+    #[test]
+    fn diff_disable_emits_remove() {
+        let mut book = RuleBook::empty();
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(1000)))
+            .unwrap();
+        let prev = book.clone();
+        book.apply_change(
+            pat("*"),
+            RuleChange::Upsert(RuleUpsert {
+                disabled: true,
+                ..upsert(1000)
+            }),
+        )
+        .unwrap();
+        let updates = book.diff(&prev);
+        assert_eq!(updates_summary(&updates), vec![("*".to_owned(), "remove")]);
+    }
+
+    #[test]
+    fn diff_reenable_emits_upsert() {
+        let mut book = RuleBook::empty();
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(1000)))
+            .unwrap();
+        book.apply_change(
+            pat("*"),
+            RuleChange::Upsert(RuleUpsert {
+                disabled: true,
+                ..upsert(1000)
+            }),
+        )
+        .unwrap();
+        let prev = book.clone();
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(1000)))
+            .unwrap();
+        let updates = book.diff(&prev);
+        assert_eq!(updates_summary(&updates), vec![("*".to_owned(), "upsert")]);
+    }
+
+    #[test]
+    fn diff_reason_only_change_emits_nothing() {
+        let mut book = RuleBook::empty();
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(1000)))
+            .unwrap();
+        let prev = book.clone();
+        book.apply_change(
+            pat("*"),
+            RuleChange::Upsert(RuleUpsert {
+                reason: Some("audit note".to_owned()),
+                ..upsert(1000)
+            }),
+        )
+        .unwrap();
+        assert!(book.diff(&prev).is_empty());
+    }
+
+    #[test]
+    fn diff_disabled_rule_in_both_books_emits_nothing() {
+        let mut book = RuleBook::empty();
+        book.apply_change(
+            pat("*"),
+            RuleChange::Upsert(RuleUpsert {
+                disabled: true,
+                ..upsert(1000)
+            }),
+        )
+        .unwrap();
+        let snapshot = book.clone();
+        assert!(book.diff(&snapshot).is_empty());
+    }
+
+    #[test]
+    fn diff_from_empty_seeds_runtime_with_visible_rules_only() {
+        let mut book = RuleBook::empty();
+        book.apply_change(pat("*"), RuleChange::Upsert(upsert(1000)))
+            .unwrap();
+        book.apply_change(
+            pat("scope1/*/tenant1"),
+            RuleChange::Upsert(RuleUpsert {
+                disabled: true,
+                ..upsert(10)
+            }),
+        )
+        .unwrap();
+        let updates = book.diff_from_empty();
+        // Only the visible (`disabled: false`) rule shows up.
+        assert_eq!(updates_summary(&updates), vec![("*".to_owned(), "upsert")]);
+    }
+}

--- a/crates/limiter/src/user_limits.rs
+++ b/crates/limiter/src/user_limits.rs
@@ -1,0 +1,63 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Runtime-side limits and rule-mutation channel types.
+//!
+//! [`UserLimits`] is the per-rule effective-limits shape used both as the
+//! in-memory value the runtime consumes when checking capacity and (under
+//! the `bilrost` feature) as the on-disk shape stored inside a
+//! [`crate::PersistedRule`]. New limit kinds are added here once.
+//!
+//! [`RuleUpdate`] is the channel-level message the per-PP `UserLimiter`
+//! consumes; it is produced by [`crate::RuleBook::diff`].
+
+use std::num::NonZeroU64;
+
+use restate_util_string::ReString;
+
+use crate::RulePattern;
+
+/// Per-rule effective limits.
+///
+/// `None` on a field means "unlimited" (no rule constrains this dimension).
+/// Under the `bilrost` feature this type is also the wire shape persisted
+/// inside [`crate::PersistedRule`] — so adding a new limit kind here means
+/// allocating a fresh `bilrost(tag(...))` next to the new field.
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "bilrost", derive(bilrost::Message))]
+#[non_exhaustive]
+pub struct UserLimits {
+    /// Maximum concurrent invocations. `None` means unlimited.
+    #[cfg_attr(feature = "bilrost", bilrost(tag(1)))]
+    pub action_concurrency: Option<NonZeroU64>,
+}
+
+impl UserLimits {
+    pub fn new(action_concurrency: Option<NonZeroU64>) -> Self {
+        Self { action_concurrency }
+    }
+}
+
+/// A single mutation produced by [`crate::RuleBook::diff`].
+///
+/// Pattern-keyed (matches the `Rules` runtime store). Disabled or absent
+/// rules in the projected view become [`RuleUpdate::Remove`]; rules whose
+/// runtime-relevant fields change become [`RuleUpdate::Upsert`].
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub enum RuleUpdate {
+    /// Insert a new rule or update an existing one with the same pattern.
+    Upsert {
+        pattern: RulePattern<ReString>,
+        limit: UserLimits,
+    },
+    /// Remove a rule by its pattern.
+    Remove { pattern: RulePattern<ReString> },
+}

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -61,7 +61,7 @@ figment = { version = "0.10.19", features = ["env", "toml"] }
 flexbuffers = { workspace = true }
 futures = { workspace = true }
 gardal = { workspace = true }
-generic-array = { version = "1.3.5" }
+generic-array = { workspace = true }
 hostname = { workspace = true }
 http = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }

--- a/crates/worker-api/src/resources.rs
+++ b/crates/worker-api/src/resources.rs
@@ -8,42 +8,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::num::NonZeroU64;
-
 use smallvec::SmallVec;
 use tokio::sync::mpsc;
 
 use restate_futures_util::concurrency::Permit;
-use restate_limiter::{LimitKey, RulePattern};
+use restate_limiter::LimitKey;
 use restate_memory::MemoryLease;
 use restate_types::Scope;
 use restate_util_string::ReString;
 
-// This lives here temporarily until it finds a proper home
-#[derive(Debug, Default, Clone)]
-#[non_exhaustive]
-pub struct UserLimits {
-    // None means unlimited
-    pub action_concurrency: Option<NonZeroU64>,
-}
-
-impl UserLimits {
-    pub fn new(action_concurrency: Option<NonZeroU64>) -> Self {
-        Self { action_concurrency }
-    }
-}
-
-/// Describes a rule mutation.
-#[allow(dead_code)]
-pub enum RuleUpdate {
-    /// Insert a new rule or update an existing one with the same pattern.
-    Upsert {
-        pattern: RulePattern<ReString>,
-        limit: UserLimits,
-    },
-    /// Remove a rule by its pattern.
-    Remove { pattern: RulePattern<ReString> },
-}
+// Re-export so consumers can keep importing from `restate_worker_api::resources`.
+pub use restate_limiter::{RuleUpdate, UserLimits};
 
 pub enum ResourceManagerUpdate {
     PermitReleased(SmallVec<[UserPermitKind; 1]>),


### PR DESCRIPTION
Introduces the cluster-global rule book that backs the in-memory `Rules`
store of each partition processor's `UserLimiter`. This commit lands the
foundational data layer for issue https://github.com/restatedev/restate/issues/4655:

  * `RuleBook` / `PersistedRule` in `restate-limiter::rule_book`,
    bilrost-encoded, `Versioned`. The `RuleBook` is keyed directly by
    `RulePattern<ReString>` — the pattern is the single source of
    truth for a rule's identity, so `PersistedRule` does not carry a
    duplicate `pattern` field. Bilrost map serialisation rides on the
    existing `bilrost_as_display_from_str!` round-trip for patterns
    via `encoding(map<general, general>)`.

  * Soft-tombstone semantics: `PersistedRule.disabled: bool` defaults
    to `false` so an active rule is bilrost's empty state and gets
    omitted from the wire.

  * Batch writer: `RuleBook::apply_changes(IntoIterator<(pattern,
    RuleChange)>)` is the single mutator. Changes are walked in input
    order and accumulated in a staging map; preconditions and the
    `MAX_RULES_PER_BOOK` cap are validated against the *evolving*
    state of the batch. The book is mutated only after the entire
    batch is known to be valid, making batches truly all-or-nothing.
    The book version is bumped by exactly one if the batch produces
    any state change. Per-rule versions are bumped only on
    runtime-relevant changes (`limits`, `disabled`); reason-only edits
    leave the per-rule version alone. `apply_change` is kept as a
    convenience wrapper for single changes.

  * `RuleChange::Upsert(RuleUpsert)` carries a fully-specified rule
    body; `RuleChange::Delete { precondition }` removes a rule.
    Optimistic concurrency is expressed via `Precondition::{ None,
    Matches(Version), DoesNotExist }` on both Upsert and Delete; a
    failed precondition surfaces as `RuleBookError::PreconditionFailed
    { pattern, precondition, actual }`.

  * `RuleBook::diff`: presence + per-rule version drives
    `Vec<RuleUpdate>` for the runtime, with `disabled` rules treated
    as absent. `diff_from_empty` for bootstrap consumers. Hard cap on
    total rules (`MAX_RULES_PER_BOOK`) — configurable knob comes
    later.

Supporting infra:

  * Moves `UserLimits` and `RuleUpdate` from `restate-worker-api` into
    `restate-limiter`. Adds `Hash` to `RulePattern`/`Pattern` so they
    can serve as `HashMap` keys.