### PR TITLE
[Restate UI] Update to v0.1.58

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8560,8 +8560,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.56"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.56#03ecafd2feaab6d90f5c9a2534945a455ef3e420"
+version = "0.1.58"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.58#11912a7b09c178757482084362890014e0ca5766"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -36,7 +36,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-time-util = { workspace = true }
 restate-types = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.56", tag = "v0.1.56" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.58", tag = "v0.1.58" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.58
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.58/ui-v0.1.58.zip