### PR TITLE
[Restate UI] Update to v0.1.61

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8699,8 +8699,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.60"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.60#c0ff611c130165d3661e4b416c1550ca3f898ce6"
+version = "0.1.61"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.61#b006889b9730de223406142bd5eee8d3e793b181"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -39,7 +39,7 @@ restate-util-time = { workspace = true }
 restate-types = { workspace = true }
 restate-util-string = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.60", tag = "v0.1.60" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.61", tag = "v0.1.61" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.61
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.61/ui-v0.1.61.zip