### PR TITLE
Update hickory-resolver to version 0.26.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,6 +1698,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "comfy-table"
 version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3137,18 +3147,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "enum-map"
 version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3828,23 +3826,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.4",
- "ring",
+ "jni",
+ "rand 0.10.1",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -3853,21 +3850,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.10.1",
  "resolv-conf",
  "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4375,6 +4397,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -4526,6 +4551,55 @@ dependencies = [
  "num-traits",
  "pyo3",
  "smallvec",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5253,6 +5327,12 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nix"
@@ -6152,6 +6232,17 @@ checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23370be78b7e5bcbb0cab4a02047eb040279a693c78daad04c2c5f1c24a83503"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]
@@ -9471,6 +9562,16 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simdutf8"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -58,7 +58,7 @@ dialoguer = { workspace = true }
 dirs = { version = "6.0" }
 figment = { version = "0.10.19", features = ["env", "toml"] }
 futures = { workspace = true }
-hickory-resolver = "0.25.2"
+hickory-resolver = "0.26.1"
 http = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true }

--- a/cli/src/commands/cloud/environments/tunnel/local.rs
+++ b/cli/src/commands/cloud/environments/tunnel/local.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 use anyhow::Result;
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt, StreamExt};
+use hickory_resolver::proto::rr::RData;
 use http::{
     Uri,
     uri::{PathAndQuery, Scheme},
@@ -60,20 +61,30 @@ pub(crate) async fn run_local(
         return Ok(());
     }
 
-    let resolver = hickory_resolver::Resolver::builder_tokio().unwrap().build();
+    let resolver = hickory_resolver::Resolver::builder_tokio()
+        .unwrap()
+        .build()
+        .map_err(|err| ServeError::Connection(err.into()))?;
 
     let tunnel_urls = resolver
         .srv_lookup(environment_info.tunnel_srv)
         .await
         .map_err(|err| ServeError::Connection(err.into()))?
+        .answers()
         .iter()
-        .map(|record| {
-            Uri::builder()
-                .scheme(Scheme::HTTPS)
-                .path_and_query(PathAndQuery::from_static("/"))
-                .authority(format!("{}:{}", record.target(), record.port()).as_str())
-                .build()
-                .map_err(|err| ServeError::Connection(err.into()))
+        .filter_map(|record| {
+            if let RData::SRV(svc) = &record.data {
+                Some(
+                    Uri::builder()
+                        .scheme(Scheme::HTTPS)
+                        .path_and_query(PathAndQuery::from_static("/"))
+                        .authority(format!("{}:{}", svc.target, svc.port).as_str())
+                        .build()
+                        .map_err(|err| ServeError::Connection(err.into())),
+                )
+            } else {
+                None
+            }
         })
         .collect::<std::result::Result<Vec<Uri>, ServeError>>()?;
 


### PR DESCRIPTION
Update hickory-resolver to version 0.26.1

Summary:

This is to fix a CI failure
```
error[vulnerability]: NSEC3 closest-encloser proof validation enters unbounded loop on cross-zone responses
    ┌─ /github/workspace/Cargo.lock:324:1
    │
324 │ hickory-proto 0.25.2 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ security vulnerability detected
    │
    ├ ID: RUSTSEC-2026-0118
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0118
    ├ The NSEC3 closest-encloser proof validation in `hickory-proto`'s
      `DnssecDnsHandle` walks from the QNAME up to the SOA owner name, building a
      list of candidate encloser names. The iterator used assumes the
      QNAME is a descendant of the SOA owner, terminating only when the current
      candidate equals the SOA name. When the SOA in a response's authority section
      is not an ancestor of the QNAME, the loop stalls at the DNS root and never
      terminates, repeatedly calling `Name::base_name()` and pushing newly allocated
      `Name` and hashed-name entries into the candidate `Vec`.

      The bug is reachable by any caller of `DnssecDnsHandle` — including the
      resolver, recursor, and client — when built with the `dnssec-ring` or
      `dnssec-aws-lc-rs` feature and configured to perform DNSSEC validation. It is
      triggered while validating a NoData or NXDomain response whose authority
      section contains an SOA record from a zone other than an ancestor of the
      QNAME, on a code path that requires NSEC3 closest-encloser proof. In practice
      this can be reached through an insecure CNAME chain that crosses zone
      boundaries into a DNSSEC-signed zone returning NoData, but the minimum
      condition is just a mismatched SOA owner on a response requiring NSEC3
      validation.

      A `debug_assert_ne!(name, Name::root())` guards the loop body, so debug builds
      abort with a panic on the first iteration past the root. Release builds
      compile the assertion out and run the loop unbounded, allocating until the
      process exhausts available memory (OOM). A reachable upstream attacker who
      can return such a response can therefore crash a debug-built validator or
      exhaust memory on a release-built one.

      The affected code was migrated from `hickory-proto` to `hickory-net` as part of
      the 0.26.0 release. The `hickory-proto` 0.26.x release no longer offers
      `DnssecDnsHandle` and so we recommend all affected users update to `hickory-net`
      0.26.1 when the implementation of that type is required.
    ├ Announcement: https://github.com/hickory-dns/hickory-dns/security/advisories/GHSA-3v94-mw7p-v465
    ├ Solution: No safe upgrade is available!
    ├ hickory-proto v0.25.2
      └── hickory-resolver v0.25.2
          └── restate-cli v1.6.3-dev
```

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4684).
* #4673
* __->__ #4684