### PR TITLE
Replace PartialEnvelope with CommandWithKeys trait

### DIFF
--- a/crates/wal-protocol/src/control.rs
+++ b/crates/wal-protocol/src/control.rs
@@ -200,19 +200,9 @@ pub struct UpdatePartitionDurabilityCommand {
     /// Timestamp which the durability point was updated
     #[bilrost(tag(3))]
     pub modification_time: MillisSinceEpoch,
-    /// partition key range
-    #[bilrost(tag(4))]
-    #[serde(default)]
-    pub partition_key_range: Keys,
 }
 
 bilrost_storage_encode_decode!(UpdatePartitionDurabilityCommand);
-
-impl HasRecordKeys for UpdatePartitionDurabilityCommand {
-    fn record_keys(&self) -> Keys {
-        self.partition_key_range.clone()
-    }
-}
 
 /// Consistently store schema across partition replicas.
 ///

--- a/crates/wal-protocol/src/control.rs
+++ b/crates/wal-protocol/src/control.rs
@@ -8,7 +8,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use bytes::Bytes;
+use std::sync::Arc;
+
+use bytes::{Buf, BufMut, Bytes};
+
+use restate_encoding::Arced;
+use restate_limiter::RuleBook;
 use restate_storage_api::fsm_table::{CurrentReplicaSetState, NextReplicaSetState};
 use restate_types::identifiers::{LeaderEpoch, PartitionId};
 use restate_types::logs::{HasRecordKeys, Keys, Lsn, SequenceNumber};
