### PR TITLE
Resolve open TODO in protocol.proto

### DIFF
--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
@@ -34,6 +34,7 @@ use restate_service_protocol_v4::entry_codec::ServiceProtocolV4Codec;
 use restate_service_protocol_v4::message_codec::{
     Decoder, Encoder, Message, MessageHeader, MessageType, StateEntry, proto,
 };
+use restate_service_protocol_v4::proto::proto_limit_key_to_limit_key;
 use restate_service_protocol_v4::proto_lite;
 use restate_tracing_instrumentation::ServiceSpan;
 use restate_types::Scope;
@@ -57,7 +58,7 @@ use restate_types::limit_key::LimitKey;
 use restate_types::schema::deployment::{Deployment, DeploymentType, ProtocolType};
 use restate_types::schema::invocation_target::{DeploymentStatus, InvocationTargetResolver};
 use restate_types::service_protocol::ServiceProtocolVersion;
-use restate_util_string::{ReString, RestateString, RestrictedValue};
+use restate_util_string::{RestateString, RestrictedValue};
 use restate_worker_api::invoker::JournalMetadata;
 use restate_worker_api::invoker::invocation_reader::{
     EagerState, InvocationReader, InvocationReaderError, InvocationReaderTransaction, JournalEntry,
@@ -1485,7 +1486,7 @@ pub struct InvokeRequest {
     key: ByteString,
     idempotency_key: Option<ByteString>,
     scope: Option<String>,
-    limit_key: Option<String>,
+    limit_key: Option<proto::LimitKey>,
     span_relation: SpanRelation,
     parameter: Bytes,
 }
@@ -1551,13 +1552,9 @@ fn resolve_call_request(
     } else {
         None
     };
-    let limit_key: LimitKey<ReString> = if let Some(limit_key) = request.limit_key {
-        limit_key
-            .parse()
-            .map_err(|_| CommandPreconditionError::InvalidLimitKey)?
-    } else {
-        LimitKey::None
-    };
+
+    let limit_key = proto_limit_key_to_limit_key(request.limit_key)
+        .map_err(|_| CommandPreconditionError::InvalidLimitKey)?;
 
     // Validate invariant: limit_key requires scope
     if !limit_key.is_empty() && invocation_target.scope().is_none() {

--- a/crates/service-protocol-v4/src/entry_codec.rs
+++ b/crates/service-protocol-v4/src/entry_codec.rs
@@ -36,13 +36,13 @@ use restate_types::journal_v2::raw::{
     CallOrSendMetadata, RawCommand, RawCommandSpecificMetadata, RawEntry, RawNotification,
     RawNotificationResultVariant,
 };
-use restate_types::{LimitKey, Scope, journal_v2::*};
+use restate_types::{Scope, journal_v2::*};
 use restate_util_string::RestateString;
 
 use crate::proto;
 use crate::proto::{
-    complete_awakeable_command_message, notification_template, output_command_message,
-    send_signal_command_message,
+    complete_awakeable_command_message, limit_key_to_proto_limit_key, notification_template,
+    output_command_message, proto_limit_key_to_limit_key, send_signal_command_message,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -143,11 +143,7 @@ impl Encoder for ServiceProtocolV4Codec {
                         .to_string(),
                     idempotency_key: idempotency_key.map(|s| s.to_string()),
                     scope: invocation_target.scope().map(ToString::to_string),
-                    limit_key: if limit_key == LimitKey::None {
-                        None
-                    } else {
-                        Some(limit_key.to_string())
-                    },
+                    limit_key: limit_key_to_proto_limit_key(&limit_key),
                     name: name.to_string(),
                     invocation_id_notification_idx: invocation_id_completion_id,
                     result_completion_id,
@@ -195,11 +191,7 @@ impl Encoder for ServiceProtocolV4Codec {
                         .to_string(),
                     idempotency_key: idempotency_key.map(|s| s.to_string()),
                     scope: invocation_target.scope().map(ToString::to_string),
-                    limit_key: if limit_key == LimitKey::None {
-                        None
-                    } else {
-                        Some(limit_key.to_string())
-                    },
+                    limit_key: limit_key_to_proto_limit_key(&limit_key),
                     name: name.to_string(),
                     invocation_id_notification_idx: invocation_id_completion_id,
                 }
@@ -747,11 +739,8 @@ impl Decoder for ServiceProtocolV4Codec {
                             idempotency_key: idempotency_key.map(|s| s.into()),
                             completion_retention_duration: metadata.completion_retention_duration,
                             journal_retention_duration: metadata.journal_retention_duration,
-                            limit_key: if let Some(limit_key) = limit_key {
-                                limit_key.parse().map_err(GenericError::from)?
-                            } else {
-                                LimitKey::None
-                            },
+                            limit_key: proto_limit_key_to_limit_key(limit_key)
+                                .map_err(GenericError::from)?,
                         },
                         invocation_id_completion_id: invocation_id_notification_idx,
                         result_completion_id,
@@ -785,11 +774,8 @@ impl Decoder for ServiceProtocolV4Codec {
                             idempotency_key: idempotency_key.map(|s| s.into()),
                             completion_retention_duration: metadata.completion_retention_duration,
                             journal_retention_duration: metadata.journal_retention_duration,
-                            limit_key: if let Some(limit_key) = limit_key {
-                                limit_key.parse().map_err(GenericError::from)?
-                            } else {
-                                LimitKey::None
-                            },
+                            limit_key: proto_limit_key_to_limit_key(limit_key)
+                                .map_err(GenericError::from)?,
                         },
                         invoke_time: invoke_time.into(),
                         invocation_id_completion_id: invocation_id_notification_idx,

--- a/crates/service-protocol-v4/src/lib.rs
+++ b/crates/service-protocol-v4/src/lib.rs
@@ -24,6 +24,8 @@ pub mod serdes;
 // service protocol messages. Otherwise, crates depending only on this feature fail clippy.
 #[allow(dead_code)]
 pub mod proto {
+    use restate_types::errors::ConversionError;
+    use restate_util_string::{ReString, RestrictedValue, ToReString};
 
     include!(concat!(env!("OUT_DIR"), "/dev.restate.service.protocol.rs"));
 
@@ -40,6 +42,39 @@ pub mod proto {
         AttachInvocationCommandMessage,
         GetInvocationOutputCommandMessage
     );
+
+    #[inline]
+    pub fn proto_limit_key_to_limit_key(
+        value: Option<LimitKey>,
+    ) -> Result<restate_types::LimitKey<ReString>, ConversionError> {
+        Ok(match value {
+            None => restate_types::LimitKey::None,
+            Some(LimitKey { l1, l2: None }) => restate_types::LimitKey::l1(
+                RestrictedValue::new(l1.to_restring()).map_err(ConversionError::invalid_data)?,
+            ),
+            Some(LimitKey { l1, l2: Some(l2) }) => restate_types::LimitKey::l2(
+                RestrictedValue::new(l1.to_restring()).map_err(ConversionError::invalid_data)?,
+                RestrictedValue::new(l2.to_restring()).map_err(ConversionError::invalid_data)?,
+            ),
+        })
+    }
+
+    #[inline]
+    pub fn limit_key_to_proto_limit_key(
+        value: &restate_types::LimitKey<ReString>,
+    ) -> Option<LimitKey> {
+        match value {
+            restate_types::LimitKey::None => None,
+            restate_types::LimitKey::L1(l1) => Some(LimitKey {
+                l1: l1.to_string(),
+                l2: None,
+            }),
+            restate_types::LimitKey::L2(l1, l2) => Some(LimitKey {
+                l1: l1.to_string(),
+                l2: Some(l2.to_string()),
+            }),
+        }
+    }
 
     mod pb_conversion {
         use restate_types::{

--- a/crates/service-protocol-v4/src/message_codec/mod.rs
+++ b/crates/service-protocol-v4/src/message_codec/mod.rs
@@ -18,6 +18,7 @@ mod encoding;
 mod header;
 
 pub use crate::proto;
+use crate::proto::limit_key_to_proto_limit_key;
 pub(crate) use encoding::default_encode_decode;
 pub use encoding::{
     Decoder, Encoder, EncodingError, MessageEncodingError, ServiceWireDecoder, ServiceWireEncoder,
@@ -408,11 +409,7 @@ impl Message {
             duration_since_last_stored_entry: duration_since_last_stored_entry.as_millis() as u64,
             random_seed,
             scope: scope.map(|scope| scope.to_string()),
-            limit_key: if limit_key == &LimitKey::None {
-                None
-            } else {
-                Some(limit_key.to_string())
-            },
+            limit_key: limit_key_to_proto_limit_key(limit_key),
             idempotency_key: idempotency_key.map(|value| value.to_string()),
         })
     }

--- a/service-protocol/dev/restate/service/protocol.proto
+++ b/service-protocol/dev/restate/service/protocol.proto
@@ -97,7 +97,7 @@ message StartMessage {
 
   // If this invocation was called with a limit key, returns the limit key
   // Since V7
-  optional string limit_key = 11;
+  optional LimitKey limit_key = 11;
 
   // If this invocation was called with an idempotency key, returns the idempotency key
   // Since V7
@@ -491,13 +491,10 @@ message CallCommandMessage {
   // Since V7.
   optional string scope = 7;
 
-  // Limit key for the invocation. Empty string means no limit key.
+  // Limit key for the invocation. None means no limit key.
   // A limit key is only valid if scope is set.
-  // TODO(tillrohrmann): Revisit string serialization of limit_key. Currently serialized as
-  // "level1" or "level1/level2" which requires parsing on read. Check whether a dedicated
-  // Protobuf message would be faster to serialize/deserialize.
   // Since V7.
-  optional string limit_key = 8;
+  optional LimitKey limit_key = 8;
 
   uint32 invocation_id_notification_idx = 10;
   uint32 result_completion_id = 11;
@@ -555,13 +552,10 @@ message OneWayCallCommandMessage {
   // Since V7.
   optional string scope = 8;
 
-  // Limit key for the invocation. Empty string means no limit key.
+  // Limit key for the invocation. None means no limit key.
   // A limit key is only valid if scope is set.
-  // TODO(tillrohrmann): Revisit string serialization of limit_key. Currently serialized as
-  // "level1" or "level1/level2" which requires parsing on read. Check whether a dedicated
-  // Protobuf message would be faster to serialize/deserialize.
   // Since V7.
-  optional string limit_key = 9;
+  optional LimitKey limit_key = 9;
 
   uint32 invocation_id_notification_idx = 10;
   string name = 12;
@@ -766,4 +760,12 @@ enum BuiltInSignal {
   SIGNAL_UNKNOWN = 0;
   CANCEL = 1;
   reserved 2 to 15;
+}
+
+// Structured representation of a limit key.
+message LimitKey {
+  // A limit key must at least have a l1 component
+  string l1 = 1;
+  // The l2 component is optional
+  optional string l2 = 2;
 }


### PR DESCRIPTION
A structured limit key is slightly faster than a pure string which gets parsed into a LimitKey. Hence, we are replacing the string value with a structured LimitKey type. You can find the micro benchmark here: https://github.com/tillrohrmann/restate/tree/benchmark-limit-key-formats.