### PR TITLE
Correct sort order for tables with variable length key fields

### DIFF
--- a/crates/storage-query-datafusion/src/keyed_service_status/schema.rs
+++ b/crates/storage-query-datafusion/src/keyed_service_status/schema.rs
@@ -12,11 +12,7 @@ use crate::table_macro::*;
 
 use datafusion::arrow::datatypes::DataType;
 
-define_sort_order!(sys_keyed_service_status(
-    partition_key,
-    service_name,
-    service_key
-));
+define_sort_order!(sys_keyed_service_status(partition_key));
 
 define_table!(sys_keyed_service_status(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.

--- a/crates/storage-query-datafusion/src/locks/schema.rs
+++ b/crates/storage-query-datafusion/src/locks/schema.rs
@@ -12,7 +12,7 @@ use crate::table_macro::*;
 
 use datafusion::arrow::datatypes::DataType;
 
-define_sort_order!(sys_locks(partition_key, scope, lock_name));
+define_sort_order!(sys_locks(partition_key));
 
 define_table!(sys_locks(
     /// Internal column that is used for partitioning. Can be ignored.

--- a/crates/storage-query-datafusion/src/promise/schema.rs
+++ b/crates/storage-query-datafusion/src/promise/schema.rs
@@ -12,7 +12,7 @@ use crate::table_macro::*;
 
 use datafusion::arrow::datatypes::DataType;
 
-define_sort_order!(sys_promise(partition_key, service_name, service_key));
+define_sort_order!(sys_promise(partition_key));
 
 define_table!(sys_promise(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.

--- a/crates/storage-query-datafusion/src/state/schema.rs
+++ b/crates/storage-query-datafusion/src/state/schema.rs
@@ -12,7 +12,7 @@ use crate::table_macro::*;
 
 use datafusion::arrow::datatypes::DataType;
 
-define_sort_order!(state(partition_key, service_name, service_key));
+define_sort_order!(state(partition_key));
 
 define_table!(state(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.

--- a/crates/storage-query-datafusion/src/user_limits/schema.rs
+++ b/crates/storage-query-datafusion/src/user_limits/schema.rs
@@ -12,7 +12,7 @@ use crate::table_macro::*;
 
 use datafusion::arrow::datatypes::DataType;
 
-define_sort_order!(sys_user_limits(partition_key, scope, l1, l2));
+define_sort_order!(sys_user_limits(partition_key));
 
 define_table!(sys_user_limits(
     /// Internal column that is used for partitioning. Can be ignored.


### PR DESCRIPTION
The problem is that variable length key fields are length encoded so that the length of the field decides its order and not the value. Hence, shorter values precede longer values which should violate DF sort order assumption.