### PR TITLE
[VQueues] Commands for pause/resume in WAL protocol

### DIFF
--- a/crates/storage-api/src/vqueue_table/scheduler.rs
+++ b/crates/storage-api/src/vqueue_table/scheduler.rs
@@ -11,6 +11,7 @@
 use bytes::{Buf, BufMut, Bytes};
 
 use restate_clock::RoughTimestamp;
+use restate_types::bilrost_storage_encode_decode;
 use restate_types::vqueues::VQueueId;
 
 use super::EntryKey;
@@ -57,12 +58,14 @@ pub struct YieldAction {
 }
 
 #[derive(Debug, Clone, bilrost::Message)]
-pub struct SchedulerDecisions {
+pub struct SchedulerDecisionsCommand {
     #[bilrost(tag(1))]
     pub qids: Vec<(VQueueId, Vec<SchedulerAction>)>,
 }
 
-impl SchedulerDecisions {
+bilrost_storage_encode_decode!(SchedulerDecisionsCommand);
+
+impl SchedulerDecisionsCommand {
     pub fn bilrost_encode<B: BufMut>(&self, b: &mut B) -> Result<(), bilrost::EncodeError> {
         bilrost::Message::encode(self, b)
     }

--- a/crates/vqueues/src/lib.rs
+++ b/crates/vqueues/src/lib.rs
@@ -973,6 +973,63 @@ where
         self.storage.update_vqueue(vqueue_id, &update);
     }
 
+    /// Marks this vqueue as paused
+    pub fn pause_queue(&mut self, at: UniqueTimestamp) {
+        let meta = self.cache.get_mut(self.handle).unwrap();
+
+        if meta.meta().queue_is_paused() {
+            // queue is already paused
+            return;
+        }
+
+        debug!("Pausing vqueue {}", meta.vqueue_id());
+        let update = metadata::Update::new(at, metadata::Action::PauseVQueue {});
+
+        // Update cache
+        let (was_active_before, is_active_now) = meta.apply_update(&update);
+
+        // Update vqueue meta in storage
+        self.storage.update_vqueue(meta.vqueue_id(), &update);
+
+        if was_active_before && !is_active_now {
+            self.storage.mark_vqueue_as_dormant(meta.vqueue_id());
+        }
+
+        if let Some(collector) = self.action_collector.as_deref_mut() {
+            let mut event = VQueueEvent::new(self.handle);
+            event.push(EventDetails::QueuePaused);
+            collector.push(A::from(event));
+        }
+    }
+
+    /// Marks this vqueue as resumed
+    pub fn resume_queue(&mut self, at: UniqueTimestamp) {
+        let meta = self.cache.get_mut(self.handle).unwrap();
+
+        if !meta.meta().queue_is_paused() {
+            // queue is not paused
+            return;
+        }
+        debug!("Resuming vqueue {}", meta.vqueue_id());
+        let update = metadata::Update::new(at, metadata::Action::ResumeVQueue {});
+
+        // Update cache
+        let (was_active_before, is_active_now) = meta.apply_update(&update);
+
+        // Update vqueue meta in storage
+        self.storage.update_vqueue(meta.vqueue_id(), &update);
+
+        if !was_active_before && is_active_now {
+            self.storage.mark_vqueue_as_active(meta.vqueue_id());
+        }
+
+        if let Some(collector) = self.action_collector.as_deref_mut() {
+            let mut event = VQueueEvent::new(self.handle);
+            event.push(EventDetails::QueueResumed);
+            collector.push(A::from(event));
+        }
+    }
+
     #[inline]
     fn build_move_metrics(
         stats: &EntryStatistics,

--- a/crates/wal-protocol/src/lib.rs
+++ b/crates/wal-protocol/src/lib.rs
@@ -12,5 +12,6 @@ pub mod control;
 pub mod timer;
 pub mod v1;
 pub mod v2;
+pub mod vqueues;
 
 pub use v1::{Command, Destination, Envelope, Header, Source};

--- a/crates/wal-protocol/src/v1.rs
+++ b/crates/wal-protocol/src/v1.rs
@@ -201,6 +201,12 @@ pub enum Command {
     /// *Since v1.7.0
     /// payload is a bilrost encoded [`restate_storage_api::vqueue_table::scheduler::SchedulerDecisions`]
     VQSchedulerDecisions(#[debug(skip)] Bytes),
+    /// payload is bilrost encoded [`vqueues::VQueuesPause`]
+    /// *Since v1.7.0
+    VQueuesPause(#[debug(skip)] Bytes),
+    /// payload is bilrost encoded [`vqueues::VQueuesResume`]
+    /// *Since v1.7.0
+    VQueuesResume(#[debug(skip)] Bytes),
 }
 
 impl Command {
@@ -258,6 +264,8 @@ impl HasRecordKeys for Envelope {
                 Keys::RangeInclusive(upsert.partition_key_range.into())
             }
             Command::VQSchedulerDecisions(_) => Keys::Single(self.partition_key()),
+            Command::VQueuesPause(_) => Keys::Single(self.partition_key()),
+            Command::VQueuesResume(_) => Keys::Single(self.partition_key()),
         }
     }
 }

--- a/crates/wal-protocol/src/v2.rs
+++ b/crates/wal-protocol/src/v2.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 
 use bilrost::encoding::encoded_len_varint;
 use bilrost::{Message, OwnedMessage};
-use bytes::{BufMut, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 
 use restate_encoding::U128;
 use restate_types::identifiers::{LeaderEpoch, PartitionId};
@@ -148,6 +148,27 @@ impl StorageDecode for Envelope<Raw> {
 }
 
 impl Envelope<Raw> {
+    /// Construct the raw envelope from the given inputs.
+    ///
+    /// It's the caller's responsibility to ensure that the bytes payload is the correct
+    /// encoded value for this command kind and this codec.
+    pub fn from_bytes_unchecked(
+        kind: CommandKind,
+        codec: StorageCodecKind,
+        dedup: Dedup,
+        bytes: Bytes,
+    ) -> Self {
+        Self {
+            header: Header {
+                dedup,
+                kind,
+                codec: Some(codec),
+            },
+            payload: PolyBytes::Bytes(bytes),
+            _p: PhantomData,
+        }
+    }
+
     /// Converts Raw Envelope into a Typed envelope. Panics
     /// if the record kind does not match the M::KIND
     pub fn into_typed<M: Command>(self) -> Envelope<M> {
@@ -275,11 +296,19 @@ pub enum CommandKind {
     /// UpsertSchema record type
     UpsertSchema = 20,
 
-    /// VQueues scheduler decisions record type.
-    VQSchedulerDecisions = 21,
-
     /// Upsert rule book
-    UpsertRuleBook = 22,
+    UpsertRuleBook = 21,
+
+    /// VQueues scheduler decisions record type.
+    VQSchedulerDecisions = 22,
+
+    /// payload is bilrost encoded [`vqueues::VQueuesPause`]
+    /// *Since v1.7.0
+    VQueuesPause = 23,
+
+    /// payload is bilrost encoded [`vqueues::VQueuesResume`]
+    /// *Since v1.7.0
+    VQueuesResume = 24,
 }
 
 /// Specifies the deduplication strategy that allows receivers to discard

--- a/crates/wal-protocol/src/v2/commands.rs
+++ b/crates/wal-protocol/src/v2/commands.rs
@@ -8,13 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+// Re-epxort vqueues commands
+pub use crate::vqueues::{VQueuesPauseCommand, VQueuesResumeCommand};
+pub use restate_storage_api::vqueue_table::scheduler::SchedulerDecisionsCommand;
+
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
 use restate_encoding::Arced;
 use restate_limiter::RuleBook;
-use restate_storage_api::vqueue_table::scheduler::{self};
 use restate_types::{
     bilrost_storage_encode_decode, flexbuffers_storage_encode_decode,
     identifiers::{WithInvocationId, WithPartitionKey},
@@ -337,22 +340,6 @@ impl HasRecordKeys for ProxyThroughCommand {
     }
 }
 
-#[derive(Clone, derive_more::Deref, derive_more::Into, derive_more::From, bilrost::Message)]
-pub struct VQSchedulerDecisionsCommand(scheduler::SchedulerDecisions);
-
-bilrost_storage_encode_decode!(VQSchedulerDecisionsCommand);
-
-impl HasRecordKeys for VQSchedulerDecisionsCommand {
-    fn record_keys(&self) -> Keys {
-        // All records in a decision are for a single partition key
-        if self.0.qids.is_empty() {
-            Keys::None
-        } else {
-            Keys::Single(self.0.qids[0].0.partition_key())
-        }
-    }
-}
-
 #[derive(Debug, Clone, bilrost::Message)]
 pub struct UpsertRuleBookCommand {
     #[bilrost(tag(1))]
@@ -483,11 +470,21 @@ command! {
 }
 
 command! {
-    @kind=CommandKind::VQSchedulerDecisions,
-    @command=VQSchedulerDecisionsCommand
+    @kind=CommandKind::UpsertRuleBook,
+    @command=UpsertRuleBookCommand
 }
 
 command! {
-    @kind=CommandKind::UpsertRuleBook,
-    @command=UpsertRuleBookCommand
+    @kind=CommandKind::VQSchedulerDecisions,
+    @command=SchedulerDecisionsCommand
+}
+
+command! {
+    @kind=CommandKind::VQueuesPause,
+    @command=VQueuesPauseCommand
+}
+
+command! {
+    @kind=CommandKind::VQueuesResume,
+    @command=VQueuesResumeCommand
 }

--- a/crates/wal-protocol/src/v2/compatibility.rs
+++ b/crates/wal-protocol/src/v2/compatibility.rs
@@ -14,11 +14,10 @@ use bilrost::OwnedMessage;
 
 use restate_encoding::U128;
 use restate_limiter::RuleBook;
-use restate_storage_api::{
-    deduplication_table::{DedupInformation, DedupSequenceNumber, EpochSequenceNumber, ProducerId},
-    vqueue_table::scheduler::SchedulerDecisions,
+use restate_storage_api::deduplication_table::{
+    DedupInformation, DedupSequenceNumber, EpochSequenceNumber, ProducerId,
 };
-use restate_types::logs::Keys;
+use restate_types::{logs::Keys, storage::StorageCodecKind};
 use restate_util_string::ReString;
 
 use super::{Raw, commands};
@@ -140,12 +139,6 @@ impl TryFrom<v1::Envelope> for v2::Envelope<Raw> {
             }
             v1::Command::UpsertSchema(payload) => Envelope::new(dedup, payload).into_raw(),
             v1::Command::VersionBarrier(payload) => Envelope::new(dedup, payload).into_raw(),
-            v1::Command::VQSchedulerDecisions(payload) => {
-                // bytes are bilrost encoded SchedulerDecision.
-                let payload = SchedulerDecisions::bilrost_decode(payload)?;
-                Envelope::new(dedup, commands::VQSchedulerDecisionsCommand::from(payload))
-                    .into_raw()
-            }
             v1::Command::UpsertRuleBook(payload) => {
                 let rule_book = RuleBook::decode(payload.rule_book)?;
                 Envelope::new(
@@ -157,6 +150,24 @@ impl TryFrom<v1::Envelope> for v2::Envelope<Raw> {
                 )
                 .into_raw()
             }
+            v1::Command::VQSchedulerDecisions(payload) => Envelope::from_bytes_unchecked(
+                v2::CommandKind::VQSchedulerDecisions,
+                StorageCodecKind::Bilrost,
+                dedup,
+                payload,
+            ),
+            v1::Command::VQueuesPause(payload) => Envelope::from_bytes_unchecked(
+                v2::CommandKind::VQueuesPause,
+                StorageCodecKind::Bilrost,
+                dedup,
+                payload,
+            ),
+            v1::Command::VQueuesResume(payload) => Envelope::from_bytes_unchecked(
+                v2::CommandKind::VQueuesResume,
+                StorageCodecKind::Bilrost,
+                dedup,
+                payload,
+            ),
         };
 
         Ok(envelope)

--- a/crates/wal-protocol/src/vqueues.rs
+++ b/crates/wal-protocol/src/vqueues.rs
@@ -1,0 +1,68 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use bytes::{Buf, BufMut, Bytes};
+
+use restate_types::bilrost_storage_encode_decode;
+use restate_types::vqueues::VQueueId;
+
+/// Note: Within a single command, all VQueue IDs must be on the same partition-key
+#[derive(Debug, Clone, bilrost::Message)]
+pub struct VQueuesPauseCommand {
+    #[bilrost(tag(1))]
+    pub vqueues: Vec<VQueueId>,
+}
+
+bilrost_storage_encode_decode!(VQueuesPauseCommand);
+
+/// Note: Within a single command, all VQueue IDs must be on the same partition-key
+#[derive(Debug, Clone, bilrost::Message)]
+pub struct VQueuesResumeCommand {
+    #[bilrost(tag(1))]
+    pub vqueues: Vec<VQueueId>,
+}
+
+bilrost_storage_encode_decode!(VQueuesResumeCommand);
+
+impl VQueuesPauseCommand {
+    pub fn bilrost_encode<B: BufMut>(&self, b: &mut B) -> Result<(), bilrost::EncodeError> {
+        bilrost::Message::encode(self, b)
+    }
+
+    pub fn encoded_len(&self) -> usize {
+        bilrost::Message::encoded_len(self)
+    }
+
+    pub fn bilrost_encode_to_bytes(&self) -> Bytes {
+        bilrost::Message::encode_to_bytes(self)
+    }
+
+    pub fn bilrost_decode<B: Buf>(buf: B) -> Result<Self, bilrost::DecodeError> {
+        bilrost::OwnedMessage::decode(buf)
+    }
+}
+
+impl VQueuesResumeCommand {
+    pub fn bilrost_encode<B: BufMut>(&self, b: &mut B) -> Result<(), bilrost::EncodeError> {
+        bilrost::Message::encode(self, b)
+    }
+
+    pub fn encoded_len(&self) -> usize {
+        bilrost::Message::encoded_len(self)
+    }
+
+    pub fn bilrost_encode_to_bytes(&self) -> Bytes {
+        bilrost::Message::encode_to_bytes(self)
+    }
+
+    pub fn bilrost_decode<B: Buf>(buf: B) -> Result<Self, bilrost::DecodeError> {
+        bilrost::OwnedMessage::decode(buf)
+    }
+}

--- a/crates/worker/src/partition/leadership/leader_state.rs
+++ b/crates/worker/src/partition/leadership/leader_state.rs
@@ -31,7 +31,7 @@ use restate_core::{Metadata, MetadataKind, TaskCenter, TaskHandle, TaskId};
 use restate_invoker_impl::InvokerHandle as InvokerChannelServiceHandle;
 use restate_limiter::RuleBook;
 use restate_partition_store::PartitionDb;
-use restate_storage_api::vqueue_table::scheduler::SchedulerDecisions;
+use restate_storage_api::vqueue_table::scheduler::SchedulerDecisionsCommand;
 use restate_types::config::Configuration;
 use restate_types::identifiers::{
     LeaderEpoch, PartitionId, PartitionKey, PartitionProcessorRpcRequestId, WithPartitionKey,
@@ -361,7 +361,7 @@ impl LeaderState {
                         .into_iter()
                         // one command per partition key
                         .map(|(partition_key, group)| {
-                            let decisions = SchedulerDecisions {
+                            let decisions = SchedulerDecisionsCommand {
                                 qids: group.collect(),
                             };
 

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -14,8 +14,6 @@ mod lifecycle;
 mod utils;
 
 pub use actions::{Action, ActionCollector};
-use restate_wal_protocol::v2::{CommandKind, commands};
-use restate_worker_api::invoker::Effect;
 
 use std::collections::HashSet;
 use std::fmt;
@@ -123,6 +121,8 @@ use restate_vqueues::{VQueue, VQueueHandle, VQueuesMetaCache};
 use restate_wal_protocol::timer::TimerKeyDisplay;
 use restate_wal_protocol::timer::TimerKeyValue;
 use restate_wal_protocol::v2;
+use restate_wal_protocol::v2::{CommandKind, commands};
+use restate_worker_api::invoker::Effect;
 
 use self::utils::SpanExt;
 use crate::metric_definitions::{
@@ -496,7 +496,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             }
             CommandKind::VQSchedulerDecisions => {
                 let scheduler_decisions = envelope
-                    .into_typed::<commands::VQSchedulerDecisionsCommand>()
+                    .into_typed::<commands::SchedulerDecisionsCommand>()
                     .into_inner()?;
                 for (qid, actions) in &scheduler_decisions.qids {
                     for action in actions {
@@ -854,6 +854,49 @@ impl<S> StateMachineApplyContext<'_, S> {
                 // Update in-memory state.
                 *self.rule_book = new_book;
 
+                Ok(())
+            }
+            CommandKind::VQueuesPause => {
+                let pause = envelope
+                    .into_typed::<commands::VQueuesPauseCommand>()
+                    .into_inner()?;
+                let at = UniqueTimestamp::from_unix_millis_unchecked(self.record_created_at);
+                for qid in pause.vqueues.iter() {
+                    let Some(mut vqueue) = VQueue::get(
+                        qid,
+                        self.storage,
+                        self.vqueues_cache,
+                        self.is_leader.then_some(self.action_collector),
+                    )
+                    .await?
+                    else {
+                        // Ignore vqueues that we don't know.
+                        continue;
+                    };
+                    vqueue.pause_queue(at);
+                }
+                Ok(())
+            }
+            CommandKind::VQueuesResume => {
+                let resume = envelope
+                    .into_typed::<commands::VQueuesResumeCommand>()
+                    .into_inner()?;
+
+                let at = UniqueTimestamp::from_unix_millis_unchecked(self.record_created_at);
+                for qid in resume.vqueues.iter() {
+                    let Some(mut vqueue) = VQueue::get(
+                        qid,
+                        self.storage,
+                        self.vqueues_cache,
+                        self.is_leader.then_some(self.action_collector),
+                    )
+                    .await?
+                    else {
+                        // Ignore vqueues that we don't know.
+                        continue;
+                    };
+                    vqueue.resume_queue(at);
+                }
                 Ok(())
             }
         }


### PR DESCRIPTION

This implements the pause/resume commands for a batch of vqueue IDs in WAL protocol and the state machine. Note that this does not
add any facility to initiate those commands. This will be done separately.