@@ -241,8 +246,28 @@ impl HasRecordKeys for UpsertSchemaCommand {
 /// The state machine decodes once on apply.
 ///
 /// Since v1.7.0.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, bilrost::Message)]
 pub struct UpsertRuleBookCommand {
-    pub partition_key_range: KeyRange,
-    pub rule_book: Bytes,
+    #[bilrost(tag(1), encoding(Arced))]
+    pub rule_book: Arc<RuleBook>,
+}
+
+bilrost_storage_encode_decode!(UpsertRuleBookCommand);
+
+impl UpsertRuleBookCommand {
+    pub fn bilrost_encode<B: BufMut>(&self, b: &mut B) -> Result<(), bilrost::EncodeError> {
+        bilrost::Message::encode(self, b)
+    }
+
+    pub fn encoded_len(&self) -> usize {
+        bilrost::Message::encoded_len(self)
+    }
+
+    pub fn bilrost_encode_to_bytes(&self) -> Bytes {
+        bilrost::Message::encode_to_bytes(self)
+    }
+
+    pub fn bilrost_decode<B: Buf>(buf: B) -> Result<Self, bilrost::DecodeError> {
+        bilrost::OwnedMessage::decode(buf)
+    }
 }

--- a/crates/wal-protocol/src/v1.rs
+++ b/crates/wal-protocol/src/v1.rs
@@ -19,11 +19,12 @@ use restate_types::invocation::{
 };
 use restate_types::logs::{self, HasRecordKeys, Keys, MatchKeyQuery};
 use restate_types::message::MessageIndex;
+use restate_types::sharding::KeyRange;
 use restate_types::state_mut::ExternalStateMutation;
 
 use crate::control::{
-    AnnounceLeaderCommand, UpdatePartitionDurabilityCommand, UpsertRuleBookCommand,
-    UpsertSchemaCommand, VersionBarrierCommand,
+    AnnounceLeaderCommand, UpdatePartitionDurabilityCommand, UpsertSchemaCommand,
+    VersionBarrierCommand,
 };
 use crate::timer::TimerKeyValue;
 
@@ -193,8 +194,9 @@ pub enum Command {
     /// Upsert the cluster-global rule book for consistent rules across
     /// replicas; the apply path persists it to the partition store and
     /// notifies the leader's `UserLimiter` of the diff.
+    ///
     /// *Since v1.7.0
-    UpsertRuleBook(UpsertRuleBookCommand),
+    UpsertRuleBook(UpsertRuleBookCommandWrapper),
     // # Commands for VQueues management
     // ----------------------------------
     /// A command to attempt a run an entry in the vqueue (invocation, or otherwise)
@@ -274,4 +276,13 @@ impl MatchKeyQuery for Envelope {
     fn matches_key_query(&self, query: &logs::KeyFilter) -> bool {
         self.record_keys().matches_key_query(query)
     }
+}
+
+/// A temporary wrapper for [`UpsertRuleBookCommand`]
+/// only used in v1 to only supply the partition_key_range
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct UpsertRuleBookCommandWrapper {
+    pub partition_key_range: KeyRange,
+    /// Bytes are bilrost encoded [`UpsertRuleBookCommand`]
+    pub command: Bytes,
 }

--- a/crates/wal-protocol/src/v2.rs
+++ b/crates/wal-protocol/src/v2.rs
@@ -188,7 +188,7 @@ impl Envelope<Raw> {
 
 impl<C: Command> Envelope<C>
 where
-    C: Clone,
+    C: StorageDecode + Clone,
 {
     /// return the envelope payload
     pub fn split(self) -> Result<(Header, C), StorageDecodeError> {
@@ -349,42 +349,9 @@ pub enum Dedup {
     },
 }
 
-/// A partial type-erased envelope mainly used for writing records.
-/// It carries the payload part with Keys.
-pub struct PartialEnvelope {
-    kind: CommandKind,
-    keys: Keys,
-    payload: Arc<dyn StorageEncode>,
-}
-
-impl PartialEnvelope {
-    pub fn kind(&self) -> CommandKind {
-        self.kind
-    }
-
-    pub fn keys(&self) -> &Keys {
-        &self.keys
-    }
-
-    /// Builds an [`Envelope<Raw>`] with keys from the [`PartialEnvelope`]
-    pub fn build(self, dedup: Dedup) -> BodyWithKeys<Envelope<Raw>> {
-        let inner = Envelope {
-            header: Header {
-                dedup,
-                kind: self.kind,
-                codec: Some(self.payload.default_codec()),
-            },
-            payload: PolyBytes::Typed(self.payload),
-            _p: PhantomData,
-        };
-
-        BodyWithKeys::new(inner, self.keys)
-    }
-}
-
 /// Marker trait implemented by strongly-typed representations of WAL record
 /// payloads.
-pub trait Command: sealed::Sealed + StorageEncode + StorageDecode + Sized {
+pub trait Command: sealed::Sealed + StorageEncode + Sized {
     const KIND: CommandKind;
 
     fn envelope(self, dedup: Dedup) -> Envelope<Self> {
@@ -399,16 +366,47 @@ pub trait Command: sealed::Sealed + StorageEncode + StorageDecode + Sized {
     }
 }
 
-impl<C> From<C> for PartialEnvelope
+impl<C> sealed::Sealed for BodyWithKeys<C> {}
+
+/// Provides record keys for a [`Command`].
+///
+/// Auto-implemented for any [`Command`] that also implements [`HasRecordKeys`].
+/// Commands without a [`HasRecordKeys`] implementation can be paired with keys
+/// explicitly via [`BodyWithKeys::new`], which also implements this trait.
+///
+/// This lets generic functions uniformly accept either a [`Command`] that
+/// carries its own keys or a [`BodyWithKeys`] wrapper supplying them.
+pub trait CommandWithKeys<C>
+where
+    C: Command,
+{
+    fn keys(&self) -> Keys;
+    fn inner(self) -> C;
+}
+
+impl<C> CommandWithKeys<C> for C
 where
     C: Command + HasRecordKeys,
 {
-    fn from(command: C) -> PartialEnvelope {
-        PartialEnvelope {
-            kind: C::KIND,
-            keys: command.record_keys(),
-            payload: Arc::new(command),
-        }
+    fn inner(self) -> C {
+        self
+    }
+
+    fn keys(&self) -> Keys {
+        self.record_keys()
+    }
+}
+
+impl<C> CommandWithKeys<C> for BodyWithKeys<C>
+where
+    C: Command,
+{
+    fn keys(&self) -> Keys {
+        BodyWithKeys::keys(self).clone()
+    }
+
+    fn inner(self) -> C {
+        BodyWithKeys::into_inner(self)
     }
 }
 
@@ -418,13 +416,17 @@ mod test {
     use bytes::BytesMut;
 
     use restate_types::{
-        GenerationalNodeId, logs::Keys, sharding::KeyRange, storage::StorageCodec,
+        GenerationalNodeId,
+        logs::{BodyWithKeys, Keys},
+        sharding::KeyRange,
+        storage::StorageCodec,
+        time::MillisSinceEpoch,
     };
 
     use super::Dedup;
     use crate::{
-        control::AnnounceLeaderCommand,
-        v2::{CommandKind, Envelope, PartialEnvelope, Raw},
+        control::{AnnounceLeaderCommand, UpdatePartitionDurabilityCommand},
+        v2::{Command, CommandKind, CommandWithKeys, Envelope, Raw},
     };
 
     #[test]
@@ -478,8 +480,6 @@ mod test {
             payload.clone(),
         );
 
-        // assert_eq!(envelope.record_keys(), Keys::RangeInclusive(0..=u64::MAX));
-
         let envelope = envelope.into_raw();
 
         assert_eq!(envelope.kind(), CommandKind::AnnounceLeader);
@@ -490,8 +490,12 @@ mod test {
         assert_announce_leader_eq(&payload, &loaded_payload);
     }
 
+    fn make_envelope<C: Command>(cmd: impl CommandWithKeys<C>) -> Envelope<Raw> {
+        Envelope::new(Dedup::None, cmd.inner()).into_raw()
+    }
+
     #[test]
-    fn partial_envelope_with_keys() {
+    fn command_with_has_record_keys() {
         let payload = AnnounceLeaderCommand {
             leader_epoch: 11.into(),
             node_id: GenerationalNodeId::new(1, 3),
@@ -501,25 +505,56 @@ mod test {
             next_config: None,
         };
 
-        let envelope: PartialEnvelope = payload.clone().into();
+        let envelope = make_envelope(payload.clone());
 
-        let keyed = envelope.build(Dedup::SelfProposal {
-            leader_epoch: 10.into(),
-            seq: 120,
-        });
-
-        assert_eq!(
-            keyed.keys(),
-            &Keys::RangeInclusive(payload.partition_key_range.into())
-        );
-
-        let envelope = keyed.into_inner();
         assert_eq!(envelope.kind(), CommandKind::AnnounceLeader);
-        let envelope = envelope.into_typed::<AnnounceLeaderCommand>();
+        let typed = envelope.into_typed::<AnnounceLeaderCommand>();
 
-        let (_, loaded_payload) = envelope.split().expect("to decode");
+        let (_, loaded_payload) = typed.split().expect("to decode");
 
         assert_announce_leader_eq(&payload, &loaded_payload);
+    }
+
+    #[test]
+    fn command_without_has_record_keys() {
+        let payload = UpdatePartitionDurabilityCommand {
+            durable_point: 0.into(),
+            modification_time: MillisSinceEpoch::now(),
+            partition_id: 10.into(),
+        };
+
+        let envelope = make_envelope(BodyWithKeys::new(payload.clone(), Keys::Single(100)));
+
+        let mut buf = BytesMut::new();
+        StorageCodec::encode(&envelope, &mut buf).unwrap();
+
+        let loaded: Envelope<Raw> = StorageCodec::decode(&mut buf).unwrap();
+
+        let typed = loaded.into_typed::<UpdatePartitionDurabilityCommand>();
+        let inner = typed.into_inner().unwrap();
+
+        assert_eq!(payload.durable_point, inner.durable_point);
+        assert_eq!(payload.modification_time, inner.modification_time);
+        assert_eq!(payload.partition_id, inner.partition_id);
+    }
+
+    #[test]
+    fn command_without_has_record_keys_type_cast() {
+        let payload = UpdatePartitionDurabilityCommand {
+            durable_point: 0.into(),
+            modification_time: MillisSinceEpoch::now(),
+            partition_id: 10.into(),
+        };
+
+        let envelope = make_envelope(BodyWithKeys::new(payload.clone(), Keys::Single(100)));
+
+        let converted = envelope.into_typed::<UpdatePartitionDurabilityCommand>();
+
+        let inner = converted.into_inner().unwrap();
+
+        assert_eq!(payload.durable_point, inner.durable_point);
+        assert_eq!(payload.modification_time, inner.modification_time);
+        assert_eq!(payload.partition_id, inner.partition_id);
     }
 
     #[track_caller]

--- a/crates/wal-protocol/src/v2/commands.rs
+++ b/crates/wal-protocol/src/v2/commands.rs
@@ -8,29 +8,24 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-// Re-epxort vqueues commands
-pub use crate::vqueues::{VQueuesPauseCommand, VQueuesResumeCommand};
-pub use restate_storage_api::vqueue_table::scheduler::SchedulerDecisionsCommand;
-
-use std::sync::Arc;
-
 use serde::{Deserialize, Serialize};
 
-use restate_encoding::Arced;
-use restate_limiter::RuleBook;
+pub use restate_storage_api::vqueue_table::scheduler::SchedulerDecisionsCommand;
 use restate_types::{
     bilrost_storage_encode_decode, flexbuffers_storage_encode_decode,
     identifiers::{WithInvocationId, WithPartitionKey},
     invocation,
     logs::{HasRecordKeys, Keys},
     message::MessageIndex,
-    sharding::KeyRange,
     state_mut,
 };
 
 use super::sealed::Sealed;
 use super::{Command, CommandKind};
-use crate::timer::{self};
+pub use crate::control::UpsertRuleBookCommand;
+use crate::timer;
+// Re-epxort vqueues commands
+pub use crate::vqueues::{VQueuesPauseCommand, VQueuesResumeCommand};
 
 pub use crate::control::{
     AnnounceLeaderCommand, UpdatePartitionDurabilityCommand, UpsertSchemaCommand,
@@ -337,22 +332,6 @@ flexbuffers_storage_encode_decode!(ProxyThroughCommand);
 impl HasRecordKeys for ProxyThroughCommand {
     fn record_keys(&self) -> Keys {
         self.proxy_partition.clone()
-    }
-}
-
-#[derive(Debug, Clone, bilrost::Message)]
-pub struct UpsertRuleBookCommand {
-    #[bilrost(tag(1))]
-    pub partition_key_range: KeyRange,
-    #[bilrost(tag(2), encoding(Arced))]
-    pub rule_book: Arc<RuleBook>,
-}
-
-bilrost_storage_encode_decode!(UpsertRuleBookCommand);
-
-impl HasRecordKeys for UpsertRuleBookCommand {
-    fn record_keys(&self) -> Keys {
-        Keys::RangeInclusive(self.partition_key_range.into())
     }
 }
 

--- a/crates/wal-protocol/src/v2/compatibility.rs
+++ b/crates/wal-protocol/src/v2/compatibility.rs
@@ -8,12 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::sync::Arc;
-
-use bilrost::OwnedMessage;
-
 use restate_encoding::U128;
-use restate_limiter::RuleBook;
 use restate_storage_api::deduplication_table::{
     DedupInformation, DedupSequenceNumber, EpochSequenceNumber, ProducerId,
 };
@@ -23,10 +18,7 @@ use restate_util_string::ReString;
 use super::{Raw, commands};
 use crate::{
     v1,
-    v2::{
-        self, Envelope,
-        commands::{TruncateOutboxCommand, UpsertRuleBookCommand},
-    },
+    v2::{self, Envelope, commands::TruncateOutboxCommand},
 };
 
 impl TryFrom<v1::Envelope> for v2::Envelope<Raw> {
@@ -139,17 +131,12 @@ impl TryFrom<v1::Envelope> for v2::Envelope<Raw> {
             }
             v1::Command::UpsertSchema(payload) => Envelope::new(dedup, payload).into_raw(),
             v1::Command::VersionBarrier(payload) => Envelope::new(dedup, payload).into_raw(),
-            v1::Command::UpsertRuleBook(payload) => {
-                let rule_book = RuleBook::decode(payload.rule_book)?;
-                Envelope::new(
-                    dedup,
-                    UpsertRuleBookCommand {
-                        partition_key_range: payload.partition_key_range,
-                        rule_book: Arc::new(rule_book),
-                    },
-                )
-                .into_raw()
-            }
+            v1::Command::UpsertRuleBook(wrapper) => Envelope::from_bytes_unchecked(
+                v2::CommandKind::UpsertRuleBook,
+                StorageCodecKind::Bilrost,
+                dedup,
+                wrapper.command,
+            ),
             v1::Command::VQSchedulerDecisions(payload) => Envelope::from_bytes_unchecked(
                 v2::CommandKind::VQSchedulerDecisions,
                 StorageCodecKind::Bilrost,

--- a/crates/worker/src/partition/leadership/durability_tracker.rs
+++ b/crates/worker/src/partition/leadership/durability_tracker.rs
@@ -9,23 +9,22 @@
 // by the Apache License, Version 2.0.
 
 use std::pin::Pin;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::task::Poll;
 use std::time::Duration;
 
 use futures::{Stream, StreamExt};
+use restate_clock::WallClock;
 use tokio::sync::watch;
 use tokio::time::{Instant, MissedTickBehavior};
 use tokio_stream::wrappers::{IntervalStream, WatchStream};
 use tracing::{debug, warn};
 
-use restate_clock::WallClock;
 use restate_core::Metadata;
 use restate_types::config::{Configuration, DurabilityMode};
-use restate_types::logs::{Keys, Lsn, SequenceNumber};
+use restate_types::identifiers::PartitionId;
+use restate_types::logs::{Lsn, SequenceNumber};
 use restate_types::nodes_config::Role;
-use restate_types::partitions::Partition;
 use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::time::MillisSinceEpoch;
 use restate_wal_protocol::control::UpdatePartitionDurabilityCommand;
@@ -41,7 +40,7 @@ static LAST_SNAPSHOT_WARNING_AT: AtomicU64 = AtomicU64::new(0);
 /// changed in the replica-set, but it'll react immediately to changes in the archived Lsn
 /// watch.
 pub struct DurabilityTracker {
-    partition: Arc<Partition>,
+    partition_id: PartitionId,
     last_reported_durable_lsn: Lsn,
     replica_set_states: PartitionReplicaSetStates,
     archived_lsn_watch: WatchStream<Option<Lsn>>,
@@ -53,7 +52,7 @@ pub struct DurabilityTracker {
 
 impl DurabilityTracker {
     pub fn new(
-        partition: Arc<Partition>,
+        partition_id: PartitionId,
         last_reported_durable_lsn: Option<Lsn>,
         replica_set_states: PartitionReplicaSetStates,
         archived_lsn_watch: watch::Receiver<Option<Lsn>>,
@@ -65,7 +64,7 @@ impl DurabilityTracker {
         let check_timer = IntervalStream::new(check_timer);
 
         Self {
-            partition,
+            partition_id,
             last_reported_durable_lsn: last_reported_durable_lsn.unwrap_or(Lsn::INVALID),
             replica_set_states,
             archived_lsn_watch: WatchStream::new(archived_lsn_watch),
@@ -184,11 +183,11 @@ impl Stream for DurabilityTracker {
             }
             DurabilityMode::ReplicaSetOnly => self
                 .replica_set_states
-                .get_min_durable_lsn(self.partition.partition_id),
+                .get_min_durable_lsn(self.partition_id),
             DurabilityMode::SnapshotAndReplicaSet => {
                 let min_durable_lsn = self
                     .replica_set_states
-                    .get_min_durable_lsn(self.partition.partition_id);
+                    .get_min_durable_lsn(self.partition_id);
                 self.last_archived.min(min_durable_lsn)
             }
             // disabled until ad-hoc snapshot sharing is supported
@@ -202,7 +201,7 @@ impl Stream for DurabilityTracker {
             DurabilityMode::Balanced => {
                 let max_durable_lsn = self
                     .replica_set_states
-                    .get_max_durable_lsn(self.partition.partition_id);
+                    .get_max_durable_lsn(self.partition_id);
                 self.last_archived.min(max_durable_lsn)
             }
         };
@@ -213,16 +212,15 @@ impl Stream for DurabilityTracker {
         }
 
         let partition_durability = UpdatePartitionDurabilityCommand {
-            partition_id: self.partition.partition_id,
+            partition_id: self.partition_id,
             durable_point: suggested,
             modification_time: MillisSinceEpoch::now(),
-            partition_key_range: Keys::RangeInclusive(self.partition.key_range.into()),
         };
         // We don't want to keep reporting the same durable Lsn over and over.
         self.last_reported_durable_lsn = suggested;
 
         debug!(
-            partition_id = %self.partition.partition_id,
+            partition_id = %self.partition_id,
             durability_mode = %durability_mode,
             "Reporting {suggested:?} as a durable point for partition"
         );

--- a/crates/worker/src/partition/leadership/leader_state.rs
+++ b/crates/worker/src/partition/leadership/leader_state.rs
@@ -50,6 +50,7 @@ use restate_vqueues::scheduler::Decisions;
 use restate_vqueues::{SchedulerService, VQueuesMeta};
 use restate_wal_protocol::Command;
 use restate_wal_protocol::control::UpsertSchemaCommand;
+use restate_wal_protocol::v1::UpsertRuleBookCommandWrapper;
 use restate_worker_api::invoker::InvokerHandle;
 use restate_worker_api::resources::ReservedResources;
 use restate_worker_api::{SchedulerStatusEntry, UserLimitCounterEntry};
@@ -454,7 +455,7 @@ impl LeaderState {
                             .await?;
                     }
                 }
-                ActionEffect::UpsertRuleBook(book) => {
+                ActionEffect::UpsertRuleBook(rule_book) => {
                     // todo(tillrohrmann) also enable the feature once the partition has been migrated
                     //  to use vqueues and then rolling back to v1.7
                     if Configuration::pinned()
@@ -462,15 +463,20 @@ impl LeaderState {
                         .experimental
                         .is_vqueues_enabled()
                     {
+                        let cmd =
+                            restate_wal_protocol::control::UpsertRuleBookCommand { rule_book };
+
+                        arena.reserve(cmd.encoded_len());
+                        // safe to unwrap because we reserved enough space
+                        cmd.bilrost_encode(&mut arena).unwrap();
+
                         self.self_proposer
                             .self_propose(
                                 self.partition_key_range.start(),
-                                Command::UpsertRuleBook(
-                                    restate_wal_protocol::control::UpsertRuleBookCommand {
-                                        partition_key_range: self.partition_key_range,
-                                        rule_book: book.bilrost_encode_to_bytes(),
-                                    },
-                                ),
+                                Command::UpsertRuleBook(UpsertRuleBookCommandWrapper {
+                                    partition_key_range: self.partition_key_range,
+                                    command: arena.split().freeze(),
+                                }),
                             )
                             .await?;
                     }

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -584,7 +584,7 @@ where
                 .map(|d| d.durable_point);
 
             let durability_tracker = DurabilityTracker::new(
-                self.partition.clone(),
+                self.partition.partition_id,
                 last_reported_durable_lsn,
                 replica_set_states,
                 partition_store.partition_db().watch_archived_lsn(),


### PR DESCRIPTION
Replace PartialEnvelope with CommandWithKeys trait

Summary:
Replaces the type-erased `PartialEnvelope` with a `CommandWithKeys` trait
that unifies how WAL writers obtain record keys for a command:

- Auto-implemented for any `Command: HasRecordKeys` (keys come from the
  command itself).
- Implemented for `BodyWithKeys<C>` so commands that don't carry their
  own keys can still be enriched at the call site.

This lets generic write paths accept either form without an intermediate allocation,
and removes the now-redundant `StorageDecode` bound from the `Command` trait.

As a result:
Roll back the changes in the `UpdatePartitionDurabilityCommand`
- `UpdatePartitionDurabilityCommand` no longer needs to carry
  `partition_key_range` (was added in a previous commit)
  the key range is supplied via `BodyWithKeys` at publish time.
  (follw up PR to handle the Write path)
- `DurabilityTracker` takes a `PartitionId` instead of
  `Arc<Partition>`, since it no longer needs the key range.
  (also a rollback)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4724).
* #4700
* __->__ #4724
* #4722