### PR TITLE
envelope-v2: write v2 envelopes with typed commands

### DIFF
--- a/crates/wal-protocol/src/lib.rs
+++ b/crates/wal-protocol/src/lib.rs
@@ -15,4 +15,5 @@ pub mod v1;
 pub mod v2;
 pub mod vqueues;
 
+// Drop v1 in v1.9
 pub use v1::{Command, Destination, Envelope, Header, Source};

--- a/crates/wal-protocol/src/v2.rs
+++ b/crates/wal-protocol/src/v2.rs
@@ -204,6 +204,20 @@ impl Envelope<Raw> {
         }
     }
 
+    pub fn from_erased_command(dedup: Dedup, erased: ErasedCommand) -> Self {
+        let ErasedCommand { kind, command } = erased;
+
+        Self {
+            header: Header {
+                dedup,
+                kind,
+                codec: Some(command.default_codec()),
+            },
+            payload: PolyBytes::Typed(command),
+            _p: PhantomData,
+        }
+    }
+
     /// Converts Raw Envelope into a Typed envelope. Panics
     /// if the record kind does not match the M::KIND
     pub fn into_typed<M: Command>(self) -> Envelope<M> {
@@ -504,6 +518,30 @@ where
 
     fn inner(self) -> C {
         BodyWithKeys::into_inner(self)
+    }
+}
+
+#[derive(derive_more::Debug, Clone)]
+pub struct ErasedCommand {
+    kind: CommandKind,
+    #[debug(skip)]
+    command: Arc<dyn StorageEncode>,
+}
+
+impl ErasedCommand {
+    pub fn new<C: Command>(cmd: C) -> Self {
+        Self {
+            kind: C::KIND,
+            command: Arc::new(cmd),
+        }
+    }
+
+    pub fn downcast_arc<C: Command>(self) -> Option<Arc<C>> {
+        self.command.downcast_arc::<C>().ok()
+    }
+
+    pub fn kind(&self) -> CommandKind {
+        self.kind
     }
 }
 

--- a/crates/wal-protocol/src/v2/commands.rs
+++ b/crates/wal-protocol/src/v2/commands.rs
@@ -135,15 +135,6 @@ impl HasRecordKeys for InvokeCommand {
 pub struct TruncateOutboxCommand {
     #[bilrost(1)]
     pub index: MessageIndex,
-
-    #[bilrost(2)]
-    pub partition_key_range: Keys,
-}
-
-impl HasRecordKeys for TruncateOutboxCommand {
-    fn record_keys(&self) -> Keys {
-        self.partition_key_range.clone()
-    }
 }
 
 bilrost_storage_encode_decode!(TruncateOutboxCommand);

--- a/crates/wal-protocol/src/v2/compatibility.rs
+++ b/crates/wal-protocol/src/v2/compatibility.rs
@@ -21,6 +21,11 @@ use crate::{
     v2::{self, Envelope, commands::TruncateOutboxCommand},
 };
 
+// TODO: Keep for backward compatibility only. Do not extend
+// v1 Commands with new commands. New commands should be
+// added to v2 only.
+//
+// Drop in v1.9
 impl TryFrom<v1::Envelope> for v2::Envelope<Raw> {
     type Error = anyhow::Error;
 
@@ -121,17 +126,9 @@ impl TryFrom<v1::Envelope> for v2::Envelope<Raw> {
             v1::Command::Timer(payload) => {
                 Envelope::new(dedup, commands::TimerCommand::from(payload)).into_raw()
             }
-            v1::Command::TruncateOutbox(payload) => Envelope::new(
-                dedup,
-                TruncateOutboxCommand {
-                    index: payload,
-                    // this actually should be a key-range but v1 unfortunately
-                    // only hold the "start" of the range.
-                    // will be fixed in v2
-                    partition_key_range: Keys::Single(partition_key),
-                },
-            )
-            .into_raw(),
+            v1::Command::TruncateOutbox(payload) => {
+                Envelope::new(dedup, TruncateOutboxCommand { index: payload }).into_raw()
+            }
             v1::Command::UpdatePartitionDurability(payload) => {
                 Envelope::new(dedup, payload).into_raw()
             }

--- a/crates/worker/src/partition/leadership/leader_state.rs
+++ b/crates/worker/src/partition/leadership/leader_state.rs
@@ -16,12 +16,13 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll, ready};
 
-use bytes::BytesMut;
 use futures::future::OptionFuture;
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt, StreamExt, stream};
 use itertools::Itertools;
 use metrics::counter;
+use restate_wal_protocol::control::UpdatePartitionDurabilityCommand;
+use restate_wal_protocol::timer::TimerKeyValue;
 use tokio_stream::wrappers::{ReceiverStream, WatchStream};
 use tracing::{debug, error, trace};
 
@@ -33,12 +34,11 @@ use restate_limiter::RuleBook;
 use restate_partition_store::PartitionDb;
 use restate_storage_api::vqueue_table::scheduler::SchedulerDecisionsCommand;
 use restate_types::identifiers::{
-    InvocationId, LeaderEpoch, PartitionId, PartitionKey, PartitionProcessorRpcRequestId,
-    WithPartitionKey,
+    InvocationId, LeaderEpoch, PartitionId, PartitionProcessorRpcRequestId, WithPartitionKey,
 };
 use restate_types::invocation::client::{InvocationOutput, SubmittedInvocationNotification};
 use restate_types::invocation::{FencingToken, PurgeInvocationRequest};
-use restate_types::logs::Keys;
+use restate_types::logs::{BodyWithKeys, Keys};
 use restate_types::net::ingest::{IngestRecord, ResponseStatus};
 use restate_types::net::partition_processor::{
     PartitionProcessorRpcError, PartitionProcessorRpcResponse,
@@ -50,10 +50,7 @@ use restate_vqueues::VQueueEvent;
 use restate_vqueues::context::HasVQueues;
 use restate_vqueues::scheduler::Decisions;
 use restate_vqueues::{SchedulerService, VQueuesMeta};
-use restate_wal_protocol::Command;
-use restate_wal_protocol::control::{UpdatePartitionDurabilityCommand, UpsertSchemaCommand};
-use restate_wal_protocol::timer::TimerKeyValue;
-use restate_wal_protocol::v1::UpsertRuleBookCommandWrapper;
+use restate_wal_protocol::v2::{CommandKind, ErasedCommand, commands};
 use restate_worker_api::invoker::InvokerHandle;
 use restate_worker_api::resources::ReservedResources;
 use restate_worker_api::{SchedulerStatusEntry, UserLimitCounterEntry};
@@ -120,7 +117,6 @@ pub struct LeaderState {
     // Unregisters the leader-query registry entry on drop. Must live as long as
     // the partition processor's select! is willing to serve scheduler queries.
     _leader_query_guard: LeaderQueryGuard,
-    encoding_arena: BytesMut,
 }
 
 impl LeaderState {
@@ -177,7 +173,6 @@ impl LeaderState {
             network_events_tx,
             network_events_stream: ReceiverStream::new(network_events_rx),
             _leader_query_guard: leader_query_guard,
-            encoding_arena: BytesMut::with_capacity(128 * 1024),
         }
     }
 
@@ -229,7 +224,6 @@ impl LeaderState {
             cleaner_handle,
             durability_tracker,
             network_events_stream,
-            encoding_arena,
             ..
         } = self;
         let partition_key_range = *partition_key_range;
@@ -340,7 +334,6 @@ impl LeaderState {
                 awaiting_rpc_actions,
                 awaiting_rpc_self_propose,
                 fencing_tokens,
-                arena: encoding_arena,
             };
 
             handle_event(event, &mut state)?;
@@ -440,28 +433,23 @@ struct LeaderEventHandlerState<'a> {
     awaiting_rpc_actions: &'a mut HashMap<PartitionProcessorRpcRequestId, RpcReciprocal>,
     awaiting_rpc_self_propose: &'a mut FuturesUnordered<SelfAppendFuture>,
     fencing_tokens: &'a mut restate_platform::hash::HashMap<InvocationId, FencingToken>,
-    arena: &'a mut BytesMut,
 }
 
 impl LeaderEventHandlerState<'_> {
     fn handle_rpc_proposal(&mut self, proposal: RpcProposal, reciprocal: RpcReciprocal) {
-        let RpcProposal {
-            partition_key,
-            cmd,
-            reply_on,
-        } = proposal;
+        let (keys, cmd, reply_on) = proposal.into_parts();
 
         match reply_on {
             ReplyOn::Apply { request_id } => {
-                self.handle_rpc_proposal_command(request_id, reciprocal, partition_key, cmd)
+                self.handle_rpc_proposal_command(request_id, reciprocal, keys, cmd)
             }
             ReplyOn::Commit { response } => {
-                self.append_and_respond_asynchronously(partition_key, cmd, reciprocal, response)
+                self.append_and_respond_asynchronously(keys, cmd, reciprocal, response)
             }
             ReplyOn::ApplyAndFence {
                 request_id,
                 invocation_id,
-            } => self.propose_pause_and_fence(request_id, reciprocal, invocation_id, cmd),
+            } => self.propose_pause_and_fence(request_id, reciprocal, invocation_id, keys, cmd),
         }
     }
 
