### PR TITLE
[VQueues] migration logic from service_status to locks table

### DIFF
--- a/crates/partition-store/src/migrations.rs
+++ b/crates/partition-store/src/migrations.rs
@@ -8,9 +8,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::{PartitionStore, Result};
-use restate_storage_api::StorageError;
+mod migrate_to_locks_table;
+
+use std::num::NonZeroU16;
+use std::sync::Arc;
+
+use bytes::BytesMut;
+use restate_types::sharding::KeyRange;
+use restate_types::sharding::subsharding::ShardPlan;
 use strum::EnumCount;
+
+use restate_clock::{AtomicStorage, HlcClock, WallClock};
+use restate_storage_api::StorageError;
+use restate_types::config::Configuration;
+
+use crate::{PartitionDb, PartitionStore, Result};
 
 // NOTE: The representation numbers here must be strictly monotonically increasing.
 #[derive(Debug, Eq, PartialEq, strum::FromRepr, strum::EnumCount)]
@@ -66,5 +78,125 @@ impl SchemaVersion {
             }
         }
         Ok(())
+    }
+}
+
+#[allow(dead_code)]
+pub struct MigrationContext<'a> {
+    clock: HlcClock<WallClock, Arc<AtomicStorage>>,
+    arena: BytesMut,
+    partition_db: &'a PartitionDb,
+    key_range: KeyRange,
+}
+
+#[allow(dead_code)]
+impl<'a> MigrationContext<'a> {
+    pub fn new(config: &Configuration, partition_db: &'a PartitionDb, key_range: KeyRange) -> Self {
+        Self {
+            clock: HlcClock::new(
+                config.common.hlc_max_drift(),
+                WallClock,
+                Arc::new(AtomicStorage::default()),
+            )
+            .expect("failed to create HLC clock"),
+            arena: BytesMut::default(),
+            partition_db,
+            key_range,
+        }
+    }
+
+    pub fn split(&self, max_shards: NonZeroU16) -> std::vec::IntoIter<Self> {
+        ShardPlan::new(self.key_range, max_shards)
+            .shards()
+            .map(|shard| {
+                let key_range = *shard.key_range();
+                assert!(
+                    key_range.num_keys() > 0,
+                    "each split range must contain at least one key"
+                );
+                self.clone_with_key_range(key_range)
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+
+    fn clone_with_key_range(&self, key_range: KeyRange) -> Self {
+        Self {
+            clock: self.clock.clone(),
+            arena: BytesMut::default(),
+            partition_db: self.partition_db,
+            key_range,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use restate_clock::ClockUpkeep;
+    use restate_rocksdb::RocksDbManager;
+    use restate_types::identifiers::{PartitionId, PartitionKey};
+    use restate_types::partitions::Partition;
+
+    use crate::PartitionStoreManager;
+
+    use super::*;
+
+    #[restate_core::test]
+    async fn split_returns_independent_sub_contexts() {
+        let _clock_guard = ClockUpkeep::start().expect("clock upkeep should start");
+        RocksDbManager::init();
+        let manager = PartitionStoreManager::create()
+            .await
+            .expect("DB storage creation succeeds");
+        let store = manager
+            .open(
+                &Partition::new(PartitionId::MIN, KeyRange::new(0, PartitionKey::MAX - 1)),
+                None,
+            )
+            .await
+            .expect("DB storage creation succeeds");
+
+        let config = Configuration::default();
+        let mut ctx = MigrationContext::new(&config, store.partition_db(), KeyRange::new(1, 100));
+        ctx.arena.extend_from_slice(b"dirty parent arena");
+
+        let mut split = ctx.split(NonZeroU16::new(2).expect("two is non-zero"));
+        assert_eq!(split.len(), 2);
+        let left_ctx = split.next().expect("left context should exist");
+        let right_ctx = split.next().expect("right context should exist");
+        assert!(split.next().is_none());
+        assert_eq!(left_ctx.key_range, KeyRange::new(1, 50));
+        assert_eq!(right_ctx.key_range, KeyRange::new(51, 100));
+        assert!(left_ctx.arena.is_empty());
+        assert!(right_ctx.arena.is_empty());
+
+        let four_shard_ranges = ctx
+            .split(NonZeroU16::new(4).expect("four is non-zero"))
+            .map(|ctx| ctx.key_range)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            four_shard_ranges,
+            vec![
+                KeyRange::new(1, 25),
+                KeyRange::new(26, 50),
+                KeyRange::new(51, 75),
+                KeyRange::new(76, 100),
+            ]
+        );
+
+        let left_timestamp = left_ctx.clock.next();
+        let right_timestamp = right_ctx.clock.next();
+        assert!(left_timestamp < right_timestamp);
+
+        let single_key_ctx =
+            MigrationContext::new(&config, store.partition_db(), KeyRange::new(42, 42));
+        let single_key_ranges = single_key_ctx
+            .split(NonZeroU16::new(2).expect("two is non-zero"))
+            .map(|ctx| ctx.key_range)
+            .collect::<Vec<_>>();
+        assert_eq!(single_key_ranges, vec![KeyRange::new(42, 42)]);
+
+        drop((ctx, left_ctx, right_ctx, single_key_ctx));
+        RocksDbManager::get().shutdown().await;
     }
 }

--- a/crates/partition-store/src/migrations/migrate_to_locks_table.rs
+++ b/crates/partition-store/src/migrations/migrate_to_locks_table.rs
@@ -1,0 +1,156 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::Context;
+use bilrost::Message;
+use bytes::BufMut;
+use rocksdb::WriteBatch;
+use tracing::debug;
+
+use restate_storage_api::StorageError;
+use restate_storage_api::lock_table::{AcquiredBy, LockState};
+use restate_storage_api::protobuf_types::PartitionStoreProtobufValue as _;
+use restate_storage_api::service_status_table::VirtualObjectStatus;
+use restate_types::sharding::PartitionKey;
+
+use crate::keys::{DecodeTableKey, EncodeTableKeyPrefix, KeyKind};
+use crate::scan::{PhysicalScan, TableScan};
+use crate::service_status_table::ServiceStatusKey;
+
+use super::MigrationContext;
+
+/// scan the sys_service_status table and migrate all entries that hold a lock
+/// into the locks table. Once the migration is done.
+///
+/// We are using direct access to rocksdb because we are not performing any async operations.
+#[allow(dead_code)]
+pub fn migrate_to_locks_table(ctx: &mut MigrationContext<'_>) -> Result<(), StorageError> {
+    let rocks = ctx.partition_db.rocksdb();
+    let key_range = ctx.key_range;
+    let mut counter = 0;
+
+    let mut iterator = ctx.partition_db.scan(PhysicalScan::from(
+        TableScan::FullScanPartitionKeyRange::<ServiceStatusKey>(key_range),
+        &mut ctx.arena,
+    ))?;
+    iterator.seek_to_first();
+
+    // 1 MiB batches
+    let mut wb = WriteBatch::with_capacity_bytes(1024 * 1024);
+    let arena = &mut ctx.arena;
+    arena.clear();
+
+    let mut opts = rocksdb::WriteOptions::default();
+    // We disable WAL since bifrost is our durable distributed log.
+    opts.disable_wal(true);
+
+    while iterator.valid() {
+        // safe to unwrap because the iterator is valid
+        let (mut key, mut value) = iterator.item().unwrap();
+        let state_key = ServiceStatusKey::deserialize_from(&mut key)?;
+        let state_value = VirtualObjectStatus::decode(&mut value)?;
+        let (partition_key, service_name, service_key) = state_key.split();
+
+        if let VirtualObjectStatus::Locked(invocation_id) = state_value {
+            KeyKind::Lock.serialize(arena);
+            crate::keys::serialize(&partition_key, arena);
+            // unscoped
+            arena.put_u8(b'u');
+            // Encode the key:
+            arena.put_slice(service_name.as_ref());
+            arena.put_u8(b'/');
+            arena.put_slice(service_key.as_ref());
+
+            let key = arena.split().freeze();
+
+            // Value
+            let value = LockState {
+                // We don't know the original acquisition time, so we use now()!
+                acquired_at: ctx.clock.next(),
+                acquired_by: AcquiredBy::InvocationId(invocation_id),
+            };
+            value.encode(arena).unwrap();
+            let value = arena.split().freeze();
+
+            wb.put_cf(ctx.partition_db.cf_handle(), key, value);
+            counter += 1;
+        }
+
+        // non-scientific threshold to trigger the commit.
+        if wb.size_in_bytes() >= 800 {
+            rocks
+                .inner()
+                .write_batch(&wb, &opts)
+                .context("failed to write batch")?;
+            wb.clear();
+        }
+
+        iterator.next();
+    }
+
+    // ensures we didn't stop because of an iterator error
+    iterator
+        .status()
+        .context("iterating over service status")
+        .map_err(StorageError::Generic)?;
+
+    // just in case!
+    if !wb.is_empty() {
+        // commit, including the last batch of records
+        rocks
+            .inner()
+            .write_batch(&wb, &opts)
+            .context("failed to write batch")?;
+    }
+
+    debug!("Finished migrating {} locks", counter);
+
+    Ok(())
+}
+
+/// Deletes old service statuses.
+#[allow(dead_code)]
+pub fn delete_service_status_data(ctx: &mut MigrationContext<'_>) -> Result<(), StorageError> {
+    let mut wb = WriteBatch::default();
+    let mut opts = rocksdb::WriteOptions::default();
+    // We disable WAL since bifrost is our durable distributed log.
+    opts.disable_wal(true);
+
+    // Delete old service statuses.
+    let mut start_key_buf = [0u8; KeyKind::SERIALIZED_LENGTH + std::mem::size_of::<PartitionKey>()];
+    EncodeTableKeyPrefix::serialize_to(
+        &ServiceStatusKey::builder().partition_key(ctx.key_range.start()),
+        &mut start_key_buf.as_mut(),
+    );
+
+    let mut end_key_buf = [0u8; KeyKind::SERIALIZED_LENGTH + std::mem::size_of::<PartitionKey>()];
+    EncodeTableKeyPrefix::serialize_to(
+        &ServiceStatusKey::builder().partition_key(ctx.key_range.end()),
+        &mut end_key_buf.as_mut(),
+    );
+    // End key is exclusive in delete range, so the end prefix is one byte
+    // beyond the max partition key on this key kind prefix.
+    let success = crate::convert_to_upper_bound(&mut end_key_buf);
+    assert!(success, "end key overflowed");
+    wb.delete_range_cf(ctx.partition_db.cf_handle(), start_key_buf, end_key_buf);
+
+    // commit, including the last batch of records
+    ctx.partition_db
+        .rocksdb()
+        .inner()
+        .write_batch(&wb, &opts)
+        .context("failed to write batch")?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "../tests/migrations_test/migrate_to_locks_table.rs"]
+mod tests;

--- a/crates/partition-store/src/partition_db.rs
+++ b/crates/partition-store/src/partition_db.rs
@@ -13,9 +13,12 @@ use std::ops::DerefMut;
 use std::sync::Arc;
 use std::time::Duration;
 
+use bytes::BytesMut;
 use parking_lot::RwLock;
 use rocksdb::table_properties::TablePropertiesExt;
-use rocksdb::{BoundColumnFamily, ExportImportFilesMetaData};
+use rocksdb::{
+    BoundColumnFamily, DBRawIteratorWithThreadMode, ExportImportFilesMetaData, ReadOptions,
+};
 use tokio::sync::{RwLock as AsyncRwLock, watch};
 use tokio::time::Instant;
 use tracing::{debug, info, instrument, warn};
@@ -23,16 +26,18 @@ use tracing::{debug, info, instrument, warn};
 use restate_core::ShutdownError;
 use restate_rocksdb::configuration::{CfConfigurator, DbConfigurator};
 use restate_rocksdb::{DbName, RocksDb, RocksError};
+use restate_storage_api::StorageError;
 use restate_types::config::Configuration;
 use restate_types::logs::Lsn;
 use restate_types::partitions::{CfName, Partition};
 use restate_util_bytecount::ByteCount;
 
-use crate::TableKind;
 use crate::durable_lsn_tracking::{AppliedLsnCollectorFactory, DurableLsnEventListener};
 use crate::keys::KeyKind;
 use crate::memory::MemoryBudget;
+use crate::scan::PhysicalScan;
 use crate::snapshots::LocalPartitionSnapshot;
+use crate::{DB_PREFIX_LENGTH, ScanMode, TableKind};
 
 use restate_util_string::ReString;
 
@@ -164,6 +169,83 @@ impl PartitionDb {
             });
         }
     }
+
+    #[track_caller]
+    pub(super) fn scan(
+        &self,
+        scan: PhysicalScan,
+    ) -> Result<DBRawIteratorWithThreadMode<'_, rocksdb::DB>, StorageError> {
+        match scan {
+            PhysicalScan::Prefix(table, _key_kind, prefix) => {
+                debug_assert!(table.has_key_kind(&prefix));
+                let prefix = prefix.freeze();
+                let opts = new_prefix_iterator_opts(prefix.as_ref());
+                let table = self.table_cf_handle(table);
+                let mut it = self
+                    .rocksdb
+                    .inner()
+                    .as_raw_db()
+                    .raw_iterator_cf_opt(table, opts);
+                it.seek(prefix);
+                Ok(it)
+            }
+            PhysicalScan::RangeExclusive(table, _key_kind, scan_mode, start, end) => {
+                debug_assert!(table.has_key_kind(&start));
+                let opts = new_range_iterator_opts(scan_mode, start.as_ref(), end.as_ref());
+                let table = self.table_cf_handle(table);
+                let mut it = self
+                    .rocksdb
+                    .inner()
+                    .as_raw_db()
+                    .raw_iterator_cf_opt(table, opts);
+                it.seek(start);
+                Ok(it)
+            }
+            PhysicalScan::RangeOpen(table, key_kind, start) => {
+                debug_assert!(table.has_key_kind(&start));
+                // We delayed the generate the synthetic iterator upper bound until this point
+                // because we might have different prefix length requirements based on the
+                // table+key_kind combination and we should keep this knowledge as low-level as
+                // possible.
+                //
+                // make the end has the same length as all prefixes to ensure rocksdb key
+                // comparator can leverage bloom filters when applicable
+                // (if auto_prefix_mode is enabled)
+                let mut end = BytesMut::zeroed(DB_PREFIX_LENGTH);
+                // We want to ensure that Range scans fall within the same key kind.
+                // So, we limit the iterator to the upper bound of this prefix
+                let kind_upper_bound = key_kind.exclusive_upper_bound();
+                end[..kind_upper_bound.len()].copy_from_slice(&kind_upper_bound);
+                let opts =
+                    new_range_iterator_opts(ScanMode::TotalOrder, start.as_ref(), end.as_ref());
+                let table = self.table_cf_handle(table);
+                let mut it = self
+                    .rocksdb
+                    .inner()
+                    .as_raw_db()
+                    .raw_iterator_cf_opt(table, opts);
+                it.seek(start);
+                Ok(it)
+            }
+        }
+    }
+}
+
+fn new_prefix_iterator_opts<B: Into<Vec<u8>>>(prefix: B) -> ReadOptions {
+    let mut opts = ReadOptions::default();
+    opts.set_prefix_same_as_start(true);
+    opts.set_iterate_range(rocksdb::PrefixRange(prefix));
+    opts.set_async_io(true);
+    opts.set_total_order_seek(false);
+    opts
+}
+
+fn new_range_iterator_opts<B: Into<Vec<u8>>>(scan_mode: ScanMode, from: B, to: B) -> ReadOptions {
+    let mut opts = ReadOptions::default();
+    opts.set_total_order_seek(scan_mode == ScanMode::TotalOrder);
+    opts.set_iterate_range(from..to);
+    opts.set_async_io(true);
+    opts
 }
 
 #[derive(Clone)]

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -287,69 +287,12 @@ impl PartitionStore {
     }
 
     #[track_caller]
