### PR TITLE
Auto inject a random idempotency key for unscoped services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7559,6 +7559,7 @@ dependencies = [
  "bytestring",
  "chrono",
  "codederror",
+ "enumset",
  "futures",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -7591,6 +7592,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-test",
+ "ulid",
  "url",
  "urlencoding",
 ]

--- a/crates/ingress-http/Cargo.toml
+++ b/crates/ingress-http/Cargo.toml
@@ -26,6 +26,7 @@ bytes = { workspace = true }
 bytestring = { workspace = true }
 chrono = { workspace = true }
 codederror = { workspace = true }
+enumset = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 http-body = { workspace = true }
@@ -47,6 +48,7 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 tower = { workspace = true, features = ["util"] }
 tower-http = { workspace = true, features = ["cors", "normalize-path", "trace", "limit"] }
+ulid = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }
 

--- a/crates/ingress-http/src/handler/mod.rs
+++ b/crates/ingress-http/src/handler/mod.rs
@@ -25,6 +25,7 @@ use std::convert::Infallible;
 use std::task::{Context, Poll};
 
 use bytestring::ByteString;
+use enumset::EnumSet;
 use error::HandlerError;
 use futures::FutureExt;
 use futures::future::BoxFuture;
@@ -33,11 +34,13 @@ use hyper::http::HeaderValue;
 use hyper::{Request, Response};
 use serde::Deserialize;
 
+use restate_core::Metadata;
 use restate_types::Scope;
 use restate_types::errors::GenericError;
 use restate_types::identifiers::{IdempotencyId, ServiceId};
 use restate_types::invocation::InvocationQuery;
 use restate_types::live::Live;
+use restate_types::nodes_config::ClusterFeature;
 use restate_types::schema::invocation_target::InvocationTargetResolver;
 use restate_types::schema::service::ServiceMetadataResolver;
 use restate_util_string::{ReString, RestrictedValue};
@@ -72,13 +75,17 @@ enum RequestType {
 pub(crate) struct Handler<Schemas, Dispatcher> {
     schemas: Live<Schemas>,
     dispatcher: Dispatcher,
+    cluster_features: EnumSet<ClusterFeature>,
 }
 
 impl<Schemas, Dispatcher> Handler<Schemas, Dispatcher> {
     pub(crate) fn new(schemas: Live<Schemas>, dispatcher: Dispatcher) -> Self {
+        let cluster_features = Metadata::with_current(|m| m.nodes_config_ref().features());
+
         Self {
             schemas,
             dispatcher,
+            cluster_features,
         }
     }
 }

--- a/crates/ingress-http/src/handler/service_handler.rs
+++ b/crates/ingress-http/src/handler/service_handler.rs
@@ -20,6 +20,7 @@ use serde::de::IntoDeserializer;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use tracing::{Instrument, debug, trace, trace_span};
+use ulid::Ulid;
 
 use restate_types::Scope;
 use restate_types::config::Configuration;
@@ -30,6 +31,7 @@ use restate_types::invocation::{
     SpanRelation, WorkflowHandlerType,
 };
 use restate_types::limit_key::LimitKey;
+use restate_types::nodes_config::ClusterFeature;
 use restate_types::schema::invocation_target::{
     DeploymentStatus, InvocationTargetMetadata, InvocationTargetResolver,
 };
@@ -118,12 +120,27 @@ where
         }
 
         // Check if Idempotency-Key is available
-        let idempotency_key = parse_idempotency(req.headers())?;
+        let mut idempotency_key = parse_idempotency(req.headers())?;
         if idempotency_key.is_some()
             && invocation_target_meta.target_ty
                 == InvocationTargetType::Workflow(WorkflowHandlerType::Workflow)
         {
             return Err(HandlerError::UnsupportedIdempotencyKey);
+        }
+
+        // Inject a new random idempotency key for
+        // calls that have no idempotency keys only
+        // if the `controlled-idempotent-sharding` is enabled.
+        if self
+            .cluster_features
+            .contains(ClusterFeature::ControlledIdempotentSharding)
+            && matches!(
+                invocation_target_meta.target_ty,
+                InvocationTargetType::Service | InvocationTargetType::VirtualObject(_)
+            )
+            && idempotency_key.is_none()
+        {
+            idempotency_key = Some(Ulid::new().to_string().into());
         }
 
         // Compute retention values

--- a/release-notes/unreleased/ingress-auto-idempotency-key.md
+++ b/release-notes/unreleased/ingress-auto-idempotency-key.md
@@ -1,0 +1,57 @@
+# Release Notes: Auto-inject idempotency key for service and virtual object calls
+
+## Behavioral Change
+
+### What Changed
+
+When the `controlled-idempotent-sharding` cluster feature is enabled, the HTTP
+ingress now automatically generates a random idempotency key for
+calls to services (`InvocationTargetType::Service`) and virtual objects
+(`InvocationTargetType::VirtualObject`) that do not already carry an
+`Idempotency-Key` header. This applies regardless of whether the call targets
+a specific scope. Calls that already provide an idempotency key, and calls to
+workflows, are left untouched.
+
+### Why This Matters
+
+The primary motivation is safe, transparent retries at the ingress. With an
+idempotency key attached to every request, the ingress can unconditionally
+retry an in-flight invocation whenever its connection to the target partition
+processor is lost or the partition leader changes, without risking duplicate
+execution: the partition processor will deduplicate on the idempotency key
+so the caller still observes exactly-once semantics.
+
+This is made practical by the `controlled-idempotent-sharding` feature, which
+caps the number of distinct vqueues an idempotent invocation can land on for
+a given service. It does so by routing the invocation to one of a bounded,
+deterministic set of 256 partition-key buckets per service (see
+[[restatectl-provision-features]]); because a vqueue is keyed by partition
+key together with service identity, capping the buckets caps the vqueues.
+Without that bound, blanket key injection would spawn a fresh vqueue per
+request and overwhelm the scheduler's per-vqueue accounting, which assumes a
+manageable number of vqueues per service.
+
+Because the injected key is freshly randomized per request, no
+cross-request deduplication is introduced — only retries of the same
+in-flight request are collapsed.
+
+### Impact on Users
+
+- **Clusters with `controlled-idempotent-sharding` enabled** (the default
+  for newly provisioned clusters): service and virtual object calls without
+  an `Idempotency-Key` header are now treated as idempotent invocations with
+  a server-generated key. They will be routed to one of the 256 controlled
+  buckets for the target rather than spread across the full partition-key
+  space. Invocation metadata is retained according to the
+  idempotent-invocation retention policy.
+- **Clusters with `controlled-idempotent-sharding` disabled**: no change.
+- **Workflows**: no change.
+- **Callers that already send an `Idempotency-Key` header**: no change.
+
+### Migration Guidance
+
+None required. Callers do not need to change anything. Operators who do not
+want this behavior can opt out at provisioning time with
+`restatectl provision --disable-feature controlled-idempotent-sharding`
+(see [[restatectl-provision-features]]). For now, the feature set is frozen
+in `NodesConfiguration` at provisioning time and cannot be toggled later. 


### PR DESCRIPTION
Auto inject a random idempotency key for unscoped services

Summary:
Automatically inject a random idempotency key for unscoped services
(that has no idempotency key) iff the controlled-idempotent-sharding
is enabled
