### PR TITLE
[shuffler] Fix build warning

### DIFF
--- a/crates/worker/src/partition/shuffle.rs
+++ b/crates/worker/src/partition/shuffle.rs
@@ -164,7 +164,7 @@ impl ShuffleMetadata {
     }
 }
 
-pub struct Shuffle<T, OR> {
+pub(super) struct Shuffle<T, OR> {
     metadata: ShuffleMetadata,
     outbox_reader: OR,
     ingestion_client: IngestionClient<T, Envelope>,


### PR DESCRIPTION
[shuffler] Fix build warning

Fixes a build warning. This showed up only during build but not
when running `clippy` for some reason!

Summary:
```
warning: trait `shuffle::OutboxReader` is more private than the item `shuffle::Shuffle<T, OR>`
   --> crates/worker/src/partition/shuffle.rs:178:1
    |
178 | / impl<T, OR> Shuffle<T, OR>
179 | | where
180 | |     T: TransportConnect,
181 | |     OR: OutboxReader + Send + Sync + 'static,
    | |_____________________________________________^ implementation `shuffle::Shuffle<T, OR>` is reachable at visibility `pub(crate)`
    |
note: but trait `shuffle::OutboxReader` is only usable at visibility `pub(in crate::partition)`
   --> crates/worker/src/partition/shuffle.rs:98:1
    |
 98 | pub(super) trait OutboxReader {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: `#[warn(private_bounds)]` on by default
```
