### PR TITLE
Use mainstream `base64` v2.24

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1040,8 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "base62"
-version = "2.2.3"
-source = "git+http://github.com/restatedev/base62?rev=dc62ff947d0ea84db0864e5c7e96c129e7b5874c#dc62ff947d0ea84db0864e5c7e96c129e7b5874c"
+version = "2.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd637ac531c60eb7fbc4684dc061c2d7d90d73d758181aa02eeff0464b9eee4b"
 
 [[package]]
 name = "base64"

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -40,8 +40,7 @@ adaptive-timeout = { workspace = true, features = ["serde"] }
 ahash = {workspace = true }
 anyhow = { workspace = true }
 arc-swap = { workspace = true }
-# pending release of https://github.com/fbernier/base62/pull/28
-base62 = { git = "http://github.com/restatedev/base62", rev = "dc62ff947d0ea84db0864e5c7e96c129e7b5874c" }
+base62 = { version = "2.2.4" }
 base64 = { workspace = true }
 bitflags = { workspace = true }
 bytes = { workspace = true }


### PR DESCRIPTION
Use mainstream `base64` v2.24

Summary:
This replaces our fork at https://github.com/restatedev/base62 which
should be archived.


Fixes #4260
