### PR TITLE
[VQueue] Update service status sync with locks table

### DIFF
--- a/crates/partition-store/src/invocation_status_table/mod.rs
+++ b/crates/partition-store/src/invocation_status_table/mod.rs
@@ -90,12 +90,15 @@ fn delete_invocation_status<S: StorageAccess>(
     storage.delete_key(&create_invocation_status_key(invocation_id))
 }
 
+// NOTE: This will only consider invoked invocations that have not been migrated to vqueues
 fn read_invoked_full_invocation_id(
     mut kv: (&[u8], &[u8]),
 ) -> Result<Option<InvokedInvocationStatusLite>> {
     let invocation_id = invocation_id_from_key_bytes(&mut kv.0)?;
     let invocation_status = InvocationLite::decode(&mut kv.1)?;
-    if let InvocationStatusDiscriminants::Invoked = invocation_status.status {
+    if invocation_status.vqueue_id.is_none()
+        && let InvocationStatusDiscriminants::Invoked = invocation_status.status
+    {
         Ok(Some(InvokedInvocationStatusLite {
             invocation_id,
             invocation_target: invocation_status.invocation_target,
@@ -116,7 +119,7 @@ impl ReadInvocationStatusTable for PartitionStore {
 }
 
 impl ScanInvocationStatusTable for PartitionStore {
-    fn scan_invoked_invocations(
+    fn scan_legacy_invoked_invocations(
         &self,
     ) -> Result<impl Stream<Item = Result<InvokedInvocationStatusLite>> + Send> {
         self.iterator_filter_map(

--- a/crates/partition-store/src/tests/invocation_status_table_test/mod.rs
+++ b/crates/partition-store/src/tests/invocation_status_table_test/mod.rs
@@ -24,13 +24,13 @@ use restate_storage_api::invocation_status_table::{
     InFlightInvocationMetadata, InvocationStatus, JournalMetadata, ReadInvocationStatusTable,
     StatusTimestamps, WriteInvocationStatusTable,
 };
-use restate_types::RestateVersion;
 use restate_types::identifiers::{InvocationId, PartitionProcessorRpcRequestId};
 use restate_types::invocation::{
     InvocationTarget, ServiceInvocationSpanContext, Source, VirtualObjectHandlerType,
 };
 use restate_types::journal_v2::UnresolvedFuture;
 use restate_types::time::MillisSinceEpoch;
+use restate_types::{LimitKey, RestateVersion};
 
 const INVOCATION_TARGET_1: InvocationTarget = InvocationTarget::VirtualObject {
     name: ByteString::from_static("abc"),
@@ -79,6 +79,8 @@ fn invoked_status(invocation_target: InvocationTarget) -> InvocationStatus {
     InvocationStatus::Invoked(InFlightInvocationMetadata {
         invocation_target,
         created_using_restate_version: RestateVersion::current(),
+        vqueue_id: None,
+        limit_key: LimitKey::None,
         journal_metadata: JournalMetadata::initialize(ServiceInvocationSpanContext::empty()),
         pinned_deployment: None,
         response_sinks: HashSet::new(),
@@ -104,6 +106,8 @@ fn suspended_status(invocation_target: InvocationTarget) -> InvocationStatus {
     InvocationStatus::Suspended {
         metadata: InFlightInvocationMetadata {
             invocation_target,
+            vqueue_id: None,
+            limit_key: LimitKey::None,
             created_using_restate_version: RestateVersion::current(),
             journal_metadata: JournalMetadata::initialize(ServiceInvocationSpanContext::empty()),
             pinned_deployment: None,

--- a/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
@@ -256,6 +256,11 @@ message InvocationStatusV2 {
 
   // Completed
   ResponseResult result = 18;
+
+  // Binary-encoded vqueue id. Empty if this invocation was not migrated to vqueues.
+  optional bytes vqueue_id = 34;
+  // If empty, no limit was set
+  string limit_key = 35;
 }
 
 
@@ -267,6 +272,9 @@ message InvocationV2Lite {
   InvocationTarget invocation_target = 2;
   // removed in v1.6
   // uint32 current_invocation_epoch = 27;
+
+  // Binary-encoded vqueue id. Empty if this invocation was not migrated to vqueues.
+  optional bytes vqueue_id = 34;
 }
 
 // A somewhat slimmer version of InvocationStatusV2 with nested messages left
@@ -311,6 +319,9 @@ message InvocationStatusV2Lazy {
 
   // Completed
   // optional bytes result_lazy = 18;
+
+  // Binary-encoded vqueue id. Empty if this invocation was not migrated to vqueues.
+  optional bytes vqueue_id = 34;
 }
 
 message VirtualObjectStatus {

--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -17,7 +17,6 @@ use bytes::Bytes;
 use bytestring::ByteString;
 use futures::Stream;
 
-use restate_types::RestateVersion;
 use restate_types::deployment::PinnedDeployment;
 use restate_types::identifiers::InvocationId;
 use restate_types::invocation::{
@@ -27,6 +26,9 @@ use restate_types::invocation::{
 use restate_types::journal_v2::UnresolvedFuture;
 use restate_types::sharding::KeyRange;
 use restate_types::time::MillisSinceEpoch;
+use restate_types::vqueues::VQueueId;
+use restate_types::{LimitKey, RestateVersion};
+use restate_util_string::ReString;
 
 use crate::Result;
 use crate::protobuf_types::PartitionStoreProtobufValue;
@@ -466,6 +468,8 @@ pub struct PreFlightInvocationJournal {
 pub struct PreFlightInvocationMetadata {
     pub response_sinks: HashSet<ServiceInvocationResponseSink>,
     pub timestamps: StatusTimestamps,
+    pub vqueue_id: Option<VQueueId>,
+    pub limit_key: LimitKey<ReString>,
 
     // --- From ServiceInvocation
     pub invocation_target: InvocationTarget,
@@ -520,8 +524,11 @@ impl PreFlightInvocationMetadata {
     pub fn from_service_invocation(
         created_at: MillisSinceEpoch,
         service_invocation: ServiceInvocation,
+        vqueue_id: Option<VQueueId>,
     ) -> Self {
         Self {
+            vqueue_id,
+            limit_key: service_invocation.limit_key,
             response_sinks: service_invocation.response_sink.into_iter().collect(),
             timestamps: StatusTimestamps::init(created_at),
             invocation_target: service_invocation.invocation_target,
@@ -585,6 +592,8 @@ impl InboxedInvocation {
 #[derive(Debug, Clone, PartialEq)]
 pub struct InFlightInvocationMetadata {
     pub invocation_target: InvocationTarget,
+    pub vqueue_id: Option<VQueueId>,
+    pub limit_key: LimitKey<ReString>,
     /// Restate version the invocation was created with.
     ///
     /// This is agreed among replicas, but be aware **it might come from the future**.
@@ -634,6 +643,8 @@ impl InFlightInvocationMetadata {
             }) => (
                 Self {
                     invocation_target: pre_flight_invocation_metadata.invocation_target,
+                    vqueue_id: pre_flight_invocation_metadata.vqueue_id,
+                    limit_key: pre_flight_invocation_metadata.limit_key,
                     created_using_restate_version: pre_flight_invocation_metadata
                         .created_using_restate_version,
                     journal_metadata: JournalMetadata::initialize(span_context),
@@ -658,6 +669,8 @@ impl InFlightInvocationMetadata {
             }) => (
                 Self {
                     invocation_target: pre_flight_invocation_metadata.invocation_target,
+                    vqueue_id: pre_flight_invocation_metadata.vqueue_id,
+                    limit_key: pre_flight_invocation_metadata.limit_key,
                     created_using_restate_version: pre_flight_invocation_metadata
                         .created_using_restate_version,
                     journal_metadata,
@@ -702,7 +715,9 @@ impl InFlightInvocationMetadata {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct CompletedInvocation {
+    pub vqueue_id: Option<VQueueId>,
     pub invocation_target: InvocationTarget,
+    pub limit_key: LimitKey<ReString>,
     /// Restate version the invocation was created with.
     ///
     /// This is agreed among replicas, but be aware **it might come from the future**.
@@ -751,6 +766,8 @@ impl CompletedInvocation {
 
         Self {
             invocation_target: in_flight_invocation_metadata.invocation_target,
+            vqueue_id: in_flight_invocation_metadata.vqueue_id,
+            limit_key: in_flight_invocation_metadata.limit_key,
             created_using_restate_version: in_flight_invocation_metadata
                 .created_using_restate_version,
             source: in_flight_invocation_metadata.source,
@@ -827,7 +844,8 @@ pub trait ScanInvocationStatusTable {
         f: F,
     ) -> Result<impl Stream<Item = Result<O>> + Send>;
 
-    fn scan_invoked_invocations(
+    /// Legacy invoked invocations are those that have not been migrated to vqueues
+    fn scan_legacy_invoked_invocations(
         &self,
     ) -> Result<impl Stream<Item = Result<InvokedInvocationStatusLite>> + Send>;
 }
@@ -845,6 +863,7 @@ pub trait WriteInvocationStatusTable {
 #[cfg(any(test, feature = "test-util"))]
 mod test_util {
     use super::*;
+    use restate_sharding::PartitionKey;
     use restate_types::identifiers::PartitionProcessorRpcRequestId;
 
     use restate_types::invocation::VirtualObjectHandlerType;
@@ -856,6 +875,33 @@ mod test_util {
     }
 
     impl PreFlightInvocationMetadata {
+        pub fn mock_with_vqueue(partition_key: PartitionKey) -> Self {
+            PreFlightInvocationMetadata {
+                invocation_target: InvocationTarget::virtual_object(
+                    "MyService",
+                    "MyKey",
+                    "mock",
+                    VirtualObjectHandlerType::Exclusive,
+                ),
+                vqueue_id: Some(VQueueId::custom(partition_key, "MyKey")),
+                limit_key: LimitKey::None,
+                created_using_restate_version: RestateVersion::current(),
+                response_sinks: HashSet::new(),
+                timestamps: StatusTimestamps::mock(),
+                source: Source::Ingress(PartitionProcessorRpcRequestId::default()),
+                execution_time: None,
+                completion_retention_duration: Duration::ZERO,
+                journal_retention_duration: Duration::ZERO,
+                idempotency_key: None,
+                input: PreFlightInvocationArgument::Input(PreFlightInvocationInput {
+                    argument: Default::default(),
+                    headers: vec![],
+                    span_context: Default::default(),
+                }),
+                random_seed: None,
+            }
+        }
+
         pub fn mock() -> Self {
             PreFlightInvocationMetadata {
                 invocation_target: InvocationTarget::virtual_object(
@@ -864,6 +910,8 @@ mod test_util {
                     "mock",
                     VirtualObjectHandlerType::Exclusive,
                 ),
+                vqueue_id: None,
+                limit_key: LimitKey::None,
                 created_using_restate_version: RestateVersion::current(),
                 response_sinks: HashSet::new(),
                 timestamps: StatusTimestamps::mock(),
@@ -883,6 +931,30 @@ mod test_util {
     }
 
     impl InFlightInvocationMetadata {
+        pub fn mock_with_vqueue(partition_key: PartitionKey) -> Self {
+            InFlightInvocationMetadata {
+                invocation_target: InvocationTarget::virtual_object(
+                    "MyService",
+                    "MyKey",
+                    "mock",
+                    VirtualObjectHandlerType::Exclusive,
+                ),
+                vqueue_id: Some(VQueueId::custom(partition_key, "MyKey")),
+                limit_key: LimitKey::None,
+                created_using_restate_version: RestateVersion::current(),
+                journal_metadata: JournalMetadata::initialize(ServiceInvocationSpanContext::empty()),
+                pinned_deployment: None,
+                response_sinks: HashSet::new(),
+                timestamps: StatusTimestamps::mock(),
+                source: Source::Ingress(PartitionProcessorRpcRequestId::default()),
+                execution_time: None,
+                completion_retention_duration: Duration::ZERO,
+                journal_retention_duration: Duration::ZERO,
+                idempotency_key: None,
+                hotfix_apply_cancellation_after_deployment_is_pinned: false,
+                random_seed: None,
+            }
+        }
         pub fn mock() -> Self {
             InFlightInvocationMetadata {
                 invocation_target: InvocationTarget::virtual_object(
@@ -891,6 +963,8 @@ mod test_util {
                     "mock",
                     VirtualObjectHandlerType::Exclusive,
                 ),
+                vqueue_id: None,
+                limit_key: LimitKey::None,
                 created_using_restate_version: RestateVersion::current(),
                 journal_metadata: JournalMetadata::initialize(ServiceInvocationSpanContext::empty()),
                 pinned_deployment: None,
@@ -908,7 +982,7 @@ mod test_util {
     }
 
     impl CompletedInvocation {
-        pub fn mock_neo() -> Self {
+        pub fn mock_neo_with_vqueue(partition_key: PartitionKey) -> Self {
             let mut timestamps = StatusTimestamps::mock();
             let now = MillisSinceEpoch::now();
             timestamps.record_running_transition_time(now);
@@ -921,6 +995,8 @@ mod test_util {
                     "mock",
                     VirtualObjectHandlerType::Exclusive,
                 ),
+                vqueue_id: Some(VQueueId::custom(partition_key, "MyKey")),
+                limit_key: LimitKey::None,
                 created_using_restate_version: RestateVersion::current(),
                 source: Source::Ingress(PartitionProcessorRpcRequestId::default()),
                 execution_time: None,
@@ -934,8 +1010,12 @@ mod test_util {
                 random_seed: None,
             }
         }
+        pub fn mock_neo() -> Self {
+            let mut timestamps = StatusTimestamps::mock();
+            let now = MillisSinceEpoch::now();
+            timestamps.record_running_transition_time(now);
+            timestamps.record_completed_transition_time(now);
 
-        pub fn mock_old() -> Self {
             CompletedInvocation {
                 invocation_target: InvocationTarget::virtual_object(
                     "MyService",
@@ -943,15 +1023,17 @@ mod test_util {
                     "mock",
                     VirtualObjectHandlerType::Exclusive,
                 ),
+                vqueue_id: None,
+                limit_key: LimitKey::None,
                 created_using_restate_version: RestateVersion::current(),
                 source: Source::Ingress(PartitionProcessorRpcRequestId::default()),
                 execution_time: None,
                 idempotency_key: None,
-                timestamps: StatusTimestamps::mock(),
+                timestamps,
                 response_result: ResponseResult::Success(Bytes::from_static(b"123")),
                 completion_retention_duration: Duration::from_secs(60 * 60),
-                journal_metadata: JournalMetadata::empty(),
                 journal_retention_duration: Duration::ZERO,
+                journal_metadata: JournalMetadata::empty(),
                 pinned_deployment: None,
                 random_seed: None,
             }
@@ -964,6 +1046,7 @@ mod test_util {
 pub struct InvocationLite {
     pub status: InvocationStatusDiscriminants,
     pub invocation_target: InvocationTarget,
+    pub vqueue_id: Option<VQueueId>,
 }
 
 impl PartitionStoreProtobufValue for InvocationLite {

--- a/crates/storage-api/src/protobuf_types.rs
+++ b/crates/storage-api/src/protobuf_types.rs
@@ -4569,7 +4569,7 @@ pub mod v1 {
             // tag 4
             pub key: &'a [u8],
             // tag 5
-            pub scope: Option<&'a str>,
+            pub scope: Option<&'a [u8]>,
         }
 
         impl<'a> InvocationTargetLazy<'a> {
@@ -4617,19 +4617,15 @@ pub mod v1 {
                             )?;
                         }
                         5u32 => {
-                            let mut bytes: &'a [u8] = &[];
-                            merge_bytes_zerocopy(wire_type, &mut bytes, &mut buf).map_err(
-                                |mut error| {
-                                    error.push(STRUCT_NAME, "scope");
-                                    error
-                                },
-                            )?;
-                            self.scope = Some(str::from_utf8(bytes).map_err(|_| {
-                                #[allow(deprecated)]
-                                let mut error = prost::DecodeError::new("scope is not valid UTF-8");
+                            merge_bytes_zerocopy(
+                                wire_type,
+                                self.scope.get_or_insert_default(),
+                                &mut buf,
+                            )
+                            .map_err(|mut error| {
                                 error.push(STRUCT_NAME, "scope");
                                 error
-                            })?);
+                            })?;
                         }
                         _ => {
                             skip_field(wire_type, tag, &mut buf, ctx.clone())?;
@@ -4639,8 +4635,9 @@ pub mod v1 {
                 Ok(())
             }
 
-            pub fn service_name(&self) -> std::result::Result<&str, ConversionError> {
-                str::from_utf8(self.name).map_err(|_| ConversionError::invalid_data_static("name"))
+            pub fn service_name(&self) -> &str {
+                // Safety: Storage is trusted. Data is validated on the write path.
+                unsafe { str::from_utf8_unchecked(self.name) }
             }
 
             pub fn key(&self) -> std::result::Result<Option<&str>, ConversionError> {
@@ -4652,8 +4649,8 @@ pub mod v1 {
                         | Ty::WorkflowWorkflow
                         | Ty::WorkflowShared,
                     ) => {
-                        let key = str::from_utf8(self.key)
-                            .map_err(|_| ConversionError::invalid_data_static("key"))?;
+                        // Safety: Storage is trusted. Data is validated on the write path.
+                        let key = unsafe { str::from_utf8_unchecked(self.key) };
 
                         Ok(Some(key))
                     }
@@ -4664,9 +4661,9 @@ pub mod v1 {
                 }
             }
 
-            pub fn handler_name(&self) -> std::result::Result<&str, ConversionError> {
-                str::from_utf8(self.handler)
-                    .map_err(|_| ConversionError::invalid_data_static("name"))
+            pub fn handler_name(&self) -> &str {
+                // Safety: Storage is trusted. Data is validated on the write path.
+                unsafe { str::from_utf8_unchecked(self.handler) }
             }
 
             pub fn service_ty(&self) -> Result<ServiceType, ConversionError> {
@@ -4686,14 +4683,16 @@ pub mod v1 {
             pub fn target_fmt(
                 &'a self,
             ) -> std::result::Result<TargetFormatter<'a>, ConversionError> {
-                let service_name = self.service_name()?;
+                let service_name = self.service_name();
                 let key = self.key()?;
-                let handler_name = self.handler_name()?;
+                let handler_name = self.handler_name();
                 Ok(TargetFormatter(service_name, key, handler_name))
             }
 
             pub fn scope(&self) -> Option<&str> {
+                // Safety: Storage is trusted. Data is validated on the write path.
                 self.scope
+                    .map(|buf| unsafe { str::from_utf8_unchecked(buf) })
             }
         }
 
@@ -4704,7 +4703,7 @@ pub mod v1 {
                     name: &value.name,
                     handler: &value.handler,
                     key: &value.key,
-                    scope: value.scope.as_deref(),
+                    scope: value.scope.as_deref().map(|x| x.as_bytes()),
                 }
             }
         }
@@ -4725,7 +4724,8 @@ pub mod v1 {
 
         impl<'a> Display for StrFormatter<'a> {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                f.write_str(str::from_utf8(self.0).map_err(|_| std::fmt::Error)?)
+                // Safety: Storage is trusted. Data is validated on the write path.
+                f.write_str(unsafe { str::from_utf8_unchecked(self.0) })
             }
         }
     }

--- a/crates/storage-api/src/protobuf_types.rs
+++ b/crates/storage-api/src/protobuf_types.rs
@@ -4149,6 +4149,7 @@ pub mod v1 {
         use bytes::Bytes;
         use prost::Message;
         use restate_types::journal_v2::UnresolvedFuture;
+        use restate_types::vqueues::VQueueId;
         use restate_types::{
             errors::ConversionError,
             identifiers::{DeploymentId, InvocationId, SubscriptionId},
@@ -4166,7 +4167,6 @@ pub mod v1 {
             wire_type: prost::encoding::WireType,
             value: &mut &'a [u8],
             buf: &mut &'a [u8],
-            _ctx: prost::encoding::DecodeContext,
         ) -> Result<(), prost::DecodeError> {
             use prost::encoding::*;
             check_wire_type(WireType::LengthDelimited, wire_type)?;
@@ -4202,6 +4202,10 @@ pub mod v1 {
             pub journal_retention_duration_lazy: Option<&'a [u8]>,
             // 30
             pub created_using_restate_version: &'a [u8],
+            // 34
+            pub vqueue_id: Option<&'a [u8]>,
+            // 35
+            pub limit_key: &'a [u8],
         }
 
         impl<'a> InvocationStatusV2Lazy<'a> {
@@ -4226,76 +4230,113 @@ pub mod v1 {
                 match tag {
                     2u32 => {
                         let value = &mut self.invocation_target_lazy;
-                        merge_bytes_zerocopy(wire_type, value.get_or_insert_default(), buf, ctx)
-                            .map_err(|mut error| {
+                        merge_bytes_zerocopy(wire_type, value.get_or_insert_default(), buf).map_err(
+                            |mut error| {
                                 error.push(STRUCT_NAME, "invocation_target_lazy");
                                 error
-                            })
+                            },
+                        )
                     }
                     3u32 => {
                         let value = &mut self.source_lazy;
-                        merge_bytes_zerocopy(wire_type, value.get_or_insert_default(), buf, ctx)
-                            .map_err(|mut error| {
+                        merge_bytes_zerocopy(wire_type, value.get_or_insert_default(), buf).map_err(
+                            |mut error| {
                                 error.push(STRUCT_NAME, "source_lazy");
                                 error
-                            })
+                            },
+                        )
                     }
                     4u32 => {
                         let value = &mut self.span_context_lazy;
-                        merge_bytes_zerocopy(wire_type, value.get_or_insert_default(), buf, ctx)
-                            .map_err(|mut error| {
+                        merge_bytes_zerocopy(wire_type, value.get_or_insert_default(), buf).map_err(
+                            |mut error| {
                                 error.push(STRUCT_NAME, "span_context_lazy");
                                 error
-                            })
+                            },
+                        )
                     }
                     11u32 => {
                         let value = &mut self.completion_retention_duration_lazy;
-                        merge_bytes_zerocopy(wire_type, value.get_or_insert_default(), buf, ctx)
-                            .map_err(|mut error| {
+                        merge_bytes_zerocopy(wire_type, value.get_or_insert_default(), buf).map_err(
+                            |mut error| {
                                 error.push(STRUCT_NAME, "completion_retention_duration_lazy");
                                 error
-                            })
+                            },
+                        )
                     }
                     12u32 => {
                         let value = &mut self.idempotency_key;
-                        merge_bytes_zerocopy(wire_type, value.get_or_insert_default(), buf, ctx)
-                            .map_err(|mut error| {
+                        merge_bytes_zerocopy(wire_type, value.get_or_insert_default(), buf).map_err(
+                            |mut error| {
                                 error.push(STRUCT_NAME, "idempotency_key");
                                 error
-                            })
+                            },
+                        )
                     }
                     15u32 => {
                         let value = &mut self.deployment_id;
-                        merge_bytes_zerocopy(wire_type, value.get_or_insert_default(), buf, ctx)
-                            .map_err(|mut error| {
+                        merge_bytes_zerocopy(wire_type, value.get_or_insert_default(), buf).map_err(
+                            |mut error| {
                                 error.push(STRUCT_NAME, "deployment_id");
                                 error
-                            })
+                            },
+                        )
                     }
                     18u32 => {
                         let value = &mut self.result_lazy;
-                        merge_bytes_zerocopy(wire_type, value.get_or_insert_default(), buf, ctx)
-                            .map_err(|mut error| {
+                        merge_bytes_zerocopy(wire_type, value.get_or_insert_default(), buf).map_err(
+                            |mut error| {
                                 error.push(STRUCT_NAME, "result_lazy");
                                 error
-                            })
+                            },
+                        )
                     }
                     29u32 => {
                         let value = &mut self.journal_retention_duration_lazy;
-                        merge_bytes_zerocopy(wire_type, value.get_or_insert_default(), buf, ctx)
-                            .map_err(|mut error| {
+                        merge_bytes_zerocopy(wire_type, value.get_or_insert_default(), buf).map_err(
+                            |mut error| {
                                 error.push(STRUCT_NAME, "journal_retention_duration_lazy");
                                 error
-                            })
+                            },
+                        )
                     }
                     30u32 => {
                         let value = &mut self.created_using_restate_version;
-                        merge_bytes_zerocopy(wire_type, value, buf, ctx).map_err(|mut error| {
+                        merge_bytes_zerocopy(wire_type, value, buf).map_err(|mut error| {
                             error.push(STRUCT_NAME, "created_using_restate_version");
                             error
                         })
                     }
+                    34u32 => {
+                        let value = &mut self.vqueue_id;
+                        merge_bytes_zerocopy(wire_type, value.get_or_insert_default(), buf).map_err(
+                            |mut error| {
+                                error.push(STRUCT_NAME, "vqueue_id");
+                                error
+                            },
+                        )
+                    }
+                    35u32 => {
+                        let value = &mut self.limit_key;
+                        merge_bytes_zerocopy(wire_type, value, buf).map_err(|mut error| {
+                            error.push(STRUCT_NAME, "limit_key");
+                            error
+                        })
+                    }
                     _ => prost::Message::merge_field(&mut self.inner, tag, wire_type, buf, ctx),
+                }
+            }
+
+            pub fn vqueue_id(&'a self) -> Option<VQueueId> {
+                self.vqueue_id
+                    .map(|buf| VQueueId::from_raw_bytes(&mut &buf[..]))
+            }
+
+            pub fn limit_key_fmt(&'a self) -> Option<impl std::fmt::Display + 'a> {
+                if self.limit_key.is_empty() {
+                    None
+                } else {
+                    Some(StrFormatter(self.limit_key))
                 }
             }
 
@@ -4552,38 +4593,37 @@ pub mod v1 {
                             })?;
                         }
                         2u32 => {
-                            merge_bytes_zerocopy(wire_type, &mut self.name, &mut buf, ctx.clone())
-                                .map_err(|mut error| {
+                            merge_bytes_zerocopy(wire_type, &mut self.name, &mut buf).map_err(
+                                |mut error| {
                                     error.push(STRUCT_NAME, "name");
                                     error
-                                })?;
+                                },
+                            )?;
                         }
                         3u32 => {
-                            merge_bytes_zerocopy(
-                                wire_type,
-                                &mut self.handler,
-                                &mut buf,
-                                ctx.clone(),
-                            )
-                            .map_err(|mut error| {
-                                error.push(STRUCT_NAME, "handler");
-                                error
-                            })?;
+                            merge_bytes_zerocopy(wire_type, &mut self.handler, &mut buf).map_err(
+                                |mut error| {
+                                    error.push(STRUCT_NAME, "handler");
+                                    error
+                                },
+                            )?;
                         }
                         4u32 => {
-                            merge_bytes_zerocopy(wire_type, &mut self.key, &mut buf, ctx.clone())
-                                .map_err(|mut error| {
+                            merge_bytes_zerocopy(wire_type, &mut self.key, &mut buf).map_err(
+                                |mut error| {
                                     error.push(STRUCT_NAME, "key");
                                     error
-                                })?
+                                },
+                            )?;
                         }
                         5u32 => {
                             let mut bytes: &'a [u8] = &[];
-                            merge_bytes_zerocopy(wire_type, &mut bytes, &mut buf, ctx.clone())
-                                .map_err(|mut error| {
+                            merge_bytes_zerocopy(wire_type, &mut bytes, &mut buf).map_err(
+                                |mut error| {
                                     error.push(STRUCT_NAME, "scope");
                                     error
-                                })?;
+                                },
+                            )?;
                             self.scope = Some(str::from_utf8(bytes).map_err(|_| {
                                 #[allow(deprecated)]
                                 let mut error = prost::DecodeError::new("scope is not valid UTF-8");
@@ -4678,6 +4718,14 @@ pub mod v1 {
                 } else {
                     write!(f, "{}/{}", self.0, self.2)
                 }
+            }
+        }
+
+        struct StrFormatter<'a>(&'a [u8]);
+
+        impl<'a> Display for StrFormatter<'a> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(str::from_utf8(self.0).map_err(|_| std::fmt::Error)?)
             }
         }
     }

--- a/crates/storage-api/src/protobuf_types.rs
+++ b/crates/storage-api/src/protobuf_types.rs
@@ -88,6 +88,7 @@ pub mod v1 {
 
     pub mod pb_conversion {
         use std::collections::HashSet;
+        use std::str::FromStr;
 
         use anyhow::anyhow;
         use bytes::{Buf, Bytes};
@@ -107,7 +108,8 @@ pub mod v1 {
         use restate_types::logs::Lsn;
         use restate_types::service_protocol::ServiceProtocolVersion;
         use restate_types::time::MillisSinceEpoch;
-        use restate_types::{GenerationalNodeId, Scope, journal_v2};
+        use restate_types::vqueues::VQueueId;
+        use restate_types::{GenerationalNodeId, LimitKey, Scope, journal_v2};
         use restate_util_string::RestateString;
 
         use super::dedup_sequence_number::Variant;
@@ -399,6 +401,8 @@ pub mod v1 {
             fn try_from(value: InvocationStatusV2) -> Result<Self, ConversionError> {
                 let InvocationStatusV2 {
                     status,
+                    vqueue_id,
+                    limit_key,
                     invocation_target,
                     source,
                     span_context,
@@ -432,6 +436,9 @@ pub mod v1 {
                 } = value;
 
                 let invocation_target = expect_or_fail!(invocation_target)?.try_into()?;
+                let vqueue_id = vqueue_id.map(|buf| VQueueId::from_raw_bytes(&mut buf.as_ref()));
+
+                let limit_key = LimitKey::from_str(&limit_key).expect("valid limit key format");
                 let created_using_restate_version =
                     restate_version_from_pb(created_using_restate_version);
                 let timestamps = crate::invocation_status_table::StatusTimestamps::new(
@@ -486,6 +493,8 @@ pub mod v1 {
                             crate::invocation_status_table::ScheduledInvocation {
                                 metadata:
                                     crate::invocation_status_table::PreFlightInvocationMetadata {
+                                        vqueue_id,
+                                        limit_key,
                                         response_sinks,
                                         timestamps,
                                         invocation_target,
@@ -534,6 +543,8 @@ pub mod v1 {
                                 inbox_sequence_number: expect_or_fail!(inbox_sequence_number)?,
                                 metadata:
                                     crate::invocation_status_table::PreFlightInvocationMetadata {
+                                        vqueue_id,
+                                        limit_key,
                                         response_sinks,
                                         timestamps,
                                         invocation_target,
@@ -557,6 +568,8 @@ pub mod v1 {
                     invocation_status_v2::Status::Invoked => {
                         Ok(crate::invocation_status_table::InvocationStatus::Invoked(
                             crate::invocation_status_table::InFlightInvocationMetadata {
+                                vqueue_id,
+                                limit_key,
                                 response_sinks,
                                 timestamps,
                                 invocation_target,
@@ -597,6 +610,8 @@ pub mod v1 {
                             crate::invocation_status_table::InvocationStatus::Suspended {
                                 metadata:
                                     crate::invocation_status_table::InFlightInvocationMetadata {
+                                        vqueue_id,
+                                        limit_key,
                                         response_sinks,
                                         timestamps,
                                         invocation_target,
@@ -632,6 +647,8 @@ pub mod v1 {
                     invocation_status_v2::Status::Paused => {
                         Ok(crate::invocation_status_table::InvocationStatus::Paused(
                             crate::invocation_status_table::InFlightInvocationMetadata {
+                                vqueue_id,
+                                limit_key,
                                 response_sinks,
                                 timestamps,
                                 invocation_target,
@@ -662,6 +679,8 @@ pub mod v1 {
                     invocation_status_v2::Status::Completed => {
                         Ok(crate::invocation_status_table::InvocationStatus::Completed(
                             crate::invocation_status_table::CompletedInvocation {
+                                vqueue_id,
+                                limit_key,
                                 timestamps,
                                 invocation_target,
                                 created_using_restate_version,
@@ -703,6 +722,8 @@ pub mod v1 {
                             metadata:
                                 crate::invocation_status_table::PreFlightInvocationMetadata {
                                     response_sinks,
+                                    vqueue_id,
+                                    limit_key,
                                     timestamps,
                                     invocation_target,
                                     created_using_restate_version,
@@ -722,6 +743,8 @@ pub mod v1 {
                         },
                     ) => InvocationStatusV2 {
                         status: invocation_status_v2::Status::Scheduled.into(),
+                        vqueue_id: vqueue_id.map(|qid| Bytes::copy_from_slice(qid.as_raw_bytes())),
+                        limit_key: limit_key.to_string(),
                         invocation_target: Some(invocation_target.into()),
                         source: Some(source.into()),
                         span_context: Some(span_context.into()),
@@ -768,6 +791,8 @@ pub mod v1 {
                         crate::invocation_status_table::ScheduledInvocation {
                             metadata:
                                 crate::invocation_status_table::PreFlightInvocationMetadata {
+                                    vqueue_id,
+                                    limit_key,
                                     response_sinks,
                                     timestamps,
                                     invocation_target,
@@ -798,6 +823,9 @@ pub mod v1 {
 
                         InvocationStatusV2 {
                             status: invocation_status_v2::Status::Scheduled.into(),
+                            vqueue_id: vqueue_id
+                                .map(|qid| Bytes::copy_from_slice(qid.as_raw_bytes())),
+                            limit_key: limit_key.to_string(),
                             invocation_target: Some(invocation_target.into()),
                             source: Some(source.into()),
                             span_context: Some(journal_metadata.span_context.into()),
@@ -848,6 +876,8 @@ pub mod v1 {
                         crate::invocation_status_table::InboxedInvocation {
                             metadata:
                                 crate::invocation_status_table::PreFlightInvocationMetadata {
+                                    vqueue_id,
+                                    limit_key,
                                     response_sinks,
                                     timestamps,
                                     invocation_target,
@@ -869,6 +899,8 @@ pub mod v1 {
                         },
                     ) => InvocationStatusV2 {
                         status: invocation_status_v2::Status::Inboxed.into(),
+                        vqueue_id: vqueue_id.map(|qid| Bytes::copy_from_slice(qid.as_raw_bytes())),
+                        limit_key: limit_key.to_string(),
                         invocation_target: Some(invocation_target.into()),
                         source: Some(source.into()),
                         span_context: Some(span_context.into()),
@@ -915,6 +947,8 @@ pub mod v1 {
                         crate::invocation_status_table::InboxedInvocation {
                             metadata:
                                 crate::invocation_status_table::PreFlightInvocationMetadata {
+                                    vqueue_id,
+                                    limit_key,
                                     response_sinks,
                                     timestamps,
                                     invocation_target,
@@ -945,6 +979,9 @@ pub mod v1 {
                         };
                         InvocationStatusV2 {
                             status: invocation_status_v2::Status::Inboxed.into(),
+                            vqueue_id: vqueue_id
+                                .map(|qid| Bytes::copy_from_slice(qid.as_raw_bytes())),
+                            limit_key: limit_key.to_string(),
                             invocation_target: Some(invocation_target.into()),
                             source: Some(source.into()),
                             span_context: Some(journal_metadata.span_context.into()),
@@ -993,6 +1030,8 @@ pub mod v1 {
                     }
                     crate::invocation_status_table::InvocationStatus::Invoked(
                         crate::invocation_status_table::InFlightInvocationMetadata {
+                            vqueue_id,
+                            limit_key,
                             invocation_target,
                             created_using_restate_version,
                             journal_metadata,
@@ -1018,6 +1057,9 @@ pub mod v1 {
 
                         InvocationStatusV2 {
                             status: invocation_status_v2::Status::Invoked.into(),
+                            vqueue_id: vqueue_id
+                                .map(|qid| Bytes::copy_from_slice(qid.as_raw_bytes())),
+                            limit_key: limit_key.to_string(),
                             invocation_target: Some(invocation_target.into()),
                             source: Some(source.into()),
                             span_context: Some(journal_metadata.span_context.into()),
@@ -1067,6 +1109,8 @@ pub mod v1 {
                     crate::invocation_status_table::InvocationStatus::Suspended {
                         metadata:
                             crate::invocation_status_table::InFlightInvocationMetadata {
+                                vqueue_id,
+                                limit_key,
                                 invocation_target,
                                 created_using_restate_version,
                                 journal_metadata,
@@ -1114,6 +1158,9 @@ pub mod v1 {
 
                         InvocationStatusV2 {
                             status: invocation_status_v2::Status::Suspended.into(),
+                            vqueue_id: vqueue_id
+                                .map(|qid| Bytes::copy_from_slice(qid.as_raw_bytes())),
+                            limit_key: limit_key.to_string(),
                             invocation_target: Some(invocation_target.into()),
                             source: Some(source.into()),
                             span_context: Some(journal_metadata.span_context.into()),
@@ -1162,6 +1209,8 @@ pub mod v1 {
                     }
                     crate::invocation_status_table::InvocationStatus::Paused(
                         crate::invocation_status_table::InFlightInvocationMetadata {
+                            vqueue_id,
+                            limit_key,
                             invocation_target,
                             created_using_restate_version,
                             journal_metadata,
@@ -1187,6 +1236,9 @@ pub mod v1 {
 
                         InvocationStatusV2 {
                             status: invocation_status_v2::Status::Paused.into(),
+                            vqueue_id: vqueue_id
+                                .map(|qid| Bytes::copy_from_slice(qid.as_raw_bytes())),
+                            limit_key: limit_key.to_string(),
                             invocation_target: Some(invocation_target.into()),
                             source: Some(source.into()),
                             span_context: Some(journal_metadata.span_context.into()),
@@ -1235,6 +1287,8 @@ pub mod v1 {
                     }
                     crate::invocation_status_table::InvocationStatus::Completed(
                         crate::invocation_status_table::CompletedInvocation {
+                            vqueue_id,
+                            limit_key,
                             invocation_target,
                             created_using_restate_version,
                             source,
@@ -1259,6 +1313,9 @@ pub mod v1 {
 
                         InvocationStatusV2 {
                             status: invocation_status_v2::Status::Completed.into(),
+                            vqueue_id: vqueue_id
+                                .map(|qid| Bytes::copy_from_slice(qid.as_raw_bytes())),
+                            limit_key: limit_key.to_string(),
                             invocation_target: Some(invocation_target.into()),
                             source: Some(source.into()),
                             span_context: Some(journal_metadata.span_context.into()),
@@ -1318,6 +1375,7 @@ pub mod v1 {
                 let InvocationV2Lite {
                     status,
                     invocation_target,
+                    vqueue_id,
                 } = value;
 
                 let invocation_target = expect_or_fail!(invocation_target)?.try_into()?;
@@ -1348,9 +1406,11 @@ pub mod v1 {
                     }
                 };
 
+                let vqueue_id = vqueue_id.map(|buf| VQueueId::from_raw_bytes(&mut buf.as_ref()));
                 Ok(crate::invocation_status_table::InvocationLite {
                     status,
                     invocation_target,
+                    vqueue_id,
                 })
             }
         }

--- a/crates/storage-query-datafusion/src/context.rs
+++ b/crates/storage-query-datafusion/src/context.rs
@@ -49,12 +49,14 @@ use crate::remote_query_scanner_manager::RemoteScannerManager;
 
 const SYS_INVOCATION_VIEW: &str = "CREATE VIEW sys_invocation as SELECT
             ss.id,
+            ss.vqueue_id,
             ss.target,
             ss.target_service_name,
             ss.target_service_key,
             ss.target_handler_name,
             ss.target_service_ty,
             ss.scope,
+            ss.limit_key,
             ss.idempotency_key,
             ss.invoked_by,
             ss.invoked_by_service_name,

--- a/crates/storage-query-datafusion/src/invocation_status/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/row.rs
@@ -37,7 +37,7 @@ pub(crate) fn append_invocation_status_row<'a>(
         && let Some(invocation_target) = invocation_status.invocation_target()?
     {
         if row.is_target_service_name_defined() {
-            row.target_service_name(invocation_target.service_name()?);
+            row.fmt_target_service_name(invocation_target.service_name());
         }
         if row.is_target_service_key_defined()
             && let Some(key) = invocation_target.key()?
@@ -45,7 +45,7 @@ pub(crate) fn append_invocation_status_row<'a>(
             row.target_service_key(key);
         }
         if row.is_target_handler_name_defined() {
-            row.target_handler_name(invocation_target.handler_name()?);
+            row.target_handler_name(invocation_target.handler_name());
         }
         if row.is_target_defined() {
             row.fmt_target(invocation_target.target_fmt()?);
@@ -318,7 +318,7 @@ fn fill_invoked_by(
                 let invocation_target = service.invocation_target()?;
 
                 if row.is_invoked_by_service_name_defined() {
-                    row.invoked_by_service_name(invocation_target.service_name()?);
+                    row.invoked_by_service_name(invocation_target.service_name());
                 }
 
                 if row.is_invoked_by_target_defined() {

--- a/crates/storage-query-datafusion/src/invocation_status/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/row.rs
@@ -69,6 +69,18 @@ pub(crate) fn append_invocation_status_row<'a>(
         row.fmt_id(invocation_id);
     }
 
+    if row.is_vqueue_id_defined()
+        && let Some(vqueue_id) = invocation_status.vqueue_id()
+    {
+        row.fmt_vqueue_id(vqueue_id);
+    }
+
+    if row.is_limit_key_defined()
+        && let Some(limit_key) = invocation_status.limit_key_fmt()
+    {
+        row.fmt_limit_key(limit_key);
+    }
+
     if row.is_idempotency_key_defined()
         && let Some(key) = invocation_status.idempotency_key()?
     {

--- a/crates/storage-query-datafusion/src/invocation_status/schema.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/schema.rs
@@ -21,6 +21,10 @@ define_table!(sys_invocation_status(
     /// [Invocation ID](/operate/invocation#invocation-identifier).
     id: DataType::LargeUtf8,
 
+    /// The VQueue assigned to the the invocation. NULL if invocation was not migrated to vqueues.
+    /// Since v1.7.0.
+    vqueue_id: DataType::Utf8,
+
     /// Either `inboxed` or `scheduled` or `invoked` or `suspended` or `paused` or `completed`
     status: DataType::LargeUtf8,
 
@@ -50,6 +54,10 @@ define_table!(sys_invocation_status(
     /// The scope of the invocation for vqueue partitioning, if scoped. NULL for unscoped invocations.
     /// Since v1.7.0.
     scope: DataType::Utf8,
+
+    /// The limit key that was used for the invocation. NULL if no limit key was set.
+    /// Since v1.7.0.
+    limit_key: DataType::Utf8,
 
     /// Idempotency key, if any.
     idempotency_key: DataType::LargeUtf8,

--- a/crates/storage-query-datafusion/src/table_docs.rs
+++ b/crates/storage-query-datafusion/src/table_docs.rs
@@ -107,6 +107,9 @@ pub fn sys_invocation_table_docs() -> OwnedTableDocs {
     let columns = vec![
         sys_invocation_status.remove("id").expect("id should exist"),
         sys_invocation_status
+            .remove("vqueue_id")
+            .expect("vqueue_id should exist"),
+        sys_invocation_status
             .remove("target")
             .expect("target should exist"),
         sys_invocation_status
@@ -124,6 +127,9 @@ pub fn sys_invocation_table_docs() -> OwnedTableDocs {
         sys_invocation_status
             .remove("scope")
             .expect("scope should exist"),
+        sys_invocation_status
+            .remove("limit_key")
+            .expect("limit_key should exist"),
         sys_invocation_status
             .remove("idempotency_key")
             .expect("idempotency_key should exist"),

--- a/crates/types/src/vqueues/vqueue_id.rs
+++ b/crates/types/src/vqueues/vqueue_id.rs
@@ -95,6 +95,17 @@ impl VQueueId {
         Self(raw)
     }
 
+    /// The dual of `from_raw_bytes`
+    ///
+    /// The key is encoded as follows:
+    /// - PartitionKey (u64) (big-endian)
+    /// - u8 For the size of the rest of the bytes (to support future evolution) with max 255
+    ///   bytes. and 0 being a special marker to indicate format change.
+    /// - [u8; SIZE]
+    pub fn as_raw_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
     // 25 bytes
     pub const fn serialized_length_fixed() -> usize {
         std::mem::size_of::<PartitionKey>() + 1 + DIGEST_LEN

--- a/crates/vqueues/src/lib.rs
+++ b/crates/vqueues/src/lib.rs
@@ -173,15 +173,14 @@ where
 
     pub async fn vqueue_from_invocation_target(
         at: UniqueTimestamp,
-        partition_key: PartitionKey,
+        qid: &VQueueId,
         invocation_target: &InvocationTarget,
         storage: &'a mut S,
         cache: &'a mut VQueuesMetaCache,
         action_collector: Option<&'a mut Vec<A>>,
         limit_key: &LimitKey<ReString>,
     ) -> Result<Self, StorageError> {
-        let qid = infer_vqueue_id_from_invocation(partition_key, invocation_target, limit_key);
-        let cache_key = match cache.load(storage, &qid).await? {
+        let cache_key = match cache.load(storage, qid).await? {
             Some(key) => key,
             None => {
                 let link = if let Some(lock_name) = invocation_target.lock_name() {
@@ -196,7 +195,7 @@ where
                     limit_key.clone(),
                     link,
                 );
-                storage.create_vqueue(&qid, &meta);
+                storage.create_vqueue(qid, &meta);
                 cache.insert(qid.clone(), meta)
             }
         };

--- a/crates/vqueues/src/scheduler/drr.rs
+++ b/crates/vqueues/src/scheduler/drr.rs
@@ -18,7 +18,7 @@ use metrics::counter;
 use pin_project::pin_project;
 use slotmap::SecondaryMap;
 use tokio::time::Instant;
-use tracing::{info, trace, warn};
+use tracing::{debug, trace, warn};
 
 use restate_limiter::RuleUpdate;
 use restate_storage_api::StorageError;
@@ -88,7 +88,7 @@ impl<S: VQueueStore> DRRScheduler<S> {
             eligible.insert_eligible(handle);
         }
 
-        info!(
+        debug!(
             "Scheduler started. num_vqueues={}, total_running_items={total_running}, total_waiting_items={total_waiting}",
             q.len(),
         );

--- a/crates/worker/src/partition/cleaner.rs
+++ b/crates/worker/src/partition/cleaner.rs
@@ -297,7 +297,7 @@ mod tests {
             )
         }
 
-        fn scan_invoked_invocations(
+        fn scan_legacy_invoked_invocations(
             &self,
         ) -> restate_storage_api::Result<
             impl Stream<Item = restate_storage_api::Result<InvokedInvocationStatusLite>> + Send,

--- a/crates/worker/src/partition/leadership/leader_state.rs
+++ b/crates/worker/src/partition/leadership/leader_state.rs
@@ -32,7 +32,6 @@ use restate_invoker_impl::InvokerHandle as InvokerChannelServiceHandle;
 use restate_limiter::RuleBook;
 use restate_partition_store::PartitionDb;
 use restate_storage_api::vqueue_table::scheduler::SchedulerDecisionsCommand;
-use restate_types::config::Configuration;
 use restate_types::identifiers::{
     LeaderEpoch, PartitionId, PartitionKey, PartitionProcessorRpcRequestId, WithPartitionKey,
 };
@@ -456,30 +455,20 @@ impl LeaderState {
                     }
                 }
                 ActionEffect::UpsertRuleBook(rule_book) => {
-                    // todo(tillrohrmann) also enable the feature once the partition has been migrated
-                    //  to use vqueues and then rolling back to v1.7
-                    if Configuration::pinned()
-                        .common
-                        .experimental
-                        .is_vqueues_enabled()
-                    {
-                        let cmd =
-                            restate_wal_protocol::control::UpsertRuleBookCommand { rule_book };
+                    let cmd = restate_wal_protocol::control::UpsertRuleBookCommand { rule_book };
+                    arena.reserve(cmd.encoded_len());
+                    // safe to unwrap because we reserved enough space
+                    cmd.bilrost_encode(&mut arena).unwrap();
 
-                        arena.reserve(cmd.encoded_len());
-                        // safe to unwrap because we reserved enough space
-                        cmd.bilrost_encode(&mut arena).unwrap();
-
-                        self.self_proposer
-                            .self_propose(
-                                self.partition_key_range.start(),
-                                Command::UpsertRuleBook(UpsertRuleBookCommandWrapper {
-                                    partition_key_range: self.partition_key_range,
-                                    command: arena.split().freeze(),
-                                }),
-                            )
-                            .await?;
-                    }
+                    self.self_proposer
+                        .self_propose(
+                            self.partition_key_range.start(),
+                            Command::UpsertRuleBook(UpsertRuleBookCommandWrapper {
+                                partition_key_range: self.partition_key_range,
+                                command: arena.split().freeze(),
+                            }),
+                        )
+                        .await?;
                 }
                 ActionEffect::AwaitingRpcSelfProposeDone => {
                     // Nothing to do here

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -466,35 +466,28 @@ where
                 })?
                 .into_guard();
 
-            let scheduler_service = if config.common.experimental.is_vqueues_enabled() {
-                let scheduler = SchedulerService::create(
-                    ResourceManager::create(
-                        partition_store.partition_db().clone(),
-                        self.invoker_capacity.concurrency.clone(),
-                        self.invoker_capacity.invocation_token_bucket.clone(),
-                        self.invoker_capacity.memory_pool.clone(),
-                        self.invoker_capacity.initial_invocation_memory,
-                    )
-                    .await?,
+            let scheduler_service = SchedulerService::create(
+                ResourceManager::create(
                     partition_store.partition_db().clone(),
-                    vqueues_cache,
+                    self.invoker_capacity.concurrency.clone(),
+                    self.invoker_capacity.invocation_token_bucket.clone(),
+                    self.invoker_capacity.memory_pool.clone(),
+                    self.invoker_capacity.initial_invocation_memory,
                 )
-                .await?;
+                .await?,
+                partition_store.partition_db().clone(),
+                vqueues_cache,
+            )
+            .await?;
 
-                // Seed the scheduler's UserLimiter with whatever rules
-                // have already been applied to this partition.
-                let initial_diff = rule_book.diff_from_empty();
-                if !initial_diff.is_empty() {
-                    scheduler.on_rules_updated(initial_diff);
-                }
-                scheduler
-            } else {
-                // we only perform the mass-resumption if vqueues are disabled
-                Self::resume_invoked_invocations(&mut invoker_handle, partition_store).await?;
+            // Seed the scheduler's UserLimiter with whatever rules
+            // have already been applied to this partition.
+            let initial_diff = rule_book.diff_from_empty();
+            if !initial_diff.is_empty() {
+                scheduler_service.on_rules_updated(initial_diff);
+            }
 
-                // noop scheduler if vqueues are disabled
-                SchedulerService::new_disabled()
-            };
+            Self::resume_invoked_invocations(&mut invoker_handle, partition_store).await?;
 
             let timer_service = TimerService::new(
                 TokioClock,
@@ -621,31 +614,33 @@ where
         invoker_handle: &mut InvokerChannelServiceHandle,
         partition_store: &mut PartitionStore,
     ) -> Result<(), Error> {
-        {
-            let mut invoked_invocations = std::pin::pin!(
-                partition_store
-                    .scan_invoked_invocations()
-                    .map_err(Error::Storage)?
-            );
+        // todo(asoli): If we are asked to migrate to vqueues (or vqueues are enabled).
+        // we must migrate all invoked invocations here (through a wal command).
+        // (blocker to v1.7.0)
 
-            let start = tokio::time::Instant::now();
-            let mut count = 0;
-            while let Some(invoked_invocation) = invoked_invocations.next().await {
-                let InvokedInvocationStatusLite {
-                    invocation_id,
-                    invocation_target,
-                } = invoked_invocation?;
-                invoker_handle
-                    .invoke(invocation_id, invocation_target)
-                    .map_err(Error::Invoker)?;
-                count += 1;
-            }
-            debug!(
-                "Leader partition resumed {} invocations in {:?}",
-                count,
-                start.elapsed(),
-            );
+        let mut invoked_invocations = std::pin::pin!(
+            partition_store
+                .scan_legacy_invoked_invocations()
+                .map_err(Error::Storage)?
+        );
+
+        let start = tokio::time::Instant::now();
+        let mut count = 0;
+        while let Some(invoked_invocation) = invoked_invocations.next().await {
+            let InvokedInvocationStatusLite {
+                invocation_id,
+                invocation_target,
+            } = invoked_invocation?;
+            invoker_handle
+                .invoke(invocation_id, invocation_target)
+                .map_err(Error::Invoker)?;
+            count += 1;
         }
+        debug!(
+            "Leader partition resumed {} invocations in {:?}",
+            count,
+            start.elapsed(),
+        );
 
         Ok(())
     }

--- a/crates/worker/src/partition/state_machine/lifecycle/paused.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/paused.rs
@@ -17,7 +17,6 @@ use restate_storage_api::invocation_status_table::{
 use restate_storage_api::journal_events::WriteJournalEventsTable;
 use restate_storage_api::lock_table::WriteLockTable;
 use restate_storage_api::vqueue_table::{EntryStatusHeader, ReadVQueueTable, WriteVQueueTable};
-use restate_types::config::Configuration;
 use restate_types::identifiers::{InvocationId, WithPartitionKey as _};
 use restate_types::journal_events::raw::RawEvent;
 use restate_types::vqueues::EntryId;
@@ -65,11 +64,7 @@ where
         // Invoker paused the invocation, let's record the event, then set the status to paused
         debug_if_leader!(ctx.is_leader, "Paused the invocation");
 
-        if Configuration::pinned()
-            .common
-            .experimental
-            .is_vqueues_enabled()
-        {
+        if invoked_meta.vqueue_id.is_some() {
             // todo: use the new status
             let entry_id = EntryId::from(invocation_id);
             let Some(header) = ctx

--- a/crates/worker/src/partition/state_machine/lifecycle/restart_as_new.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/restart_as_new.rs
@@ -25,9 +25,9 @@ use restate_storage_api::service_status_table::{
     ReadVirtualObjectStatusTable, WriteVirtualObjectStatusTable,
 };
 use restate_storage_api::timer_table::WriteTimerTable;
-use restate_storage_api::vqueue_table::{EntryStatusHeader, ReadVQueueTable, WriteVQueueTable};
+use restate_storage_api::vqueue_table::{ReadVQueueTable, WriteVQueueTable};
 use restate_storage_api::{journal_table as journal_table_v1, journal_table_v2};
-use restate_types::LimitKey;
+use restate_types::config::Configuration;
 use restate_types::identifiers::{DeploymentId, EntryIndex, InvocationId, WithPartitionKey};
 use restate_types::invocation::client::RestartAsNewInvocationResponse;
 use restate_types::invocation::{
@@ -35,7 +35,7 @@ use restate_types::invocation::{
 };
 use restate_types::journal_v2;
 use restate_types::journal_v2::{CommandMetadata, EntryMetadata, EntryType, NotificationId};
-use restate_types::vqueues::EntryId;
+use restate_vqueues::VQueue;
 
 use crate::debug_if_leader;
 use crate::partition::state_machine::{Action, CommandHandler, Error, StateMachineApplyContext};
@@ -245,6 +245,21 @@ where
         );
 
         // Let's prep the PreFlightInvocationMetadata
+        //
+        // If the old invocation was already vqueue-enabled, we carry down the same vqueue id.
+        // if not and we are now in vqueue-enabled mode, we assign a vqueue id to it.
+        let qid = completed_invocation.vqueue_id.or_else(|| {
+            Configuration::pinned()
+                .common
+                .experimental
+                .is_vqueues_enabled()
+                .then_some(VQueue::infer_vqueue_id_from_invocation(
+                    new_invocation_id.partition_key(),
+                    &completed_invocation.invocation_target,
+                    &completed_invocation.limit_key,
+                ))
+        });
+
         let pre_flight_invocation_metadata = PreFlightInvocationMetadata {
             timestamps: StatusTimestamps::init(ctx.record_created_at),
             invocation_target: completed_invocation.invocation_target,
@@ -261,6 +276,8 @@ where
                 pinned_deployment,
             }),
             source: Source::RestartAsNew(invocation_id),
+            vqueue_id: qid,
+            limit_key: completed_invocation.limit_key,
             completion_retention_duration: completed_invocation.completion_retention_duration,
             journal_retention_duration: completed_invocation.journal_retention_duration,
             random_seed: completed_invocation.random_seed,
@@ -272,51 +289,8 @@ where
         };
 
         // --- Invocation metadata ready, now go through the usual flow
-
-        // Look up limit_key from the original invocation's vqueue entry.
-        //
-        // Scope is already on the InvocationTarget (carried from the original invocation).
-        //
-        // TODO(vqueues): Revalidate this approach. It relies on VQueueMeta outliving
-        // all its entries — specifically, that the vqueue metadata is not removed
-        // before the vqueue entry itself is cleaned up (i.e., retention is over).
-        // If this assumption is violated, we'd silently lose limit_key on
-        // restart. Consider storing limit_key directly in the vqueue
-        // EntryStatus to avoid the extra lookup.
-        let limit_key = {
-            let entry_id = EntryId::from(&invocation_id);
-            if let Some(entry_status) = ctx
-                .storage
-                .get_vqueue_entry_status(invocation_id.partition_key(), &entry_id)
-                .await?
-            {
-                if let Some(vqueue_cache_key) = ctx
-                    .vqueues_cache
-                    .load(ctx.storage, entry_status.vqueue_id())
-                    .await?
-                {
-                    ctx.vqueues_cache
-                        .get_mut(vqueue_cache_key)
-                        .unwrap()
-                        .meta()
-                        .limit_key()
-                        .clone()
-                } else {
-                    LimitKey::None
-                }
-            } else {
-                // No vqueue entry (e.g., invocation predates vqueues)
-                LimitKey::None
-            }
-        };
-
-        ctx.on_pre_flight_invocation(
-            &new_invocation_id,
-            pre_flight_invocation_metadata,
-            None,
-            &limit_key,
-        )
-        .await?;
+        ctx.on_pre_flight_invocation(&new_invocation_id, pre_flight_invocation_metadata, None)
+            .await?;
 
         // --- Reply all good
         ctx.reply(

--- a/crates/worker/src/partition/state_machine/lifecycle/resume.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/resume.rs
@@ -11,7 +11,6 @@
 use restate_storage_api::invocation_status_table::InvocationStatus;
 use restate_storage_api::lock_table::WriteLockTable;
 use restate_storage_api::vqueue_table::{ReadVQueueTable, WriteVQueueTable};
-use restate_types::config::Configuration;
 use restate_types::identifiers::InvocationId;
 
 use crate::debug_if_leader;
@@ -41,11 +40,7 @@ where
 
         metadata.timestamps.update(ctx.record_created_at);
 
-        if Configuration::pinned()
-            .common
-            .experimental
-            .is_vqueues_enabled()
-        {
+        if metadata.vqueue_id.is_some() {
             ctx.vqueue_move_invocation_to_inbox_stage(&self.invocation_id)
                 .await?;
         } else {

--- a/crates/worker/src/partition/state_machine/lifecycle/suspend.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/suspend.rs
@@ -18,7 +18,6 @@ use restate_storage_api::journal_events::WriteJournalEventsTable;
 use restate_storage_api::journal_table_v2::ReadJournalTable;
 use restate_storage_api::lock_table::WriteLockTable;
 use restate_storage_api::vqueue_table::{EntryStatusHeader, ReadVQueueTable, WriteVQueueTable};
-use restate_types::config::Configuration;
 use restate_types::identifiers::{InvocationId, WithPartitionKey};
 use restate_types::journal_events::raw::RawEvent;
 use restate_types::journal_events::{Event, SuspendedEvent};
@@ -109,11 +108,7 @@ where
                 .timestamps
                 .update(ctx.record_created_at);
 
-            if Configuration::pinned()
-                .common
-                .experimental
-                .is_vqueues_enabled()
-            {
+            if in_flight_invocation_metadata.vqueue_id.is_some() {
                 let now = UniqueTimestamp::from_unix_millis_unchecked(ctx.record_created_at);
                 let entry_id = EntryId::from(&self.invocation_id);
                 let Some(header) = ctx

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -923,21 +923,36 @@ impl<S> StateMachineApplyContext<'_, S> {
             return Ok(());
         };
 
-        // Extract limit_key before consuming the ServiceInvocation
-        let limit_key = std::mem::take(&mut service_invocation.limit_key);
+        // Invariant: limit_key requires scope (defense-in-depth, ingress should also validate)
+        debug_assert!(
+            service_invocation.limit_key.is_empty()
+                || service_invocation.invocation_target.scope().is_some(),
+            "limit_key set without scope — this should have been rejected at the ingress"
+        );
 
         // Prepare PreFlightInvocationMetadata structure
         let submit_notification_sink = service_invocation.submit_notification_sink.take();
+
+        let qid = Configuration::pinned()
+            .common
+            .experimental
+            .is_vqueues_enabled()
+            .then_some(VQueue::infer_vqueue_id_from_invocation(
+                service_invocation.partition_key(),
+                &service_invocation.invocation_target,
+                &service_invocation.limit_key,
+            ));
+
         let pre_flight_invocation_metadata = PreFlightInvocationMetadata::from_service_invocation(
             self.record_created_at,
             service_invocation,
+            qid,
         );
 
         self.on_pre_flight_invocation(
             &invocation_id,
             pre_flight_invocation_metadata,
             submit_notification_sink,
-            &limit_key,
         )
         .await
     }
@@ -947,7 +962,6 @@ impl<S> StateMachineApplyContext<'_, S> {
         invocation_id: &InvocationId,
         mut pre_flight_invocation_metadata: PreFlightInvocationMetadata,
         submit_notification_sink: Option<SubmitNotificationSink>,
-        limit_key: &LimitKey<ReString>,
     ) -> Result<(), Error>
     where
         S: WriteInvocationStatusTable
@@ -964,16 +978,6 @@ impl<S> StateMachineApplyContext<'_, S> {
             + journal_table_v2::WriteJournalTable,
     {
         // A pre-flight invocation has been already deduplicated
-
-        // Invariant: limit_key requires scope (defense-in-depth, ingress should also validate)
-        debug_assert!(
-            limit_key.is_empty()
-                || pre_flight_invocation_metadata
-                    .invocation_target
-                    .scope()
-                    .is_some(),
-            "limit_key set without scope — this should have been rejected at the ingress"
-        );
 
         // 0. Prepare the journal table v2. This ensures that all newly created invocations will
         // have a journal v2 created. To handle already existing invocations for which we didn't
@@ -1026,18 +1030,13 @@ impl<S> StateMachineApplyContext<'_, S> {
                 });
         }
 
-        if Configuration::pinned()
-            .common
-            .experimental
-            .is_vqueues_enabled()
-        {
+        if pre_flight_invocation_metadata.vqueue_id.is_some() {
             // skips the rest of this logic and jumps straight to vqueues' implementation
             return self
                 .vqueue_enqueue(
                     invocation_id,
                     pre_flight_invocation_metadata,
                     submit_notification_sink,
-                    limit_key,
                 )
                 .await;
         }
@@ -1100,12 +1099,12 @@ impl<S> StateMachineApplyContext<'_, S> {
     }
 
     // Uses vqueues, replaces on_pre_flight_invocation
+    // Invocations landing here must have the vqueue_id set in metadata.
     async fn vqueue_enqueue(
         &mut self,
         invocation_id: &InvocationId,
         metadata: PreFlightInvocationMetadata,
         submit_notification_sink: Option<SubmitNotificationSink>,
-        limit_key: &LimitKey<ReString>,
     ) -> Result<(), Error>
     where
         S: WriteInvocationStatusTable
@@ -1122,14 +1121,18 @@ impl<S> StateMachineApplyContext<'_, S> {
     {
         let record_unique_ts = UniqueTimestamp::from_unix_millis_unchecked(self.record_created_at);
 
+        let qid = metadata
+            .vqueue_id
+            .as_ref()
+            .expect("invariant violation: vqueue id must be set");
         VQueue::vqueue_from_invocation_target(
             record_unique_ts,
-            invocation_id.partition_key(),
+            qid,
             &metadata.invocation_target,
             self.storage,
             self.vqueues_cache,
             self.is_leader.then_some(self.action_collector),
-            limit_key,
+            &metadata.limit_key,
         )
         .await?
         .enqueue_new(
@@ -1972,6 +1975,7 @@ impl<S> StateMachineApplyContext<'_, S> {
                     response_sinks,
                     invocation_target,
                     input,
+                    vqueue_id,
                     ..
                 },
         } = inboxed_invocation;
@@ -1985,38 +1989,31 @@ impl<S> StateMachineApplyContext<'_, S> {
             Some(&invocation_target),
         )?;
 
-        if Configuration::pinned()
-            .common
-            .experimental
-            .is_vqueues_enabled()
-        {
-            let record_unique_ts =
-                UniqueTimestamp::from_unix_millis_unchecked(self.record_created_at);
-            let new_status = match termination_flavor {
-                TerminationFlavor::Kill => vqueue_table::Status::Killed,
-                TerminationFlavor::Cancel => vqueue_table::Status::Cancelled,
-            };
-            // Is this an invocation that has a vqueue inbox?
-            if !VQueue::end_by_id(
-                self.storage,
-                self.vqueues_cache,
-                self.is_leader.then_some(self.action_collector),
-                record_unique_ts,
-                invocation_id.partition_key(),
-                &EntryId::from(invocation_id),
-                new_status,
-            )
-            .await?
-            {
-                // Assuming it's an old-style inbox, fallback to deleting it from inbox since we
-                // can't find the entry state.
-                self.do_delete_inbox_entry(
-                    invocation_target.as_keyed_service_id().expect(
-                        "Because the invocation is inboxed, it must have a keyed service id",
-                    ),
-                    inbox_sequence_number,
+        if let Some(vqueue_id) = vqueue_id {
+            if let Some(entry_status) = self
+                .storage
+                .get_vqueue_entry_status(
+                    invocation_id.partition_key(),
+                    &EntryId::from(invocation_id),
                 )
-                .await?;
+                .await?
+            {
+                let record_unique_ts =
+                    UniqueTimestamp::from_unix_millis_unchecked(self.record_created_at);
+                let new_status = match termination_flavor {
+                    TerminationFlavor::Kill => vqueue_table::Status::Killed,
+                    TerminationFlavor::Cancel => vqueue_table::Status::Cancelled,
+                };
+
+                VQueue::get(
+                    &vqueue_id,
+                    self.storage,
+                    self.vqueues_cache,
+                    self.is_leader.then_some(self.action_collector),
+                )
+                .await?
+                .expect("terminate expects vqueue to exist")
+                .end(record_unique_ts, &entry_status, new_status);
             }
         } else {
             // Delete inbox entry and invocation status.
@@ -2088,6 +2085,7 @@ impl<S> StateMachineApplyContext<'_, S> {
                     input,
                     invocation_target,
                     execution_time,
+                    vqueue_id,
                     ..
                 },
         } = scheduled_invocation;
@@ -2101,40 +2099,31 @@ impl<S> StateMachineApplyContext<'_, S> {
             Some(&invocation_target),
         )?;
 
-        if Configuration::pinned()
-            .common
-            .experimental
-            .is_vqueues_enabled()
-        {
-            let record_unique_ts =
-                UniqueTimestamp::from_unix_millis_unchecked(self.record_created_at);
-            let new_status = match termination_flavor {
-                TerminationFlavor::Kill => vqueue_table::Status::Killed,
-                TerminationFlavor::Cancel => vqueue_table::Status::Cancelled,
-            };
-
-            // Is this an invocation that has a vqueue inbox?
-            if !VQueue::end_by_id(
-                self.storage,
-                self.vqueues_cache,
-                self.is_leader.then_some(self.action_collector),
-                record_unique_ts,
-                invocation_id.partition_key(),
-                &EntryId::from(invocation_id),
-                new_status,
-            )
-            .await?
+        if let Some(vqueue_id) = vqueue_id {
+            if let Some(entry_status) = self
+                .storage
+                .get_vqueue_entry_status(
+                    invocation_id.partition_key(),
+                    &EntryId::from(invocation_id),
+                )
+                .await?
             {
-                // Assuming it's an old-style inbox, fallback to deleting the timer
-                if let Some(execution_time) = execution_time {
-                    self.do_delete_timer(TimerKey::neo_invoke(
-                        execution_time.as_u64(),
-                        invocation_id.invocation_uuid(),
-                    ))
-                    .await?;
-                } else {
-                    warn!("Scheduled invocations must always have an execution time.");
-                }
+                let record_unique_ts =
+                    UniqueTimestamp::from_unix_millis_unchecked(self.record_created_at);
+                let new_status = match termination_flavor {
+                    TerminationFlavor::Kill => vqueue_table::Status::Killed,
+                    TerminationFlavor::Cancel => vqueue_table::Status::Cancelled,
+                };
+
+                VQueue::get(
+                    &vqueue_id,
+                    self.storage,
+                    self.vqueues_cache,
+                    self.is_leader.then_some(self.action_collector),
+                )
+                .await?
+                .expect("terminate expects vqueue to exist")
+                .end(record_unique_ts, &entry_status, new_status);
             }
         } else {
             // Delete timer
@@ -2817,10 +2806,8 @@ impl<S> StateMachineApplyContext<'_, S> {
                 // todo: remove when vqueues are always enabled
                 if self.is_leader
                     && let YieldReason::ExhaustedMemoryBudget { .. } = reason
-                    && !Configuration::pinned()
-                        .common
-                        .experimental
-                        .is_vqueues_enabled()
+                    && let Some(metadata) = invocation_status.get_invocation_metadata()
+                    && metadata.vqueue_id.is_none()
                 {
                     let Some(invocation_target) = invocation_status.invocation_target().cloned()
                     else {
@@ -2925,6 +2912,8 @@ impl<S> StateMachineApplyContext<'_, S> {
             .as_ref()
             .map(|pd| pd.service_protocol_version);
 
+        let vqueue_id = invocation_metadata.vqueue_id.clone();
+        let mut end_status = vqueue_table::Status::Succeeded;
         // If there are any response sinks, or we need to store back the completed status,
         //  we need to find the latest output entry
         if !invocation_metadata.response_sinks.is_empty() || !completion_retention.is_zero() {
@@ -2948,6 +2937,10 @@ impl<S> StateMachineApplyContext<'_, S> {
                 warn!("Invocation completed without an output entry. This is not supported yet.");
                 return Ok(());
             };
+
+            if let ResponseResult::Failure(_) = &response_result {
+                end_status = vqueue_table::Status::Failed;
+            }
 
             // Send responses out
             self.send_response_to_sinks(
@@ -3007,41 +3000,30 @@ impl<S> StateMachineApplyContext<'_, S> {
             .await?;
         }
 
-        if Configuration::pinned()
-            .common
-            .experimental
-            .is_vqueues_enabled()
-        {
-            if invocation_target.invocation_target_ty()
-                == InvocationTargetType::VirtualObject(VirtualObjectHandlerType::Exclusive)
-            {
-                let keyed_service_id = invocation_target.as_keyed_service_id().expect(
-                    "When the handler type is Exclusive, the invocation target must have a key",
-                );
-                // We consumed the inbox, nothing else to do here
-                self.storage
-                    .put_virtual_object_status(&keyed_service_id, &VirtualObjectStatus::Unlocked)
-                    .map_err(Error::Storage)?;
-            }
-
+        if let Some(vqueue_id) = vqueue_id {
+            let Some(entry_status) = self
+                .storage
+                .get_vqueue_entry_status(
+                    invocation_id.partition_key(),
+                    &EntryId::from(invocation_id),
+                )
+                .await?
+            else {
+                // Invocation has been removed already!
+                return Ok(());
+            };
             let record_unique_ts =
                 UniqueTimestamp::from_unix_millis_unchecked(self.record_created_at);
 
-            // we need to remove the invocation from the running list
-            VQueue::end_by_id(
+            VQueue::get(
+                &vqueue_id,
                 self.storage,
                 self.vqueues_cache,
                 self.is_leader.then_some(self.action_collector),
-                record_unique_ts,
-                invocation_id.partition_key(),
-                &EntryId::from(invocation_id),
-                // todo(tillrohrmann): This is a temporary, we should extract the new state from the code
-                // above and use that instead.
-                vqueue_table::Status::Succeeded,
             )
-            .await?;
-
-            return Ok(());
+            .await?
+            .expect("terminate expects vqueue to exist")
+            .end(record_unique_ts, &entry_status, end_status);
         } else {
             // Consume inbox and move on
             self.consume_inbox(&invocation_target).await?;
@@ -3333,14 +3315,6 @@ impl<S> StateMachineApplyContext<'_, S> {
             + WriteJournalTable
             + journal_table_v2::WriteJournalTable,
     {
-        if Configuration::pinned()
-            .common
-            .experimental
-            .is_vqueues_enabled()
-        {
-            return Ok(());
-        }
-
         // Inbox exists only for virtual object exclusive handler cases
         if invocation_target.invocation_target_ty()
             == InvocationTargetType::VirtualObject(VirtualObjectHandlerType::Exclusive)
@@ -4637,24 +4611,20 @@ impl<S> StateMachineApplyContext<'_, S> {
         );
 
         metadata.timestamps.update(self.record_created_at);
-        let invocation_target = metadata.invocation_target.clone();
-        self.storage
-            .put_invocation_status(&invocation_id, &InvocationStatus::Invoked(metadata))
-            .map_err(Error::Storage)?;
 
-        if Configuration::pinned()
-            .common
-            .experimental
-            .is_vqueues_enabled()
-        {
+        if metadata.vqueue_id.is_some() {
             self.vqueue_move_invocation_to_inbox_stage(&invocation_id)
                 .await?;
         } else {
             self.action_collector.push(Action::Invoke {
                 invocation_id,
-                invocation_target,
+                invocation_target: metadata.invocation_target.clone(),
             });
         }
+
+        self.storage
+            .put_invocation_status(&invocation_id, &InvocationStatus::Invoked(metadata))
+            .map_err(Error::Storage)?;
 
         Ok(())
     }
@@ -4687,11 +4657,7 @@ impl<S> StateMachineApplyContext<'_, S> {
 
         metadata.timestamps.update(self.record_created_at);
 
-        if Configuration::pinned()
-            .common
-            .experimental
-            .is_vqueues_enabled()
-        {
+        if metadata.vqueue_id.is_some() {
             let now = UniqueTimestamp::from_unix_millis_unchecked(self.record_created_at);
             let entry_id = EntryId::from(&invocation_id);
             let Some(header) = self
@@ -5404,7 +5370,7 @@ impl<S> StateMachineApplyContext<'_, S> {
 
         let mut vqueue = VQueue::vqueue_from_invocation_target(
             now,
-            service_id.partition_key(),
+            &qid,
             &target,
             self.storage,
             self.vqueues_cache,

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -3269,6 +3269,26 @@ impl<S> StateMachineApplyContext<'_, S> {
         match status {
             InvocationStatus::Scheduled(ScheduledInvocation { metadata, .. })
             | InvocationStatus::Inboxed(InboxedInvocation { metadata, .. }) => {
+                // Validate that if VO, that it's not locked already.
+                let invocation_target = &metadata.invocation_target;
+                if matches!(
+                    invocation_target.invocation_target_ty(),
+                    InvocationTargetType::VirtualObject(VirtualObjectHandlerType::Exclusive)
+                ) {
+                    let keyed_service_id = invocation_target.as_keyed_service_id().expect(
+                        "When the handler type is Exclusive, the invocation target must have a key",
+                    );
+                    // Lock the service in the old status table.
+                    // Obsolete: Remove in lieu of using Locks when service status table is fully migrated to
+                    // locks table.
+                    self.storage
+                        .put_virtual_object_status(
+                            &keyed_service_id,
+                            &VirtualObjectStatus::Locked(invocation_id),
+                        )
+                        .map_err(Error::Storage)?;
+                }
+
                 let (metadata, invocation_input) =
                     InFlightInvocationMetadata::from_pre_flight_invocation_metadata(
                         metadata,

--- a/crates/worker/src/partition/state_machine/tests/idempotency.rs
+++ b/crates/worker/src/partition/state_machine/tests/idempotency.rs
@@ -115,6 +115,8 @@ async fn complete_already_completed_invocation() {
     txn.put_invocation_status(
         &invocation_id,
         &InvocationStatus::Completed(CompletedInvocation {
+            vqueue_id: None,
+            limit_key: LimitKey::None,
             invocation_target: invocation_target.clone(),
             created_using_restate_version: RestateVersion::current(),
             source: Source::Ingress(PartitionProcessorRpcRequestId::new()),


### PR DESCRIPTION

This adds back the "write" path of the code that was removed in #4752. The write path
will be guarded after we have a FSM variable denoting that service_status is no longer
needed.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4774).
* __->__ #4774
* #4768
* #4767
* #4761