### PR TITLE
Surface vqueues_enabled via StateMachineFeatures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
       serviceImage: "ghcr.io/restatedev/test-services-java:main"
       testArtifactOutput: sdk-java-integration-journal-table-v2-test-report
       envVars: |
-        RESTATE_INTERNAL_FORCE_MIN_RESTATE_VERSION=1.6.0-dev
+        RESTATE_INTERNAL_STATE_MACHINE_FEATURES=EnableJournalV2
 
   sdk-java-vqueues:
     name: Vqueues Run SDK-Java integration tests
@@ -366,7 +366,7 @@ jobs:
           testArtifactOutput: e2e-journal-table-v2-test-report
           restateContainerImage: localhost/restatedev/restate-commit-download:latest
           envVars: |
-            RESTATE_INTERNAL_FORCE_MIN_RESTATE_VERSION=1.6.0-dev
+            RESTATE_INTERNAL_STATE_MACHINE_FEATURES=EnableJournalV2
           # Ignore forward compatibility tests as long as the previous version is not at least v1.6.0-dev. Otherwise,
           # the previous version will hang at applying the version barrier with version 1.6.0-dev.
           exclusions: |

--- a/crates/types/src/partitions/features.rs
+++ b/crates/types/src/partitions/features.rs
@@ -14,7 +14,7 @@ use crate::storage::{
     StorageCodecKind, StorageDecode, StorageDecodeError, StorageEncode, StorageEncodeError, decode,
     encode,
 };
-use crate::{RESTATE_VERSION_1_7_0, SemanticRestateVersion};
+use crate::{RESTATE_VERSION_1_6_0, RESTATE_VERSION_1_7_0, SemanticRestateVersion};
 
 /// A change to the set of state-machine features enabled on a partition.
 ///
@@ -28,13 +28,20 @@ use crate::{RESTATE_VERSION_1_7_0, SemanticRestateVersion};
 /// the change.
 ///
 /// *Since v1.7.0*
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, strum::FromRepr)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, strum::FromRepr, strum::EnumString, strum::Display,
+)]
+#[strum(ascii_case_insensitive)]
 #[repr(u16)]
 pub enum PartitionFeatureChange {
+    /// Enable journal v2 by default.
+    ///
+    /// *Since v1.7.0*
+    EnableJournalV2 = 1,
     /// Enable vqueues for the partition.
     ///
     /// *Since v1.7.0*
-    EnableVqueues = 1,
+    EnableVqueues = 2,
 }
 
 impl PartitionFeatureChange {
@@ -48,6 +55,7 @@ impl PartitionFeatureChange {
     /// across all changes carried by the barrier.
     pub fn min_required_version(self) -> &'static SemanticRestateVersion {
         match self {
+            Self::EnableJournalV2 => &RESTATE_VERSION_1_6_0,
             Self::EnableVqueues => &RESTATE_VERSION_1_7_0,
         }
     }
@@ -56,13 +64,8 @@ impl PartitionFeatureChange {
     /// change had an effect on the state machine features.
     pub fn apply_to(self, features: &mut PersistedStateMachineFeatures) -> bool {
         match self {
-            Self::EnableVqueues => {
-                let before = features.vqueues;
-                features.vqueues = true;
-
-                // we enable the feature if it was disabled before
-                !before
-            }
+            Self::EnableJournalV2 => !std::mem::replace(&mut features.journal_v2, true),
+            Self::EnableVqueues => !std::mem::replace(&mut features.vqueues, true),
         }
     }
 }
@@ -79,10 +82,15 @@ impl PartitionFeatureChange {
     Debug, Clone, Default, PartialEq, Eq, bilrost::Message, serde::Serialize, serde::Deserialize,
 )]
 pub struct PersistedStateMachineFeatures {
-    /// Virtual queues are enabled on this partition.
+    /// Journal v2 should be used by this partition.
     ///
     /// *Since v1.7.0*
     #[bilrost(tag(1))]
+    pub journal_v2: bool,
+    /// Virtual queues are enabled on this partition.
+    ///
+    /// *Since v1.7.0*
+    #[bilrost(tag(2))]
     pub vqueues: bool,
 }
 
@@ -109,6 +117,16 @@ impl StorageDecode for PersistedStateMachineFeatures {
     }
 }
 
