### PR TITLE
[Restate UI] Update to v0.1.62

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8699,8 +8699,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.61"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.61#b006889b9730de223406142bd5eee8d3e793b181"
+version = "0.1.62"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.62#4f09f124cc00ed5083e65a69cfd94eb09dd1934a"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -39,7 +39,7 @@ restate-util-time = { workspace = true }
 restate-types = { workspace = true }
 restate-util-string = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.61", tag = "v0.1.61" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.62", tag = "v0.1.62" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.62
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.62/ui-v0.1.62.zip