### PR TITLE
[Restate UI] Update to v0.1.60

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8700,8 +8700,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.59"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.59#2a9a0d27806c3048338315d6644c366a373f705f"
+version = "0.1.60"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.60#c0ff611c130165d3661e4b416c1550ca3f898ce6"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -39,7 +39,7 @@ restate-util-time = { workspace = true }
 restate-types = { workspace = true }
 restate-util-string = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.59", tag = "v0.1.59" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.60", tag = "v0.1.60" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.60
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.60/ui-v0.1.60.zip