+impl FromIterator<PartitionFeatureChange> for PersistedStateMachineFeatures {
+    fn from_iter<I: IntoIterator<Item = PartitionFeatureChange>>(iter: I) -> Self {
+        let mut features = Self::default();
+        for change in iter {
+            change.apply_to(&mut features);
+        }
+        features
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -130,5 +148,20 @@ mod tests {
         assert!(!features.vqueues);
         PartitionFeatureChange::EnableVqueues.apply_to(&mut features);
         assert!(features.vqueues);
+    }
+
+    #[test]
+    fn from_str_round_trip_and_case_insensitive() {
+        use std::str::FromStr;
+
+        assert_eq!(
+            PartitionFeatureChange::from_str("EnableVqueues").unwrap(),
+            PartitionFeatureChange::EnableVqueues,
+        );
+        assert_eq!(
+            PartitionFeatureChange::from_str("enablejournalv2").unwrap(),
+            PartitionFeatureChange::EnableJournalV2,
+        );
+        assert!(PartitionFeatureChange::from_str("not-a-feature").is_err());
     }
 }

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -16,6 +16,7 @@ pub mod trim_queue;
 use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::mem;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -56,14 +57,12 @@ use restate_types::net::ingest::IngestRecord;
 use restate_types::net::partition_processor::{
     PartitionProcessorRpcError, PartitionProcessorRpcResponse,
 };
-use restate_types::partitions::Partition;
 use restate_types::partitions::state::PartitionReplicaSetStates;
+use restate_types::partitions::{Partition, PartitionFeatureChange};
 use restate_types::retries::with_jitter;
 use restate_types::schema::Schema;
 use restate_types::storage::{StorageDecodeError, StorageEncodeError};
-use restate_types::{
-    GenerationalNodeId, RESTATE_VERSION_1_6_0, RESTATE_VERSION_1_7_0, SemanticRestateVersion,
-};
+use restate_types::{GenerationalNodeId, SemanticRestateVersion};
 use restate_vqueues::scheduler::{self};
 use restate_vqueues::{ResourceManager, SchedulerService, VQueuesMeta, VQueuesMetaCache};
 use restate_wal_protocol::control::{
@@ -87,7 +86,7 @@ use crate::partition::leadership::leader_state::LeaderState;
 use crate::partition::leadership::self_proposer::SelfProposer;
 use crate::partition::shuffle;
 use crate::partition::shuffle::{OutboxReaderError, Shuffle, ShuffleMetadata};
-use crate::partition::state_machine::{Action, StateMachine};
+use crate::partition::state_machine::{Action, StateMachine, StateMachineFeatures};
 use crate::partition::types::InvokerEffect;
 use crate::partition_processor_manager::PartitionLeaderHandlesRegistry;
 use crate::rule_book_cache::RuleBookCacheHandle;
@@ -333,6 +332,7 @@ where
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     #[instrument(level = "debug", skip_all, fields(leader_epoch = %announce_leader.leader_epoch))]
     pub async fn on_announce_leader(
         &mut self,
@@ -342,6 +342,8 @@ where
         config: &Configuration,
         vqueues_cache: &mut VQueuesMetaCache,
         rule_book: &RuleBook,
+        state_machine_features: impl StateMachineFeatures,
+        min_restate_version: &SemanticRestateVersion,
     ) -> Result<bool, Error> {
         self.last_seen_leader_epoch = Some(announce_leader.leader_epoch);
 
@@ -363,6 +365,8 @@ where
                             vqueues_cache,
                             config,
                             rule_book,
+                            state_machine_features,
+                            min_restate_version,
                         )
                         .await?
                     }
@@ -400,6 +404,7 @@ where
         Ok(self.is_leader())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn become_leader(
         &mut self,
         partition_store: &mut PartitionStore,
@@ -407,6 +412,8 @@ where
         vqueues_cache: &mut VQueuesMetaCache,
         config: &Configuration,
         rule_book: &RuleBook,
+        state_machine_features: impl StateMachineFeatures,
+        min_restate_version: &SemanticRestateVersion,
     ) -> Result<(), Error> {
         if let State::Candidate {
             leader_epoch,
@@ -527,47 +534,59 @@ where
             let mut self_proposer = self_proposer.take().expect("must be present");
             self_proposer.mark_as_leader();
 
-            let mut min_restate_version = partition_store.get_min_restate_version().await?;
+            // Collect feature changes to apply as a single VersionBarrierCommand.
+            //
+            // RESTATE_INTERNAL_STATE_MACHINE_FEATURES is a comma-separated list of
+            // PartitionFeatureChange variant names (case-insensitive) used by internal
+            // testing to enable specific features explicitly.
+            let mut feature_changes: Vec<PartitionFeatureChange> =
+                if let Ok(raw) = std::env::var("RESTATE_INTERNAL_STATE_MACHINE_FEATURES") {
+                    raw.split(',')
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .filter_map(|name| match PartitionFeatureChange::from_str(name) {
+                            Ok(change) => Some(change),
+                            Err(_) => {
+                                warn!(
+                                    "Ignoring unknown state-machine feature \
+                                     '{name}' from RESTATE_INTERNAL_STATE_MACHINE_FEATURES"
+                                );
+                                None
+                            }
+                        })
+                        .collect()
+                } else {
+                    Vec::new()
+                };
 
-            // Force the provided min Restate version, this is used for internal testing only
-            if let Some(forced_min_restate_version) =
-                std::env::var("RESTATE_INTERNAL_FORCE_MIN_RESTATE_VERSION")
-                    .ok()
-                    .and_then(|min_restate_version| {
-                        SemanticRestateVersion::parse(&min_restate_version).ok()
-                    })
+            // In v1.7.0 we enable by default writing to the journal v2.
+            if !state_machine_features.use_journal_v2_as_default()
+                && !feature_changes.contains(&PartitionFeatureChange::EnableJournalV2)
             {
-                self_proposer
-                    .self_propose(
-                        self.partition.key_range.start(),
-                        Command::VersionBarrier(VersionBarrierCommand {
-                            version: forced_min_restate_version.clone(),
-                            partition_key_range: Keys::RangeInclusive(
-                                self.partition.key_range.into(),
-                            ),
-                            human_reason: Some("Force min Restate version".to_owned()),
-                            feature_changes: Vec::new(),
-                        }),
-                    )
-                    .await?;
-
-                min_restate_version = min_restate_version.max(forced_min_restate_version);
+                feature_changes.push(PartitionFeatureChange::EnableJournalV2);
             }
 
-            // In v1.7.0 we enable by default writing to the journal v2 which requires min Restate v1.6.0
-            if SemanticRestateVersion::current().is_equal_or_newer_than(&RESTATE_VERSION_1_7_0)
-                && RESTATE_VERSION_1_6_0.is_newer_than(&min_restate_version)
-            {
+            if !feature_changes.is_empty() {
+                // Smallest version that supports every listed feature, but never below
+                // the partition's current min_restate_version.
+                let barrier_version = feature_changes
+                    .iter()
+                    .map(|c| c.min_required_version())
+                    .max()
+                    .expect("non-empty")
+                    .max(min_restate_version)
+                    .clone();
+
                 self_proposer
                     .self_propose(
                         self.partition.key_range.start(),
                         Command::VersionBarrier(VersionBarrierCommand {
-                            version: RESTATE_VERSION_1_6_0.clone(),
+                            version: barrier_version,
                             partition_key_range: Keys::RangeInclusive(
                                 self.partition.key_range.into(),
                             ),
-                            human_reason: Some("Enable journal v2 by default".to_owned()),
-                            feature_changes: Vec::new(),
+                            human_reason: Some("Apply state-machine feature changes".to_owned()),
+                            feature_changes: feature_changes.iter().map(|c| c.id()).collect(),
                         }),
                     )
                     .await?;
@@ -874,6 +893,7 @@ mod tests {
     use crate::partition::LeadershipInfo;
     use crate::partition::leadership::trim_queue::TrimQueue;
     use crate::partition::leadership::{LeadershipState, State};
+    use crate::partition::state_machine::StateMachineFeatures;
     use crate::partition_processor_manager::PartitionLeaderHandlesRegistry;
     use crate::rule_book_cache::RuleBookCacheHandle;
     use assert2::let_assert;
@@ -890,7 +910,7 @@ mod tests {
     use restate_types::partitions::state::PartitionReplicaSetStates;
     use restate_types::partitions::{Partition, PartitionConfiguration};
     use restate_types::sharding::KeyRange;
-    use restate_types::{GenerationalNodeId, Version};
+    use restate_types::{GenerationalNodeId, SemanticRestateVersion, Version};
     use restate_vqueues::VQueuesMetaCache;
     use restate_wal_protocol::Command;
     use restate_wal_protocol::Envelope;
@@ -904,6 +924,18 @@ mod tests {
     const NODE_ID: GenerationalNodeId = GenerationalNodeId::new(0, 0);
     const PARTITION_KEY_RANGE: KeyRange = KeyRange::FULL;
     const PARTITION: Partition = Partition::new(PARTITION_ID, PARTITION_KEY_RANGE);
+
+    struct MockStateMachineFeatures;
+
+    impl StateMachineFeatures for MockStateMachineFeatures {
+        fn use_journal_v2_as_default(&self) -> bool {
+            true
+        }
+
+        fn is_vqueues_enabled(&self) -> bool {
+            false
+        }
+    }
 
     #[test(restate_core::test)]
     async fn become_leader_then_step_down() -> googletest::Result<()> {
@@ -976,6 +1008,8 @@ mod tests {
                 &Configuration::pinned(),
                 &mut VQueuesMetaCache::new_empty(1024),
                 &rule_book,
+                MockStateMachineFeatures,
+                SemanticRestateVersion::current(),
             )
             .await?;
 

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -74,6 +74,7 @@ use restate_types::net::partition_processor::{
     PartitionProcessorRpcResponse,
 };
 use restate_types::net::{RpcRequest, ingest};
+use restate_types::partitions::PartitionFeatureChange;
 use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::retries::{RetryPolicy, with_jitter};
 use restate_types::schema::Schema;
@@ -269,7 +270,23 @@ impl PartitionProcessorBuilder {
         let outbox_seq_number = partition_store.get_outbox_seq_number().await?;
         let outbox_head_seq_number = partition_store.get_outbox_head_seq_number().await?;
         let min_restate_version = partition_store.get_min_restate_version().await?;
-        let enabled_features = partition_store.get_state_machine_features().await?;
+        let mut enabled_features = partition_store.get_state_machine_features().await?;
+
+        // for backward compatibility because PartitionFeatureChanges were only introduced with v1.7,
+        // we need to enable journal v2 if the min restate version is >= v1.6.0
+        if !enabled_features.journal_v2
+            && min_restate_version.is_equal_or_newer_than(
+                PartitionFeatureChange::EnableJournalV2.min_required_version(),
+            )
+        {
+            PartitionFeatureChange::EnableJournalV2.apply_to(&mut enabled_features);
+
+            // update the internal storage
+            let mut txn = partition_store.transaction();
+            txn.put_state_machine_features(&enabled_features)?;
+            txn.commit().await?;
+        }
+
         let schema = partition_store.get_schema().await?;
         let rule_book = Arc::new(partition_store.get_rule_book().await?.unwrap_or_default());
 
@@ -722,6 +739,8 @@ where
                                 config,
                                 &mut vqueues,
                                 &self.state_machine.rule_book,
+                                &self.state_machine,
+                                &self.state_machine.min_restate_version,
                             ).await?;
 
                             Span::current().record("is_leader", is_leader);

--- a/crates/worker/src/partition/state_machine/entries/mod.rs
+++ b/crates/worker/src/partition/state_machine/entries/mod.rs
@@ -431,21 +431,24 @@ mod tests {
         Header, InvocationResponse, InvocationTarget, JournalCompletionTarget, ResponseResult,
     };
     use restate_types::journal_v2::{CallCommand, CallRequest};
-    use restate_types::{RESTATE_VERSION_1_6_0, SemanticRestateVersion};
+    use restate_types::partitions::{PartitionFeatureChange, PersistedStateMachineFeatures};
     use restate_wal_protocol::v2::{Command, commands};
 
     #[restate_core::test]
     async fn update_journal_and_commands_length() {
-        run_update_journal_and_commands_length(SemanticRestateVersion::unknown()).await;
+        run_update_journal_and_commands_length(PersistedStateMachineFeatures::default()).await;
     }
 
     #[restate_core::test]
     async fn update_journal_and_commands_length_journal_v2_enabled() {
-        run_update_journal_and_commands_length(RESTATE_VERSION_1_6_0.clone()).await;
+        run_update_journal_and_commands_length(PersistedStateMachineFeatures::from_iter([
+            PartitionFeatureChange::EnableJournalV2,
+        ]))
+        .await;
     }
 
-    async fn run_update_journal_and_commands_length(min_restate_version: SemanticRestateVersion) {
-        let mut test_env = TestEnv::create_with_min_restate_version(min_restate_version).await;
+    async fn run_update_journal_and_commands_length(features: PersistedStateMachineFeatures) {
+        let mut test_env = TestEnv::create_with_features(features).await;
         let invocation_id = fixtures::mock_start_invocation(&mut test_env).await;
         fixtures::mock_pinned_deployment_v5(&mut test_env, invocation_id).await;
 

--- a/crates/worker/src/partition/state_machine/entries/notification.rs
+++ b/crates/worker/src/partition/state_machine/entries/notification.rs
@@ -98,8 +98,8 @@ mod tests {
         BuiltInSignal, CommandType, Entry, EntryType, Failure, FailureMetadata, NotificationId,
         Signal, SignalId, SignalResult, SleepCommand, SleepCompletion,
     };
+    use restate_types::partitions::{PartitionFeatureChange, PersistedStateMachineFeatures};
     use restate_types::time::MillisSinceEpoch;
-    use restate_types::{RESTATE_VERSION_1_6_0, SemanticRestateVersion};
     use restate_wal_protocol::timer::TimerKeyValue;
     use restate_wal_protocol::v2::{Command, commands};
     use rstest::rstest;
@@ -148,19 +148,24 @@ mod tests {
 
     #[restate_core::test]
     async fn notify_signal_received_before_pinned_deployment() {
-        run_notify_signal_received_before_pinned_deployment(SemanticRestateVersion::unknown())
-            .await;
+        run_notify_signal_received_before_pinned_deployment(
+            PersistedStateMachineFeatures::default(),
+        )
+        .await;
     }
 
     #[restate_core::test]
     async fn notify_signal_received_before_pinned_deployment_journal_v2_enabled() {
-        run_notify_signal_received_before_pinned_deployment(RESTATE_VERSION_1_6_0.clone()).await;
+        run_notify_signal_received_before_pinned_deployment(
+            PersistedStateMachineFeatures::from_iter([PartitionFeatureChange::EnableJournalV2]),
+        )
+        .await;
     }
 
     async fn run_notify_signal_received_before_pinned_deployment(
-        min_restate_version: SemanticRestateVersion,
+        features: PersistedStateMachineFeatures,
     ) {
-        let mut test_env = TestEnv::create_with_min_restate_version(min_restate_version).await;
+        let mut test_env = TestEnv::create_with_features(features).await;
         let invocation_id = fixtures::mock_start_invocation(&mut test_env).await;
 
         // Send signal notification before pinned deployment

--- a/crates/worker/src/partition/state_machine/lifecycle/cancel.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/cancel.rs
@@ -141,9 +141,9 @@ mod tests {
     use restate_types::journal_v2::{
         CANCEL_NOTIFICATION_ID, CANCEL_SIGNAL, CommandType, Entry, EntryMetadata, EntryType,
     };
+    use restate_types::partitions::{PartitionFeatureChange, PersistedStateMachineFeatures};
     use restate_types::service_protocol::ServiceProtocolVersion;
     use restate_types::time::MillisSinceEpoch;
-    use restate_types::{RESTATE_VERSION_1_6_0, SemanticRestateVersion};
     use restate_wal_protocol::v2::{Command, commands};
     use restate_worker_api::invoker::Effect;
 
@@ -251,7 +251,10 @@ mod tests {
     #[restate_core::test]
     async fn cancel_invoked_invocation_without_pinned_deployment_with_journal_table_v2_default() {
         let mut test_env =
-            TestEnv::create_with_min_restate_version(RESTATE_VERSION_1_6_0.clone()).await;
+            TestEnv::create_with_features(PersistedStateMachineFeatures::from_iter([
+                PartitionFeatureChange::EnableJournalV2,
+            ]))
+            .await;
         let invocation_id = fixtures::mock_start_invocation(&mut test_env).await;
 
         // Send signal notification before pinning the deployment
@@ -286,7 +289,7 @@ mod tests {
     #[restate_core::test]
     async fn cancel_scheduled_invocation_through_notify_signal() -> anyhow::Result<()> {
         Box::pin(run_cancel_scheduled_invocation_through_notify_signal(
-            SemanticRestateVersion::unknown(),
+            PersistedStateMachineFeatures::default(),
         ))
         .await
     }
@@ -295,15 +298,15 @@ mod tests {
     async fn cancel_scheduled_invocation_through_notify_signal_journal_v2_enabled()
     -> anyhow::Result<()> {
         Box::pin(run_cancel_scheduled_invocation_through_notify_signal(
-            RESTATE_VERSION_1_6_0.clone(),
+            PersistedStateMachineFeatures::from_iter([PartitionFeatureChange::EnableJournalV2]),
         ))
         .await
     }
 
     async fn run_cancel_scheduled_invocation_through_notify_signal(
-        min_restate_version: SemanticRestateVersion,
+        features: PersistedStateMachineFeatures,
     ) -> anyhow::Result<()> {
-        let mut test_env = TestEnv::create_with_min_restate_version(min_restate_version).await;
+        let mut test_env = TestEnv::create_with_features(features).await;
 
         let invocation_id = InvocationId::mock_random();
         let rpc_id = PartitionProcessorRpcRequestId::new();
@@ -377,7 +380,7 @@ mod tests {
     #[restate_core::test]
     async fn cancel_inboxed_invocation_through_notify_signal() -> anyhow::Result<()> {
         Box::pin(run_cancel_inboxed_invocation_through_notify_signal(
-            SemanticRestateVersion::unknown(),
+            PersistedStateMachineFeatures::default(),
         ))
         .await
     }
@@ -386,15 +389,15 @@ mod tests {
     async fn cancel_inboxed_invocation_through_notify_signal_journal_v2_enabled()
     -> anyhow::Result<()> {
         Box::pin(run_cancel_inboxed_invocation_through_notify_signal(
-            RESTATE_VERSION_1_6_0.clone(),
+            PersistedStateMachineFeatures::from_iter([PartitionFeatureChange::EnableJournalV2]),
         ))
         .await
     }
 
     async fn run_cancel_inboxed_invocation_through_notify_signal(
-        min_restate_version: SemanticRestateVersion,
+        features: PersistedStateMachineFeatures,
     ) -> anyhow::Result<()> {
-        let mut test_env = TestEnv::create_with_min_restate_version(min_restate_version).await;
+        let mut test_env = TestEnv::create_with_features(features).await;
 
         let invocation_target = InvocationTarget::mock_virtual_object();
         let invocation_id = InvocationId::mock_generate(&invocation_target);

--- a/crates/worker/src/partition/state_machine/lifecycle/restart_as_new.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/restart_as_new.rs
@@ -310,7 +310,6 @@ mod tests {
     use restate_storage_api::invocation_status_table::{
         InFlightInvocationMetadata, InvocationStatusDiscriminants, ReadInvocationStatusTable,
     };
-    use restate_types::RESTATE_VERSION_1_6_0;
     use restate_types::identifiers::{
         DeploymentId, InvocationId, InvocationUuid, PartitionProcessorRpcRequestId,
         WithPartitionKey,
@@ -324,6 +323,7 @@ mod tests {
         CommandType, CompletionType, NotificationType, OutputCommand, OutputResult, Signal,
         SignalId, SignalResult, SleepCommand,
     };
+    use restate_types::partitions::{PartitionFeatureChange, PersistedStateMachineFeatures};
     use restate_types::service_protocol::ServiceProtocolVersion;
     use restate_types::time::MillisSinceEpoch;
     use restate_wal_protocol::timer::TimerKeyValue;
@@ -408,7 +408,10 @@ mod tests {
         // This works only when using journal table v2 as default!
         // The corner case with journal table v1 is handled by the rpc handler instead.
         let mut test_env =
-            TestEnv::create_with_min_restate_version(RESTATE_VERSION_1_6_0.clone()).await;
+            TestEnv::create_with_features(PersistedStateMachineFeatures::from_iter([
+                PartitionFeatureChange::EnableJournalV2,
+            ]))
+            .await;
 
         // Start invocation, then kill it
         let invocation_target = InvocationTarget::mock_virtual_object();

--- a/crates/worker/src/partition/state_machine/lifecycle/suspend.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/suspend.rs
@@ -171,8 +171,8 @@ mod tests {
         SignalResult, SleepCommand, SleepCompletion, UnresolvedFuture, all_completed,
         all_succeeded_or_first_failed, first_completed, first_succeeded_or_all_failed, unknown,
     };
+    use restate_types::partitions::{PartitionFeatureChange, PersistedStateMachineFeatures};
     use restate_types::time::MillisSinceEpoch;
-    use restate_types::{RESTATE_VERSION_1_6_0, SemanticRestateVersion};
     use restate_wal_protocol::timer::TimerKeyValue;
     use restate_wal_protocol::v2::{Command, commands};
     use std::time::{Duration, SystemTime};
@@ -292,16 +292,19 @@ mod tests {
 
     #[restate_core::test]
     async fn suspend_waiting_on_signal() {
-        run_suspend_waiting_on_signal(SemanticRestateVersion::unknown()).await;
+        run_suspend_waiting_on_signal(PersistedStateMachineFeatures::default()).await;
     }
 
     #[restate_core::test]
     async fn suspend_waiting_on_signal_journal_v2_enabled() {
-        run_suspend_waiting_on_signal(RESTATE_VERSION_1_6_0.clone()).await;
+        run_suspend_waiting_on_signal(PersistedStateMachineFeatures::from_iter([
+            PartitionFeatureChange::EnableJournalV2,
+        ]))
+        .await;
     }
 
-    async fn run_suspend_waiting_on_signal(min_restate_version: SemanticRestateVersion) {
-        let mut test_env = TestEnv::create_with_min_restate_version(min_restate_version).await;
+    async fn run_suspend_waiting_on_signal(features: PersistedStateMachineFeatures) {
+        let mut test_env = TestEnv::create_with_features(features).await;
         let invocation_id = fixtures::mock_start_invocation(&mut test_env).await;
         // We don't pin the deployment here, but this should work nevertheless.
 

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -66,7 +66,6 @@ use restate_storage_api::{Result as StorageResult, journal_table};
 use restate_storage_api::{StorageError, journal_table_v2};
 use restate_tracing_instrumentation as instrumentation;
 use restate_types::clock::UniqueTimestamp;
-use restate_types::config::Configuration;
 use restate_types::errors::{
     ALREADY_COMPLETED_INVOCATION_ERROR, CANCELED_INVOCATION_ERROR, GenericError, InvocationError,
     KILLED_INVOCATION_ERROR, NOT_FOUND_INVOCATION_ERROR, NOT_READY_INVOCATION_ERROR,
@@ -97,6 +96,7 @@ use restate_types::journal::enriched::{
     AwakeableEnrichmentResult, CallEnrichmentResult, EnrichedEntryHeader,
 };
 use restate_types::journal::raw::{EntryHeader, RawEntryCodec, RawEntryCodecError};
+use restate_types::journal_v2;
 use restate_types::journal_v2::command::{OutputCommand, OutputResult};
 use restate_types::journal_v2::raw::RawEntry;
 use restate_types::journal_v2::{
@@ -114,7 +114,6 @@ use restate_types::state_mut::StateMutationVersion;
 use restate_types::storage::{StorageDecodeError, StoredRawEntry, StoredRawEntryHeader};
 use restate_types::time::MillisSinceEpoch;
 use restate_types::vqueues::{self, EntryId, VQueueId};
-use restate_types::{RESTATE_VERSION_1_6_0, journal_v2};
 use restate_types::{RestateVersion, SemanticRestateVersion};
 use restate_types::{Versioned, journal::*};
 use restate_util_string::ReString;
@@ -133,17 +132,51 @@ use crate::metric_definitions::{
 use crate::partition::state_machine::lifecycle::OnCancelCommand;
 use crate::partition::types::{InvokerEffectKind, OutboxMessageExt};
 
-trait StateMachineFeatures {
+/// Read-only view of the state-machine features currently enabled for a partition.
+///
+/// Each feature is gated either on the partition's persisted minimum Restate-server version
+/// (`min_restate_version`) or on its persisted opt-in feature set
+/// ([`PersistedStateMachineFeatures`]), depending on what the feature requires. See each method's
+/// doc-comment for the specific gate.
+pub(crate) trait StateMachineFeatures {
     /// Write to journal v2 instead of journal v1 by default. This is a preparational step for
     /// removing the journal v1 after enabling this feature and migrating all unpinned invocations
     /// from journal v1 to journal v2.
     fn use_journal_v2_as_default(&self) -> bool;
+
+    /// Whether vqueue-related code paths are active on this partition.
+    ///
+    /// *Since v1.7.0*
+    fn is_vqueues_enabled(&self) -> bool;
 }
 
-impl StateMachineFeatures for SemanticRestateVersion {
+impl<T: StateMachineFeatures> StateMachineFeatures for &T {
     fn use_journal_v2_as_default(&self) -> bool {
-        // use journal v2 as default if the min Restate version is >= v1.6.0
-        self.is_equal_or_newer_than(&RESTATE_VERSION_1_6_0)
+        (*self).use_journal_v2_as_default()
+    }
+
+    fn is_vqueues_enabled(&self) -> bool {
+        (*self).is_vqueues_enabled()
+    }
+}
+
+impl StateMachineFeatures for StateMachine {
+    fn use_journal_v2_as_default(&self) -> bool {
+        self.enabled_features.journal_v2
+    }
+
+    fn is_vqueues_enabled(&self) -> bool {
+        self.enabled_features.vqueues
+    }
+}
+
+impl<S> StateMachineFeatures for StateMachineApplyContext<'_, S> {
+    fn use_journal_v2_as_default(&self) -> bool {
+        self.enabled_features.journal_v2
+    }
+
+    fn is_vqueues_enabled(&self) -> bool {
+        self.enabled_features.vqueues
     }
 }
 
@@ -952,9 +985,7 @@ impl<S> StateMachineApplyContext<'_, S> {
         // Prepare PreFlightInvocationMetadata structure
         let submit_notification_sink = service_invocation.submit_notification_sink.take();
 
-        let qid = Configuration::pinned()
-            .common
-            .experimental
+        let qid = self
             .is_vqueues_enabled()
             .then_some(VQueue::infer_vqueue_id_from_invocation(
                 service_invocation.partition_key(),
@@ -1002,7 +1033,7 @@ impl<S> StateMachineApplyContext<'_, S> {
         // have a journal v2 created. To handle already existing invocations for which we didn't
         // create the journal yet, there is a separate path in init_journal to create the journal
         // v2. This change has been introduced with v1.6
-        if self.min_restate_version.use_journal_v2_as_default()
+        if self.use_journal_v2_as_default()
             && let PreFlightInvocationArgument::Input(PreFlightInvocationInput {
                 argument,
                 headers,
@@ -1525,7 +1556,7 @@ impl<S> StateMachineApplyContext<'_, S> {
         // the journal v2 by default (setting the min Restate version to v1.6.0). For invocations
         // that are created afterwards, Restate will create the journal in
         // [`StateMachineApplyContext::on_pre_flight_invocation`].
-        if self.min_restate_version.use_journal_v2_as_default() {
+        if self.use_journal_v2_as_default() {
             // Prepare the new entry
             let new_entry: journal_v2::Entry = InputCommand {
                 headers: invocation_input.headers,
@@ -1664,11 +1695,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             + WriteLockTable
             + ReadVQueueTable,
     {
-        if Configuration::pinned()
-            .common
-            .experimental
-            .is_vqueues_enabled()
-        {
+        if self.is_vqueues_enabled() {
             self.vqueue_enqueue_state_mutation(mutation).await?;
         } else {
             let service_status = self

--- a/crates/worker/src/partition/state_machine/tests/delayed_send.rs
+++ b/crates/worker/src/partition/state_machine/tests/delayed_send.rs
@@ -12,22 +12,26 @@ use super::*;
 
 use restate_storage_api::inbox_table::ReadInboxTable;
 use restate_types::invocation::SubmitNotificationSink;
+use restate_types::partitions::PartitionFeatureChange;
 use restate_types::time::MillisSinceEpoch;
 use std::time::{Duration, SystemTime};
 use test_log::test;
 
 #[restate_core::test]
 async fn send_with_delay() {
-    run_send_with_delay(SemanticRestateVersion::unknown()).await
+    run_send_with_delay(PersistedStateMachineFeatures::default()).await
 }
 
 #[restate_core::test]
 async fn send_with_delay_journal_v2_enabled() {
-    run_send_with_delay(RESTATE_VERSION_1_6_0.clone()).await
+    run_send_with_delay(PersistedStateMachineFeatures::from_iter([
+        PartitionFeatureChange::EnableJournalV2,
+    ]))
+    .await
 }
 
-async fn run_send_with_delay(min_restate_version: SemanticRestateVersion) {
-    let mut test_env = TestEnv::create_with_min_restate_version(min_restate_version).await;
+async fn run_send_with_delay(features: PersistedStateMachineFeatures) {
+    let mut test_env = TestEnv::create_with_features(features).await;
 
     let invocation_target = InvocationTarget::mock_service();
     let invocation_id = InvocationId::mock_random();
@@ -122,7 +126,9 @@ async fn send_with_delay_where_experimental_feature_journal_table_v2_is_enabled_
     );
 
     // Now let's update the features
-    test_env.set_min_restate_version(RESTATE_VERSION_1_6_0.clone());
+    test_env.set_enabled_features(PersistedStateMachineFeatures::from_iter([
+        PartitionFeatureChange::EnableJournalV2,
+    ]));
 
     // Now fire the timer
     let actions = test_env

--- a/crates/worker/src/partition/state_machine/tests/kill_cancel.rs
+++ b/crates/worker/src/partition/state_machine/tests/kill_cancel.rs
@@ -25,6 +25,7 @@ use restate_types::invocation::{IngressInvocationResponseSink, TerminationFlavor
 use restate_types::journal::enriched::EnrichedEntryHeader;
 use restate_types::journal_v2::NotificationId;
 use restate_types::journal_v2::UnresolvedFuture;
+use restate_types::partitions::PartitionFeatureChange;
 use restate_types::service_protocol;
 use rstest::rstest;
 use test_log::test;
@@ -32,20 +33,23 @@ use test_log::test;
 #[restate_core::test]
 async fn kill_inboxed_invocation() -> anyhow::Result<()> {
     Box::pin(run_kill_inboxed_invocation(
-        SemanticRestateVersion::unknown(),
+        PersistedStateMachineFeatures::default(),
     ))
     .await
 }
 
 #[restate_core::test]
 async fn kill_inboxed_invocation_journal_v2_enabled() -> anyhow::Result<()> {
-    Box::pin(run_kill_inboxed_invocation(RESTATE_VERSION_1_6_0.clone())).await
+    Box::pin(run_kill_inboxed_invocation(
+        PersistedStateMachineFeatures::from_iter([PartitionFeatureChange::EnableJournalV2]),
+    ))
+    .await
 }
 
 async fn run_kill_inboxed_invocation(
-    min_restate_version: SemanticRestateVersion,
+    features: PersistedStateMachineFeatures,
 ) -> anyhow::Result<()> {
-    let mut test_env = TestEnv::create_with_min_restate_version(min_restate_version).await;
+    let mut test_env = TestEnv::create_with_features(features).await;
 
     let invocation_target = InvocationTarget::mock_virtual_object();
     let invocation_id = InvocationId::mock_generate(&invocation_target);

--- a/crates/worker/src/partition/state_machine/tests/mod.rs
+++ b/crates/worker/src/partition/state_machine/tests/mod.rs
@@ -85,20 +85,18 @@ impl TestEnv {
     }
 
     pub async fn create() -> Self {
-        Self::create_with_min_restate_version(SemanticRestateVersion::unknown()).await
+        Self::create_with_features(PersistedStateMachineFeatures::default()).await
     }
 
-    pub async fn create_with_min_restate_version(
-        min_restate_version: SemanticRestateVersion,
-    ) -> Self {
+    pub async fn create_with_features(features: PersistedStateMachineFeatures) -> Self {
         Self::create_with_state_machine(StateMachine::new(
             0,    /* inbox_seq_number */
             0,    /* outbox_seq_number */
             None, /* outbox_head_seq_number */
             KeyRange::FULL,
-            min_restate_version,
-            PersistedStateMachineFeatures::default(), /* enabled_features */
-            None,                                     /* schema */
+            SemanticRestateVersion::current().clone(),
+            features, /* enabled_features */
+            None,     /* schema */
             Arc::new(RuleBook::default()),
             RuleBookCacheHandle::detached(),
         ))
@@ -312,8 +310,8 @@ impl TestEnv {
         );
     }
 
-    pub fn set_min_restate_version(&mut self, min_restate_version: SemanticRestateVersion) {
-        self.state_machine.min_restate_version = min_restate_version;
+    pub fn set_enabled_features(&mut self, features: PersistedStateMachineFeatures) {
+        self.state_machine.enabled_features = features;
     }
 }
 


### PR DESCRIPTION
Extend the StateMachineFeatures trait with is_vqueues_enabled (gated on the
persisted feature flag) and move the impl from SemanticRestateVersion to
StateMachine + StateMachineApplyContext so each method can consult both the
min Restate version and the persisted feature set. Replace the in-state-machine
Configuration::pinned().common.experimental.is_vqueues_enabled() call sites
with self.is_vqueues_enabled() / ctx.is_vqueues_enabled().

The current approach is quite simple. If we need the knowledge about enabled features at other places like the storage layer, we might want to think about a more generic access pattern.

This PR is based on #4770.