@@ -471,8 +459,8 @@ impl LeaderEventHandlerState<'_> {
         reciprocal: Reciprocal<
             Oneshot<Result<PartitionProcessorRpcResponse, PartitionProcessorRpcError>>,
         >,
-        partition_key: PartitionKey,
-        cmd: Command,
+        keys: Keys,
+        cmd: ErasedCommand,
     ) {
         match self.awaiting_rpc_actions.entry(request_id) {
             Entry::Occupied(mut o) => {
@@ -486,7 +474,7 @@ impl LeaderEventHandlerState<'_> {
             }
             Entry::Vacant(v) => {
                 // In this case, no one proposed this command yet, let's try to propose it
-                if let Err(e) = self.self_proposer.self_propose(partition_key, cmd) {
+                if let Err(e) = self.self_proposer.self_propose_erased(keys, cmd) {
                     reciprocal.send(Err(PartitionProcessorRpcError::Internal(e.to_string())));
                 } else {
                     v.insert(reciprocal);
@@ -513,8 +501,12 @@ impl LeaderEventHandlerState<'_> {
             Oneshot<Result<PartitionProcessorRpcResponse, PartitionProcessorRpcError>>,
         >,
         invocation_id: InvocationId,
-        cmd: Command,
+        keys: Keys,
+        cmd: ErasedCommand,
     ) {
+        debug_assert!(keys == Keys::Single(invocation_id.partition_key()));
+        debug_assert!(cmd.kind() == CommandKind::PauseInvocation);
+
         match self.awaiting_rpc_actions.entry(request_id) {
             Entry::Occupied(mut o) => {
                 // Retry of an already-proposed pause: replace the reciprocal and fail the old one.
@@ -529,7 +521,7 @@ impl LeaderEventHandlerState<'_> {
             Entry::Vacant(v) => {
                 if let Err(e) = self
                     .self_proposer
-                    .self_propose(invocation_id.partition_key(), cmd)
+                    .self_propose_erased(Keys::Single(invocation_id.partition_key()), cmd)
                 {
                     reciprocal.send(Err(PartitionProcessorRpcError::Internal(e.to_string())));
                 } else {
@@ -548,15 +540,12 @@ impl LeaderEventHandlerState<'_> {
     /// responses).
     fn append_and_respond_asynchronously(
         &mut self,
-        partition_key: PartitionKey,
-        cmd: Command,
+        keys: Keys,
+        cmd: ErasedCommand,
         reciprocal: RpcReciprocal,
         success_response: PartitionProcessorRpcResponse,
     ) {
-        match self
-            .self_proposer
-            .append_with_notification(partition_key, cmd)
-        {
+        match self.self_proposer.append_with_notification(keys, cmd) {
             Ok(result) => {
                 self.awaiting_rpc_self_propose.push(SelfAppendFuture::new(
                     result.commit_token,
@@ -616,7 +605,6 @@ impl LeaderEventHandler for Decisions {
             qids.len()
         );
 
-        let arena = &mut state.arena;
         let commands: Vec<_> = qids
             .into_iter()
             .chunk_by(|(id, _)| id.partition_key())
@@ -627,14 +615,8 @@ impl LeaderEventHandler for Decisions {
                     qids: group.collect(),
                 };
 
-                arena.reserve(decisions.encoded_len());
-                // safe to unwrap because we reserved enough space
-                decisions.bilrost_encode(&mut *arena).unwrap();
+                BodyWithKeys::new(decisions, Keys::Single(partition_key))
 
-                (
-                    partition_key,
-                    Command::VQSchedulerDecisions(arena.split().freeze()),
-                )
                 // an action goes into command, and resources are popped
             })
             // Unfortunately chunk_by cannot generate an ExactSizeIterator.
@@ -651,10 +633,10 @@ impl LeaderEventHandler for UpdatePartitionDurabilityCommand {
     fn handle(self, state: &mut LeaderEventHandlerState<'_>) -> Result<(), Error> {
         // based on configuration, whether to consider partition-local durability in
         // the replica-set as a sufficient source of durability, or only snapshots.
-        state.self_proposer.self_propose(
-            state.partition_key_range.start(),
-            Command::UpdatePartitionDurability(self),
-        )?;
+        state.self_proposer.self_propose(BodyWithKeys::new(
+            self,
+            Keys::RangeInclusive(state.partition_key_range.into()),
+        ))?;
         Ok(())
     }
 }
@@ -673,10 +655,10 @@ impl LeaderEventHandler for InvokerEffect {
             if self.effect.kind.is_terminal() {
                 state.fencing_tokens.remove(&invocation_id);
             }
-            state.self_proposer.self_propose(
-                invocation_id.partition_key(),
-                Command::InvokerEffect(self.effect),
-            )?;
+
+            state
+                .self_proposer
+                .self_propose(commands::InvokerEffectCommand::from(*self.effect))?;
         } else {
             debug!(
                 restate.invocation.id = %invocation_id,
@@ -691,10 +673,13 @@ impl LeaderEventHandler for shuffle::OutboxTruncation {
     fn handle(self, state: &mut LeaderEventHandlerState<'_>) -> Result<(), Error> {
         // todo: Until we support partition splits we need to get rid of outboxes or introduce partition
         //  specific destination messages that are identified by a partition_id
-        state.self_proposer.self_propose(
-            state.partition_key_range.start(),
-            Command::TruncateOutbox(self.index()),
-        )?;
+
+        state.self_proposer.self_propose(BodyWithKeys::new(
+            commands::TruncateOutboxCommand {
+                index: self.index(),
+            },
+            Keys::RangeInclusive(state.partition_key_range.into()),
+        ))?;
         Ok(())
     }
 }
@@ -703,33 +688,36 @@ impl LeaderEventHandler for TimerKeyValue {
     fn handle(self, state: &mut LeaderEventHandlerState<'_>) -> Result<(), Error> {
         state
             .self_proposer
-            .self_propose(self.invocation_id().partition_key(), Command::Timer(self))?;
+            .self_propose(commands::TimerCommand::from(self))?;
         Ok(())
     }
 }
 
 impl LeaderEventHandler for CleanerEffect {
     fn handle(self, state: &mut LeaderEventHandlerState<'_>) -> Result<(), Error> {
-        let (invocation_id, cmd) = match self {
-            CleanerEffect::PurgeJournal(invocation_id) => (
-                invocation_id,
-                Command::PurgeJournal(PurgeInvocationRequest {
-                    invocation_id,
-                    response_sink: None,
-                }),
-            ),
-            CleanerEffect::PurgeInvocation(invocation_id) => (
-                invocation_id,
-                Command::PurgeInvocation(PurgeInvocationRequest {
-                    invocation_id,
-                    response_sink: None,
-                }),
-            ),
-        };
+        match self {
+            CleanerEffect::PurgeJournal(invocation_id) => {
+                state
+                    .self_proposer
+                    .self_propose(commands::PurgeJournalCommand::from(
+                        PurgeInvocationRequest {
+                            invocation_id,
+                            response_sink: None,
+                        },
+                    ))?;
+            }
+            CleanerEffect::PurgeInvocation(invocation_id) => {
+                state
+                    .self_proposer
+                    .self_propose(commands::PurgeInvocationCommand::from(
+                        PurgeInvocationRequest {
+                            invocation_id,
+                            response_sink: None,
+                        },
+                    ))?;
+            }
+        }
 
-        state
-            .self_proposer
-            .self_propose(invocation_id.partition_key(), cmd)?;
         Ok(())
     }
 }
@@ -737,13 +725,12 @@ impl LeaderEventHandler for CleanerEffect {
 impl LeaderEventHandler for Schema {
     fn handle(self, state: &mut LeaderEventHandlerState<'_>) -> Result<(), Error> {
         if SemanticRestateVersion::current().is_equal_or_newer_than(&RESTATE_VERSION_1_7_0) {
-            state.self_proposer.self_propose(
-                state.partition_key_range.start(),
-                Command::UpsertSchema(UpsertSchemaCommand {
+            state
+                .self_proposer
+                .self_propose(commands::UpsertSchemaCommand {
                     partition_key_range: Keys::RangeInclusive(state.partition_key_range.into()),
                     schema: self,
-                }),
-            )?;
+                })?;
         }
         Ok(())
     }
@@ -752,17 +739,11 @@ impl LeaderEventHandler for Schema {
 impl LeaderEventHandler for Arc<RuleBook> {
     fn handle(self, state: &mut LeaderEventHandlerState<'_>) -> Result<(), Error> {
         let cmd = restate_wal_protocol::control::UpsertRuleBookCommand { rule_book: self };
-        state.arena.reserve(cmd.encoded_len());
-        // safe to unwrap because we reserved enough space
-        cmd.bilrost_encode(&mut state.arena).unwrap();
 
-        state.self_proposer.self_propose(
-            state.partition_key_range.start(),
-            Command::UpsertRuleBook(UpsertRuleBookCommandWrapper {
-                partition_key_range: state.partition_key_range,
-                command: state.arena.split().freeze(),
-            }),
-        )?;
+        state.self_proposer.self_propose(BodyWithKeys::new(
+            cmd,
+            Keys::RangeInclusive(state.partition_key_range.into()),
+        ))?;
         Ok(())
     }
 }

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -65,7 +65,6 @@ use restate_util_time::DurationExt;
 use restate_vqueues::context::{HasVQueues, HasVQueuesMut};
 use restate_vqueues::scheduler::{self};
 use restate_vqueues::{ResourceManager, SchedulerService, VQueuesMeta};
-use restate_wal_protocol::Command;
 use restate_wal_protocol::control::{
     AnnounceLeaderCommand, UpdatePartitionDurabilityCommand, VersionBarrierCommand,
 };
@@ -336,14 +335,14 @@ where
         let campaign_started_at = Instant::now();
         let leader_epoch = leadership_info.leader_epoch;
 
-        let announce_leader = Command::AnnounceLeader(Box::new(AnnounceLeaderCommand {
+        let announce_leader = AnnounceLeaderCommand {
             node_id: node_ctx.my_node_id(),
             leader_epoch,
             epoch_version: Some(leadership_info.version),
             partition_key_range: ctx.key_range(),
             current_config: Some(leadership_info.current_config),
             next_config: leadership_info.next_config,
-        }));
+        };
 
         let mut self_proposer = SelfProposer::new(
             ctx.log_id(),
@@ -351,7 +350,7 @@ where
             &node_ctx.bifrost,
         )?;
 
-        self_proposer.self_propose_unaccounted(ctx.key_range().start(), announce_leader)?;
+        self_proposer.self_propose_unaccounted(announce_leader)?;
 
         self.state = State::Candidate {
             at: Instant::now(),
@@ -611,15 +610,12 @@ where
                         .collect::<Vec<_>>()
                         .join(", ")
                 );
-                self_proposer.self_propose_unaccounted(
-                    processor.key_range().start(),
-                    Command::VersionBarrier(VersionBarrierCommand {
-                        version: barrier_version,
-                        partition_key_range: Keys::RangeInclusive(processor.key_range().into()),
-                        human_reason: Some("Apply state-machine feature changes".to_owned()),
-                        feature_changes: feature_changes.into_iter().map(|c| c.id()).collect(),
-                    }),
-                )?;
+                self_proposer.self_propose_unaccounted(VersionBarrierCommand {
+                    version: barrier_version,
+                    partition_key_range: Keys::RangeInclusive(processor.key_range().into()),
+                    human_reason: Some("Apply state-machine feature changes".to_owned()),
+                    feature_changes: feature_changes.into_iter().map(|c| c.id()).collect(),
+                })?;
 
                 // Switch to BecomingLeader state until we finish any pending tasks to enable the
                 // new features. We will transition us to an effective leader when the state
@@ -1028,11 +1024,9 @@ impl RpcProcessingPermit {
 mod tests {
     use std::num::NonZeroUsize;
     use std::sync::Arc;
-
     use test_log::test;
     use tokio_stream::StreamExt;
 
-    use assert2::let_assert;
     use restate_bifrost::Bifrost;
     use restate_core::partitions::PartitionRouting;
     use restate_core::{TaskCenter, TestCoreEnv};
@@ -1048,8 +1042,8 @@ mod tests {
     };
     use restate_types::sharding::KeyRange;
     use restate_types::{GenerationalNodeId, Version};
-    use restate_wal_protocol::Command;
-    use restate_wal_protocol::Envelope;
+    use restate_wal_protocol::control::AnnounceLeaderCommand;
+    use restate_wal_protocol::v2::{Envelope, Raw, commands};
     use restate_worker_api::invoker::capacity::InvokerCapacity;
 
     use crate::partition::leadership::{LeadershipState, State};
@@ -1123,9 +1117,12 @@ mod tests {
             .expect("valid reader");
 
         let record = reader.next().await.unwrap()?;
-        let envelope = record.try_decode::<Envelope>().unwrap()?;
+        let envelope = record
+            .try_decode::<Envelope<Raw>>()
+            .unwrap()?
+            .into_typed::<AnnounceLeaderCommand>();
 
-        let_assert!(Command::AnnounceLeader(announce_leader) = envelope.command);
+        let announce_leader = envelope.into_inner()?;
         assert_eq!(announce_leader.node_id, NODE_ID);
         assert_eq!(announce_leader.leader_epoch, leader_epoch);
         assert_eq!(announce_leader.partition_key_range, PARTITION_KEY_RANGE);
@@ -1148,8 +1145,11 @@ mod tests {
         assert!(!state.is_effective_leader());
 
         let record = reader.next().await.unwrap()?;
-        let envelope = record.try_decode::<Envelope>().unwrap()?;
-        let_assert!(Command::VersionBarrier(barrier) = envelope.command);
+        let envelope = record
+            .try_decode::<Envelope<Raw>>()
+            .unwrap()?
+            .into_typed::<commands::VersionBarrierCommand>();
+        let barrier = envelope.into_inner()?;
         assert!(
             barrier
                 .feature_changes

--- a/crates/worker/src/partition/leadership/self_proposer.rs
+++ b/crates/worker/src/partition/leadership/self_proposer.rs
@@ -8,19 +8,19 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::sync::Arc;
-
 use futures::never::Never;
 
 use restate_bifrost::{
     Bifrost, EnqueueError, EnqueueWithNotificationResult, ErrorRecoveryStrategy, InputRecord,
 };
-use restate_storage_api::deduplication_table::{DedupInformation, EpochSequenceNumber};
+use restate_storage_api::deduplication_table::EpochSequenceNumber;
 use restate_types::{
-    config::Configuration, identifiers::PartitionKey, logs::LogId, net::ingest::IngestRecord,
+    config::Configuration,
+    logs::{BodyWithKeys, Keys, LogId},
+    net::ingest::IngestRecord,
     time::NanosSinceEpoch,
 };
-use restate_wal_protocol::{Command, Destination, Envelope, Header, Source};
+use restate_wal_protocol::v2::{Command, CommandWithKeys, Dedup, Envelope, ErasedCommand, Raw};
 
 use crate::partition::leadership::Error;
 
@@ -33,7 +33,7 @@ static BIFROST_APPENDER_TASK: &str = "bifrost-appender";
 
 pub struct SelfProposer {
     epoch_sequence_number: EpochSequenceNumber,
-    bifrost_appender: restate_bifrost::AppenderHandle<Envelope>,
+    bifrost_appender: restate_bifrost::AppenderHandle<Envelope<Raw>>,
 }
 
 impl SelfProposer {
@@ -72,32 +72,29 @@ impl SelfProposer {
 
     /// Self-propose many commands to Bifrost, attaching ESN-based dedup information.
     /// Returns the number of bytes proposed (the serialized size of all the commands).
-    pub fn self_propose_many(
-        &mut self,
-        cmds: impl ExactSizeIterator<Item = (PartitionKey, Command)>,
-    ) -> Result<usize, Error> {
+    pub fn self_propose_many<I, T, C>(&mut self, cmds: I) -> Result<usize, Error>
+    where
+        I: ExactSizeIterator<Item = T>,
+        T: CommandWithKeys<C>,
+        C: Command,
+    {
         // allocate a sequence number range for the batch
         let leader_epoch = self.epoch_sequence_number.leader_epoch;
 
         let start_seq = self.epoch_sequence_number.sequence_number;
         let end_seq = start_seq + cmds.len() as u64;
 
-        let envelopes = cmds.enumerate().map(|(idx, (partition_key, cmd))| {
-            let esn = EpochSequenceNumber {
-                leader_epoch,
-                sequence_number: start_seq + idx as u64,
-            };
-            let header = Header {
-                dest: Destination::Processor {
-                    partition_key,
-                    dedup: Some(DedupInformation::self_proposal(esn)),
-                },
-                source: Source::Processor {
-                    partition_key: Some(partition_key),
+        let envelopes = cmds.enumerate().map(|(idx, command)| {
+            let keys = command.keys();
+            let envelope = Envelope::new(
+                Dedup::SelfProposal {
                     leader_epoch,
+                    seq: start_seq + idx as u64,
                 },
-            };
-            Arc::new(Envelope::new(header, cmd))
+                command.inner(),
+            )
+            .into_raw();
+            BodyWithKeys::new(envelope, keys)
         });
 
         let bytes_written = self
@@ -117,16 +114,43 @@ impl SelfProposer {
 
     /// Self-propose a single command to Bifrost, attaching ESN-based dedup information.
     /// Returns the number of bytes proposed (the serialized size of the command).
-    pub fn self_propose(
+    pub fn self_propose<C: Command>(
         &mut self,
-        partition_key: PartitionKey,
-        cmd: Command,
+        command: impl CommandWithKeys<C>,
     ) -> Result<usize, Error> {
-        let envelope = Envelope::new(self.create_self_propose_header(partition_key), cmd);
+        let esn = self.next_esn();
+        let dedup = Dedup::SelfProposal {
+            leader_epoch: esn.leader_epoch,
+            seq: esn.sequence_number,
+        };
+
+        let keys = command.keys();
+        let envelope = Envelope::new(dedup, command.inner());
 
         self.bifrost_appender
             .sender()
-            .enqueue(Arc::new(envelope))
+            .enqueue(BodyWithKeys::new(envelope.into_raw(), keys))
+            .map_err(|e| Error::SelfProposer(e.to_string()))
+    }
+
+    /// Self-propose a single erased-command to Bifrost, attaching ESN-based dedup information.
+    /// Returns the number of bytes proposed (the serialized size of the command).
+    pub fn self_propose_erased(
+        &mut self,
+        keys: Keys,
+        command: ErasedCommand,
+    ) -> Result<usize, Error> {
+        let esn = self.next_esn();
+        let dedup = Dedup::SelfProposal {
+            leader_epoch: esn.leader_epoch,
+            seq: esn.sequence_number,
+        };
+
+        let envelope = Envelope::from_erased_command(dedup, command);
+
+        self.bifrost_appender
+            .sender()
+            .enqueue(BodyWithKeys::new(envelope, keys))
             .map_err(|e| Error::SelfProposer(e.to_string()))
     }
 
@@ -135,16 +159,22 @@ impl SelfProposer {
     /// on the appender.
     /// This should only be used for commands that can't afford a backpressue.
     /// Returns the number of bytes proposed (the serialized size of the command).
-    pub fn self_propose_unaccounted(
+    pub fn self_propose_unaccounted<C: Command>(
         &mut self,
-        partition_key: PartitionKey,
-        cmd: Command,
+        command: impl CommandWithKeys<C>,
     ) -> Result<usize, Error> {
-        let envelope = Envelope::new(self.create_self_propose_header(partition_key), cmd);
+        let esn = self.next_esn();
+        let dedup = Dedup::SelfProposal {
+            leader_epoch: esn.leader_epoch,
+            seq: esn.sequence_number,
+        };
+
+        let keys = command.keys();
+        let envelope = Envelope::new(dedup, command.inner());
 
         self.bifrost_appender
             .sender()
-            .enqueue_unaccounted(Arc::new(envelope))
+            .enqueue_unaccounted(BodyWithKeys::new(envelope.into_raw(), keys))
             .map_err(|e| Error::SelfProposer(e.to_string()))
     }
 
@@ -156,24 +186,14 @@ impl SelfProposer {
     /// which makes them safe for fire-and-forget ingress commands (signals, invocation responses).
     pub fn append_with_notification(
         &mut self,
-        partition_key: PartitionKey,
-        cmd: Command,
+        keys: Keys,
+        command: ErasedCommand,
     ) -> Result<EnqueueWithNotificationResult, Error> {
-        let header = Header {
-            dest: Destination::Processor {
-                partition_key,
-                dedup: None,
-            },
-            source: Source::Processor {
-                partition_key: Some(partition_key),
-                leader_epoch: self.epoch_sequence_number.leader_epoch,
-            },
-        };
-        let envelope = Envelope::new(header, cmd);
+        let envelope = Envelope::from_erased_command(Dedup::None, command);
 
         self.bifrost_appender
             .sender()
-            .enqueue_with_notification(Arc::new(envelope))
+            .enqueue_with_notification(BodyWithKeys::new(envelope, keys))
             .map_err(|e| Error::SelfProposer(e.to_string()))
     }
 
@@ -209,22 +229,6 @@ impl SelfProposer {
         })
     }
 
-    fn create_self_propose_header(&mut self, partition_key: PartitionKey) -> Header {
-        let esn = self.epoch_sequence_number;
-        self.epoch_sequence_number = self.epoch_sequence_number.next();
-
-        Header {
-            dest: Destination::Processor {
-                partition_key,
-                dedup: Some(DedupInformation::self_proposal(esn)),
-            },
-            source: Source::Processor {
-                partition_key: Some(partition_key),
-                leader_epoch: self.epoch_sequence_number.leader_epoch,
-            },
-        }
-    }
-
     /// Waits for self proposer to fail. This method will only complete with an error if the self
     /// proposer has failed. There is no guarantee up to which point the self proposer has finished
     /// processing the proposed commands.
@@ -243,5 +247,11 @@ impl SelfProposer {
 
     pub fn wait_for_capacity(&self) -> impl std::future::Future<Output = ()> + 'static {
         self.bifrost_appender.sender_ref().wait_for_capacity()
+    }
+
+    fn next_esn(&mut self) -> EpochSequenceNumber {
+        let esn = self.epoch_sequence_number;
+        self.epoch_sequence_number = self.epoch_sequence_number.next();
+        esn
     }
 }

--- a/crates/worker/src/partition/processor/commands/truncate_outbox.rs
+++ b/crates/worker/src/partition/processor/commands/truncate_outbox.rs
@@ -106,10 +106,7 @@ mod tests {
         storage: &mut PartitionStore,
         index: MessageIndex,
     ) {
-        let envelope = TruncateOutboxCommand::test_envelope(TruncateOutboxCommand {
-            index,
-            partition_key_range: Keys::None,
-        });
+        let envelope = TruncateOutboxCommand::test_envelope(TruncateOutboxCommand { index });
         let record = DataRecord::new(
             NanosSinceEpoch::RESTATE_EPOCH,
             Keys::None,

--- a/crates/worker/src/partition/rpc/append_invocation.rs
+++ b/crates/worker/src/partition/rpc/append_invocation.rs
@@ -9,11 +9,11 @@
 // by the Apache License, Version 2.0.
 
 use super::*;
-use restate_types::identifiers::WithPartitionKey;
 use restate_types::invocation;
 use restate_types::invocation::{
     ServiceInvocation, ServiceInvocationResponseSink, SubmitNotificationSink,
 };
+use restate_wal_protocol::v2::commands;
 
 pub(super) struct Request {
     pub(super) request_id: PartitionProcessorRpcRequestId,
@@ -49,13 +49,9 @@ impl<'a, TSchemas, TStorage> RpcHandler<Request> for RpcContext<'a, TSchemas, TS
             }
         };
 
-        let partition_key = service_invocation.partition_key();
-        let cmd = Command::Invoke(Box::new(service_invocation));
-
-        Decision::Propose(RpcProposal {
-            partition_key,
-            cmd,
-            reply_on: match append_invocation_reply_on {
+        Decision::Propose(RpcProposal::new(
+            commands::InvokeCommand::from(service_invocation),
+            match append_invocation_reply_on {
                 AppendInvocationReplyOn::Appended => ReplyOn::Commit {
                     response: PartitionProcessorRpcResponse::Appended,
                 },
@@ -63,7 +59,7 @@ impl<'a, TSchemas, TStorage> RpcHandler<Request> for RpcContext<'a, TSchemas, TS
                     ReplyOn::Apply { request_id }
                 }
             },
-        })
+        ))
     }
 }
 
@@ -92,70 +88,78 @@ mod tests {
 
     #[test(restate_core::test)]
     async fn reply_on_appended() {
-        let_assert!(
-            Decision::Propose(RpcProposal {
-                cmd: Command::Invoke(service_invocation),
-                reply_on: ReplyOn::Commit { response },
-                ..
-            }) = handle(Default::default(), AppendInvocationReplyOn::Appended).await
-        );
+        let (_, service_invocation_command, reply_on) =
+            handle(Default::default(), AppendInvocationReplyOn::Appended)
+                .await
+                .extract_as_rpc_proposal::<commands::InvokeCommand>();
+
+        let service_invocation: ServiceInvocation = service_invocation_command.into();
+        let_assert!(ReplyOn::Commit { response } = reply_on);
+
         assert_eq!(response, PartitionProcessorRpcResponse::Appended);
         assert_that!(
             service_invocation,
-            points_to(all!(
+            all!(
                 field!(ServiceInvocation.response_sink, none()),
                 field!(ServiceInvocation.submit_notification_sink, none()),
-            ))
+            )
         );
     }
 
     #[test(restate_core::test)]
     async fn reply_on_submitted() {
         let request_id = PartitionProcessorRpcRequestId::new();
+
+        let (_, service_invocation_command, reply_on) =
+            handle(request_id, AppendInvocationReplyOn::Submitted)
+                .await
+                .extract_as_rpc_proposal::<commands::InvokeCommand>();
+
+        let service_invocation: ServiceInvocation = service_invocation_command.into();
         let_assert!(
-            Decision::Propose(RpcProposal {
-                cmd: Command::Invoke(service_invocation),
-                reply_on: ReplyOn::Apply {
-                    request_id: actual_request_id,
-                },
-                ..
-            }) = handle(request_id, AppendInvocationReplyOn::Submitted).await
+            ReplyOn::Apply {
+                request_id: actual_request_id
+            } = reply_on
         );
+
         assert_eq!(actual_request_id, request_id);
         assert_that!(
             service_invocation,
-            points_to(all!(
+            all!(
                 field!(ServiceInvocation.response_sink, none()),
                 field!(
                     ServiceInvocation.submit_notification_sink,
                     some(eq(SubmitNotificationSink::Ingress { request_id }))
                 ),
-            ))
+            )
         );
     }
 
     #[test(restate_core::test)]
     async fn reply_on_output() {
         let request_id = PartitionProcessorRpcRequestId::new();
+
+        let (_, service_invocation_command, reply_on) =
+            handle(request_id, AppendInvocationReplyOn::Output)
+                .await
+                .extract_as_rpc_proposal::<commands::InvokeCommand>();
+
+        let service_invocation: ServiceInvocation = service_invocation_command.into();
         let_assert!(
-            Decision::Propose(RpcProposal {
-                cmd: Command::Invoke(service_invocation),
-                reply_on: ReplyOn::Apply {
-                    request_id: actual_request_id,
-                },
-                ..
-            }) = handle(request_id, AppendInvocationReplyOn::Output).await
+            ReplyOn::Apply {
+                request_id: actual_request_id
+            } = reply_on
         );
         assert_eq!(actual_request_id, request_id);
         assert_that!(
             service_invocation,
-            points_to(all!(
+            all!(
                 field!(
                     ServiceInvocation.response_sink,
                     some(eq(ServiceInvocationResponseSink::Ingress { request_id }))
                 ),
                 field!(ServiceInvocation.submit_notification_sink, none()),
-            ))
+            )
         );
     }
 }

--- a/crates/worker/src/partition/rpc/append_invocation_response.rs
+++ b/crates/worker/src/partition/rpc/append_invocation_response.rs
@@ -9,10 +9,9 @@
 // by the Apache License, Version 2.0.
 
 use super::*;
-use restate_types::identifiers::WithPartitionKey;
 use restate_types::invocation::InvocationResponse;
 use restate_types::net::partition_processor::PartitionProcessorRpcResponse;
-use restate_wal_protocol::Command;
+use restate_wal_protocol::v2::commands;
 
 pub(super) struct Request {
     pub(super) invocation_response: InvocationResponse,
@@ -25,12 +24,11 @@ impl<'a, TSchemas, TStorage> RpcHandler<Request> for RpcContext<'a, TSchemas, TS
             invocation_response,
         }: Request,
     ) -> Decision {
-        Decision::Propose(RpcProposal {
-            partition_key: invocation_response.partition_key(),
-            cmd: Command::InvocationResponse(invocation_response),
-            reply_on: ReplyOn::Commit {
+        Decision::Propose(RpcProposal::new(
+            commands::InvocationResponseCommand::from(invocation_response),
+            ReplyOn::Commit {
                 response: PartitionProcessorRpcResponse::Appended,
             },
-        })
+        ))
     }
 }

--- a/crates/worker/src/partition/rpc/append_signal.rs
+++ b/crates/worker/src/partition/rpc/append_signal.rs
@@ -9,11 +9,11 @@
 // by the Apache License, Version 2.0.
 
 use super::*;
-use restate_types::identifiers::{InvocationId, WithPartitionKey};
+use restate_types::identifiers::InvocationId;
 use restate_types::invocation::NotifySignalRequest;
 use restate_types::journal_v2::Signal;
 use restate_types::net::partition_processor::PartitionProcessorRpcResponse;
-use restate_wal_protocol::Command;
+use restate_wal_protocol::v2::commands;
 
 pub(super) struct Request {
     pub(super) invocation_id: InvocationId,
@@ -28,15 +28,14 @@ impl<'a, TSchemas, TStorage> RpcHandler<Request> for RpcContext<'a, TSchemas, TS
             signal,
         }: Request,
     ) -> Decision {
-        Decision::Propose(RpcProposal {
-            partition_key: invocation_id.partition_key(),
-            cmd: Command::NotifySignal(NotifySignalRequest {
+        Decision::Propose(RpcProposal::new(
+            commands::NotifySignalCommand::from(NotifySignalRequest {
                 invocation_id,
                 signal,
             }),
-            reply_on: ReplyOn::Commit {
+            ReplyOn::Commit {
                 response: PartitionProcessorRpcResponse::Appended,
             },
-        })
+        ))
     }
 }

--- a/crates/worker/src/partition/rpc/cancel_invocation.rs
+++ b/crates/worker/src/partition/rpc/cancel_invocation.rs
@@ -9,12 +9,12 @@
 // by the Apache License, Version 2.0.
 
 use super::*;
-use restate_types::identifiers::{InvocationId, WithPartitionKey};
+use restate_types::identifiers::InvocationId;
 use restate_types::invocation::{
     IngressInvocationResponseSink, InvocationMutationResponseSink, InvocationTermination,
     TerminationFlavor,
 };
-use restate_wal_protocol::Command;
+use restate_wal_protocol::v2::commands;
 
 pub(super) struct Request {
     pub(super) request_id: PartitionProcessorRpcRequestId,
@@ -29,16 +29,15 @@ impl<'a, TSchemas, TStorage> RpcHandler<Request> for RpcContext<'a, TSchemas, TS
             invocation_id,
         }: Request,
     ) -> Decision {
-        Decision::Propose(RpcProposal {
-            partition_key: invocation_id.partition_key(),
-            cmd: Command::TerminateInvocation(InvocationTermination {
+        Decision::Propose(RpcProposal::new(
+            commands::TerminateInvocationCommand::from(InvocationTermination {
                 invocation_id,
                 flavor: TerminationFlavor::Cancel,
                 response_sink: Some(InvocationMutationResponseSink::Ingress(
                     IngressInvocationResponseSink { request_id },
                 )),
             }),
-            reply_on: ReplyOn::Apply { request_id },
-        })
+            ReplyOn::Apply { request_id },
+        ))
     }
 }

--- a/crates/worker/src/partition/rpc/get_invocation_output.rs
+++ b/crates/worker/src/partition/rpc/get_invocation_output.rs
@@ -11,7 +11,6 @@
 use super::*;
 use restate_storage_api::StorageError;
 use restate_storage_api::invocation_status_table::{InvocationStatus, ReadInvocationStatusTable};
-use restate_types::identifiers::WithPartitionKey;
 use restate_types::invocation;
 use restate_types::invocation::client::{InvocationOutput, InvocationOutputResponse};
 use restate_types::invocation::{
@@ -20,7 +19,7 @@ use restate_types::invocation::{
 use restate_types::net::partition_processor::{
     GetInvocationOutputResponseMode, PartitionProcessorRpcError, PartitionProcessorRpcResponse,
 };
-use restate_wal_protocol::Command;
+use restate_wal_protocol::v2::commands;
 
 pub(super) struct Request {
     pub(super) request_id: PartitionProcessorRpcRequestId,
@@ -86,15 +85,14 @@ where
                     return Decision::Reply(Ok(ready_result));
                 }
 
-                Decision::Propose(RpcProposal {
-                    partition_key: invocation_query.partition_key(),
-                    cmd: Command::AttachInvocation(AttachInvocationRequest {
+                Decision::Propose(RpcProposal::new(
+                    commands::AttachInvocationCommand::from(AttachInvocationRequest {
                         invocation_query,
                         block_on_inflight: true,
                         response_sink: ServiceInvocationResponseSink::Ingress { request_id },
                     }),
-                    reply_on: ReplyOn::Apply { request_id },
-                })
+                    ReplyOn::Apply { request_id },
+                ))
             }
             GetInvocationOutputResponseMode::ReplyIfNotReady => {
                 // Reading invocation output from a non-leader partition processor can return

--- a/crates/worker/src/partition/rpc/kill_invocation.rs
+++ b/crates/worker/src/partition/rpc/kill_invocation.rs
@@ -9,12 +9,12 @@
 // by the Apache License, Version 2.0.
 
 use super::*;
-use restate_types::identifiers::{InvocationId, WithPartitionKey};
+use restate_types::identifiers::InvocationId;
 use restate_types::invocation::{
     IngressInvocationResponseSink, InvocationMutationResponseSink, InvocationTermination,
     TerminationFlavor,
 };
-use restate_wal_protocol::Command;
+use restate_wal_protocol::v2::commands;
 
 pub(super) struct Request {
     pub(super) request_id: PartitionProcessorRpcRequestId,
@@ -29,16 +29,15 @@ impl<'a, TSchemas, TStorage> RpcHandler<Request> for RpcContext<'a, TSchemas, TS
             invocation_id,
         }: Request,
     ) -> Decision {
-        Decision::Propose(RpcProposal {
-            partition_key: invocation_id.partition_key(),
-            cmd: Command::TerminateInvocation(InvocationTermination {
+        Decision::Propose(RpcProposal::new(
+            commands::TerminateInvocationCommand::from(InvocationTermination {
                 invocation_id,
                 flavor: TerminationFlavor::Kill,
                 response_sink: Some(InvocationMutationResponseSink::Ingress(
                     IngressInvocationResponseSink { request_id },
                 )),
             }),
-            reply_on: ReplyOn::Apply { request_id },
-        })
+            ReplyOn::Apply { request_id },
+        ))
     }
 }

--- a/crates/worker/src/partition/rpc/mod.rs
+++ b/crates/worker/src/partition/rpc/mod.rs
@@ -25,26 +25,47 @@ use std::sync::Arc;
 use restate_storage_api::invocation_status_table::ReadInvocationStatusTable;
 use restate_storage_api::journal_table as journal_table_v1;
 use restate_storage_api::journal_table_v2::ReadJournalTable;
-use restate_types::identifiers::{
-    InvocationId, PartitionId, PartitionKey, PartitionProcessorRpcRequestId,
-};
+use restate_types::identifiers::{InvocationId, PartitionId, PartitionProcessorRpcRequestId};
 use restate_types::invocation::InvocationRequest;
+use restate_types::logs::Keys;
 use restate_types::net::partition_processor::{
     AppendInvocationReplyOn, PartitionProcessorRpcError, PartitionProcessorRpcRequest,
     PartitionProcessorRpcRequestInner, PartitionProcessorRpcResponse,
 };
 use restate_types::schema::deployment::DeploymentResolver;
-use restate_wal_protocol::Command;
+use restate_wal_protocol::v2::{Command, CommandWithKeys, ErasedCommand};
 
-#[derive(Debug, Clone)]
+#[derive(Clone, derive_more::Debug)]
 pub(crate) struct RpcProposal {
-    pub(crate) partition_key: PartitionKey,
-    pub(crate) cmd: Command,
-    pub(crate) reply_on: ReplyOn,
+    keys: Keys,
+    cmd: ErasedCommand,
+    reply_on: ReplyOn,
 }
 
-#[derive(Debug)]
+impl RpcProposal {
+    pub(crate) fn new<C: Command>(cmd: impl CommandWithKeys<C>, reply_on: ReplyOn) -> Self {
+        let keys = cmd.keys();
+        let cmd = cmd.inner();
+        Self {
+            keys,
+            cmd: ErasedCommand::new(cmd),
+            reply_on,
+        }
+    }
+
+    pub(crate) fn into_parts(self) -> (Keys, ErasedCommand, ReplyOn) {
+        let Self {
+            keys,
+            cmd,
+            reply_on,
+        } = self;
+
+        (keys, cmd, reply_on)
+    }
+}
+
 #[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
 pub(crate) enum Decision {
     Propose(RpcProposal),
     /// Reply immediately; nothing is proposed.
@@ -55,6 +76,25 @@ pub(crate) enum Decision {
         notification: InvokerNotification,
         reply: PartitionProcessorRpcResponse,
     },
+}
+
+impl Decision {
+    #[cfg(test)]
+    fn extract_as_rpc_proposal<C: Command>(self) -> (Keys, C, ReplyOn) {
+        let Self::Propose(proposal) = self else {
+            panic!("Invalid Decision variant, expecting Decision::Propose");
+        };
+
+        let Some(inner) = proposal.cmd.downcast_arc::<C>() else {
+            panic!("Command type is not match '{}'", C::KIND);
+        };
+
+        (
+            proposal.keys,
+            Arc::into_inner(inner).expect("only owner"),
+            proposal.reply_on,
+        )
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/worker/src/partition/rpc/pause_invocation.rs
+++ b/crates/worker/src/partition/rpc/pause_invocation.rs
@@ -11,6 +11,7 @@
 use super::*;
 use restate_storage_api::invocation_status_table::InvocationStatus;
 use restate_types::identifiers::{InvocationId, WithPartitionKey};
+use restate_types::logs::BodyWithKeys;
 use restate_types::net::partition_processor::PauseInvocationRpcResponse;
 use restate_wal_protocol::invocation::PauseInvocationCommand;
 
@@ -63,20 +64,19 @@ where
             // replies via Action::ForwardPauseInvocationResponse. propose_pause_and_fence clears
             // the leader's in-memory fencing token (after appending the command) so that any
             // straggler effect from the attempt we are pausing is dropped at write time.
-            return Decision::Propose(RpcProposal {
-                partition_key: invocation_id.partition_key(),
-                cmd: Command::PauseInvocation(
+            return Decision::Propose(RpcProposal::new(
+                BodyWithKeys::new(
                     PauseInvocationCommand {
                         invocation_id,
                         request_id: Some(request_id),
-                    }
-                    .bilrost_encode_to_bytes(),
+                    },
+                    Keys::Single(invocation_id.partition_key()),
                 ),
-                reply_on: ReplyOn::ApplyAndFence {
+                ReplyOn::ApplyAndFence {
                     request_id,
                     invocation_id,
                 },
-            });
+            ));
         }
 
         // -- Legacy path for invoker-owned (non-VQueue) invocations: best-effort invoker poke.
@@ -105,7 +105,9 @@ mod tests {
     use std::assert_matches;
     use std::future::ready;
 
+    use assert2::let_assert;
     use restate_storage_api::invocation_status_table::InFlightInvocationMetadata;
+    use restate_wal_protocol::v2::commands;
     use test_log::test;
 
     use super::*;
@@ -225,22 +227,20 @@ mod tests {
         )
         .await;
 
-        let Decision::Propose(RpcProposal {
-            partition_key,
-            cmd: Command::PauseInvocation(bytes),
-            reply_on:
-                ReplyOn::ApplyAndFence {
-                    request_id: actual_request_id,
-                    invocation_id: actual_invocation_id,
-                },
-        }) = decision
-        else {
-            panic!("expected a fenced pause proposal");
-        };
-        assert_eq!(partition_key, invocation_id.partition_key());
+        let (keys, pause, reply_on) =
+            decision.extract_as_rpc_proposal::<commands::PauseInvocationCommand>();
+
+        let_assert!(
+            ReplyOn::ApplyAndFence {
+                request_id: actual_request_id,
+                invocation_id: actual_invocation_id,
+            } = reply_on
+        );
+
+        assert!(matches!(keys, Keys::Single(pk) if pk == invocation_id.partition_key()));
+
         assert_eq!(actual_request_id, request_id);
         assert_eq!(actual_invocation_id, invocation_id);
-        let pause = PauseInvocationCommand::bilrost_decode(bytes).unwrap();
         assert_eq!(pause.invocation_id, invocation_id);
         assert_eq!(pause.request_id, Some(request_id));
     }

--- a/crates/worker/src/partition/rpc/purge_invocation.rs
+++ b/crates/worker/src/partition/rpc/purge_invocation.rs
@@ -9,11 +9,11 @@
 // by the Apache License, Version 2.0.
 
 use super::*;
-use restate_types::identifiers::{InvocationId, WithPartitionKey};
+use restate_types::identifiers::InvocationId;
 use restate_types::invocation::{
     IngressInvocationResponseSink, InvocationMutationResponseSink, PurgeInvocationRequest,
 };
-use restate_wal_protocol::Command;
+use restate_wal_protocol::v2::commands;
 
 pub(super) struct Request {
     pub(super) request_id: PartitionProcessorRpcRequestId,
@@ -28,15 +28,14 @@ impl<'a, TSchemas, TStorage> RpcHandler<Request> for RpcContext<'a, TSchemas, TS
             invocation_id,
         }: Request,
     ) -> Decision {
-        Decision::Propose(RpcProposal {
-            partition_key: invocation_id.partition_key(),
-            cmd: Command::PurgeInvocation(PurgeInvocationRequest {
+        Decision::Propose(RpcProposal::new(
+            commands::PurgeInvocationCommand::from(PurgeInvocationRequest {
                 invocation_id,
                 response_sink: Some(InvocationMutationResponseSink::Ingress(
                     IngressInvocationResponseSink { request_id },
                 )),
             }),
-            reply_on: ReplyOn::Apply { request_id },
-        })
+            ReplyOn::Apply { request_id },
+        ))
     }
 }

--- a/crates/worker/src/partition/rpc/purge_journal.rs
+++ b/crates/worker/src/partition/rpc/purge_journal.rs
@@ -9,11 +9,11 @@
 // by the Apache License, Version 2.0.
 
 use super::*;
-use restate_types::identifiers::{InvocationId, WithPartitionKey};
+use restate_types::identifiers::InvocationId;
 use restate_types::invocation::{
     IngressInvocationResponseSink, InvocationMutationResponseSink, PurgeInvocationRequest,
 };
-use restate_wal_protocol::Command;
+use restate_wal_protocol::v2::commands;
 
 pub(super) struct Request {
     pub(super) request_id: PartitionProcessorRpcRequestId,
@@ -28,15 +28,14 @@ impl<'a, TSchemas, TStorage> RpcHandler<Request> for RpcContext<'a, TSchemas, TS
             invocation_id,
         }: Request,
     ) -> Decision {
-        Decision::Propose(RpcProposal {
-            partition_key: invocation_id.partition_key(),
-            cmd: Command::PurgeJournal(PurgeInvocationRequest {
+        Decision::Propose(RpcProposal::new(
+            commands::PurgeJournalCommand::from(PurgeInvocationRequest {
                 invocation_id,
                 response_sink: Some(InvocationMutationResponseSink::Ingress(
                     IngressInvocationResponseSink { request_id },
                 )),
             }),
-            reply_on: ReplyOn::Apply { request_id },
-        })
+            ReplyOn::Apply { request_id },
+        ))
     }
 }

--- a/crates/worker/src/partition/rpc/restart_as_new_invocation.rs
+++ b/crates/worker/src/partition/rpc/restart_as_new_invocation.rs
@@ -30,6 +30,7 @@ use restate_types::journal_v2::{CommandMetadata, EntryMetadata, EntryType};
 use restate_types::net::partition_processor::RestartAsNewInvocationRpcResponse;
 use restate_types::service_protocol::ServiceProtocolVersion;
 use restate_types::{invocation, journal_v2};
+use restate_wal_protocol::v2::commands;
 
 pub(super) struct Request {
     pub(super) request_id: PartitionProcessorRpcRequestId,
@@ -231,17 +232,16 @@ where
             );
 
             // Propose the usual Invoke command
-            let cmd = Command::Invoke(Box::new(service_invocation));
+            let cmd = commands::InvokeCommand::from(service_invocation);
 
             // Propose and done
             // This path should be no longer needed once we switch to the journal v2 by default.
-            return Decision::Propose(RpcProposal {
-                partition_key: invocation_id.partition_key(),
+            return Decision::Propose(RpcProposal::new(
                 cmd,
-                reply_on: ReplyOn::Commit {
+                ReplyOn::Commit {
                     response: RestartAsNewInvocationRpcResponse::Ok { new_invocation_id }.into(),
                 },
-            });
+            ));
         }
 
         // For Restart from prefix, the PP will actually execute the operation,
@@ -359,7 +359,7 @@ where
         }
 
         // Pass the ball to the state machine, the PP will reply to the RPC request.
-        let cmd = Command::RestartAsNewInvocation(RestartAsNewInvocationRequest {
+        let cmd = commands::RestartAsNewInvocationCommand::from(RestartAsNewInvocationRequest {
             invocation_id,
             new_invocation_id,
             copy_prefix_up_to_index_included,
@@ -368,11 +368,8 @@ where
                 IngressInvocationResponseSink { request_id },
             )),
         });
-        Decision::Propose(RpcProposal {
-            partition_key: invocation_id.partition_key(),
-            cmd,
-            reply_on: ReplyOn::Apply { request_id },
-        })
+
+        Decision::Propose(RpcProposal::new(cmd, ReplyOn::Apply { request_id }))
     }
 }
 
@@ -759,21 +756,16 @@ mod tests {
             },
         )
         .await;
-        let (service_invocation, response) = match decision {
-            Decision::Propose(RpcProposal {
-                cmd: Command::Invoke(service_invocation),
-                reply_on: ReplyOn::Commit { response },
-                ..
-            }) => (service_invocation, response),
-            Decision::Propose(RpcProposal { cmd, .. }) => panic!("unexpected proposal: {cmd:?}"),
-            Decision::Reply(reply) => panic!("unexpected reply: {reply:?}"),
-            Decision::NotifyInvokerAndReply { .. } => {
-                panic!("unexpected invoker notification")
-            }
-        };
+
+        let (_, service_invocation_command, reply_on) =
+            decision.extract_as_rpc_proposal::<commands::InvokeCommand>();
+
+        let_assert!(ReplyOn::Commit { response } = reply_on);
+        let service_invocation: ServiceInvocation = service_invocation_command.into();
+
         assert_that!(
             service_invocation,
-            points_to(all!(
+            all!(
                 field!(ServiceInvocation.invocation_id, not(eq(old_invocation_id))),
                 field!(ServiceInvocation.argument, eq(payload_clone)),
                 field!(ServiceInvocation.headers, eq(headers_clone)),
@@ -783,7 +775,7 @@ mod tests {
                 ),
                 field!(ServiceInvocation.response_sink, none()),
                 field!(ServiceInvocation.submit_notification_sink, none()),
-            ))
+            )
         );
         assert_that!(
             response,
@@ -984,14 +976,13 @@ mod tests {
             },
         )
         .await;
-        let Decision::Propose(RpcProposal {
-            cmd: Command::RestartAsNewInvocation(request),
-            reply_on: ReplyOn::Apply { .. },
-            ..
-        }) = decision
-        else {
-            panic!("expected an on-apply restart-as-new proposal");
-        };
+
+        let (_, restart_as_new_command, reply_on) =
+            decision.extract_as_rpc_proposal::<commands::RestartAsNewInvocationCommand>();
+
+        let_assert!(ReplyOn::Apply { .. } = reply_on);
+        let request: RestartAsNewInvocationRequest = restart_as_new_command.into();
+
         assert_eq!(request.copy_prefix_up_to_index_included, 0);
         assert_eq!(request.patch_deployment_id, None);
     }
@@ -1029,14 +1020,13 @@ mod tests {
             },
         )
         .await;
-        let Decision::Propose(RpcProposal {
-            cmd: Command::RestartAsNewInvocation(request),
-            reply_on: ReplyOn::Apply { .. },
-            ..
-        }) = decision
-        else {
-            panic!("expected an on-apply restart-as-new proposal");
-        };
+
+        let (_, restart_as_new_command, reply_on) =
+            decision.extract_as_rpc_proposal::<commands::RestartAsNewInvocationCommand>();
+
+        let_assert!(ReplyOn::Apply { .. } = reply_on);
+        let request: RestartAsNewInvocationRequest = restart_as_new_command.into();
+
         assert_eq!(request.copy_prefix_up_to_index_included, 0);
         assert_eq!(request.patch_deployment_id, None);
     }
@@ -1246,14 +1236,13 @@ mod tests {
             },
         )
         .await;
-        let Decision::Propose(RpcProposal {
-            cmd: Command::RestartAsNewInvocation(request),
-            reply_on: ReplyOn::Apply { .. },
-            ..
-        }) = decision
-        else {
-            panic!("expected an on-apply restart-as-new proposal");
-        };
+
+        let (_, restart_as_new_command, reply_on) =
+            decision.extract_as_rpc_proposal::<commands::RestartAsNewInvocationCommand>();
+
+        let_assert!(ReplyOn::Apply { .. } = reply_on);
+        let request: RestartAsNewInvocationRequest = restart_as_new_command.into();
+
         assert_eq!(request.copy_prefix_up_to_index_included, 1);
         assert_eq!(request.patch_deployment_id, None);
     }
@@ -1293,14 +1282,13 @@ mod tests {
             },
         )
         .await;
-        let Decision::Propose(RpcProposal {
-            cmd: Command::RestartAsNewInvocation(request),
-            reply_on: ReplyOn::Apply { .. },
-            ..
-        }) = decision
-        else {
-            panic!("expected an on-apply restart-as-new proposal");
-        };
+
+        let (_, restart_as_new_command, reply_on) =
+            decision.extract_as_rpc_proposal::<commands::RestartAsNewInvocationCommand>();
+
+        let_assert!(ReplyOn::Apply { .. } = reply_on);
+        let request: RestartAsNewInvocationRequest = restart_as_new_command.into();
+
         assert_eq!(request.copy_prefix_up_to_index_included, 1);
         assert_eq!(request.patch_deployment_id, Some(latest_id));
     }

--- a/crates/worker/src/partition/rpc/resume_invocation.rs
+++ b/crates/worker/src/partition/rpc/resume_invocation.rs
@@ -11,13 +11,14 @@
 use super::*;
 use crate::partition::state_machine::resolve_pinned_deployment;
 use restate_storage_api::invocation_status_table::{InvocationStatus, ReadInvocationStatusTable};
-use restate_types::identifiers::{InvocationId, WithPartitionKey};
+use restate_types::identifiers::InvocationId;
 use restate_types::invocation::client::PatchDeploymentId;
 use restate_types::invocation::{
     IngressInvocationResponseSink, InvocationMutationResponseSink, ResumeInvocationRequest,
 };
 use restate_types::net::partition_processor::ResumeInvocationRpcResponse;
 use restate_types::schema::deployment::DeploymentResolver;
+use restate_wal_protocol::v2::commands;
 
 pub(super) struct Request {
     pub(super) request_id: PartitionProcessorRpcRequestId,
@@ -59,9 +60,8 @@ where
                     // is no running attempt to fence, so use the plain proposal path -- unlike
                     // pause's `propose_pause_and_fence`. Writing the new `update_deployment_id` field
                     // is safe here: vqueues being enabled implies a cluster min version >= 1.7.0.
-                    Decision::Propose(RpcProposal {
-                        partition_key: invocation_id.partition_key(),
-                        cmd: Command::ResumeInvocation(ResumeInvocationRequest {
+                    Decision::Propose(RpcProposal::new(
+                        commands::ResumeInvocationCommand::from(ResumeInvocationRequest {
                             invocation_id,
                             update_deployment_id: Some(update_deployment_id),
                             update_pinned_deployment_id: None,
@@ -70,8 +70,8 @@ where
                                 IngressInvocationResponseSink { request_id },
                             )),
                         }),
-                        reply_on: ReplyOn::Apply { request_id },
-                    })
+                        ReplyOn::Apply { request_id },
+                    ))
                 } else {
                     // Legacy invoker-owned path: there is a live attempt, so the pinned deployment
                     // cannot be patched. Poke the invoker to retry now, if possible.
@@ -92,9 +92,8 @@ where
                     // VQueue path: forward the unresolved patch; the apply path resolves it against
                     // the status as of the command's log position. Safe to write the new
                     // `update_deployment_id` field -- vqueues imply a cluster min version >= 1.7.0.
-                    return Decision::Propose(RpcProposal {
-                        partition_key: invocation_id.partition_key(),
-                        cmd: Command::ResumeInvocation(ResumeInvocationRequest {
+                    return Decision::Propose(RpcProposal::new(
+                        commands::ResumeInvocationCommand::from(ResumeInvocationRequest {
                             invocation_id,
                             update_deployment_id: Some(update_deployment_id),
                             update_pinned_deployment_id: None,
@@ -103,8 +102,8 @@ where
                                 IngressInvocationResponseSink { request_id },
                             )),
                         }),
-                        reply_on: ReplyOn::Apply { request_id },
-                    });
+                        ReplyOn::Apply { request_id },
+                    ));
                 }
 
                 // Non-VQueue path: a pre-1.7.0 node may still apply this command and does not know
@@ -125,9 +124,8 @@ where
                     }
                 };
 
-                Decision::Propose(RpcProposal {
-                    partition_key: invocation_id.partition_key(),
-                    cmd: Command::ResumeInvocation(ResumeInvocationRequest {
+                Decision::Propose(RpcProposal::new(
+                    commands::ResumeInvocationCommand::from(ResumeInvocationRequest {
                         invocation_id,
                         update_deployment_id: None,
                         update_pinned_deployment_id,
@@ -136,8 +134,8 @@ where
                             IngressInvocationResponseSink { request_id },
                         )),
                     }),
-                    reply_on: ReplyOn::Apply { request_id },
-                })
+                    ReplyOn::Apply { request_id },
+                ))
             }
             Ok(InvocationStatus::Scheduled(_)) | Ok(InvocationStatus::Inboxed(_)) => {
                 Decision::Reply(Ok(ResumeInvocationRpcResponse::NotStarted.into()))
@@ -173,6 +171,7 @@ mod tests {
     use restate_types::schema::deployment::Deployment;
     use restate_types::schema::deployment::test_util::MockDeploymentMetadataRegistry;
     use restate_types::service_protocol::ServiceProtocolVersion;
+    use restate_types::sharding::WithPartitionKey;
     use rstest::rstest;
     use test_log::test;
 
@@ -270,13 +269,12 @@ mod tests {
             Default::default(),
         )
         .await;
-        let_assert!(
-            Decision::Propose(RpcProposal {
-                cmd: Command::ResumeInvocation(request),
-                reply_on: ReplyOn::Apply { .. },
-                ..
-            }) = decision
-        );
+
+        let (_, resume_invocation_command, reply_on) =
+            decision.extract_as_rpc_proposal::<commands::ResumeInvocationCommand>();
+
+        let_assert!(ReplyOn::Apply { .. } = reply_on);
+        let request: ResumeInvocationRequest = resume_invocation_command.into();
         assert_eq!(request.invocation_id, invocation_id);
     }
 
@@ -309,15 +307,17 @@ mod tests {
             Default::default(),
         )
         .await;
+
+        let (_, resume_invocation_command, reply_on) =
+            decision.extract_as_rpc_proposal::<commands::ResumeInvocationCommand>();
+
         let_assert!(
-            Decision::Propose(RpcProposal {
-                cmd: Command::ResumeInvocation(resume_invocation_request),
-                reply_on: ReplyOn::Apply {
-                    request_id: actual_request_id,
-                },
-                ..
-            }) = decision
+            ReplyOn::Apply {
+                request_id: actual_request_id
+            } = reply_on
         );
+
+        let resume_invocation_request: ResumeInvocationRequest = resume_invocation_command.into();
         assert_eq!(actual_request_id, request_id);
         assert_that!(
             resume_invocation_request,


### PR DESCRIPTION

Switch the worker's write path from the v1 Envelope/Command enum to v2
typed commands and Envelope<Raw>.

SelfProposer::{self_propose, self_propose_many, append_with_notification}
are now generic over `C: Command + HasRecordKeys` and derive the partition
key from the command via `record_keys()` — the explicit `partition_key`
parameter threaded through LeadershipState, the Actuator trait, and every
RPC handler is gone.

All worker RPC paths (append_invocation, append_invocation_response,
append_signal, cancel/kill/purge_invocation, purge_journal,
resume_invocation, restart_as_new_invocation, get_invocation_output) and
all leader-side ActionEffect proposals (Invoker, Shuffle, Timer, Cleaner,
UpsertSchema, UpsertRuleBook, scheduler decisions, version barriers,
AnnounceLeader) now construct typed commands::*Command values directly,
removing the Command::* enum wrapping and the BytesMut arena previously
used to pre-encode scheduler decisions.

With v2 envelopes now being written, drop the `try_v1_first` branch in
PartitionProcessor::decode_record — v2 is the fast path and v1 stays as
the TypedValueMismatch fallback for replay of older records. Tests under
leadership and rpc are updated to mock the new generic Actuator signatures
and decode via Envelope<Raw>::into_typed::<commands::*>().
