### PR TITLE
Gate unscoped idempotent service bucketing on cluster feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,7 @@ jobs:
           # todo remove once we use v1.6 as the LAST_COMPATIBLE_RESTATE_SERVER_VERSION in the e2e tests
           envVars: |
             RESTATE_WORKER__INVOKER__experimental_features_allow_protocol_v6=true
+            RESTATE_disable_controlled_idempotent_sharding=true
 
   e2e-enable-journal-table-v2:
     name: Run E2E tests with Journal Table V2 feature

--- a/crates/core/protobuf/node_ctl_svc.proto
+++ b/crates/core/protobuf/node_ctl_svc.proto
@@ -35,6 +35,11 @@ service NodeCtlSvc {
       returns (TriggerCompactionResponse);
 }
 
+enum ClusterFeature {
+  ClusterFeature_UNKNOWN = 0;
+  CONTROLLED_IDEMPOTENT_SHARDING = 1;
+} 
+
 message ProvisionClusterRequest {
   bool dry_run = 1;
   // if unset then the configured cluster num partitions will be used
@@ -52,6 +57,9 @@ message ProvisionClusterRequest {
   // if unset then the configured cluster default target nodeset size will be
   // used
   optional uint32 target_nodeset_size = 6;
+  // A set of cluster wide enabled 
+  // features.
+  repeated ClusterFeature features = 7;
 }
 
 message ProvisionClusterResponse {

--- a/crates/core/src/protobuf.rs
+++ b/crates/core/src/protobuf.rs
@@ -31,6 +31,8 @@ pub mod cluster_ctrl_svc {
 }
 
 pub mod node_ctl_svc {
+    use enumset::EnumSet;
+    use restate_types::nodes_config;
     use tonic::codec::CompressionEncoding;
     use tonic::transport::Channel;
 
@@ -73,5 +75,59 @@ pub mod node_ctl_svc {
             .accept_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Gzip)
             .send_compressed(DEFAULT_GRPC_COMPRESSION)
+    }
+
+    impl From<ClusterFeature> for nodes_config::ClusterFeature {
+        fn from(value: ClusterFeature) -> Self {
+            match value {
+                ClusterFeature::Unknown => Self::Unknown,
+                ClusterFeature::ControlledIdempotentSharding => Self::ControlledIdempotentSharding,
+            }
+        }
+    }
+
+    impl From<nodes_config::ClusterFeature> for ClusterFeature {
+        fn from(value: nodes_config::ClusterFeature) -> Self {
+            match value {
+                nodes_config::ClusterFeature::Unknown => Self::Unknown,
+                nodes_config::ClusterFeature::ControlledIdempotentSharding => {
+                    Self::ControlledIdempotentSharding
+                }
+            }
+        }
+    }
+
+    /// Converts the wire representation of cluster features (a slice of i32) into an
+    /// [`EnumSet`] of [`nodes_config::ClusterFeature`]. Returns an error if any entry is
+    /// out of range or maps to the `Unknown` sentinel.
+    pub fn cluster_features_from_proto(
+        features: &[i32],
+    ) -> anyhow::Result<EnumSet<nodes_config::ClusterFeature>> {
+        let mut set = EnumSet::empty();
+        for raw in features {
+            let proto_feature = ClusterFeature::try_from(*raw)
+                .map_err(|_| anyhow::anyhow!("unknown cluster feature id {raw}"))?;
+            let feature = nodes_config::ClusterFeature::from(proto_feature);
+            if matches!(feature, nodes_config::ClusterFeature::Unknown) {
+                anyhow::bail!("cluster feature 'unknown' is not a valid selection");
+            }
+            set.insert(feature);
+        }
+        Ok(set)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn cluster_features_from_proto_round_trips_known_features() {
+            let raw = [ClusterFeature::ControlledIdempotentSharding as i32];
+            let parsed = cluster_features_from_proto(&raw).expect("known feature accepted");
+            assert!(parsed.contains(nodes_config::ClusterFeature::ControlledIdempotentSharding));
+
+            assert!(cluster_features_from_proto(&[ClusterFeature::Unknown as i32]).is_err());
+            assert!(cluster_features_from_proto(&[i32::MAX]).is_err());
+        }
     }
 }

--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -59,7 +59,7 @@ use restate_types::logs::metadata::ProviderConfiguration;
 use restate_types::net::address::{
     AdminPort, AdvertisedAddress, FabricPort, HttpIngressPort, ListenerPort, PeerNetAddress,
 };
-use restate_types::nodes_config::MetadataServerState;
+use restate_types::nodes_config::{ClusterFeature, MetadataServerState};
 use restate_types::protobuf::common::MetadataServerStatus;
 use restate_types::replication::ReplicationProperty;
 use restate_types::retries::RetryPolicy;
@@ -855,6 +855,7 @@ impl StartedNode {
         num_partitions: Option<NonZeroU16>,
         partition_replication: ReplicationProperty,
         provider_configuration: Option<ProviderConfiguration>,
+        features: EnumSet<ClusterFeature>,
     ) -> anyhow::Result<bool> {
         let channel = create_tonic_channel(
             self.advertised_address().clone(),
@@ -878,6 +879,10 @@ impl StartedNode {
                     .target_nodeset_size()
                     .map(|nodeset_size| nodeset_size.as_u32())
             }),
+            features: features
+                .iter()
+                .map(|f| restate_core::protobuf::node_ctl_svc::ClusterFeature::from(f) as i32)
+                .collect(),
         };
 
         let retry_policy = RetryPolicy::exponential(

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -19,6 +19,7 @@ mod roles;
 use std::time::Duration;
 
 use anyhow::Context;
+use enumset::EnumSet;
 use prost_dto::IntoProst;
 use std::sync::Arc;
 use tracing::{debug, info, trace, warn};
@@ -57,7 +58,9 @@ use restate_types::logs::metadata::{Logs, LogsConfiguration, ProviderConfigurati
 use restate_types::logs::{self, RecordCache};
 use restate_types::metadata::{GlobalMetadata, Precondition};
 use restate_types::net::listener::AddressBook;
-use restate_types::nodes_config::{ClusterFingerprint, NodeConfig, NodesConfiguration, Role};
+use restate_types::nodes_config::{
+    ClusterFeature, ClusterFingerprint, NodeConfig, NodesConfiguration, Role,
+};
 use restate_types::partition_table::{PartitionReplication, PartitionTable, PartitionTableBuilder};
 use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::protobuf::common::{
@@ -491,6 +494,7 @@ impl Node {
                             &metadata_writer,
                             &common_opts,
                             &cluster_configuration,
+                            ClusterFeature::default_features(),
                         )
                         .await;
 
@@ -713,9 +717,10 @@ async fn provision_cluster_metadata(
     metadata_writer: &MetadataWriter,
     common_opts: &CommonOptions,
     cluster_configuration: &ClusterConfiguration,
+    features: EnumSet<ClusterFeature>,
 ) -> anyhow::Result<bool> {
     let (initial_nodes_configuration, initial_partition_table, initial_logs) =
-        generate_initial_metadata(common_opts, cluster_configuration);
+        generate_initial_metadata(common_opts, cluster_configuration, features);
 
     let result = retry_on_retryable_error(common_opts.network_error_retry_policy.clone(), || {
         metadata_writer
@@ -747,12 +752,16 @@ async fn provision_cluster_metadata(
     Ok(result)
 }
 
-fn create_initial_nodes_configuration(common_opts: &CommonOptions) -> NodesConfiguration {
+fn create_initial_nodes_configuration(
+    common_opts: &CommonOptions,
+    features: EnumSet<ClusterFeature>,
+) -> NodesConfiguration {
     let mut initial_nodes_configuration = NodesConfiguration::new(
         Version::MIN,
         common_opts.cluster_name().to_owned(),
         ClusterFingerprint::generate(),
     );
+    initial_nodes_configuration.set_features(features);
     let my_advertised_address =
         TaskCenter::with_current(|tc| common_opts.advertised_address(tc.address_book()));
 
@@ -776,6 +785,7 @@ fn create_initial_nodes_configuration(common_opts: &CommonOptions) -> NodesConfi
 fn generate_initial_metadata(
     common_opts: &CommonOptions,
     cluster_configuration: &ClusterConfiguration,
+    features: EnumSet<ClusterFeature>,
 ) -> (NodesConfiguration, PartitionTable, Logs) {
     let mut initial_partition_table_builder = PartitionTableBuilder::default();
     initial_partition_table_builder
@@ -789,7 +799,7 @@ fn generate_initial_metadata(
         cluster_configuration.bifrost_provider.clone(),
     ));
 
-    let initial_nodes_configuration = create_initial_nodes_configuration(common_opts);
+    let initial_nodes_configuration = create_initial_nodes_configuration(common_opts, features);
 
     (
         initial_nodes_configuration,

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -485,16 +485,22 @@ impl Node {
                     config.common.cluster_name()
                 );
             } else {
+                let mut default_features = ClusterFeature::default_features();
+                if config.common.disable_controlled_idempotent_sharding {
+                    default_features -= ClusterFeature::ControlledIdempotentSharding
+                }
+
                 TaskCenter::spawn(TaskKind::SystemBoot, "auto-provision-cluster", {
                     let cluster_configuration = ClusterConfiguration::from_configuration(&config);
                     let metadata_writer = metadata_writer.clone();
                     let common_opts = config.common.clone();
+
                     async move {
                         let response = provision_cluster_metadata(
                             &metadata_writer,
                             &common_opts,
                             &cluster_configuration,
-                            ClusterFeature::default_features(),
+                            default_features,
                         )
                         .await;
 
@@ -536,6 +542,16 @@ impl Node {
         .await
             .context("Giving up trying to initialize the node. Make sure that it can reach the metadata store and don't forget to provision the cluster on a fresh start")?
             .context("Failed initializing the node")?;
+
+        if metadata
+            .nodes_config_ref()
+            .features()
+            .contains(ClusterFeature::ControlledIdempotentSharding)
+        {
+            restate_types::identifiers::enable_controlled_idempotent_sharding();
+        } else {
+            debug!("Feature `controlled-idempotent-sharding` is disabled");
+        }
 
         self.failure_detector
             .start(self.updateable_config.clone().map(|c| &c.common.gossip))?;

--- a/crates/node/src/network_server/grpc_svc_handler.rs
+++ b/crates/node/src/network_server/grpc_svc_handler.rs
@@ -31,6 +31,7 @@ use restate_core::protobuf::node_ctl_svc::{
     ClusterHealthResponse, DatabaseCompactionResult, EmbeddedMetadataClusterHealth,
     GetMetadataRequest, GetMetadataResponse, IdentResponse, ProvisionClusterRequest,
     ProvisionClusterResponse, TriggerCompactionRequest, TriggerCompactionResponse,
+    cluster_features_from_proto,
 };
 use restate_core::{Identification, MetadataWriter};
 use restate_core::{Metadata, MetadataKind};
@@ -170,6 +171,8 @@ impl NodeCtlSvc for NodeCtlSvcHandler {
         let config = Configuration::pinned();
 
         let dry_run = request.dry_run;
+        let features = cluster_features_from_proto(&request.features)
+            .map_err(|err| Status::invalid_argument(err.to_string()))?;
         let cluster_configuration = Self::resolve_cluster_configuration(&config, request)
             .map_err(|err| Status::invalid_argument(err.to_string()))?;
 
@@ -183,6 +186,7 @@ impl NodeCtlSvc for NodeCtlSvcHandler {
             &self.metadata_writer,
             &config.common,
             &cluster_configuration,
+            features,
         )
         .await
         .map_err(|err| Status::internal(err.to_string()))?;

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -484,6 +484,16 @@ pub struct CommonOptions {
 
     #[serde(flatten)]
     pub experimental: Experimental,
+
+    /// # Explicitly disable the `controlled-idempotent-sharding`
+    ///
+    /// TODO: Removed in Restate v1.8. This is a stopgap solution to
+    /// fix e2e forward compatibility tests.
+    ///
+    /// Since v1.7
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    #[cfg_attr(feature = "schemars", schemars(skip))]
+    pub disable_controlled_idempotent_sharding: bool,
 }
 
 /// Declares the [`Experimental`] feature-flag struct from a list of feature names.
@@ -825,6 +835,7 @@ impl Default for CommonOptions {
             gossip: GossipOptions::default(),
             hlc_max_drift: FriendlyDuration::from_millis(5000),
             experimental: Experimental::default(),
+            disable_controlled_idempotent_sharding: false,
         }
     }
 }

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -145,12 +145,22 @@ pub type EntryIndex = u32;
 
 /// Returns the partition key computed from either the service_key, or idempotency_key, if possible
 fn deterministic_partition_key(
+    service_name: &str,
     service_key: Option<&str>,
     idempotency_key: Option<&str>,
 ) -> Option<PartitionKey> {
     service_key
         .map(partitioner::HashPartitioner::compute_partition_key)
-        .or_else(|| idempotency_key.map(partitioner::HashPartitioner::compute_partition_key))
+        .or_else(|| {
+            idempotency_key.map(|idempotency_key| {
+                // todo: replace this with a flag.
+                if true {
+                    partitioner::HashPartitioner::compute_partition_key(idempotency_key)
+                } else {
+                    unscoped_idempotent_service_partition_key(service_name, idempotency_key)
+                }
+            })
+        })
 }
 
 /// Number of partition keys each unscoped service can spread over.
@@ -159,6 +169,11 @@ fn deterministic_partition_key(
 /// pick one key out of a bounded, service-specific set.
 ///
 /// This can be configurable in the future and it wouldn't affect correctness if users want to change it.
+///
+/// NOTE: This same constant is also used by unscoped idempotent services, where its value is
+/// effectively immutable: changing it would re-shard idempotent invocations onto different
+/// partitions and break deduplication. If you ever need to tune the scatter width for
+/// non-idempotent services only, split this into two separate constants first.
 const UNSCOPED_SERVICE_PARTITION_KEY_FANOUT: u8 = 255;
 
 /// Computes one of the deterministic partition keys assigned to an unscoped service.
@@ -187,6 +202,18 @@ fn random_unscoped_service_partition_key(service_name: &str) -> PartitionKey {
     let bucket = rand::rng().random_range(0..UNSCOPED_SERVICE_PARTITION_KEY_FANOUT);
     unscoped_service_partition_key(service_name, bucket)
 }
+
+fn unscoped_idempotent_service_partition_key(
+    service_name: &str,
+    idempotency_key: &str,
+) -> PartitionKey {
+    let intermittent_key = partitioner::HashPartitioner::compute_partition_key(idempotency_key);
+    let bucket = intermittent_key % UNSCOPED_SERVICE_PARTITION_KEY_FANOUT as u64;
+
+    debug_assert!(bucket < UNSCOPED_SERVICE_PARTITION_KEY_FANOUT as u64);
+    unscoped_service_partition_key(service_name, bucket as u8)
+}
+
 /// A family of resource identifiers that tracks the timestamp of its creation.
 pub trait TimestampAwareId {
     /// The timestamp when this ID was created.
@@ -535,6 +562,7 @@ impl InvocationId {
             // --- Partition key generation
             // Either try to generate the deterministic partition key, if possible
             deterministic_partition_key(
+                invocation_target.service_name(),
                 invocation_target.key().map(|bs| bs.as_ref()),
                 idempotency_key,
             )
@@ -736,6 +764,7 @@ impl IdempotencyId {
             .map(|s| s.partition_key())
             .or_else(|| {
                 deterministic_partition_key(
+                    &service_name,
                     service_key.as_ref().map(|bs| bs.as_ref()),
                     Some(&idempotency_key),
                 )

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -21,6 +21,7 @@ use std::hash::Hash;
 use std::mem::size_of;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use base64::Engine;
 use bytes::Bytes;
@@ -153,8 +154,7 @@ fn deterministic_partition_key(
         .map(partitioner::HashPartitioner::compute_partition_key)
         .or_else(|| {
             idempotency_key.map(|idempotency_key| {
-                // todo: replace this with a flag.
-                if true {
+                if !is_controlled_idempotent_sharding_enabled() {
                     partitioner::HashPartitioner::compute_partition_key(idempotency_key)
                 } else {
                     unscoped_idempotent_service_partition_key(service_name, idempotency_key)
@@ -175,6 +175,16 @@ fn deterministic_partition_key(
 /// partitions and break deduplication. If you ever need to tune the scatter width for
 /// non-idempotent services only, split this into two separate constants first.
 const UNSCOPED_SERVICE_PARTITION_KEY_FANOUT: u8 = 255;
+
+static CONTROLLED_IDEMPOTENT_SHARDING: AtomicBool = AtomicBool::new(false);
+
+fn is_controlled_idempotent_sharding_enabled() -> bool {
+    CONTROLLED_IDEMPOTENT_SHARDING.load(Ordering::Relaxed)
+}
+
+pub fn enable_controlled_idempotent_sharding() {
+    CONTROLLED_IDEMPOTENT_SHARDING.store(true, Ordering::Relaxed)
+}
 
 /// Computes one of the deterministic partition keys assigned to an unscoped service.
 ///

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -145,6 +145,43 @@ pub enum Role {
     MetadataServer,
 }
 
+#[derive(
+    Debug, Hash, EnumSetType, Ord, PartialOrd, strum::Display, serde::Serialize, serde::Deserialize,
+)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[enumset(serialize_repr = "list")]
+#[serde(rename_all = "kebab-case")]
+#[strum(serialize_all = "kebab-case")]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[cfg_attr(feature = "clap", clap(rename_all = "kebab-case"))]
+pub enum ClusterFeature {
+    #[cfg_attr(feature = "clap", clap(skip))]
+    Unknown,
+    /// Confines idempotent invocations on unscoped services to a bounded, per-service
+    /// set of partition-key buckets instead of hashing the idempotency key over the
+    /// full partition-key space.
+    ///
+    /// When disabled, the partition key for an idempotent invocation is derived by
+    /// hashing the idempotency key directly, spreading invocations across all
+    /// partitions. When enabled, each unscoped service is assigned a deterministic
+    /// set of partition-key buckets, and an idempotent invocation is routed to
+    /// one bucket selected by its idempotency key — colocating a service's
+    /// idempotent traffic on a small, predictable subset of partitions.
+    ///
+    /// This is a one-way, cluster-wide decision: once idempotent invocations have
+    /// been accepted under a given sharding scheme, switching schemes would
+    /// re-shard them onto different partitions and break deduplication. For that
+    /// reason this flag is persisted in [`NodesConfiguration`] at provisioning
+    /// time and cannot be toggled afterward.
+    ControlledIdempotentSharding,
+}
+
+impl ClusterFeature {
+    pub fn default_features() -> EnumSet<Self> {
+        enumset::enum_set!(Self::ControlledIdempotentSharding)
+    }
+}
+
 #[serde_as]
 #[derive(derive_more::Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct NodesConfiguration {
@@ -162,6 +199,10 @@ pub struct NodesConfiguration {
     // The last modification time.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     modified_at: Option<UniqueTimestamp>,
+    // A set of enabled cluster wide features.
+    // Those features can be only enabled during cluster provisioning
+    #[serde(default)]
+    features: EnumSet<ClusterFeature>,
 }
 
 impl Default for NodesConfiguration {
@@ -173,6 +214,7 @@ impl Default for NodesConfiguration {
             nodes: Default::default(),
             name_lookup: Default::default(),
             modified_at: None,
+            features: EnumSet::empty(),
         }
     }
 }
@@ -270,6 +312,7 @@ impl NodesConfiguration {
             modified_at: Some(UniqueTimestamp::from_unix_millis_unchecked(
                 WallClock::now_ms(),
             )),
+            features: EnumSet::empty(),
         }
     }
 
@@ -284,6 +327,7 @@ impl NodesConfiguration {
             modified_at: Some(UniqueTimestamp::from_unix_millis_unchecked(
                 WallClock::now_ms(),
             )),
+            features: EnumSet::empty(),
         }
     }
 
@@ -308,6 +352,14 @@ impl NodesConfiguration {
 
     pub fn cluster_name(&self) -> &str {
         &self.cluster_name
+    }
+
+    pub fn features(&self) -> EnumSet<ClusterFeature> {
+        self.features
+    }
+
+    pub fn set_features(&mut self, features: EnumSet<ClusterFeature>) {
+        self.features |= features;
     }
 
     pub fn increment_version(&mut self) {

--- a/release-notes/unreleased/restatectl-provision-features.md
+++ b/release-notes/unreleased/restatectl-provision-features.md
@@ -1,0 +1,52 @@
+# Release Notes: `restatectl provision --disable-feature`
+
+## New Feature
+
+### What Changed
+
+`restatectl provision` now enables all available cluster-wide features by
+default at bootstrap time. Operators can opt out of specific features with the
+new `--disable-feature` flag. The resulting feature set is persisted in
+`NodesConfiguration` and cannot be changed after provisioning.
+
+```bash
+# Provision with all default features enabled (default behavior)
+restatectl provision
+
+# Explicitly opt out of a feature
+restatectl provision --disable-feature controlled-idempotent-sharding
+# or comma-separated / repeated
+restatectl provision --disable-feature controlled-idempotent-sharding,other-feature
+```
+
+The dry-run preview lists the features that will be enabled, as well as any
+features explicitly disabled via the flag.
+
+### Impact on Users
+
+- Existing deployments: no change. Clusters that were provisioned before this
+  release continue to behave exactly as before — their feature set is frozen
+  in `NodesConfiguration` at the version they were provisioned with.
+- New deployments: all default features are enabled out of the box. Pass
+  `--disable-feature` only if you need to opt out of a specific feature.
+
+### Migration Guidance
+
+None — the flag is optional. Use it only if you need to disable a feature that
+is on by default.
+
+The current set of features enabled by default:
+
+- `controlled-idempotent-sharding` — changes how idempotent invocations
+  on unscoped services map to partition keys. Without the feature, the
+  partition key is derived by hashing the idempotency key directly, spreading
+  invocations across the full partition-key space. With the feature enabled,
+  each unscoped service has a bounded, deterministic set of 255 partition-key
+  buckets, and an idempotent invocation is routed to one of those buckets
+  based on its idempotency key.
+
+  This is a one-way decision: once a cluster has accepted idempotent
+  invocations under a given sharding scheme, changing the scheme would
+  re-shard those invocations onto different partitions and break
+  deduplication. That is why the feature set is persisted in
+  `NodesConfiguration` and cannot be toggled after provisioning.

--- a/server/tests/cluster.rs
+++ b/server/tests/cluster.rs
@@ -82,6 +82,7 @@ async fn replicated_loglet() -> googletest::Result<()> {
             None,
             ReplicationProperty::new_unchecked(3),
             Some(ProviderConfiguration::Replicated(replicated_loglet_config)),
+            EnumSet::empty(),
         )
         .await
         .into_test_result()?;
@@ -135,6 +136,7 @@ async fn cluster_chaos_test() -> googletest::Result<()> {
             None,
             ReplicationProperty::new_unchecked(3),
             Some(ProviderConfiguration::Replicated(replicated_loglet_config)),
+            EnumSet::empty(),
         )
         .await
         .into_test_result()?;

--- a/server/tests/trim_gap_handling.rs
+++ b/server/tests/trim_gap_handling.rs
@@ -93,6 +93,7 @@ async fn fast_forward_over_trim_gap() -> googletest::Result<()> {
             None,
             ReplicationProperty::new_unchecked(1),
             Some(ProviderConfiguration::Replicated(replicated_loglet_config)),
+            EnumSet::empty(),
         )
         .await
         .into_test_result()?;

--- a/tools/restatectl/src/commands/provision.rs
+++ b/tools/restatectl/src/commands/provision.rs
@@ -16,8 +16,11 @@ use tonic::Code;
 
 use restate_cli_util::ui::console::confirm_or_exit;
 use restate_cli_util::{CliContext, c_error, c_println, c_warn};
-use restate_core::protobuf::node_ctl_svc::{ProvisionClusterRequest, new_node_ctl_client};
+use restate_core::protobuf::node_ctl_svc::{
+    ClusterFeature as ProtoClusterFeature, ProvisionClusterRequest, new_node_ctl_client,
+};
 use restate_types::logs::metadata::{ProviderConfiguration, ProviderKind};
+use restate_types::nodes_config::ClusterFeature;
 use restate_types::replication::ReplicationProperty;
 
 use crate::commands::config::cluster_config_string;
@@ -54,6 +57,15 @@ pub struct ProvisionOpts {
     /// It's recommended to leave it unset (defaults to 0)
     #[clap(long)]
     log_default_nodeset_size: Option<u16>,
+
+    /// Cluster-wide features to disable. All available features are enabled by
+    /// default at provision time; pass this flag to explicitly opt out of one or
+    /// more of them. Can only be set at provision time.
+    ///
+    /// Accepts comma-separated values or repeated flags
+    /// (e.g. `--disable-feature a,b` or `--disable-feature a --disable-feature b`).
+    #[clap(long = "disable-feature", value_delimiter = ',', num_args = 1..)]
+    disable_features: Vec<ClusterFeature>,
 }
 
 async fn provision_cluster(
@@ -90,6 +102,17 @@ async fn provision_cluster(
         .or_else(|| provision_opts.replication.clone())
         .map(Into::into);
 
+    let enabled_features: Vec<ClusterFeature> = ClusterFeature::default_features()
+        .iter()
+        .filter(|f| !provision_opts.disable_features.contains(f))
+        .collect();
+
+    let features: Vec<i32> = enabled_features
+        .iter()
+        .copied()
+        .map(|f| ProtoClusterFeature::from(f) as i32)
+        .collect();
+
     let request = ProvisionClusterRequest {
         dry_run: true,
         num_partitions: provision_opts.num_partitions.map(u32::from),
@@ -99,6 +122,7 @@ async fn provision_cluster(
             .map(|provider| provider.to_string()),
         log_replication,
         target_nodeset_size: provision_opts.log_default_nodeset_size.map(Into::into),
+        features: features.clone(),
     };
 
     let response = match client.provision_cluster(request).await {
@@ -121,6 +145,20 @@ async fn provision_cluster(
         "{}",
         cluster_config_string(&cluster_configuration_to_provision)?
     );
+
+    if !enabled_features.is_empty() {
+        c_println!("Features to enable:");
+        for f in &enabled_features {
+            c_println!("  - {f}");
+        }
+    }
+
+    if !provision_opts.disable_features.is_empty() {
+        c_println!("Features explicitly disabled:");
+        for f in &provision_opts.disable_features {
+            c_println!("  - {f}");
+        }
+    }
 
     if let Some(default_provider) = &cluster_configuration_to_provision.bifrost_provider {
         let default_provider = ProviderConfiguration::try_from(default_provider.clone())?;
@@ -163,6 +201,7 @@ async fn provision_cluster(
         log_provider,
         log_replication,
         target_nodeset_size,
+        features,
     };
 
     match client.provision_cluster(request).await {


### PR DESCRIPTION
Gate unscoped idempotent service bucketing on cluster feature

Replaces the placeholder `if true` branch in `deterministic_partition_key`
with a global atomic flag, flipped on at startup when the freshly-loaded
NodesConfiguration carries the `UnscopedIdempotentServiceBucketing`
feature. When the feature is on, idempotent invocations for unscoped
services are routed through the per-service fanout set introduced in
previous commit; otherwise the legacy raw-hash behavior is preserved.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4776).
* __->__ #4776
* #4775
* #4766