### PR TITLE
Enable hw acceleration for sha2 whenever possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8641,6 +8641,7 @@ version = "1.7.0-dev"
 dependencies = [
  "arrayvec",
  "bilrost",
+ "criterion",
  "derive_more",
  "enum-map",
  "gardal",
@@ -8648,6 +8649,7 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "pin-project",
+ "pprof",
  "restate-clock",
  "restate-core",
  "restate-futures-util",
@@ -8666,6 +8668,7 @@ dependencies = [
  "sha2 0.10.9",
  "slotmap",
  "smallvec",
+ "tikv-jemallocator",
  "tokio",
  "tokio-util",
  "tracing",
@@ -8905,6 +8908,7 @@ dependencies = [
  "serde_core",
  "serde_json",
  "serde_with",
+ "sha2 0.10.9",
  "signal-hook",
  "simd-adler32",
  "slab",
@@ -9503,6 +9507,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+ "sha2-asm",
 ]
 
 [[package]]
@@ -9514,6 +9519,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.2",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -239,7 +239,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_core = { version = "1" }
 serde_json = "1.0"
 serde_with = "3.16"
-sha2 = "0.10.9"
+sha2 = { version = "0.10.9" }
 static_assertions = { version = "1.1.0" }
 strum = { version = "0.27.2", features = ["derive"] }
 smallvec = { version = "1.15.1", features = ["serde", "union"] }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -108,6 +108,9 @@ ulid = { workspace = true }
 utoipa = { workspace = true, optional = true, features = ["time"] }
 xxhash-rust = { workspace = true, features = ["xxh3"] }
 
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+sha2 = { workspace = true, features = ["asm"] }
+
 [dev-dependencies]
 restate-types = {path = ".", default-features = false, features = ["test-util"]}
 restate-test-util = { workspace = true }

--- a/crates/vqueues/Cargo.toml
+++ b/crates/vqueues/Cargo.toml
@@ -43,9 +43,22 @@ tokio = { workspace = true, features = ["sync"] }
 tokio-util = { workspace = true, features = ["time"] }
 tracing = { workspace = true }
 
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+sha2 = { workspace = true, features = ["asm"] }
+
 [dev-dependencies]
 restate-core = { workspace = true, features = ["test-util"] }
 restate-partition-store = { workspace = true }
+
+criterion = { workspace = true }
+pprof = { version = "0.15", features = ["criterion", "flamegraph", "frame-pointer"] }
+
+[target.'cfg(not(target_env = "msvc"))'.dev-dependencies]
+tikv-jemallocator = { workspace = true }
+
+[[bench]]
+name = "generate_vqueue_id"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/vqueues/benches/generate_vqueue_id.rs
+++ b/crates/vqueues/benches/generate_vqueue_id.rs
@@ -1,0 +1,125 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::hint::black_box;
+use std::time::Duration;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use pprof::criterion::{Output, PProfProfiler};
+use pprof::flamegraph::Options;
+
+use restate_limiter::LimitKey;
+use restate_types::Scope;
+use restate_types::identifiers::PartitionKey;
+use restate_util_string::ReString;
+use restate_vqueues::generate_vqueue_id;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+pub fn flamegraph_options<'a>() -> Options<'a> {
+    #[allow(unused_mut)]
+    let mut options = Options::default();
+    if cfg!(target_os = "macos") {
+        // Ignore different thread origins to merge traces. This seems not needed on Linux.
+        options.base = vec!["__pthread_joiner_wake".to_string(), "_main".to_string()];
+    }
+    options
+}
+
+fn bench_generate_vqueue_id(c: &mut Criterion) {
+    let partition_key: PartitionKey = 0xDEAD_BEEF_CAFE_F00D;
+    let scope = Scope::try_non_interned("my_scope.v2").unwrap();
+    let limit_key_none: LimitKey<ReString> = LimitKey::None;
+    let limit_key_l1: LimitKey<ReString> = "tenant_42".parse().unwrap();
+    let limit_key_l2: LimitKey<ReString> = "tenant_42/workflow_77".parse().unwrap();
+    let service_name = "MyWonderfulService";
+    let key = "user-key-1234567890";
+
+    let mut group = c.benchmark_group("generate_vqueue_id");
+    group
+        .sample_size(200)
+        .measurement_time(Duration::from_secs(5));
+
+    group.bench_function("shared/no-scope/no-limit", |b| {
+        b.iter(|| {
+            black_box(generate_vqueue_id(
+                black_box(partition_key),
+                black_box(None),
+                black_box(&limit_key_none),
+                black_box(false),
+                black_box(service_name),
+                black_box(None),
+            ))
+        });
+    });
+
+    group.bench_function("shared/scope/no-limit", |b| {
+        b.iter(|| {
+            black_box(generate_vqueue_id(
+                black_box(partition_key),
+                black_box(Some(&scope)),
+                black_box(&limit_key_none),
+                black_box(false),
+                black_box(service_name),
+                black_box(None),
+            ))
+        });
+    });
+
+    group.bench_function("shared/scope/l1", |b| {
+        b.iter(|| {
+            black_box(generate_vqueue_id(
+                black_box(partition_key),
+                black_box(Some(&scope)),
+                black_box(&limit_key_l1),
+                black_box(false),
+                black_box(service_name),
+                black_box(None),
+            ))
+        });
+    });
+
+    group.bench_function("shared/scope/l2", |b| {
+        b.iter(|| {
+            black_box(generate_vqueue_id(
+                black_box(partition_key),
+                black_box(Some(&scope)),
+                black_box(&limit_key_l2),
+                black_box(false),
+                black_box(service_name),
+                black_box(None),
+            ))
+        });
+    });
+
+    group.bench_function("exclusive/scope/l1/key", |b| {
+        b.iter(|| {
+            black_box(generate_vqueue_id(
+                black_box(partition_key),
+                black_box(Some(&scope)),
+                black_box(&limit_key_l1),
+                black_box(true),
+                black_box(service_name),
+                black_box(Some(key)),
+            ))
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(997, Output::Flamegraph(Some(flamegraph_options()))));
+    targets = bench_generate_vqueue_id
+);
+criterion_main!(benches);

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -293,6 +293,7 @@ pprof_util = { version = "0.8", default-features = false, features = ["flamegrap
 prost = { version = "0.14", default-features = false, features = ["no-recursion-limit"] }
 quick-xml = { version = "0.39", features = ["overlapped-lists", "serialize"] }
 rustix = { version = "1", features = ["fs", "stdio", "termios"] }
+sha2 = { version = "0.10", features = ["asm"] }
 signal-hook = { version = "0.3" }
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats", "use_std"] }
 tikv-jemalloc-sys = { version = "0.6", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
@@ -313,6 +314,7 @@ pprof_util = { version = "0.8", default-features = false, features = ["flamegrap
 prost = { version = "0.14", default-features = false, features = ["no-recursion-limit"] }
 quick-xml = { version = "0.39", features = ["overlapped-lists", "serialize"] }
 rustix = { version = "1", features = ["fs", "stdio", "termios"] }
+sha2 = { version = "0.10", features = ["asm"] }
 signal-hook = { version = "0.3" }
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats", "use_std"] }
 tikv-jemalloc-sys = { version = "0.6", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
@@ -333,6 +335,7 @@ pprof_util = { version = "0.8", default-features = false, features = ["flamegrap
 prost = { version = "0.14", default-features = false, features = ["no-recursion-limit"] }
 quick-xml = { version = "0.39", features = ["overlapped-lists", "serialize"] }
 rustix = { version = "1", features = ["fs", "stdio", "termios"] }
+sha2 = { version = "0.10", features = ["asm"] }
 signal-hook = { version = "0.3" }
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats", "use_std"] }
 tikv-jemalloc-sys = { version = "0.6", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
@@ -353,6 +356,7 @@ pprof_util = { version = "0.8", default-features = false, features = ["flamegrap
 prost = { version = "0.14", default-features = false, features = ["no-recursion-limit"] }
 quick-xml = { version = "0.39", features = ["overlapped-lists", "serialize"] }
 rustix = { version = "1", features = ["fs", "stdio", "termios"] }
+sha2 = { version = "0.10", features = ["asm"] }
 signal-hook = { version = "0.3" }
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats", "use_std"] }
 tikv-jemalloc-sys = { version = "0.6", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }


### PR DESCRIPTION

Up to 5X faster SHA256/512 compression on x86_64 and aarch64 when hardware support is available. Looked at upgrading to 0.11 but it performed a bit worse.

Also adds a benchmark for generating vqueue ids.