-    fn iterator_from<K: EncodeTableKeyPrefix>(
+    pub(super) fn iterator_from<K: EncodeTableKeyPrefix>(
         &self,
         scan: TableScan<K>,
     ) -> Result<DBRawIteratorWithThreadMode<'_, DB>> {
         let scan: PhysicalScan = scan.into();
-        match scan {
-            PhysicalScan::Prefix(table, key_kind, prefix) => {
-                assert!(table.has_key_kind(&prefix));
-                let prefix = prefix.freeze();
-                let opts = self.new_prefix_iterator_opts(key_kind, prefix.clone());
-                let table = self.table_handle(table);
-                let mut it = self
-                    .db
-                    .rocksdb()
-                    .inner()
-                    .as_raw_db()
-                    .raw_iterator_cf_opt(table, opts);
-                it.seek(prefix);
-                Ok(it)
-            }
-            PhysicalScan::RangeExclusive(table, _key_kind, scan_mode, start, end) => {
-                assert!(table.has_key_kind(&start));
-                let start = start.freeze();
-                let end = end.freeze();
-                let opts = self.new_range_iterator_opts(scan_mode, start.clone(), end);
-                let table = self.table_handle(table);
-                let mut it = self
-                    .db
-                    .rocksdb()
-                    .inner()
-                    .as_raw_db()
-                    .raw_iterator_cf_opt(table, opts);
-                it.seek(start);
-                Ok(it)
-            }
-            PhysicalScan::RangeOpen(table, _key_kind, start) => {
-                // We delayed the generate the synthetic iterator upper bound until this point
-                // because we might have different prefix length requirements based on the
-                // table+key_kind combination and we should keep this knowledge as low-level as
-                // possible.
-                //
-                // make the end has the same length as all prefixes to ensure rocksdb key
-                // comparator can leverage bloom filters when applicable
-                // (if auto_prefix_mode is enabled)
-                let mut end = BytesMut::zeroed(DB_PREFIX_LENGTH);
-                // We want to ensure that Range scans fall within the same key kind.
-                // So, we limit the iterator to the upper bound of this prefix
-                let kind_upper_bound = K::KEY_KIND.exclusive_upper_bound();
-                end[..kind_upper_bound.len()].copy_from_slice(&kind_upper_bound);
-                let start = start.freeze();
-                let end = end.freeze();
-                let opts = self.new_range_iterator_opts(ScanMode::TotalOrder, start.clone(), end);
-                let table = self.table_handle(table);
-                let mut it = self
-                    .db
-                    .rocksdb()
-                    .inner()
-                    .as_raw_db()
-                    .raw_iterator_cf_opt(table, opts);
-                it.seek(start);
-                Ok(it)
-            }
-        }
+        self.db.scan(scan)
     }
 
     #[allow(clippy::type_complexity)]

