### PR TITLE
[cli] sort handlers list by name in cli svc status output

### DIFF
--- a/cli/src/commands/services/status/mod.rs
+++ b/cli/src/commands/services/status/mod.rs
@@ -16,6 +16,7 @@ use chrono_humanize::Tense;
 use cling::prelude::*;
 use comfy_table::{Cell, Table};
 
+use itertools::Itertools;
 use restate_cli_util::c_println;
 use restate_cli_util::ui::console::{Styled, StyledTable};
 use restate_cli_util::ui::stylesheet::Style;
@@ -126,7 +127,11 @@ async fn render_handlers_status(
     svc: ServiceMetadata,
     svc_status: &ServiceStatus,
 ) -> Result<()> {
-    for (_, handler) in svc.handlers {
+    for handler in svc
+        .handlers
+        .values()
+        .sorted_unstable_by(|a, b| a.name.cmp(&b.name))
+    {
         let mut row = vec![];
         row.push(Cell::new(format!("  {}", &handler.name)));
         // Pending


### PR DESCRIPTION
When using `svc status` in watch mode, the handler status list keeps dancing due to the indeterministic order of iterating on the handlers hashmap. This minor PR sorts the handlers output by their name such that it's more readable in watch mode.

## Before

https://github.com/user-attachments/assets/564d88cc-d369-47fd-9eaa-8850c74a8465

## After

https://github.com/user-attachments/assets/5d84663d-64f6-473f-9de5-156aa763b396




