### PR TITLE
[VQueues] migration logic from state_table to scoped state_table

### DIFF
--- a/crates/partition-store/src/migrations.rs
+++ b/crates/partition-store/src/migrations.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 mod migrate_to_locks_table;
+mod migrate_to_scoped_state_table;
 
 use std::num::NonZeroU16;
 use std::sync::Arc;
@@ -134,12 +135,30 @@ impl<'a> MigrationContext<'a> {
 mod tests {
     use restate_clock::ClockUpkeep;
     use restate_rocksdb::RocksDbManager;
-    use restate_types::identifiers::{PartitionId, PartitionKey};
+    use restate_types::identifiers::{PartitionId, PartitionKey, ServiceId, WithPartitionKey};
     use restate_types::partitions::Partition;
+    use std::collections::HashSet;
 
     use crate::PartitionStoreManager;
 
     use super::*;
+
+    pub fn distinct_service_ids(count: usize) -> Vec<ServiceId> {
+        let mut service_ids = Vec::with_capacity(count);
+        let mut partition_keys = HashSet::with_capacity(count);
+
+        for idx in 0..10_000 {
+            let service_id = ServiceId::new(None, "migration-svc", format!("migration-key-{idx}"));
+            if partition_keys.insert(service_id.partition_key()) {
+                service_ids.push(service_id);
+                if service_ids.len() == count {
+                    return service_ids;
+                }
+            }
+        }
+
+        panic!("failed to find distinct service partition keys");
+    }
 
     #[restate_core::test]
     async fn split_returns_independent_sub_contexts() {

--- a/crates/partition-store/src/migrations/migrate_to_scoped_state_table.rs
+++ b/crates/partition-store/src/migrations/migrate_to_scoped_state_table.rs
@@ -1,0 +1,138 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::Context;
+use bytes::BufMut;
+use rocksdb::WriteBatch;
+use tracing::debug;
+
+use restate_storage_api::StorageError;
+use restate_types::sharding::PartitionKey;
+
+use crate::keys::{EncodeTableKeyPrefix, KeyKind};
+use crate::scan::{PhysicalScan, TableScan};
+use crate::state_table::StateKey;
+
+use super::MigrationContext;
+
+/// Scan the unscoped state table and copy every entry into the scoped state
+/// table with `scope = None`. The value bytes are copied through unchanged.
+///
+/// We use direct rocksdb access because no async operations are needed.
+#[allow(dead_code)]
+pub fn migrate_to_scoped_state_table(ctx: &mut MigrationContext<'_>) -> Result<(), StorageError> {
+    let rocks = ctx.partition_db.rocksdb();
+    let key_range = ctx.key_range;
+    let mut counter = 0;
+
+    let mut iterator = ctx.partition_db.scan(PhysicalScan::from(
+        TableScan::FullScanPartitionKeyRange::<StateKey>(key_range),
+        &mut ctx.arena,
+    ))?;
+    iterator.seek_to_first();
+
+    // 1 MiB batches
+    let mut wb = WriteBatch::with_capacity_bytes(1024 * 1024);
+    let arena = &mut ctx.arena;
+    arena.clear();
+
+    let mut opts = rocksdb::WriteOptions::default();
+    // We disable WAL since bifrost is our durable distributed log.
+    opts.disable_wal(true);
+
+    while iterator.valid() {
+        // safe to unwrap because the iterator is valid
+        let (mut key, value) = iterator.item().unwrap();
+        // Advance past the legacy `KeyKind::State` prefix and the partition_key.
+        // The remaining bytes are the wire-identical suffix
+        // (service_name | service_key | state_key) shared with `ScopedStateKey`.
+        let kind = KeyKind::deserialize(&mut key)?;
+        debug_assert_eq!(kind, KeyKind::State);
+        let partition_key: PartitionKey = crate::keys::deserialize(&mut key)?;
+
+        KeyKind::ScopedState.serialize(arena);
+        crate::keys::serialize(&partition_key, arena);
+        // unscoped
+        arena.put_u8(b'u');
+        arena.put_slice(key);
+        let new_key = arena.split().freeze();
+
+        wb.put_cf(ctx.partition_db.cf_handle(), new_key, value);
+        counter += 1;
+
+        // non-scientific threshold to trigger the commit.
+        if wb.size_in_bytes() >= 800 {
+            rocks
+                .inner()
+                .write_batch(&wb, &opts)
+                .context("failed to write batch")?;
+            wb.clear();
+        }
+
+        iterator.next();
+    }
+
+    // ensures we didn't stop because of an iterator error
+    iterator
+        .status()
+        .context("iterating over state entries")
+        .map_err(StorageError::Generic)?;
+
+    // just in case!
+    if !wb.is_empty() {
+        // commit, including the last batch of records
+        rocks
+            .inner()
+            .write_batch(&wb, &opts)
+            .context("failed to write batch")?;
+    }
+
+    debug!("Finished migrating {} state entries", counter);
+
+    Ok(())
+}
+
+/// Deletes the legacy unscoped state range.
+#[allow(dead_code)]
+pub fn delete_state_data(ctx: &mut MigrationContext<'_>) -> Result<(), StorageError> {
+    let mut wb = WriteBatch::default();
+    let mut opts = rocksdb::WriteOptions::default();
+    // We disable WAL since bifrost is our durable distributed log.
+    opts.disable_wal(true);
+
+    let mut start_key_buf = [0u8; KeyKind::SERIALIZED_LENGTH + std::mem::size_of::<PartitionKey>()];
+    EncodeTableKeyPrefix::serialize_to(
+        &StateKey::builder().partition_key(ctx.key_range.start()),
+        &mut start_key_buf.as_mut(),
+    );
+
+    let mut end_key_buf = [0u8; KeyKind::SERIALIZED_LENGTH + std::mem::size_of::<PartitionKey>()];
+    EncodeTableKeyPrefix::serialize_to(
+        &StateKey::builder().partition_key(ctx.key_range.end()),
+        &mut end_key_buf.as_mut(),
+    );
+    // End key is exclusive in delete range, so the end prefix is one byte
+    // beyond the max partition key on this key kind prefix.
+    let success = crate::convert_to_upper_bound(&mut end_key_buf);
+    assert!(success, "end key overflowed");
+    wb.delete_range_cf(ctx.partition_db.cf_handle(), start_key_buf, end_key_buf);
+
+    ctx.partition_db
+        .rocksdb()
+        .inner()
+        .write_batch(&wb, &opts)
+        .context("failed to write batch")?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "../tests/migrations_test/migrate_to_scoped_state_table.rs"]
+mod tests;

--- a/crates/partition-store/src/tests/migrations_test/migrate_to_locks_table.rs
+++ b/crates/partition-store/src/tests/migrations_test/migrate_to_locks_table.rs
@@ -30,6 +30,7 @@ use restate_types::partitions::Partition;
 use restate_types::sharding::KeyRange;
 
 use crate::migrations::MigrationContext;
+use crate::migrations::tests::distinct_service_ids;
 use crate::{PartitionStore, PartitionStoreManager};
 
 async fn storage_test_environment() -> PartitionStore {
@@ -44,23 +45,6 @@ async fn storage_test_environment() -> PartitionStore {
         )
         .await
         .expect("DB storage creation succeeds")
-}
-
-fn distinct_service_ids(count: usize) -> Vec<ServiceId> {
-    let mut service_ids = Vec::with_capacity(count);
-    let mut partition_keys = HashSet::with_capacity(count);
-
-    for idx in 0..10_000 {
-        let service_id = ServiceId::new(None, "migration-svc", format!("migration-key-{idx}"));
-        if partition_keys.insert(service_id.partition_key()) {
-            service_ids.push(service_id);
-            if service_ids.len() == count {
-                return service_ids;
-            }
-        }
-    }
-
-    panic!("failed to find distinct service partition keys");
 }
 
 fn lock_name(service_id: &ServiceId) -> LockName {
@@ -128,8 +112,10 @@ async fn migrate_to_locks_table_moves_service_status_locks_to_lock_table() {
         rocksdb.partition_db(),
         rocksdb.partition_key_range(),
     );
-    super::migrate_to_locks_table(&mut ctx).expect("migration should succeed");
-    super::delete_service_status_data(&mut ctx).expect("service status cleanup should succeed");
+    crate::migrations::migrate_to_locks_table::migrate_to_locks_table(&mut ctx)
+        .expect("migration should succeed");
+    crate::migrations::migrate_to_locks_table::delete_service_status_data(&mut ctx)
+        .expect("service status cleanup should succeed");
 
     for service_id in &service_ids {
         assert_eq!(
@@ -221,8 +207,8 @@ async fn migrate_to_locks_table_runs_split_ranges_concurrently_with_shared_conte
         let mut migrations = Vec::with_capacity(contexts.len());
         for mut ctx in contexts {
             migrations.push(scope.spawn(move || {
-                super::migrate_to_locks_table(&mut ctx)?;
-                super::delete_service_status_data(&mut ctx)
+                crate::migrations::migrate_to_locks_table::migrate_to_locks_table(&mut ctx)?;
+                crate::migrations::migrate_to_locks_table::delete_service_status_data(&mut ctx)
             }));
         }
 

--- a/crates/partition-store/src/tests/migrations_test/migrate_to_scoped_state_table.rs
+++ b/crates/partition-store/src/tests/migrations_test/migrate_to_scoped_state_table.rs
@@ -1,0 +1,143 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::HashMap;
+
+use bytes::{Bytes, BytesMut};
+
+use restate_rocksdb::RocksDbManager;
+use restate_storage_api::Transaction;
+use restate_storage_api::state_table::WriteStateTable;
+use restate_types::config::Configuration;
+use restate_types::identifiers::{PartitionId, PartitionKey, ServiceId, WithPartitionKey};
+use restate_types::partitions::Partition;
+use restate_types::sharding::KeyRange;
+
+use crate::PartitionStoreManager;
+use crate::keys::DecodeTableKey;
+use crate::migrations::MigrationContext;
+use crate::migrations::migrate_to_scoped_state_table;
+use crate::migrations::tests::distinct_service_ids;
+use crate::scan::{PhysicalScan, TableScan};
+use crate::state_table::{ScopedStateKey, StateKey};
+
+#[restate_core::test]
+async fn migrate_to_scoped_state_table_moves_unscoped_state_to_scoped_table() {
+    RocksDbManager::init();
+    let manager = PartitionStoreManager::create()
+        .await
+        .expect("DB storage creation succeeds");
+    let mut rocksdb = manager
+        .open(
+            &Partition::new(PartitionId::MIN, KeyRange::new(0, PartitionKey::MAX - 1)),
+            None,
+        )
+        .await
+        .expect("DB storage creation succeeds");
+
+    let service_ids = distinct_service_ids(3);
+    let entries: Vec<(ServiceId, Bytes, Bytes)> = service_ids
+        .iter()
+        .flat_map(|service_id| {
+            [
+                (
+                    service_id.clone(),
+                    Bytes::from_static(b"k1"),
+                    Bytes::from_static(b"v1"),
+                ),
+                (
+                    service_id.clone(),
+                    Bytes::from_static(b"k2"),
+                    Bytes::from_static(b"v2"),
+                ),
+            ]
+        })
+        .collect();
+
+    let mut txn = rocksdb.transaction();
+    for (service_id, state_key, value) in &entries {
+        txn.put_user_state(service_id, state_key, value.as_ref())
+            .expect("state write should succeed");
+    }
+    txn.commit().await.expect("commit should succeed");
+
+    let config = Configuration::default();
+    let mut ctx = MigrationContext::new(
+        &config,
+        rocksdb.partition_db(),
+        rocksdb.partition_key_range(),
+    );
+    migrate_to_scoped_state_table::migrate_to_scoped_state_table(&mut ctx)
+        .expect("migration should succeed");
+    migrate_to_scoped_state_table::delete_state_data(&mut ctx)
+        .expect("state cleanup should succeed");
+
+    // The legacy `b"st"` range must be empty after cleanup.
+    let mut arena = BytesMut::new();
+    let mut unscoped_iter = rocksdb
+        .partition_db()
+        .scan(PhysicalScan::from(
+            TableScan::FullScanPartitionKeyRange::<StateKey>(rocksdb.partition_key_range()),
+            &mut arena,
+        ))
+        .expect("scan should start");
+    unscoped_iter.seek_to_first();
+    assert!(
+        !unscoped_iter.valid(),
+        "legacy unscoped state rows should have been deleted"
+    );
+    unscoped_iter
+        .status()
+        .expect("unscoped scan should not error");
+    drop(unscoped_iter);
+    arena.clear();
+
+    // Every migrated row must now live under `b"sS"` with `scope == None`.
+    let mut observed: HashMap<(PartitionKey, String, String, Bytes), Bytes> = HashMap::new();
+    let mut scoped_iter = rocksdb
+        .partition_db()
+        .scan(PhysicalScan::from(
+            TableScan::FullScanPartitionKeyRange::<ScopedStateKey>(rocksdb.partition_key_range()),
+            &mut arena,
+        ))
+        .expect("scan should start");
+    scoped_iter.seek_to_first();
+    while scoped_iter.valid() {
+        let (mut key, value) = scoped_iter.item().expect("iterator should be valid");
+        let scoped_key =
+            ScopedStateKey::deserialize_from(&mut key).expect("scoped key should deserialize");
+        let (partition_key, scope, service_name, service_key, state_key) = scoped_key.split();
+        assert_eq!(scope, None, "migrated entries must have scope=None");
+        observed.insert(
+            (
+                partition_key,
+                service_name.as_str().to_string(),
+                service_key.as_str().to_string(),
+                state_key,
+            ),
+            Bytes::copy_from_slice(value),
+        );
+        scoped_iter.next();
+    }
+    scoped_iter.status().expect("scoped scan should not error");
+
+    assert_eq!(observed.len(), entries.len());
+    for (service_id, state_key, value) in &entries {
+        let lookup = (
+            service_id.partition_key(),
+            service_id.service_name.to_string(),
+            service_id.key.to_string(),
+            state_key.clone(),
+        );
+        assert_eq!(observed.get(&lookup), Some(value));
+    }
+
+    RocksDbManager::get().shutdown().await;
+}


### PR DESCRIPTION
Copy every unscoped `KeyKind::State` row into the equivalent `KeyKind::ScopedState` row with `scope = None`, then range-delete the legacy unscoped range.