### PR TITLE
[VQueues] migration logic from promise_table to scoped promise_table

### DIFF
--- a/crates/partition-store/src/migrations.rs
+++ b/crates/partition-store/src/migrations.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 mod migrate_to_locks_table;
+mod migrate_to_scoped_promise_table;
 mod migrate_to_scoped_state_table;
 
 use std::num::NonZeroU16;

--- a/crates/partition-store/src/migrations/migrate_to_scoped_promise_table.rs
+++ b/crates/partition-store/src/migrations/migrate_to_scoped_promise_table.rs
@@ -1,0 +1,139 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::Context;
+use bytes::BufMut;
+use rocksdb::WriteBatch;
+use tracing::debug;
+
+use restate_storage_api::StorageError;
+use restate_types::sharding::PartitionKey;
+
+use crate::keys::{EncodeTableKeyPrefix, KeyKind};
+use crate::promise_table::PromiseKey;
+use crate::scan::{PhysicalScan, TableScan};
+
+use super::MigrationContext;
+
+/// Scan the unscoped promise table and copy every entry into the scoped
+/// promise table with `scope = None`. The value bytes are copied through
+/// unchanged.
+///
+/// We use direct rocksdb access because no async operations are needed.
+#[allow(dead_code)]
+pub fn migrate_to_scoped_promise_table(ctx: &mut MigrationContext<'_>) -> Result<(), StorageError> {
+    let rocks = ctx.partition_db.rocksdb();
+    let key_range = ctx.key_range;
+    let mut counter = 0;
+
+    let mut iterator = ctx.partition_db.scan(PhysicalScan::from(
+        TableScan::FullScanPartitionKeyRange::<PromiseKey>(key_range),
+        &mut ctx.arena,
+    ))?;
+    iterator.seek_to_first();
+
+    // 1 MiB batches
+    let mut wb = WriteBatch::with_capacity_bytes(1024 * 1024);
+    let arena = &mut ctx.arena;
+    arena.clear();
+
+    let mut opts = rocksdb::WriteOptions::default();
+    // We disable WAL since bifrost is our durable distributed log.
+    opts.disable_wal(true);
+
+    while iterator.valid() {
+        // safe to unwrap because the iterator is valid
+        let (mut key, value) = iterator.item().unwrap();
+        // Advance past the legacy `KeyKind::Promise` prefix and the partition_key.
+        // The remaining bytes are the wire-identical suffix
+        // (service_name | service_key | key) shared with `ScopedPromiseKey`.
+        let kind = KeyKind::deserialize(&mut key)?;
+        debug_assert_eq!(kind, KeyKind::Promise);
+        let partition_key: PartitionKey = crate::keys::deserialize(&mut key)?;
+
+        KeyKind::ScopedPromise.serialize(arena);
+        crate::keys::serialize(&partition_key, arena);
+        // unscoped
+        arena.put_u8(b'u');
+        arena.put_slice(key);
+        let new_key = arena.split().freeze();
+
+        wb.put_cf(ctx.partition_db.cf_handle(), new_key, value);
+        counter += 1;
+
+        // non-scientific threshold to trigger the commit.
+        if wb.size_in_bytes() >= 800 {
+            rocks
+                .inner()
+                .write_batch(&wb, &opts)
+                .context("failed to write batch")?;
+            wb.clear();
+        }
+
+        iterator.next();
+    }
+
+    // ensures we didn't stop because of an iterator error
+    iterator
+        .status()
+        .context("iterating over promises")
+        .map_err(StorageError::Generic)?;
+
+    // just in case!
+    if !wb.is_empty() {
+        // commit, including the last batch of records
+        rocks
+            .inner()
+            .write_batch(&wb, &opts)
+            .context("failed to write batch")?;
+    }
+
+    debug!("Finished migrating {} promises", counter);
+
+    Ok(())
+}
+
+/// Deletes the legacy unscoped promise range.
+#[allow(dead_code)]
+pub fn delete_promise_data(ctx: &mut MigrationContext<'_>) -> Result<(), StorageError> {
+    let mut wb = WriteBatch::default();
+    let mut opts = rocksdb::WriteOptions::default();
+    // We disable WAL since bifrost is our durable distributed log.
+    opts.disable_wal(true);
+
+    let mut start_key_buf = [0u8; KeyKind::SERIALIZED_LENGTH + std::mem::size_of::<PartitionKey>()];
+    EncodeTableKeyPrefix::serialize_to(
+        &PromiseKey::builder().partition_key(ctx.key_range.start()),
+        &mut start_key_buf.as_mut(),
+    );
+
+    let mut end_key_buf = [0u8; KeyKind::SERIALIZED_LENGTH + std::mem::size_of::<PartitionKey>()];
+    EncodeTableKeyPrefix::serialize_to(
+        &PromiseKey::builder().partition_key(ctx.key_range.end()),
+        &mut end_key_buf.as_mut(),
+    );
+    // End key is exclusive in delete range, so the end prefix is one byte
+    // beyond the max partition key on this key kind prefix.
+    let success = crate::convert_to_upper_bound(&mut end_key_buf);
+    assert!(success, "end key overflowed");
+    wb.delete_range_cf(ctx.partition_db.cf_handle(), start_key_buf, end_key_buf);
+
+    ctx.partition_db
+        .rocksdb()
+        .inner()
+        .write_batch(&wb, &opts)
+        .context("failed to write batch")?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "../tests/migrations_test/migrate_to_scoped_promise_table.rs"]
+mod tests;

