### PR TITLE
Expose applied rule-book and schema versions on partition state

### DIFF
--- a/crates/storage-query-datafusion/src/partition_state/row.rs
+++ b/crates/storage-query-datafusion/src/partition_state/row.rs
@@ -58,4 +58,12 @@ pub(crate) fn append_partition_row(
     if let Some(lsn) = state.target_tail_lsn {
         row.target_tail_lsn(lsn.into());
     }
+
+    if let Some(version) = state.last_applied_rule_book_version {
+        row.applied_rule_book_version(u32::from(version));
+    }
+
+    if let Some(version) = state.last_applied_schema_version {
+        row.applied_schema_version(u32::from(version));
+    }
 }

--- a/crates/storage-query-datafusion/src/partition_state/schema.rs
+++ b/crates/storage-query-datafusion/src/partition_state/schema.rs
@@ -56,5 +56,11 @@ define_table!(
 
         /// Target tail LSN
         target_tail_lsn: DataType::UInt64,
+
+        /// Version of the rule book currently applied by the partition processor
+        applied_rule_book_version: DataType::UInt32,
+
+        /// Version of the schema currently applied by the partition processor
+        applied_schema_version: DataType::UInt32,
     )
 );

--- a/crates/types/protobuf/restate/cluster.proto
+++ b/crates/types/protobuf/restate/cluster.proto
@@ -72,6 +72,8 @@ message PartitionProcessorStatus {
   optional restate.common.Lsn last_archived_log_lsn = 12;
   // Set if replay_status is CATCHING_UP
   optional restate.common.Lsn target_tail_lsn = 11;
+  optional restate.common.Version last_applied_rule_book_version = 13;
+  optional restate.common.Version last_applied_schema_version = 14;
 }
 
 message ReplicationProperty { string replication_property = 1; }

--- a/crates/types/src/cluster/cluster_state.rs
+++ b/crates/types/src/cluster/cluster_state.rs
@@ -206,6 +206,15 @@ pub struct PartitionProcessorStatus {
     // Set if replay_status is CatchingUp
     #[bilrost(12)]
     pub target_tail_lsn: Option<Lsn>,
+    /// Version of the rule book currently applied by the partition processor.
+    /// `None` until the first rule book is observed (i.e. while the state
+    /// machine still holds `RuleBook::default()` at `Version::INVALID`).
+    #[bilrost(13)]
+    pub last_applied_rule_book_version: Option<Version>,
+    /// Version of the schema currently applied by the partition processor.
+    /// `None` until the first schema is observed.
+    #[bilrost(14)]
+    pub last_applied_schema_version: Option<Version>,
 }
 
 impl Default for PartitionProcessorStatus {
@@ -223,6 +232,8 @@ impl Default for PartitionProcessorStatus {
             durable_lsn: None,
             last_archived_log_lsn: None,
             target_tail_lsn: None,
+            last_applied_rule_book_version: None,
+            last_applied_schema_version: None,
         }
     }
 }

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -79,7 +79,7 @@ use restate_types::retries::{RetryPolicy, with_jitter};
 use restate_types::schema::Schema;
 use restate_types::storage::StorageDecodeError;
 use restate_types::time::{MillisSinceEpoch, NanosSinceEpoch};
-use restate_types::{GenerationalNodeId, SemanticRestateVersion, Version};
+use restate_types::{GenerationalNodeId, SemanticRestateVersion, Version, Versioned};
 use restate_util_string::{ReString, ToReString};
 use restate_util_time::DurationExt;
 use restate_vqueues::{VQueuesMeta, VQueuesMetaCache};
@@ -631,6 +631,11 @@ where
                             durable_lsn,
                         );
                     }
+                    let rule_book_version = self.state_machine.rule_book.version();
+                    self.status.last_applied_rule_book_version =
+                        (rule_book_version >= Version::MIN).then_some(rule_book_version);
+                    self.status.last_applied_schema_version =
+                        self.state_machine.schema.as_ref().map(Versioned::version);
                     self.status_watch_tx.send_modify(|old| {
                         old.clone_from(&self.status);
                         old.updated_at = MillisSinceEpoch::now();

--- a/release-notes/unreleased/partition-state-applied-versions.md
+++ b/release-notes/unreleased/partition-state-applied-versions.md
@@ -1,0 +1,17 @@
+# Release Notes: Expose applied rule-book and schema versions on `partition_state`
+
+## New Feature
+
+### What Changed
+`partition_state` now exposes two additional columns:
+
+- `applied_rule_book_version` — the rule-book version currently applied by the
+  partition processor (set once the first `UpsertRuleBook` command has been
+  observed).
+- `applied_schema_version` — the schema version currently applied by the
+  partition processor.
+
+The same two columns are also surfaced as `RULE-BOOK` and `SCHEMA` in
+`restatectl partition list`. Internally, the values flow through new
+`last_applied_rule_book_version` and `last_applied_schema_version` fields on
+`PartitionProcessorStatus`.

--- a/tools/restatectl/src/commands/partition/list.rs
+++ b/tools/restatectl/src/commands/partition/list.rs
@@ -110,7 +110,17 @@ pub async fn list_partitions(
     // Show information organized by partition and node
     let mut partitions_table = Table::new_styled();
     partitions_table.set_styled_header(vec![
-        "ID", "NODE", "MODE", "STATUS", "EPOCH", "APPLIED", "DURABLE", "ARCHIVED", "LSN-LAG",
+        "ID",
+        "NODE",
+        "MODE",
+        "STATUS",
+        "EPOCH",
+        "APPLIED",
+        "DURABLE",
+        "ARCHIVED",
+        "LSN-LAG",
+        "SCHEMA",
+        "RULE-BOOK",
         "UPDATED",
     ]);
 
@@ -211,6 +221,20 @@ pub async fn list_partitions(
                             // (tail - 1) - applied_lsn = tail - (applied_lsn + 1)
                             tail.value.saturating_sub(applied.value + 1).to_string()
                         })
+                        .unwrap_or_else(|| "-".to_owned()),
+                ),
+                Cell::new(
+                    processor
+                        .status
+                        .last_applied_schema_version
+                        .map(|v| Version::from(v).to_string())
+                        .unwrap_or_else(|| "-".to_owned()),
+                ),
+                Cell::new(
+                    processor
+                        .status
+                        .last_applied_rule_book_version
+                        .map(|v| Version::from(v).to_string())
                         .unwrap_or_else(|| "-".to_owned()),
                 ),
                 render_as_duration(processor.status.updated_at, Tense::Past),


### PR DESCRIPTION
Add last_applied_rule_book_version and last_applied_schema_version to PartitionProcessorStatus so the rule-book and schema versions currently held by each partition processor can be observed without inspecting node logs. Surface them as the applied_rule_book_version and applied_schema_version columns on the partition_state SQL table, and as SCHEMA and RULE-BOOK columns in restatectl partition list.