### PR TITLE
[minor] Remove superfluous invocation_status write on journal events

### DIFF
--- a/crates/partition-store/src/journal_events/mod.rs
+++ b/crates/partition-store/src/journal_events/mod.rs
@@ -162,9 +162,9 @@ fn delete_journal_events<S: StorageAccess>(
 impl ReadJournalEventsTable for PartitionStore {
     fn get_journal_events(
         &mut self,
-        invocation_id: InvocationId,
+        invocation_id: &InvocationId,
     ) -> Result<impl Stream<Item = Result<EventView>> + Send> {
-        Ok(stream::iter(get_journal_events(self, &invocation_id)?))
+        Ok(stream::iter(get_journal_events(self, invocation_id)?))
     }
 }
 
@@ -223,25 +223,25 @@ impl ScanJournalEventsTable for PartitionStore {
 impl ReadJournalEventsTable for PartitionStoreTransaction<'_> {
     fn get_journal_events(
         &mut self,
-        invocation_id: InvocationId,
+        invocation_id: &InvocationId,
     ) -> Result<impl Stream<Item = Result<EventView>> + Send> {
-        Ok(stream::iter(get_journal_events(self, &invocation_id)?))
+        Ok(stream::iter(get_journal_events(self, invocation_id)?))
     }
 }
 
 impl WriteJournalEventsTable for PartitionStoreTransaction<'_> {
     fn put_journal_event(
         &mut self,
-        invocation_id: InvocationId,
+        invocation_id: &InvocationId,
         event: EventView,
         lsn: u64,
     ) -> Result<()> {
-        self.assert_partition_key(&invocation_id)?;
-        put_journal_event(self, &invocation_id, event, lsn)
+        self.assert_partition_key(invocation_id)?;
+        put_journal_event(self, invocation_id, event, lsn)
     }
 
-    fn delete_journal_events(&mut self, invocation_id: InvocationId) -> Result<()> {
-        self.assert_partition_key(&invocation_id)?;
-        delete_journal_events(self, &invocation_id)
+    fn delete_journal_events(&mut self, invocation_id: &InvocationId) -> Result<()> {
+        self.assert_partition_key(invocation_id)?;
+        delete_journal_events(self, invocation_id)
     }
 }

--- a/crates/partition-store/src/tests/journal_events_table_test/mod.rs
+++ b/crates/partition-store/src/tests/journal_events_table_test/mod.rs
@@ -41,11 +41,11 @@ async fn event() {
     let event_view = EventView::new(MillisSinceEpoch::now(), 0, event);
 
     // Populate
-    txn.put_journal_event(MOCK_INVOCATION_ID_1, event_view.clone(), 0)
+    txn.put_journal_event(&MOCK_INVOCATION_ID_1, event_view.clone(), 0)
         .unwrap();
 
     // Get all events
-    let mut journal_events = txn.get_journal_events(MOCK_INVOCATION_ID_1).unwrap();
+    let mut journal_events = txn.get_journal_events(&MOCK_INVOCATION_ID_1).unwrap();
     assert_eq!(journal_events.next().await.unwrap().unwrap(), event_view);
 
     assert!(journal_events.next().await.is_none());
@@ -56,11 +56,11 @@ async fn event() {
     // Verify we can remove events
 
     let mut txn = rocksdb.transaction();
-    txn.delete_journal_events(MOCK_INVOCATION_ID_1).unwrap();
+    txn.delete_journal_events(&MOCK_INVOCATION_ID_1).unwrap();
     txn.commit().await.expect("should not fail");
 
     // Should be empty
-    let mut journal_events = rocksdb.get_journal_events(MOCK_INVOCATION_ID_1).unwrap();
+    let mut journal_events = rocksdb.get_journal_events(&MOCK_INVOCATION_ID_1).unwrap();
     assert!(journal_events.next().await.is_none());
     drop(journal_events);
 

--- a/crates/storage-api/src/journal_events/mod.rs
+++ b/crates/storage-api/src/journal_events/mod.rs
@@ -21,7 +21,7 @@ use restate_types::time::MillisSinceEpoch;
 pub trait ReadJournalEventsTable {
     fn get_journal_events(
         &mut self,
-        invocation_id: InvocationId,
+        invocation_id: &InvocationId,
     ) -> Result<impl Stream<Item = Result<EventView>> + Send>;
 }
 
@@ -44,12 +44,12 @@ pub trait ScanJournalEventsTable {
 pub trait WriteJournalEventsTable {
     fn put_journal_event(
         &mut self,
-        invocation_id: InvocationId,
+        invocation_id: &InvocationId,
         event: EventView,
         lsn: u64,
     ) -> Result<()>;
 
-    fn delete_journal_events(&mut self, invocation_id: InvocationId) -> Result<()>;
+    fn delete_journal_events(&mut self, invocation_id: &InvocationId) -> Result<()>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/worker/src/partition/state_machine/lifecycle/event.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/event.rs
@@ -8,48 +8,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
-use restate_storage_api::invocation_status_table::{InvocationStatus, WriteInvocationStatusTable};
+use restate_storage_api::invocation_status_table::InvocationStatus;
 use restate_storage_api::journal_events::{EventView, WriteJournalEventsTable};
 use restate_types::identifiers::InvocationId;
 use restate_types::journal_events::raw::RawEvent;
 
-pub struct OnInvokerEventCommand {
-    pub invocation_id: InvocationId,
-    pub invocation_status: InvocationStatus,
+use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
+
+pub struct ApplyEventCommand<'e> {
+    pub invocation_id: &'e InvocationId,
+    pub invocation_status: &'e InvocationStatus,
     pub event: RawEvent,
-}
-
-impl<'ctx, 's: 'ctx, S: WriteJournalEventsTable + WriteInvocationStatusTable>
-    CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>> for OnInvokerEventCommand
-{
-    async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
-        let Self {
-            invocation_id,
-            mut invocation_status,
-            event,
-        } = self;
-        ApplyEventCommand {
-            invocation_id,
-            invocation_status: &mut invocation_status,
-            event,
-        }
-        .apply(ctx)
-        .await?;
-
-        // Store invocation status
-        ctx.storage
-            .put_invocation_status(&invocation_id, &invocation_status)
-            .map_err(Error::Storage)?;
-
-        Ok(())
-    }
-}
-
-pub(super) struct ApplyEventCommand<'e> {
-    pub(super) invocation_id: InvocationId,
-    pub(super) invocation_status: &'e InvocationStatus,
-    pub(super) event: RawEvent,
 }
 
 impl<'e, 'ctx: 'e, 's: 'ctx, S: WriteJournalEventsTable>
@@ -116,7 +85,7 @@ mod tests {
             .await;
 
         assert_that!(
-            test_env.read_journal_events(invocation_id).await,
+            test_env.read_journal_events(&invocation_id).await,
             elements_are![eq(Event::TransientError(transient_error_event.clone()))]
         );
 

--- a/crates/worker/src/partition/state_machine/lifecycle/mod.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/mod.rs
@@ -26,7 +26,7 @@ mod suspend;
 mod version_barrier;
 
 pub(super) use cancel::OnCancelCommand;
-pub(super) use event::OnInvokerEventCommand;
+pub(super) use event::ApplyEventCommand;
 pub(super) use manual_resume::OnManualResumeCommand;
 pub(super) use migrate_journal_table::VerifyOrMigrateJournalTableToV2Command;
 pub(super) use notify_get_invocation_output_response::OnNotifyGetInvocationOutputResponse;

--- a/crates/worker/src/partition/state_machine/lifecycle/paused.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/paused.rs
@@ -27,13 +27,13 @@ use crate::debug_if_leader;
 use crate::partition::state_machine::lifecycle::event::ApplyEventCommand;
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
 
-pub struct OnPausedCommand {
-    pub invocation_id: InvocationId,
+pub struct OnPausedCommand<'a> {
+    pub invocation_id: &'a InvocationId,
     pub paused_event: RawEvent,
 }
 
 impl<'ctx, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>>
-    for OnPausedCommand
+    for OnPausedCommand<'_>
 where
     S: ReadInvocationStatusTable
         + WriteInvocationStatusTable
@@ -49,7 +49,7 @@ where
             invocation_id,
             paused_event,
         } = self;
-        let invoked_meta = match ctx.get_invocation_status(&invocation_id).await? {
+        let invoked_meta = match ctx.get_invocation_status(invocation_id).await? {
             InvocationStatus::Invoked(meta) => meta,
             InvocationStatus::Suspended { .. }
             | InvocationStatus::Paused(_)
@@ -71,7 +71,7 @@ where
             .is_vqueues_enabled()
         {
             // todo: use the new status
-            let entry_id = EntryId::from(&invocation_id);
+            let entry_id = EntryId::from(invocation_id);
             let Some(header) = ctx
                 .storage
                 .get_vqueue_entry_status(invocation_id.partition_key(), &entry_id)
@@ -100,7 +100,7 @@ where
 
         ApplyEventCommand {
             invocation_id,
-            invocation_status: &mut invocation_status,
+            invocation_status: &invocation_status,
             event: paused_event,
         }
         .apply(ctx)
@@ -112,7 +112,7 @@ where
         }
 
         ctx.storage
-            .put_invocation_status(&self.invocation_id, &invocation_status)?;
+            .put_invocation_status(self.invocation_id, &invocation_status)?;
 
         Ok(())
     }
@@ -175,7 +175,7 @@ mod tests {
             )
         );
         assert_that!(
-            test_env.read_journal_events(invocation_id).await,
+            test_env.read_journal_events(&invocation_id).await,
             elements_are![eq(paused_event)]
         );
 

--- a/crates/worker/src/partition/state_machine/lifecycle/purge.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/purge.rs
@@ -24,12 +24,13 @@ use restate_types::invocation::{
 };
 use tracing::trace;
 
-pub struct OnPurgeCommand {
-    pub invocation_id: InvocationId,
+pub struct OnPurgeCommand<'a> {
+    pub invocation_id: &'a InvocationId,
     pub response_sink: Option<InvocationMutationResponseSink>,
 }
 
-impl<'ctx, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>> for OnPurgeCommand
+impl<'ctx, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>>
+    for OnPurgeCommand<'_>
 where
     S: WriteJournalTable
         + ReadInvocationStatusTable
@@ -44,7 +45,7 @@ where
             invocation_id,
             response_sink,
         } = self;
-        match ctx.get_invocation_status(&invocation_id).await? {
+        match ctx.get_invocation_status(invocation_id).await? {
             InvocationStatus::Completed(CompletedInvocation {
                 invocation_target,
                 journal_metadata,

--- a/crates/worker/src/partition/state_machine/lifecycle/purge_journal.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/purge_journal.rs
@@ -20,13 +20,13 @@ use restate_types::invocation::InvocationMutationResponseSink;
 use restate_types::invocation::client::PurgeInvocationResponse;
 use tracing::trace;
 
-pub struct OnPurgeJournalCommand {
-    pub invocation_id: InvocationId,
+pub struct OnPurgeJournalCommand<'a> {
+    pub invocation_id: &'a InvocationId,
     pub response_sink: Option<InvocationMutationResponseSink>,
 }
 
 impl<'ctx, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>>
-    for OnPurgeJournalCommand
+    for OnPurgeJournalCommand<'_>
 where
     S: WriteJournalTable
         + ReadInvocationStatusTable
@@ -39,7 +39,7 @@ where
             invocation_id,
             response_sink,
         } = self;
-        match ctx.get_invocation_status(&invocation_id).await? {
+        match ctx.get_invocation_status(invocation_id).await? {
             InvocationStatus::Completed(mut completed) => {
                 let pinned_service_protocol_version = completed
                     .pinned_deployment
@@ -62,7 +62,7 @@ where
 
                 // Update invocation status
                 ctx.storage.put_invocation_status(
-                    &invocation_id,
+                    invocation_id,
                     &InvocationStatus::Completed(completed),
                 )?;
                 ctx.reply_to_purge_journal(response_sink, PurgeInvocationResponse::Ok);

--- a/crates/worker/src/partition/state_machine/lifecycle/suspend.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/suspend.rs
@@ -86,7 +86,7 @@ where
 
             if self.emit_event {
                 ApplyEventCommand {
-                    invocation_id: self.invocation_id,
+                    invocation_id: &self.invocation_id,
                     invocation_status: &invocation_status,
                     event: RawEvent::from(Event::Suspended(SuspendedEvent {
                         awaiting_on: self.awaiting_on.clone(),
@@ -701,7 +701,7 @@ mod tests {
             ok(is_variant(InvocationStatusDiscriminants::Suspended))
         );
         assert_that!(
-            test_env.read_journal_events(invocation_id).await,
+            test_env.read_journal_events(&invocation_id).await,
             elements_are![eq(Event::Suspended(SuspendedEvent {
                 awaiting_on: awaiting_on.clone()
             }))]
@@ -744,7 +744,7 @@ mod tests {
         );
         // Still exactly the one event from the first transition.
         assert_that!(
-            test_env.read_journal_events(invocation_id).await,
+            test_env.read_journal_events(&invocation_id).await,
             elements_are![eq(Event::Suspended(SuspendedEvent { awaiting_on }))]
         );
 

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -691,7 +691,7 @@ impl<S> StateMachineApplyContext<'_, S> {
                     .into();
 
                 lifecycle::OnPurgeCommand {
-                    invocation_id: purge_invocation_request.invocation_id,
+                    invocation_id: &purge_invocation_request.invocation_id,
                     response_sink: purge_invocation_request.response_sink,
                 }
                 .apply(self)
@@ -705,7 +705,7 @@ impl<S> StateMachineApplyContext<'_, S> {
                     .into();
 
                 lifecycle::OnPurgeJournalCommand {
-                    invocation_id: purge_invocation_request.invocation_id,
+                    invocation_id: &purge_invocation_request.invocation_id,
                     response_sink: purge_invocation_request.response_sink,
                 }
                 .apply(self)
@@ -2057,7 +2057,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             )
             .await?;
         }
-        self.do_free_invocation(invocation_id)?;
+        self.do_free_invocation(&invocation_id)?;
 
         // If there's a journal, delete journal
         if let PreFlightInvocationArgument::Journal(PreFlightInvocationJournal {
@@ -2070,7 +2070,7 @@ impl<S> StateMachineApplyContext<'_, S> {
                 .map(|pd| pd.service_protocol_version);
 
             self.do_drop_journal(
-                invocation_id,
+                &invocation_id,
                 journal_metadata.length,
                 pinned_service_protocol_version,
             )
@@ -2179,7 +2179,7 @@ impl<S> StateMachineApplyContext<'_, S> {
         }
 
         // Free invocation
-        self.do_free_invocation(invocation_id)?;
+        self.do_free_invocation(&invocation_id)?;
 
         // If there's a journal, delete journal
         if let PreFlightInvocationArgument::Journal(PreFlightInvocationJournal {
@@ -2192,7 +2192,7 @@ impl<S> StateMachineApplyContext<'_, S> {
                 .map(|pd| pd.service_protocol_version);
 
             self.do_drop_journal(
-                invocation_id,
+                &invocation_id,
                 journal_metadata.length,
                 pinned_service_protocol_version,
             )
@@ -2538,7 +2538,7 @@ impl<S> StateMachineApplyContext<'_, S> {
                 // where the invocation should be executed
                 self.on_service_invocation(*service_invocation).await
             }
-            Timer::CleanInvocationStatus(invocation_id) => {
+            Timer::CleanInvocationStatus(ref invocation_id) => {
                 lifecycle::OnPurgeCommand {
                     invocation_id,
                     response_sink: None,
@@ -2723,9 +2723,9 @@ impl<S> StateMachineApplyContext<'_, S> {
                 .await?;
             }
             InvokerEffectKind::JournalEvent { event } => {
-                lifecycle::OnInvokerEventCommand {
-                    invocation_id: effect.invocation_id,
-                    invocation_status,
+                lifecycle::ApplyEventCommand {
+                    invocation_id: &effect.invocation_id,
+                    invocation_status: &invocation_status,
                     event,
                 }
                 .apply(self)
@@ -2800,7 +2800,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             }
             InvokerEffectKind::Paused { paused_event } => {
                 lifecycle::OnPausedCommand {
-                    invocation_id: effect.invocation_id,
+                    invocation_id: &effect.invocation_id,
                     paused_event,
                 }
                 .apply(self)
@@ -2985,12 +2985,12 @@ impl<S> StateMachineApplyContext<'_, S> {
 
         // If no retention, immediately cleanup the invocation status
         if completion_retention.is_zero() {
-            self.do_free_invocation(invocation_id)?;
+            self.do_free_invocation(&invocation_id)?;
         }
 
         if journal_retention.is_zero() {
             self.do_drop_journal(
-                invocation_id,
+                &invocation_id,
                 journal_length,
                 pinned_service_protocol_version,
             )
@@ -3540,7 +3540,7 @@ impl<S> StateMachineApplyContext<'_, S> {
                 if let Some(service_id) =
                     invocation_metadata.invocation_target.as_keyed_service_id()
                 {
-                    self.do_clear_all_state(service_id, invocation_id)?;
+                    self.do_clear_all_state(service_id, &invocation_id)?;
                 } else {
                     warn!(
                         "Trying to process entry {} for a target that has no state",
@@ -4779,7 +4779,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             .map_err(Error::Storage)
     }
 
-    fn do_free_invocation(&mut self, invocation_id: InvocationId) -> Result<(), Error>
+    fn do_free_invocation(&mut self, invocation_id: &InvocationId) -> Result<(), Error>
     where
         S: WriteInvocationStatusTable,
     {
@@ -4790,7 +4790,7 @@ impl<S> StateMachineApplyContext<'_, S> {
         );
 
         self.storage
-            .put_invocation_status(&invocation_id, &InvocationStatus::Free)
+            .put_invocation_status(invocation_id, &InvocationStatus::Free)
             .map_err(Error::Storage)
     }
 
@@ -4982,7 +4982,7 @@ impl<S> StateMachineApplyContext<'_, S> {
     fn do_clear_all_state(
         &mut self,
         service_id: ServiceId,
-        invocation_id: InvocationId,
+        invocation_id: &InvocationId,
     ) -> Result<(), Error>
     where
         S: WriteStateTable,
@@ -5062,7 +5062,7 @@ impl<S> StateMachineApplyContext<'_, S> {
 
     async fn do_drop_journal(
         &mut self,
-        invocation_id: InvocationId,
+        invocation_id: &InvocationId,
         journal_length: EntryIndex,
         pinned_protocol_version: Option<ServiceProtocolVersion>,
     ) -> Result<(), Error>
@@ -5076,13 +5076,13 @@ impl<S> StateMachineApplyContext<'_, S> {
         );
 
         if pinned_protocol_version.is_none_or(|sp| sp < ServiceProtocolVersion::V4) {
-            WriteJournalTable::delete_journal(self.storage, &invocation_id, journal_length)
+            WriteJournalTable::delete_journal(self.storage, invocation_id, journal_length)
                 .map_err(Error::Storage)?;
         };
         if pinned_protocol_version.is_none_or(|sp| sp >= ServiceProtocolVersion::V4) {
             journal_table_v2::WriteJournalTable::delete_journal(
                 self.storage,
-                &invocation_id,
+                invocation_id,
                 journal_length,
             )
             .map_err(Error::Storage)?

--- a/crates/worker/src/partition/state_machine/tests/mod.rs
+++ b/crates/worker/src/partition/state_machine/tests/mod.rs
@@ -246,7 +246,7 @@ impl TestEnv {
     }
 
     /// Returns journal events ordered by timestamps
-    pub async fn read_journal_events(&mut self, invocation_id: InvocationId) -> Vec<Event> {
+    pub async fn read_journal_events(&mut self, invocation_id: &InvocationId) -> Vec<Event> {
         let mut events =
             restate_storage_api::journal_events::ReadJournalEventsTable::get_journal_events(
                 self.storage(),


### PR DESCRIPTION

Additionally, this makes more progress on passing InvocationId by reference when move isn't needed.