--- a/crates/partition-store/src/tests/migrations_test/migrate_to_scoped_promise_table.rs
+++ b/crates/partition-store/src/tests/migrations_test/migrate_to_scoped_promise_table.rs
@@ -1,0 +1,156 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::HashMap;
+
+use bytes::BytesMut;
+use bytestring::ByteString;
+
+use restate_rocksdb::RocksDbManager;
+use restate_storage_api::Transaction;
+use restate_storage_api::promise_table::{Promise, PromiseResult, PromiseState, WritePromiseTable};
+use restate_storage_api::protobuf_types::PartitionStoreProtobufValue;
+use restate_types::config::Configuration;
+use restate_types::errors::InvocationErrorCode;
+use restate_types::identifiers::{PartitionId, PartitionKey, ServiceId, WithPartitionKey};
+use restate_types::partitions::Partition;
+use restate_types::sharding::KeyRange;
+
+use crate::PartitionStoreManager;
+use crate::keys::DecodeTableKey;
+use crate::migrations::MigrationContext;
+use crate::migrations::migrate_to_scoped_promise_table;
+use crate::migrations::tests::distinct_service_ids;
+use crate::promise_table::{PromiseKey, ScopedPromiseKey};
+use crate::scan::{PhysicalScan, TableScan};
+
+#[restate_core::test]
+async fn migrate_to_scoped_promise_table_moves_unscoped_promises_to_scoped_table() {
+    RocksDbManager::init();
+    let manager = PartitionStoreManager::create()
+        .await
+        .expect("DB storage creation succeeds");
+    let mut rocksdb = manager
+        .open(
+            &Partition::new(PartitionId::MIN, KeyRange::new(0, PartitionKey::MAX - 1)),
+            None,
+        )
+        .await
+        .expect("DB storage creation succeeds");
+
+    let service_ids = distinct_service_ids(3);
+    let entries: Vec<(ServiceId, ByteString, Promise)> = service_ids
+        .iter()
+        .enumerate()
+        .flat_map(|(idx, service_id)| {
+            [
+                (
+                    service_id.clone(),
+                    ByteString::from(format!("promise-a-{idx}")),
+                    Promise {
+                        state: PromiseState::NotCompleted(vec![]),
+                    },
+                ),
+                (
+                    service_id.clone(),
+                    ByteString::from(format!("promise-b-{idx}")),
+                    Promise {
+                        state: PromiseState::Completed(PromiseResult::Failure(
+                            InvocationErrorCode::from(500u16),
+                            ByteString::from_static("nope"),
+                            vec![],
+                        )),
+                    },
+                ),
+            ]
+        })
+        .collect();
+
+    let mut txn = rocksdb.transaction();
+    for (service_id, key, promise) in &entries {
+        txn.put_promise(service_id, key, promise)
+            .expect("promise write should succeed");
+    }
+    txn.commit().await.expect("commit should succeed");
+
+    let config = Configuration::default();
+    let mut ctx = MigrationContext::new(
+        &config,
+        rocksdb.partition_db(),
+        rocksdb.partition_key_range(),
+    );
+    migrate_to_scoped_promise_table::migrate_to_scoped_promise_table(&mut ctx)
+        .expect("migration should succeed");
+    migrate_to_scoped_promise_table::delete_promise_data(&mut ctx)
+        .expect("promise cleanup should succeed");
+
+    // The legacy `b"pr"` range must be empty after cleanup.
+    let mut arena = BytesMut::new();
+    let mut unscoped_iter = rocksdb
+        .partition_db()
+        .scan(PhysicalScan::from(
+            TableScan::FullScanPartitionKeyRange::<PromiseKey>(rocksdb.partition_key_range()),
+            &mut arena,
+        ))
+        .expect("scan should start");
+    unscoped_iter.seek_to_first();
+    assert!(
+        !unscoped_iter.valid(),
+        "legacy unscoped promise rows should have been deleted"
+    );
+    unscoped_iter
+        .status()
+        .expect("unscoped scan should not error");
+    drop(unscoped_iter);
+    arena.clear();
+
+    // Every migrated row must now live under `b"sP"` with `scope == None`.
+    let mut observed: HashMap<(PartitionKey, String, String, String), Promise> = HashMap::new();
+    let mut scoped_iter = rocksdb
+        .partition_db()
+        .scan(PhysicalScan::from(
+            TableScan::FullScanPartitionKeyRange::<ScopedPromiseKey>(rocksdb.partition_key_range()),
+            &mut arena,
+        ))
+        .expect("scan should start");
+    scoped_iter.seek_to_first();
+    while scoped_iter.valid() {
+        let (mut key, mut value) = scoped_iter.item().expect("iterator should be valid");
+        let scoped_key =
+            ScopedPromiseKey::deserialize_from(&mut key).expect("scoped key should deserialize");
+        let (partition_key, scope, service_name, service_key, promise_key) = scoped_key.split();
+        assert_eq!(scope, None, "migrated entries must have scope=None");
+        let promise = Promise::decode(&mut value).expect("promise value should decode");
+        observed.insert(
+            (
+                partition_key,
+                service_name.as_str().to_string(),
+                service_key.as_str().to_string(),
+                promise_key.as_str().to_string(),
+            ),
+            promise,
+        );
+        scoped_iter.next();
+    }
+    scoped_iter.status().expect("scoped scan should not error");
+
+    assert_eq!(observed.len(), entries.len());
+    for (service_id, key, promise) in &entries {
+        let lookup = (
+            service_id.partition_key(),
+            service_id.service_name.to_string(),
+            service_id.key.to_string(),
+            key.to_string(),
+        );
+        assert_eq!(observed.get(&lookup), Some(promise));
+    }
+
+    RocksDbManager::get().shutdown().await;
+}


### PR DESCRIPTION
Copy every unscoped `KeyKind::Promise` row into the equivalent
`KeyKind::ScopedPromise` row with `scope = None`, then range-delete
the legacy unscoped range. Mirrors the shape of the previous
state_table -> scoped state_table migration; remains
`#[allow(dead_code)]` until wired into `SchemaVersion::do_migration`.

This PR is based on #4771.