### PR TITLE
storage-query-datafusion: fix scoped state/promise scan with service_key filter

### DIFF
--- a/crates/storage-query-datafusion/src/promise/table.rs
+++ b/crates/storage-query-datafusion/src/promise/table.rs
@@ -42,7 +42,9 @@ pub(crate) fn register_self(
         SysPromiseBuilder::schema(),
         sys_promise_sort_order(),
         remote_scanner_manager.create_distributed_scanner(NAME, local_scanner),
-        FirstMatchingPartitionKeyExtractor::default().with_service_key("service_key"),
+        FirstMatchingPartitionKeyExtractor::default()
+            .with_scope("scope")
+            .with_service_key("service_key"),
     );
     ctx.register_partitioned_table(NAME, Arc::new(table))
 }

--- a/crates/storage-query-datafusion/src/state/table.rs
+++ b/crates/storage-query-datafusion/src/state/table.rs
@@ -44,7 +44,9 @@ pub(crate) fn register_self(
         StateBuilder::schema(),
         state_sort_order(),
         remote_scanner_manager.create_distributed_scanner(NAME, local_scanner),
-        FirstMatchingPartitionKeyExtractor::default().with_service_key("service_key"),
+        FirstMatchingPartitionKeyExtractor::default()
+            .with_scope("scope")
+            .with_service_key("service_key"),
     );
     ctx.register_partitioned_table(NAME, Arc::new(table))
 }

--- a/crates/storage-query-datafusion/src/tests.rs
+++ b/crates/storage-query-datafusion/src/tests.rs
@@ -11,6 +11,7 @@
 use std::future::Future;
 use std::time::{Duration, SystemTime};
 
+use bytes::Bytes;
 use datafusion::arrow::array::{
     ArrayRef, DurationMillisecondArray, LargeStringArray, ListArray, StringArray,
     TimestampMillisecondArray, UInt32Array, UInt64Array,
@@ -25,11 +26,12 @@ use restate_storage_api::Transaction;
 use restate_storage_api::invocation_status_table::{
     CompletedInvocation, InFlightInvocationMetadata, InvocationStatus, WriteInvocationStatusTable,
 };
+use restate_storage_api::state_table::WriteStateTable;
 use restate_storage_api::vqueue_table::stats::WaitStats;
 use restate_types::Scope;
 use restate_types::errors::InvocationError;
 use restate_types::identifiers::InvocationUuid;
-use restate_types::identifiers::{DeploymentId, InvocationId, PartitionKey};
+use restate_types::identifiers::{DeploymentId, InvocationId, PartitionKey, ServiceId};
 use restate_types::invocation::InvocationTarget;
 use restate_types::journal::EntryType;
 use restate_types::journal_v2::NotificationId;
@@ -631,5 +633,66 @@ async fn query_sys_invocation_status_scope() {
             }),
             row_column_matcher(1, "scope", extract_nullable_string, eq(None)),
         )
+    );
+}
+
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_state_scoped_with_service_key_filter() {
+    // Regression: combining `scope = ...` and `service_key = ...` filters used to
+    // return zero rows because the partition-key extractor narrowed the scan to
+    // hash(service_key), but scoped rows live under hash(scope).
+    let scope = Scope::try_from_static("c").unwrap();
+    let scoped_i1 = ServiceId::new(Some(scope.clone()), "workflow", "i1");
+    let scoped_i2 = ServiceId::new(Some(scope.clone()), "workflow", "i2");
+    let state_key = Bytes::from_static(b"a");
+    let value = b"\"b\"";
+
+    let mut engine = MockQueryEngine::create().await;
+
+    let mut tx = engine.partition_store().transaction();
+    tx.put_user_state(&scoped_i1, &state_key, value).unwrap();
+    tx.put_user_state(&scoped_i2, &state_key, value).unwrap();
+    tx.commit().await.unwrap();
+
+    let scope_only = engine
+        .execute(
+            "SELECT service_key FROM state \
+             WHERE service_name = 'workflow' AND scope = 'c' \
+             ORDER BY service_key",
+        )
+        .await
+        .unwrap()
+        .stream
+        .collect::<Vec<datafusion::common::Result<RecordBatch>>>()
+        .await
+        .remove(0)
+        .unwrap();
+
+    assert_eq!(scope_only.num_rows(), 2);
+    assert_that!(
+        scope_only,
+        all!(
+            row!(0, { "service_key" => LargeStringArray: eq("i1") }),
+            row!(1, { "service_key" => LargeStringArray: eq("i2") }),
+        )
+    );
+
+    let scope_and_key = engine
+        .execute(
+            "SELECT service_key FROM state \
+             WHERE service_name = 'workflow' AND scope = 'c' AND service_key = 'i1'",
+        )
+        .await
+        .unwrap()
+        .stream
+        .collect::<Vec<datafusion::common::Result<RecordBatch>>>()
+        .await
+        .remove(0)
+        .unwrap();
+
+    assert_eq!(scope_and_key.num_rows(), 1);
+    assert_that!(
+        scope_and_key,
+        row!(0, { "service_key" => LargeStringArray: eq("i1") })
     );
 }


### PR DESCRIPTION
The state and sys_promise providers only configured `with_service_key("service_key")` as their partition-key extractor. Scoped rows in ScopedStateKey/ScopedPromiseKey live under `partition_key = hash(scope)` (see ServiceId::new), so a query like `WHERE scope = 'c' AND service_key = 'i1'` narrowed the scan range to hash('i1') and returned zero rows. The scope-only variant of the same query worked because it fell back to a full partition scan.

Prepend `.with_scope("scope")` so the scope-derived partition key wins when present, matching the pattern already used by sys_locks and sys_vqueue_meta.