### PR TITLE
[CLI] Drop Cognito IDP support; always use WorkOS

### DIFF
--- a/cli/src/commands/cloud/config_discovery.rs
+++ b/cli/src/commands/cloud/config_discovery.rs
@@ -17,9 +17,7 @@ use url::Url;
 
 #[derive(Debug, Deserialize)]
 pub struct DiscoveredAuthConfig {
-    pub provider: String,
     pub client_id: String,
-    pub login_base_url: Option<Url>,
 }
 
 pub async fn fetch_auth_config(discovery_url: &Url) -> Result<DiscoveredAuthConfig> {

--- a/cli/src/commands/cloud/login.rs
+++ b/cli/src/commands/cloud/login.rs
@@ -8,25 +8,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::net::SocketAddr;
-
 use anyhow::{Context, Result, anyhow};
-use axum::{extract, response::Html};
 use cling::prelude::*;
 use indicatif::ProgressBar;
 use restate_cli_util::{CliContext, c_println, c_success, c_tip};
-use serde::{Deserialize, Serialize};
-use tokio::sync::mpsc;
+use serde::Deserialize;
 use toml_edit::{DocumentMut, table, value};
-use url::Url;
 
 use crate::{
     build_info,
     cli_env::CliEnv,
     clients::cloud::{CloudClient, CloudClientInterface},
 };
-
-use super::IdentityProvider;
 
 #[derive(Run, Parser, Collect, Clone)]
 #[cling(run = "run_login")]
@@ -43,8 +36,8 @@ pub async fn run_login(State(env): State<CliEnv>, _opts: &Login) -> Result<()> {
         .parse::<DocumentMut>()
         .context("Failed to parse config file as TOML")?;
 
-    let identity_provider = env.config.cloud.resolve_identity_provider().await?;
-    let access_token = auth_flow(&env, &identity_provider).await?;
+    let client_id = env.config.cloud.resolve_workos_client_id().await?;
+    let access_token = workos_auth_flow(&client_id).await?;
 
     write_access_token(&mut doc, &access_token)?;
 
@@ -73,213 +66,6 @@ pub async fn run_login(State(env): State<CliEnv>, _opts: &Login) -> Result<()> {
     }
 
     Ok(())
-}
-
-async fn auth_flow(env: &CliEnv, identity_provider: &IdentityProvider) -> Result<String> {
-    match identity_provider {
-        IdentityProvider::Cognito {
-            client_id,
-            login_base_url,
-        } => cognito_auth_flow(env, client_id, login_base_url).await,
-        IdentityProvider::WorkOS { client_id } => workos_auth_flow(client_id).await,
-    }
-}
-
-async fn cognito_auth_flow(env: &CliEnv, client_id: &str, login_base_url: &Url) -> Result<String> {
-    let client = reqwest::Client::builder()
-        .user_agent(format!(
-            "{}/{} {}-{}",
-            env!("CARGO_PKG_NAME"),
-            build_info::RESTATE_CLI_VERSION,
-            std::env::consts::OS,
-            std::env::consts::ARCH,
-        ))
-        .https_only(true)
-        .connect_timeout(CliContext::get().connect_timeout())
-        .build()
-        .context("Failed to build oauth token client")?;
-
-    let redirect_ports = env.config.cloud.redirect_ports();
-    let mut i = 0;
-    let listener = loop {
-        if i >= redirect_ports.len() {
-            return Err(anyhow!(
-                "Failed to bind oauth callback server to localhost. Tried ports: [{:?}]",
-                redirect_ports
-            ));
-        }
-        if let Ok(listener) =
-            tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], redirect_ports[i])))
-                .await
-        {
-            break listener;
-        }
-        i += 1
-    };
-
-    let port = listener
-        .local_addr()
-        .expect("failed to get local address of login http listener")
-        .port();
-    let redirect_uri = format!("http://localhost:{port}/callback");
-
-    let (result_send, mut result_recv) = mpsc::channel(1);
-
-    let state = uuid::Uuid::now_v7().simple().to_string();
-
-    let mut login_uri = login_base_url.join("/login")?;
-    login_uri
-        .query_pairs_mut()
-        .clear()
-        .append_pair("response_type", "code")
-        .append_pair("client_id", client_id)
-        .append_pair("redirect_uri", &redirect_uri)
-        .append_pair("state", &state)
-        .append_pair("scope", "openid");
-
-    let router = axum::Router::new()
-        .route(
-            "/callback",
-            axum::routing::get(
-                |extract::State(state): extract::State<RedirectState>,
-                 extract::Query(params): extract::Query<RedirectParams>| async move {
-                    let post_login = include_str!("./postlogin.html");
-                    match handle_redirect(&state, params).await {
-                        Ok(access_token) => {
-                            state.result_send.send(Ok(access_token)).await.expect(
-                                "Expected access_token to be sent successfully over channel",
-                            );
-                            Html::from(
-                                post_login.replace(
-                                    "MESSAGE",
-                                    "Login Successful! You can close this window.",
-                                ),
-                            )
-                        }
-                        Err(err) => {
-                            state
-                                .result_send
-                                .send(Err(err))
-                                .await
-                                .expect("Expected error to be sent successfully over channel");
-                            Html::from(
-                                post_login.replace("MESSAGE", "Login failed – please try again."),
-                            )
-                        }
-                    }
-                },
-            ),
-        )
-        .with_state(RedirectState {
-            client,
-            login_base_url: login_base_url.clone(),
-            client_id: client_id.to_string(),
-            redirect_uri,
-            result_send,
-            state,
-        });
-
-    let server = axum::serve(listener, router.into_make_service());
-    let server_fut = std::future::IntoFuture::into_future(server);
-    tokio::pin!(server_fut);
-    let result_fut = result_recv.recv();
-    tokio::pin!(result_fut);
-
-    c_println!("Opening browser to {login_uri}");
-
-    if let Err(_err) = open::that(login_uri.to_string()) {
-        c_println!("Failed to open browser automatically. Please open the above URL manually.")
-    }
-
-    let progress = ProgressBar::new_spinner();
-    progress.set_style(indicatif::ProgressStyle::with_template("{spinner} {msg}").unwrap());
-    progress.enable_steady_tick(std::time::Duration::from_millis(120));
-    progress.set_message("Waiting for login redirect...");
-
-    let result = tokio::select! {
-        server_result = server_fut => {
-            match server_result {
-                Ok(()) => {
-                    Err(anyhow!("Authentication callback server exited before we received an access token"))
-                }
-                Err(err) => {
-                    Err(anyhow!("Authentication callback server exited unexpectedly: {err}"))
-                }
-            }
-        }
-        result = result_fut => {
-            match result {
-                Some(Ok(access_token)) => Ok(access_token),
-                Some(Err(err)) => {
-                    Err(anyhow!("Unable to obtain a valid access token: {err}"))
-                }
-                None => {
-                    Err(anyhow!("Unable to obtain a valid access token (channel closed)"))
-                }
-            }
-        }
-    };
-    progress.finish_and_clear();
-    result
-}
-
-#[derive(Clone)]
-struct RedirectState {
-    client: reqwest::Client,
-    login_base_url: Url,
-    client_id: String,
-    redirect_uri: String,
-    state: String,
-    result_send: mpsc::Sender<Result<String>>,
-}
-
-#[derive(Deserialize)]
-struct RedirectParams {
-    code: String,
-    state: String,
-}
-
-#[derive(Serialize)]
-struct TokenParams<'a> {
-    grant_type: &'static str,
-    client_id: &'a str,
-    code: String,
-    redirect_uri: &'a str,
-}
-
-#[derive(Deserialize)]
-struct TokenResponse {
-    access_token: String,
-}
-
-async fn handle_redirect(state: &RedirectState, params: RedirectParams) -> Result<String> {
-    if state.state != params.state {
-        return Err(anyhow!(
-            "State mismatch; expected redirect with {} but instead received {}",
-            state.state,
-            params.state
-        ));
-    }
-
-    let response: TokenResponse = state
-        .client
-        .post(state.login_base_url.join("/oauth2/token")?)
-        .form(&TokenParams {
-            grant_type: "authorization_code",
-            client_id: &state.client_id,
-            code: params.code,
-            redirect_uri: &state.redirect_uri,
-        })
-        .send()
-        .await
-        .context("Failed to reach /oauth2/token endpoint")?
-        .error_for_status()
-        .context("Bad status code from /oauth2/token endpoint")?
-        .json()
-        .await
-        .context("Failed to decode JSON response from /oauth2/token endpoint")?;
-
-    Ok(response.access_token)
 }
 
 fn write_access_token(doc: &mut DocumentMut, access_token: &str) -> Result<()> {

--- a/cli/src/commands/cloud/mod.rs
+++ b/cli/src/commands/cloud/mod.rs
@@ -15,30 +15,15 @@ mod login;
 use base64::Engine;
 use cling::prelude::*;
 use serde::{Deserialize, Serialize};
-use tracing::{debug, warn};
+use tracing::debug;
 use url::Url;
-
-#[derive(Clone, Debug)]
-pub enum IdentityProvider {
-    Cognito {
-        client_id: String,
-        login_base_url: Url,
-    },
-    WorkOS {
-        client_id: String,
-    },
-}
 
 #[derive(Clone, Default, Serialize, Deserialize)]
 pub struct CloudConfig {
     #[serde(flatten)]
     pub environment_info: Option<EnvironmentInfo>, // Set on a profile on login
     pub api_base_url: Option<Url>,
-    // Optional manual overrides
-    pub provider: Option<String>,
     pub client_id: Option<String>,
-    pub login_base_url: Option<Url>,
-    pub redirect_ports: Option<Vec<u16>>,
     #[serde(flatten)]
     pub credentials: Option<Credentials>, // Set globally on login
 }
@@ -54,128 +39,37 @@ pub struct Credentials {
     access_token: String,
 }
 
-pub const DEFAULT_REDIRECT_PORTS: &[u16] = &[33912, 44643, 47576, 54788, 61844];
 pub const DEFAULT_API_BASE_URL: &str = "https://api.us.restate.cloud";
-
-// Legacy fallback defaults (used when discovery fails)
-const LEGACY_CLIENT_ID: &str = "5q3dsdnrr5r400jvibd8d3k66l";
-const LEGACY_LOGIN_BASE_URL: &str = "https://auth.restate.cloud";
+pub const DEFAULT_WORKOS_CLIENT_ID: &str = "client_01K8ZW3DSQK9D7PW0DT4DBRVSC";
 
 impl CloudConfig {
-    pub fn redirect_ports(&self) -> &[u16] {
-        self.redirect_ports
-            .as_deref()
-            .unwrap_or(DEFAULT_REDIRECT_PORTS)
-    }
-
     pub fn api_base_url(&self) -> Url {
         self.api_base_url
             .clone()
             .unwrap_or_else(|| Url::parse(DEFAULT_API_BASE_URL).expect("default API URL is valid"))
     }
 
-    pub async fn resolve_identity_provider(&self) -> anyhow::Result<IdentityProvider> {
-        if let Some(provider) = &self.provider {
-            return self.resolve_explicit_provider(provider);
+    pub async fn resolve_workos_client_id(&self) -> anyhow::Result<String> {
+        if let Some(client_id) = &self.client_id {
+            debug!("Using configured WorkOS client_id={}", client_id);
+            return Ok(client_id.clone());
         }
 
-        let discovery_url = self
-            .api_base_url()
+        let api_base_url = self.api_base_url();
+        let default_api_base_url =
+            Url::parse(DEFAULT_API_BASE_URL).expect("default API URL is valid");
+        if api_base_url == default_api_base_url {
+            debug!("Using built-in prod WorkOS client_id");
+            return Ok(DEFAULT_WORKOS_CLIENT_ID.to_string());
+        }
+
+        let discovery_url = api_base_url
             .join(".auth-config")
             .expect("valid auth-config path");
 
-        match config_discovery::fetch_auth_config(&discovery_url).await {
-            Ok(config) => {
-                debug!(
-                    "Discovered auth config: provider={}, client_id={}",
-                    config.provider, config.client_id
-                );
-                self.resolve_discovered_provider(&config)
-            }
-            Err(e) => {
-                warn!("Auth config discovery failed, using legacy defaults: {}", e);
-                Ok(self.resolve_legacy_provider())
-            }
-        }
-    }
-
-    fn resolve_explicit_provider(&self, provider: &str) -> anyhow::Result<IdentityProvider> {
-        let client_id = self.client_id.as_deref().ok_or_else(|| {
-            anyhow::anyhow!("Explicit provider config requires client_id to be set")
-        })?;
-
-        match provider {
-            "cognito" => {
-                let login_base_url = self.login_base_url.clone().ok_or_else(|| {
-                    anyhow::anyhow!("Cognito provider requires login_base_url to be set")
-                })?;
-                debug!(
-                    "Using explicit Cognito provider: client_id={}, login_base_url={}",
-                    client_id, login_base_url
-                );
-                Ok(IdentityProvider::Cognito {
-                    client_id: client_id.to_string(),
-                    login_base_url,
-                })
-            }
-            "workos" => {
-                debug!("Using explicit WorkOS provider: client_id={}", client_id);
-                Ok(IdentityProvider::WorkOS {
-                    client_id: client_id.to_string(),
-                })
-            }
-            other => {
-                anyhow::bail!(
-                    "Unknown identity provider: {other}. Expected 'cognito' or 'workos'."
-                );
-            }
-        }
-    }
-
-    fn resolve_discovered_provider(
-        &self,
-        config: &config_discovery::DiscoveredAuthConfig,
-    ) -> anyhow::Result<IdentityProvider> {
-        match config.provider.as_str() {
-            "cognito" => {
-                let login_base_url = config.login_base_url.clone().ok_or_else(|| {
-                    anyhow::anyhow!("Discovered Cognito provider missing login_base_url")
-                })?;
-                debug!(
-                    "Using discovered Cognito provider: client_id={}, login_base_url={}",
-                    config.client_id, login_base_url
-                );
-                Ok(IdentityProvider::Cognito {
-                    client_id: config.client_id.clone(),
-                    login_base_url,
-                })
-            }
-            "workos" => {
-                debug!(
-                    "Using discovered WorkOS provider: client_id={}",
-                    config.client_id
-                );
-                Ok(IdentityProvider::WorkOS {
-                    client_id: config.client_id.clone(),
-                })
-            }
-            other => {
-                anyhow::bail!(
-                    "Unknown identity provider from discovery: {other}. Expected 'cognito' or 'workos'."
-                );
-            }
-        }
-    }
-
-    fn resolve_legacy_provider(&self) -> IdentityProvider {
-        debug!(
-            "Using legacy Cognito provider: client_id={}, login_base_url={}",
-            LEGACY_CLIENT_ID, LEGACY_LOGIN_BASE_URL
-        );
-        IdentityProvider::Cognito {
-            client_id: LEGACY_CLIENT_ID.to_string(),
-            login_base_url: Url::parse(LEGACY_LOGIN_BASE_URL).expect("valid legacy login URL"),
-        }
+        let config = config_discovery::fetch_auth_config(&discovery_url).await?;
+        debug!("Discovered WorkOS client_id={}", config.client_id);
+        Ok(config.client_id)
     }
 }
 


### PR DESCRIPTION
## Summary
- Removes the dynamic IDP discovery in `restate cloud login`. The CLI no longer asks `.auth-config` whether to use Cognito or WorkOS -- it always uses WorkOS.
- Deletes all Cognito-specific code: hosted-UI login URL, localhost OAuth2 callback server, token exchange, redirect ports config.
- Bakes in the prod WorkOS `client_id` so the common case skips the discovery round-trip entirely.

## Client ID resolution order
1. `client_id` set in config -> use it (escape hatch, works in prod too)
2. `api_base_url` unset or matches the prod default -> use the built-in `DEFAULT_WORKOS_CLIENT_ID`
3. `api_base_url` is anything else (dev, one-off install) -> hit `.auth-config` to discover

This makes `api_base_url` the single dev switch: change it and discovery kicks in automatically; leave it alone and prod login is purely local config + WorkOS.

## Why
The discovery endpoint existed to let pre-migration CLI binaries follow the server from Cognito to WorkOS without a forced upgrade. With the migration done, hardcoding the public client_id is the standard pattern for CLI/mobile OAuth clients (gh, gcloud, stripe, vercel, etc.).

## Test plan
- [x] \`restate cloud login\` against prod (no config) succeeds without hitting \`.auth-config\`
- [x] \`restate cloud login\` with \`api_base_url = "https://api.dev.restate.cloud"\` discovers the dev client_id via \`.auth-config\` and succeeds
- [ ] \`restate cloud login\` with explicit \`client_id\` in config uses that value
- [ ] Existing config files with leftover \`provider\`, \`login_base_url\`, \`redirect_ports\` keys still parse (serde ignores unknown fields)