### PR TITLE
storage-query-datafusion: expose scope on sys_invocation_status

### DIFF
--- a/crates/storage-api/src/protobuf_types.rs
+++ b/crates/storage-api/src/protobuf_types.rs
@@ -4467,6 +4467,8 @@ pub mod v1 {
             pub handler: &'a [u8],
             // tag 4
             pub key: &'a [u8],
+            // tag 5
+            pub scope: Option<&'a str>,
         }
 
         impl<'a> InvocationTargetLazy<'a> {
@@ -4514,6 +4516,20 @@ pub mod v1 {
                                     error.push(STRUCT_NAME, "key");
                                     error
                                 })?
+                        }
+                        5u32 => {
+                            let mut bytes: &'a [u8] = &[];
+                            merge_bytes_zerocopy(wire_type, &mut bytes, &mut buf, ctx.clone())
+                                .map_err(|mut error| {
+                                    error.push(STRUCT_NAME, "scope");
+                                    error
+                                })?;
+                            self.scope = Some(str::from_utf8(bytes).map_err(|_| {
+                                #[allow(deprecated)]
+                                let mut error = prost::DecodeError::new("scope is not valid UTF-8");
+                                error.push(STRUCT_NAME, "scope");
+                                error
+                            })?);
                         }
                         _ => {
                             skip_field(wire_type, tag, &mut buf, ctx.clone())?;
@@ -4575,6 +4591,10 @@ pub mod v1 {
                 let handler_name = self.handler_name()?;
                 Ok(TargetFormatter(service_name, key, handler_name))
             }
+
+            pub fn scope(&self) -> Option<&str> {
+                self.scope
+            }
         }
 
         impl<'a> From<&'a InvocationTarget> for InvocationTargetLazy<'a> {
@@ -4584,6 +4604,7 @@ pub mod v1 {
                     name: &value.name,
                     handler: &value.handler,
                     key: &value.key,
+                    scope: value.scope.as_deref(),
                 }
             }
         }

--- a/crates/storage-query-datafusion/src/context.rs
+++ b/crates/storage-query-datafusion/src/context.rs
@@ -54,6 +54,7 @@ const SYS_INVOCATION_VIEW: &str = "CREATE VIEW sys_invocation as SELECT
             ss.target_service_key,
             ss.target_handler_name,
             ss.target_service_ty,
+            ss.scope,
             ss.idempotency_key,
             ss.invoked_by,
             ss.invoked_by_service_name,

--- a/crates/storage-query-datafusion/src/invocation_status/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/row.rs
@@ -32,7 +32,8 @@ pub(crate) fn append_invocation_status_row<'a>(
         || row.is_target_service_key_defined()
         || row.is_target_handler_name_defined()
         || row.is_target_defined()
-        || row.is_target_service_ty_defined())
+        || row.is_target_service_ty_defined()
+        || row.is_scope_defined())
         && let Some(invocation_target) = invocation_status.invocation_target()?
     {
         if row.is_target_service_name_defined() {
@@ -55,6 +56,11 @@ pub(crate) fn append_invocation_status_row<'a>(
                 ServiceType::VirtualObject => "virtual_object",
                 ServiceType::Workflow => "workflow",
             });
+        }
+        if row.is_scope_defined()
+            && let Some(scope) = invocation_target.scope()
+        {
+            row.scope(scope);
         }
     }
 

--- a/crates/storage-query-datafusion/src/invocation_status/schema.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/schema.rs
@@ -47,6 +47,10 @@ define_table!(sys_invocation_status(
     /// The service type. Either `service` or `virtual_object` or `workflow`.
     target_service_ty: DataType::LargeUtf8,
 
+    /// The scope of the invocation for vqueue partitioning, if scoped. NULL for unscoped invocations.
+    /// Since v1.7.0.
+    scope: DataType::Utf8,
+
     /// Idempotency key, if any.
     idempotency_key: DataType::LargeUtf8,
 

--- a/crates/storage-query-datafusion/src/table_docs.rs
+++ b/crates/storage-query-datafusion/src/table_docs.rs
@@ -121,6 +121,9 @@ pub fn sys_invocation_table_docs() -> OwnedTableDocs {
             .remove("target_service_ty")
             .expect("target_service_ty should exist"),
         sys_invocation_status
+            .remove("scope")
+            .expect("scope should exist"),
+        sys_invocation_status
             .remove("idempotency_key")
             .expect("idempotency_key should exist"),
         sys_invocation_status

--- a/crates/storage-query-datafusion/src/tests.rs
+++ b/crates/storage-query-datafusion/src/tests.rs
@@ -556,3 +556,80 @@ fn extract_uint32_list(column: &ArrayRef, row: usize) -> Option<Vec<u32>> {
 
     Some(row_value_downcast.values().to_owned().into())
 }
+
+fn extract_nullable_string(column: &ArrayRef, row: usize) -> Option<Option<String>> {
+    use datafusion::arrow::array::Array;
+
+    let column = column
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("Downcast ref to StringArray");
+    if column.len() <= row {
+        return None;
+    }
+    if column.is_null(row) {
+        Some(None)
+    } else {
+        Some(Some(column.value(row).to_string()))
+    }
+}
+
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_sys_invocation_status_scope() {
+    let scoped_id = InvocationId::from_parts(0, InvocationUuid::from_u128(1));
+    let unscoped_id = InvocationId::from_parts(0, InvocationUuid::from_u128(2));
+
+    let scope = Scope::try_from_static("tenant-A").unwrap();
+    let scoped_target = InvocationTarget::scoped_service("svc", "h", scope);
+    let unscoped_target = InvocationTarget::service("svc", "h");
+
+    let mut engine = MockQueryEngine::create().await;
+
+    let mut tx = engine.partition_store().transaction();
+    tx.put_invocation_status(
+        &scoped_id,
+        &InvocationStatus::Invoked(InFlightInvocationMetadata {
+            invocation_target: scoped_target,
+            ..InFlightInvocationMetadata::mock()
+        }),
+    )
+    .unwrap();
+    tx.put_invocation_status(
+        &unscoped_id,
+        &InvocationStatus::Invoked(InFlightInvocationMetadata {
+            invocation_target: unscoped_target,
+            ..InFlightInvocationMetadata::mock()
+        }),
+    )
+    .unwrap();
+    tx.commit().await.unwrap();
+
+    let records = engine
+        .execute("SELECT id, scope FROM sys_invocation_status ORDER BY id ASC")
+        .await
+        .unwrap()
+        .stream
+        .collect::<Vec<datafusion::common::Result<RecordBatch>>>()
+        .await
+        .remove(0)
+        .unwrap();
+
+    assert_that!(
+        records,
+        all!(
+            row!(0, {
+                "id" => LargeStringArray: eq(scoped_id.to_string()),
+            }),
+            row_column_matcher(
+                0,
+                "scope",
+                extract_nullable_string,
+                eq(Some("tenant-A".to_string()))
+            ),
+            row!(1, {
+                "id" => LargeStringArray: eq(unscoped_id.to_string()),
+            }),
+            row_column_matcher(1, "scope", extract_nullable_string, eq(None)),
+        )
+    );
+}


### PR DESCRIPTION
Surface the InvocationTarget scope as a new `scope` column on
sys_invocation_status (and the derived sys_invocation view), populated
for every status variant that carries an InvocationTarget. The lazy
protobuf decoder for InvocationTarget is extended to read tag 5
(`optional string scope`), which was previously skipped.