--- a/crates/partition-store/src/scan.rs
+++ b/crates/partition-store/src/scan.rs
@@ -8,15 +8,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use bytes::BytesMut;
+
+use restate_types::identifiers::{PartitionId, PartitionKey};
+use restate_types::sharding::KeyRange;
+
 use crate::keys::{EncodeTableKey, EncodeTableKeyPrefix, KeyEncode, KeyKind};
 use crate::scan::TableScan::{
     FullScanPartitionKeyRange, KeyRangeInclusiveInSinglePartition, SinglePartition,
     SinglePartitionKeyPrefix,
 };
 use crate::{PaddedPartitionId, ScanMode, TableKind};
-use bytes::BytesMut;
-use restate_types::identifiers::{PartitionId, PartitionKey};
-use restate_types::sharding::KeyRange;
 
 // Note: we take extra arguments like (PartitionId or PartitionKey) only to make sure that
 // call-sites know what they are opting to. Those values might not actually be used to perform the
@@ -41,15 +43,18 @@ pub(crate) enum PhysicalScan {
     RangeOpen(TableKind, KeyKind, BytesMut),
 }
 
-impl<K: EncodeTableKeyPrefix> From<TableScan<K>> for PhysicalScan {
-    fn from(scan: TableScan<K>) -> Self {
+impl PhysicalScan {
+    pub fn from<K: EncodeTableKeyPrefix>(scan: TableScan<K>, arena: &mut BytesMut) -> Self {
         match scan {
             SinglePartitionKeyPrefix(_partition_key, key) => {
-                PhysicalScan::Prefix(K::TABLE, K::KEY_KIND, key.serialize())
+                key.serialize_to(arena);
+                PhysicalScan::Prefix(K::TABLE, K::KEY_KIND, arena.split())
             }
             KeyRangeInclusiveInSinglePartition(_partition_id, start, end) => {
-                let start = start.serialize();
-                let mut end = end.serialize();
+                start.serialize_to(arena);
+                let start = arena.split();
+                end.serialize_to(arena);
+                let mut end = arena.split();
                 if try_increment(&mut end) {
                     PhysicalScan::RangeExclusive(
                         K::TABLE,
@@ -66,28 +71,26 @@ impl<K: EncodeTableKeyPrefix> From<TableScan<K>> for PhysicalScan {
             }
             SinglePartition(partition_id) => {
                 let partition_id = PaddedPartitionId::from(partition_id);
-                let mut prefix_start = BytesMut::with_capacity(
-                    partition_id.serialized_length() + KeyKind::SERIALIZED_LENGTH,
-                );
-                K::serialize_key_kind(&mut prefix_start);
-                partition_id.encode(&mut prefix_start);
+                arena.reserve(partition_id.serialized_length() + KeyKind::SERIALIZED_LENGTH);
+                K::serialize_key_kind(arena);
+                partition_id.encode(arena);
+                let prefix_start = arena.split();
                 PhysicalScan::Prefix(K::TABLE, K::KEY_KIND, prefix_start)
             }
             FullScanPartitionKeyRange(range) => {
                 let start = range.start();
                 let end = range.end();
-                let mut start_bytes =
-                    BytesMut::with_capacity(start.serialized_length() + KeyKind::SERIALIZED_LENGTH);
-                K::serialize_key_kind(&mut start_bytes);
-                start.encode(&mut start_bytes);
+                arena.reserve(start.serialized_length() + KeyKind::SERIALIZED_LENGTH);
+                K::serialize_key_kind(arena);
+                start.encode(arena);
+                let start_bytes = arena.split();
                 match end.checked_add(1) {
                     None => PhysicalScan::RangeOpen(K::TABLE, K::KEY_KIND, start_bytes),
                     Some(end) => {
-                        let mut end_bytes = BytesMut::with_capacity(
-                            end.serialized_length() + KeyKind::SERIALIZED_LENGTH,
-                        );
-                        K::serialize_key_kind(&mut end_bytes);
-                        end.encode(&mut end_bytes);
+                        arena.reserve(end.serialized_length() + KeyKind::SERIALIZED_LENGTH);
+                        K::serialize_key_kind(arena);
+                        end.encode(arena);
+                        let end_bytes = arena.split();
                         PhysicalScan::RangeExclusive(
                             K::TABLE,
                             K::KEY_KIND,
@@ -99,6 +102,13 @@ impl<K: EncodeTableKeyPrefix> From<TableScan<K>> for PhysicalScan {
                 }
             }
         }
+    }
+}
+
+impl<K: EncodeTableKeyPrefix> From<TableScan<K>> for PhysicalScan {
+    fn from(scan: TableScan<K>) -> Self {
+        let mut arena = BytesMut::new();
+        PhysicalScan::from(scan, &mut arena)
     }
 }
 

--- a/crates/partition-store/src/tests/migrations_test/migrate_to_locks_table.rs
+++ b/crates/partition-store/src/tests/migrations_test/migrate_to_locks_table.rs
@@ -1,0 +1,261 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::{HashMap, HashSet};
+use std::num::NonZeroU16;
+use std::ops::ControlFlow;
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use restate_clock::ClockUpkeep;
+use restate_rocksdb::RocksDbManager;
+use restate_storage_api::Transaction;
+use restate_storage_api::lock_table::{AcquiredBy, LoadLocks, ScanLocksTable, WriteLockTable};
+use restate_storage_api::service_status_table::{
+    ReadVirtualObjectStatusTable, VirtualObjectStatus, WriteVirtualObjectStatusTable,
+};
+use restate_types::LockName;
+use restate_types::config::Configuration;
+use restate_types::identifiers::{
+    InvocationId, InvocationUuid, PartitionId, PartitionKey, ServiceId, WithPartitionKey,
+};
+use restate_types::partitions::Partition;
+use restate_types::sharding::KeyRange;
+
+use crate::migrations::MigrationContext;
+use crate::{PartitionStore, PartitionStoreManager};
+
+async fn storage_test_environment() -> PartitionStore {
+    RocksDbManager::init();
+    let manager = PartitionStoreManager::create()
+        .await
+        .expect("DB storage creation succeeds");
+    manager
+        .open(
+            &Partition::new(PartitionId::MIN, KeyRange::new(0, PartitionKey::MAX - 1)),
+            None,
+        )
+        .await
+        .expect("DB storage creation succeeds")
+}
+
+fn distinct_service_ids(count: usize) -> Vec<ServiceId> {
+    let mut service_ids = Vec::with_capacity(count);
+    let mut partition_keys = HashSet::with_capacity(count);
+
+    for idx in 0..10_000 {
+        let service_id = ServiceId::new(None, "migration-svc", format!("migration-key-{idx}"));
+        if partition_keys.insert(service_id.partition_key()) {
+            service_ids.push(service_id);
+            if service_ids.len() == count {
+                return service_ids;
+            }
+        }
+    }
+
+    panic!("failed to find distinct service partition keys");
+}
+
+fn lock_name(service_id: &ServiceId) -> LockName {
+    LockName::parse(&format!("{}/{}", service_id.service_name, service_id.key))
+        .expect("lock name should be valid")
+}
+
+async fn collect_locks(rocksdb: &PartitionStore) -> HashMap<String, (PartitionKey, InvocationId)> {
+    let observed = Arc::new(Mutex::new(HashMap::new()));
+    let observed_for_scan = Arc::clone(&observed);
+
+    rocksdb
+        .for_each_lock(
+            rocksdb.partition_key_range(),
+            move |(partition_key, scope, lock_name, state)| {
+                assert_eq!(scope, None);
+                let invocation_id = match state.acquired_by {
+                    AcquiredBy::InvocationId(invocation_id) => invocation_id,
+                    other => panic!("unexpected lock owner: {other:?}"),
+                };
+                observed_for_scan
+                    .lock()
+                    .expect("lock should not be poisoned")
+                    .insert(lock_name.to_string(), (partition_key, invocation_id));
+                ControlFlow::Continue(())
+            },
+        )
+        .expect("lock scan should start")
+        .await
+        .expect("lock scan should succeed");
+
+    Arc::try_unwrap(observed)
+        .expect("scan should drop its observer clone")
+        .into_inner()
+        .expect("lock should not be poisoned")
+}
+
+#[restate_core::test]
+async fn migrate_to_locks_table_moves_service_status_locks_to_lock_table() {
+    let _clock_guard = ClockUpkeep::start().expect("clock upkeep should start");
+    let mut rocksdb = storage_test_environment().await;
+    let service_ids = distinct_service_ids(3);
+    let lock_names = service_ids.iter().map(lock_name).collect::<Vec<_>>();
+    let invocation_ids = service_ids
+        .iter()
+        .enumerate()
+        .map(|(idx, service_id)| {
+            InvocationId::from_parts(
+                service_id.partition_key(),
+                InvocationUuid::from_u128(12345678900001 + idx as u128),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let mut txn = rocksdb.transaction();
+    for (service_id, invocation_id) in service_ids.iter().zip(invocation_ids.iter()) {
+        txn.put_virtual_object_status(service_id, &VirtualObjectStatus::Locked(*invocation_id))
+            .expect("service status write should succeed");
+    }
+    txn.commit().await.expect("commit should succeed");
+
+    let config = Configuration::default();
+    let mut ctx = MigrationContext::new(
+        &config,
+        rocksdb.partition_db(),
+        rocksdb.partition_key_range(),
+    );
+    super::migrate_to_locks_table(&mut ctx).expect("migration should succeed");
+    super::delete_service_status_data(&mut ctx).expect("service status cleanup should succeed");
+
+    for service_id in &service_ids {
+        assert_eq!(
+            rocksdb
+                .get_virtual_object_status(service_id)
+                .await
+                .expect("service status read should succeed"),
+            VirtualObjectStatus::Unlocked
+        );
+    }
+
+    let observed = collect_locks(&rocksdb).await;
+    assert_eq!(observed.len(), service_ids.len());
+    for ((service_id, lock_name), invocation_id) in service_ids
+        .iter()
+        .zip(lock_names.iter())
+        .zip(invocation_ids.iter())
+    {
+        assert_eq!(
+            observed.get(&lock_name.to_string()),
+            Some(&(service_id.partition_key(), *invocation_id))
+        );
+    }
+
+    let mut txn = rocksdb.transaction();
+    txn.release_lock(&None, &lock_names[0]);
+    txn.commit().await.expect("commit should succeed");
+
+    let mut still_locked = HashSet::new();
+    rocksdb
+        .partition_db()
+        .scan_all_locked(|scope, lock_name| {
+            still_locked.insert((scope, lock_name.to_string()));
+        })
+        .expect("lock scan should succeed");
+
+    assert!(!still_locked.contains(&(None, lock_names[0].to_string())));
+    assert!(still_locked.contains(&(None, lock_names[1].to_string())));
+    assert!(still_locked.contains(&(None, lock_names[2].to_string())));
+
+    RocksDbManager::get().shutdown().await;
+}
+
+#[restate_core::test]
+async fn migrate_to_locks_table_runs_split_ranges_concurrently_with_shared_context() {
+    let _clock_guard = ClockUpkeep::start().expect("clock upkeep should start");
+    let mut rocksdb = storage_test_environment().await;
+    let key_range = KeyRange::new(1, 100);
+    let service_ids = key_range
+        .iter()
+        .map(|partition_key| {
+            ServiceId::with_partition_key(
+                partition_key,
+                "migration-svc",
+                format!("migration-key-{partition_key}"),
+            )
+        })
+        .collect::<Vec<_>>();
+    let lock_names = service_ids.iter().map(lock_name).collect::<Vec<_>>();
+    let invocation_ids = service_ids
+        .iter()
+        .enumerate()
+        .map(|(idx, service_id)| {
+            InvocationId::from_parts(
+                service_id.partition_key(),
+                InvocationUuid::from_u128(12345678900001 + idx as u128),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let mut txn = rocksdb.transaction();
+    for (service_id, invocation_id) in service_ids.iter().zip(invocation_ids.iter()) {
+        txn.put_virtual_object_status(service_id, &VirtualObjectStatus::Locked(*invocation_id))
+            .expect("service status write should succeed");
+    }
+    txn.commit().await.expect("commit should succeed");
+
+    let config = Configuration::default();
+    let ctx = MigrationContext::new(&config, rocksdb.partition_db(), key_range);
+    let contexts = ctx
+        .split(NonZeroU16::new(2).expect("two is non-zero"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        contexts.iter().map(|ctx| ctx.key_range).collect::<Vec<_>>(),
+        vec![KeyRange::new(1, 50), KeyRange::new(51, 100)]
+    );
+
+    thread::scope(|scope| {
+        let mut migrations = Vec::with_capacity(contexts.len());
+        for mut ctx in contexts {
+            migrations.push(scope.spawn(move || {
+                super::migrate_to_locks_table(&mut ctx)?;
+                super::delete_service_status_data(&mut ctx)
+            }));
+        }
+
+        for migration in migrations {
+            migration
+                .join()
+                .expect("migration thread should not panic")
+                .expect("migration should succeed");
+        }
+    });
+
+    for service_id in &service_ids {
+        assert_eq!(
+            rocksdb
+                .get_virtual_object_status(service_id)
+                .await
+                .expect("service status read should succeed"),
+            VirtualObjectStatus::Unlocked
+        );
+    }
+
+    let observed = collect_locks(&rocksdb).await;
+    assert_eq!(observed.len(), service_ids.len());
+    for ((service_id, lock_name), invocation_id) in service_ids
+        .iter()
+        .zip(lock_names.iter())
+        .zip(invocation_ids.iter())
+    {
+        assert_eq!(
+            observed.get(&lock_name.to_string()),
+            Some(&(service_id.partition_key(), *invocation_id))
+        );
+    }
+
+    RocksDbManager::get().shutdown().await;
+}

--- a/crates/rocksdb/src/rock_access.rs
+++ b/crates/rocksdb/src/rock_access.rs
@@ -318,6 +318,22 @@ impl RocksAccess {
             });
     }
 
+    /// Runs a manual compaction on the Range of keys given on the
+    /// given column family.
+    pub fn compact_cf<A, B>(
+        &self,
+        cf_handle: &Arc<rocksdb::BoundColumnFamily<'_>>,
+        opts: &CompactOptions,
+        start_key: Option<A>,
+        end_key: Option<B>,
+    ) where
+        A: AsRef<[u8]>,
+        B: AsRef<[u8]>,
+    {
+        self.db
+            .compact_range_cf_opt(cf_handle, start_key, end_key, opts)
+    }
+
     pub fn set_options_cf(
         &self,
         cf: impl AsRef<str>,


### PR DESCRIPTION

- Migrate locked service-status entries into the locks table and split migration contexts by shard so migration and cleanup can run concurrently.
- Support for concurrent migration by splitting the partition key range into sub-shards.
- Added CF compaction API
