### PR TITLE
Gate EnableVqueues on partitions with no in-flight data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,24 +145,6 @@ jobs:
       restateCommit: ${{ github.event.pull_request.head.sha || github.sha }}
       serviceImage: "ghcr.io/restatedev/test-services-java:main"
 
-  sdk-java-journal-table-v2:
-    name: Run SDK-Java integration tests with Journal Table v2
-    permissions:
-      contents: read
-      issues: read
-      checks: write
-      pull-requests: write
-      actions: read
-    secrets: inherit
-    needs: docker
-    uses: restatedev/sdk-java/.github/workflows/integration.yaml@main
-    with:
-      restateCommit: ${{ github.event.pull_request.head.sha || github.sha }}
-      serviceImage: "ghcr.io/restatedev/test-services-java:main"
-      testArtifactOutput: sdk-java-integration-journal-table-v2-test-report
-      envVars: |
-        RESTATE_INTERNAL_STATE_MACHINE_FEATURES=EnableJournalV2
-
   sdk-java-vqueues:
     name: Vqueues Run SDK-Java integration tests
     # for the time being we don't expect all tests to pass
@@ -324,55 +306,6 @@ jobs:
           envVars: |
             RESTATE_WORKER__INVOKER__experimental_features_allow_protocol_v6=true
             RESTATE_disable_controlled_idempotent_sharding=true
-
-  e2e-enable-journal-table-v2:
-    name: Run E2E tests with Journal Table V2 feature
-    runs-on: warp-ubuntu-latest-x64-4x
-    permissions:
-      contents: read
-      issues: read
-      checks: write
-      pull-requests: write
-      actions: read
-    needs: docker
-    steps:
-      - name: Set up Docker containerd snapshotter
-        uses: docker/setup-docker-action@v4
-        with:
-          version: "v28.5.2"
-          set-host: true
-          daemon-config: |
-            {
-              "features": {
-                "containerd-snapshotter": true
-              }
-            }
-
-      ### Download the Restate container image, if needed
-      - name: Download restate snapshot from in-progress workflow
-        uses: actions/download-artifact@v4
-        with:
-          name: restate.tar
-      - name: Install restate snapshot
-        run: |
-          output=$(docker load --input restate.tar | head -n 1)
-          docker tag "${output#*: }" "localhost/restatedev/restate-commit-download:latest"
-          docker image ls -a
-
-      ### Run e2e tests
-      - name: Run E2E tests
-        uses: restatedev/e2e/e2e-tests@main
-        with:
-          testArtifactOutput: e2e-journal-table-v2-test-report
-          restateContainerImage: localhost/restatedev/restate-commit-download:latest
-          envVars: |
-            RESTATE_INTERNAL_STATE_MACHINE_FEATURES=EnableJournalV2
-          # Ignore forward compatibility tests as long as the previous version is not at least v1.6.0-dev. Otherwise,
-          # the previous version will hang at applying the version barrier with version 1.6.0-dev.
-          exclusions: |
-            exclusions:
-              "versionCompat":
-                - "dev.restate.sdktesting.tests.ForwardCompatibilityTest.*"
 
   e2e-vqueues:
     name: Run E2E tests with vqueues

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
       serviceImage: "ghcr.io/restatedev/test-services-java:main"
       testArtifactOutput: sdk-java-integration-journal-table-v2-test-report
       envVars: |
-        RESTATE_INTERNAL_FORCE_MIN_RESTATE_VERSION=1.6.0-dev
+        RESTATE_INTERNAL_STATE_MACHINE_FEATURES=EnableJournalV2
 
   sdk-java-vqueues:
     name: Vqueues Run SDK-Java integration tests
@@ -366,7 +366,7 @@ jobs:
           testArtifactOutput: e2e-journal-table-v2-test-report
           restateContainerImage: localhost/restatedev/restate-commit-download:latest
           envVars: |
-            RESTATE_INTERNAL_FORCE_MIN_RESTATE_VERSION=1.6.0-dev
+            RESTATE_INTERNAL_STATE_MACHINE_FEATURES=EnableJournalV2
           # Ignore forward compatibility tests as long as the previous version is not at least v1.6.0-dev. Otherwise,
           # the previous version will hang at applying the version barrier with version 1.6.0-dev.
           exclusions: |

--- a/crates/partition-store/src/inbox_table/mod.rs
+++ b/crates/partition-store/src/inbox_table/mod.rs
@@ -42,6 +42,13 @@ define_table_key!(
     )
 );
 
+fn any_inbox_entry_in_range<S: StorageAccess>(storage: &mut S, range: KeyRange) -> Result<bool> {
+    storage.get_first_blocking(
+        TableScan::FullScanPartitionKeyRange::<InboxKey>(range),
+        |kv| Ok(kv.is_some()),
+    )
+}
+
 fn peek_inbox<S: StorageAccess>(
     storage: &mut S,
     service_id: &ServiceId,
@@ -97,6 +104,10 @@ impl ReadInboxTable for PartitionStore {
         self.assert_partition_key(service_id)?;
         inbox(self, service_id)
     }
+
+    async fn any_inbox_entry_in_range(&mut self, range: KeyRange) -> Result<bool> {
+        any_inbox_entry_in_range(self, range)
+    }
 }
 
 impl ScanInboxTable for PartitionStore {
@@ -141,6 +152,10 @@ impl ReadInboxTable for PartitionStoreTransaction<'_> {
     ) -> Result<impl Stream<Item = Result<SequenceNumberInboxEntry>> + Send> {
         self.assert_partition_key(service_id)?;
         inbox(self, service_id)
+    }
+
+    async fn any_inbox_entry_in_range(&mut self, range: KeyRange) -> Result<bool> {
+        any_inbox_entry_in_range(self, range)
     }
 }
 

--- a/crates/partition-store/src/invocation_status_table/mod.rs
+++ b/crates/partition-store/src/invocation_status_table/mod.rs
@@ -22,6 +22,7 @@ use restate_storage_api::protobuf_types::PartitionStoreProtobufValue;
 use restate_storage_api::protobuf_types::v1::lazy::InvocationStatusV2Lazy;
 use restate_storage_api::{Result, StorageError};
 use restate_types::identifiers::{InvocationId, InvocationUuid, PartitionKey, WithPartitionKey};
+use restate_types::sharding::KeyRange;
 use restate_util_string::format_restring;
 
 use crate::TableScan::FullScanPartitionKeyRange;
@@ -90,6 +91,31 @@ fn delete_invocation_status<S: StorageAccess>(
     storage.delete_key(&create_invocation_status_key(invocation_id))
 }
 
+fn any_non_completed_invocation_in_range<S: StorageAccess>(
+    storage: &S,
+    range: KeyRange,
+) -> Result<bool> {
+    let mut iterator = storage.iterator_from(TableScan::FullScanPartitionKeyRange::<
+        InvocationStatusKey,
+    >(range))?;
+
+    while let Some((_, mut value)) = iterator.item() {
+        let lite = InvocationLite::decode(&mut value)?;
+        if !matches!(lite.status, InvocationStatusDiscriminants::Completed)
+            && !matches!(lite.status, InvocationStatusDiscriminants::Killed)
+        {
+            return Ok(true);
+        }
+        iterator.next();
+    }
+
+    if let Some(err) = iterator.status().err() {
+        return Err(StorageError::Generic(err.into()));
+    }
+
+    Ok(false)
+}
+
 // NOTE: This will only consider invoked invocations that have not been migrated to vqueues
 fn read_invoked_full_invocation_id(
     mut kv: (&[u8], &[u8]),
@@ -115,6 +141,10 @@ impl ReadInvocationStatusTable for PartitionStore {
     ) -> Result<InvocationStatus> {
         self.assert_partition_key(invocation_id)?;
         get_invocation_status(self, invocation_id)
+    }
+
+    async fn any_non_completed_invocation_in_range(&mut self, range: KeyRange) -> Result<bool> {
+        any_non_completed_invocation_in_range(self, range)
     }
 }
 
@@ -272,6 +302,10 @@ impl ReadInvocationStatusTable for PartitionStoreTransaction<'_> {
     ) -> Result<InvocationStatus> {
         self.assert_partition_key(invocation_id)?;
         get_invocation_status(self, invocation_id)
+    }
+
+    async fn any_non_completed_invocation_in_range(&mut self, range: KeyRange) -> Result<bool> {
+        any_non_completed_invocation_in_range(self, range)
     }
 }
 

--- a/crates/storage-api/src/inbox_table/mod.rs
+++ b/crates/storage-api/src/inbox_table/mod.rs
@@ -93,6 +93,13 @@ pub trait ReadInboxTable {
         &mut self,
         service_id: &ServiceId,
     ) -> Result<impl Stream<Item = Result<SequenceNumberInboxEntry>> + Send>;
+
+    /// Returns `true` as soon as any inbox entry is found in `range`.
+    /// Implemented as a single RocksDB seek; no value decoding is performed.
+    fn any_inbox_entry_in_range(
+        &mut self,
+        range: KeyRange,
+    ) -> impl Future<Output = Result<bool>> + Send;
 }
 
 pub trait ScanInboxTable {

--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -807,6 +807,15 @@ pub trait ReadInvocationStatusTable {
         &mut self,
         invocation_id: &InvocationId,
     ) -> impl Future<Output = Result<InvocationStatus>> + Send;
+
+    /// Returns `true` as soon as an [`InvocationStatus`] that is not
+    /// [`InvocationStatus::Completed`] is found in `range`. The iterator walks
+    /// entries decoding only the variant discriminator and early-exits on the
+    /// first non-`Completed` hit.
+    fn any_non_completed_invocation_in_range(
+        &mut self,
+        range: KeyRange,
+    ) -> impl Future<Output = Result<bool>> + Send;
 }
 
 #[derive(Debug, Clone)]

--- a/crates/storage-api/src/lib.rs
+++ b/crates/storage-api/src/lib.rs
@@ -116,6 +116,7 @@ pub trait Transaction:
     + invocation_status_table::WriteInvocationStatusTable
     + service_status_table::ReadVirtualObjectStatusTable
     + service_status_table::WriteVirtualObjectStatusTable
+    + inbox_table::ReadInboxTable
     + inbox_table::WriteInboxTable
     + outbox_table::WriteOutboxTable
     + deduplication_table::WriteDeduplicationTable

--- a/crates/types/src/partitions/features.rs
+++ b/crates/types/src/partitions/features.rs
@@ -14,7 +14,7 @@ use crate::storage::{
     StorageCodecKind, StorageDecode, StorageDecodeError, StorageEncode, StorageEncodeError, decode,
     encode,
 };
-use crate::{RESTATE_VERSION_1_7_0, SemanticRestateVersion};
+use crate::{RESTATE_VERSION_1_6_0, RESTATE_VERSION_1_7_0, SemanticRestateVersion};
 
 /// A change to the set of state-machine features enabled on a partition.
 ///
@@ -28,13 +28,20 @@ use crate::{RESTATE_VERSION_1_7_0, SemanticRestateVersion};
 /// the change.
 ///
 /// *Since v1.7.0*
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, strum::FromRepr)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, strum::FromRepr, strum::EnumString, strum::Display,
+)]
+#[strum(ascii_case_insensitive)]
 #[repr(u16)]
 pub enum PartitionFeatureChange {
+    /// Enable journal v2 by default.
+    ///
+    /// *Since v1.7.0*
+    EnableJournalV2 = 1,
     /// Enable vqueues for the partition.
     ///
     /// *Since v1.7.0*
-    EnableVqueues = 1,
+    EnableVqueues = 2,
 }
 
 impl PartitionFeatureChange {
@@ -48,6 +55,7 @@ impl PartitionFeatureChange {
     /// across all changes carried by the barrier.
     pub fn min_required_version(self) -> &'static SemanticRestateVersion {
         match self {
+            Self::EnableJournalV2 => &RESTATE_VERSION_1_6_0,
             Self::EnableVqueues => &RESTATE_VERSION_1_7_0,
         }
     }
@@ -56,13 +64,8 @@ impl PartitionFeatureChange {
     /// change had an effect on the state machine features.
     pub fn apply_to(self, features: &mut PersistedStateMachineFeatures) -> bool {
         match self {
-            Self::EnableVqueues => {
-                let before = features.vqueues;
-                features.vqueues = true;
-
-                // we enable the feature if it was disabled before
-                !before
-            }
+            Self::EnableJournalV2 => !std::mem::replace(&mut features.journal_v2, true),
+            Self::EnableVqueues => !std::mem::replace(&mut features.vqueues, true),
         }
     }
 }
@@ -79,10 +82,15 @@ impl PartitionFeatureChange {
     Debug, Clone, Default, PartialEq, Eq, bilrost::Message, serde::Serialize, serde::Deserialize,
 )]
 pub struct PersistedStateMachineFeatures {
-    /// Virtual queues are enabled on this partition.
+    /// Journal v2 should be used by this partition.
     ///
     /// *Since v1.7.0*
     #[bilrost(tag(1))]
+    pub journal_v2: bool,
+    /// Virtual queues are enabled on this partition.
+    ///
+    /// *Since v1.7.0*
+    #[bilrost(tag(2))]
     pub vqueues: bool,
 }
 
@@ -109,6 +117,16 @@ impl StorageDecode for PersistedStateMachineFeatures {
     }
 }
 
+impl FromIterator<PartitionFeatureChange> for PersistedStateMachineFeatures {
+    fn from_iter<I: IntoIterator<Item = PartitionFeatureChange>>(iter: I) -> Self {
+        let mut features = Self::default();
+        for change in iter {
+            change.apply_to(&mut features);
+        }
+        features
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -130,5 +148,20 @@ mod tests {
         assert!(!features.vqueues);
         PartitionFeatureChange::EnableVqueues.apply_to(&mut features);
         assert!(features.vqueues);
+    }
+
+    #[test]
+    fn from_str_round_trip_and_case_insensitive() {
+        use std::str::FromStr;
+
+        assert_eq!(
+            PartitionFeatureChange::from_str("EnableVqueues").unwrap(),
+            PartitionFeatureChange::EnableVqueues,
+        );
+        assert_eq!(
+            PartitionFeatureChange::from_str("enablejournalv2").unwrap(),
+            PartitionFeatureChange::EnableJournalV2,
+        );
+        assert!(PartitionFeatureChange::from_str("not-a-feature").is_err());
     }
 }

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -16,6 +16,7 @@ pub mod trim_queue;
 use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::mem;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -56,14 +57,12 @@ use restate_types::net::ingest::IngestRecord;
 use restate_types::net::partition_processor::{
     PartitionProcessorRpcError, PartitionProcessorRpcResponse,
 };
-use restate_types::partitions::Partition;
 use restate_types::partitions::state::PartitionReplicaSetStates;
+use restate_types::partitions::{Partition, PartitionFeatureChange};
 use restate_types::retries::with_jitter;
 use restate_types::schema::Schema;
 use restate_types::storage::{StorageDecodeError, StorageEncodeError};
-use restate_types::{
-    GenerationalNodeId, RESTATE_VERSION_1_6_0, RESTATE_VERSION_1_7_0, SemanticRestateVersion,
-};
+use restate_types::{GenerationalNodeId, SemanticRestateVersion};
 use restate_vqueues::scheduler::{self};
 use restate_vqueues::{ResourceManager, SchedulerService, VQueuesMeta, VQueuesMetaCache};
 use restate_wal_protocol::control::{
@@ -87,7 +86,7 @@ use crate::partition::leadership::leader_state::LeaderState;
 use crate::partition::leadership::self_proposer::SelfProposer;
 use crate::partition::shuffle;
 use crate::partition::shuffle::{OutboxReaderError, Shuffle, ShuffleMetadata};
-use crate::partition::state_machine::{Action, StateMachine};
+use crate::partition::state_machine::{Action, StateMachine, StateMachineFeatures};
 use crate::partition::types::InvokerEffect;
 use crate::partition_processor_manager::PartitionLeaderHandlesRegistry;
 use crate::rule_book_cache::RuleBookCacheHandle;
@@ -333,6 +332,7 @@ where
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     #[instrument(level = "debug", skip_all, fields(leader_epoch = %announce_leader.leader_epoch))]
     pub async fn on_announce_leader(
         &mut self,
@@ -342,6 +342,8 @@ where
         config: &Configuration,
         vqueues_cache: &mut VQueuesMetaCache,
         rule_book: &RuleBook,
+        state_machine_features: impl StateMachineFeatures,
+        min_restate_version: &SemanticRestateVersion,
     ) -> Result<bool, Error> {
         self.last_seen_leader_epoch = Some(announce_leader.leader_epoch);
 
@@ -363,6 +365,8 @@ where
                             vqueues_cache,
                             config,
                             rule_book,
+                            state_machine_features,
+                            min_restate_version,
                         )
                         .await?
                     }
@@ -400,6 +404,7 @@ where
         Ok(self.is_leader())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn become_leader(
         &mut self,
         partition_store: &mut PartitionStore,
@@ -407,6 +412,8 @@ where
         vqueues_cache: &mut VQueuesMetaCache,
         config: &Configuration,
         rule_book: &RuleBook,
+        state_machine_features: impl StateMachineFeatures,
+        min_restate_version: &SemanticRestateVersion,
     ) -> Result<(), Error> {
         if let State::Candidate {
             leader_epoch,
@@ -527,47 +534,59 @@ where
             let mut self_proposer = self_proposer.take().expect("must be present");
             self_proposer.mark_as_leader();
 
-            let mut min_restate_version = partition_store.get_min_restate_version().await?;
+            // Collect feature changes to apply as a single VersionBarrierCommand.
+            //
+            // RESTATE_INTERNAL_STATE_MACHINE_FEATURES is a comma-separated list of
+            // PartitionFeatureChange variant names (case-insensitive) used by internal
+            // testing to enable specific features explicitly.
+            let mut feature_changes: Vec<PartitionFeatureChange> =
+                if let Ok(raw) = std::env::var("RESTATE_INTERNAL_STATE_MACHINE_FEATURES") {
+                    raw.split(',')
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .filter_map(|name| match PartitionFeatureChange::from_str(name) {
+                            Ok(change) => Some(change),
+                            Err(_) => {
+                                warn!(
+                                    "Ignoring unknown state-machine feature \
+                                     '{name}' from RESTATE_INTERNAL_STATE_MACHINE_FEATURES"
+                                );
+                                None
+                            }
+                        })
+                        .collect()
+                } else {
+                    Vec::new()
+                };
 
-            // Force the provided min Restate version, this is used for internal testing only
-            if let Some(forced_min_restate_version) =
-                std::env::var("RESTATE_INTERNAL_FORCE_MIN_RESTATE_VERSION")
-                    .ok()
-                    .and_then(|min_restate_version| {
-                        SemanticRestateVersion::parse(&min_restate_version).ok()
-                    })
+            // In v1.7.0 we enable by default writing to the journal v2.
+            if !state_machine_features.use_journal_v2_as_default()
+                && !feature_changes.contains(&PartitionFeatureChange::EnableJournalV2)
             {
-                self_proposer
-                    .self_propose(
-                        self.partition.key_range.start(),
-                        Command::VersionBarrier(VersionBarrierCommand {
-                            version: forced_min_restate_version.clone(),
-                            partition_key_range: Keys::RangeInclusive(
-                                self.partition.key_range.into(),
-                            ),
-                            human_reason: Some("Force min Restate version".to_owned()),
-                            feature_changes: Vec::new(),
-                        }),
-                    )
-                    .await?;
-
-                min_restate_version = min_restate_version.max(forced_min_restate_version);
+                feature_changes.push(PartitionFeatureChange::EnableJournalV2);
             }
 
-            // In v1.7.0 we enable by default writing to the journal v2 which requires min Restate v1.6.0
-            if SemanticRestateVersion::current().is_equal_or_newer_than(&RESTATE_VERSION_1_7_0)
-                && RESTATE_VERSION_1_6_0.is_newer_than(&min_restate_version)
-            {
+            if !feature_changes.is_empty() {
+                // Smallest version that supports every listed feature, but never below
+                // the partition's current min_restate_version.
+                let barrier_version = feature_changes
+                    .iter()
+                    .map(|c| c.min_required_version())
+                    .max()
+                    .expect("non-empty")
+                    .max(min_restate_version)
+                    .clone();
+
                 self_proposer
                     .self_propose(
                         self.partition.key_range.start(),
                         Command::VersionBarrier(VersionBarrierCommand {
-                            version: RESTATE_VERSION_1_6_0.clone(),
+                            version: barrier_version,
                             partition_key_range: Keys::RangeInclusive(
                                 self.partition.key_range.into(),
                             ),
-                            human_reason: Some("Enable journal v2 by default".to_owned()),
-                            feature_changes: Vec::new(),
+                            human_reason: Some("Apply state-machine feature changes".to_owned()),
+                            feature_changes: feature_changes.iter().map(|c| c.id()).collect(),
                         }),
                     )
                     .await?;
@@ -874,6 +893,7 @@ mod tests {
     use crate::partition::LeadershipInfo;
     use crate::partition::leadership::trim_queue::TrimQueue;
     use crate::partition::leadership::{LeadershipState, State};
+    use crate::partition::state_machine::StateMachineFeatures;
     use crate::partition_processor_manager::PartitionLeaderHandlesRegistry;
     use crate::rule_book_cache::RuleBookCacheHandle;
     use assert2::let_assert;
@@ -890,7 +910,7 @@ mod tests {
     use restate_types::partitions::state::PartitionReplicaSetStates;
     use restate_types::partitions::{Partition, PartitionConfiguration};
     use restate_types::sharding::KeyRange;
-    use restate_types::{GenerationalNodeId, Version};
+    use restate_types::{GenerationalNodeId, SemanticRestateVersion, Version};
     use restate_vqueues::VQueuesMetaCache;
     use restate_wal_protocol::Command;
     use restate_wal_protocol::Envelope;
@@ -904,6 +924,18 @@ mod tests {
     const NODE_ID: GenerationalNodeId = GenerationalNodeId::new(0, 0);
     const PARTITION_KEY_RANGE: KeyRange = KeyRange::FULL;
     const PARTITION: Partition = Partition::new(PARTITION_ID, PARTITION_KEY_RANGE);
+
+    struct MockStateMachineFeatures;
+
+    impl StateMachineFeatures for MockStateMachineFeatures {
+        fn use_journal_v2_as_default(&self) -> bool {
+            true
+        }
+
+        fn is_vqueues_enabled(&self) -> bool {
+            false
+        }
+    }
 
     #[test(restate_core::test)]
     async fn become_leader_then_step_down() -> googletest::Result<()> {
@@ -976,6 +1008,8 @@ mod tests {
                 &Configuration::pinned(),
                 &mut VQueuesMetaCache::new_empty(1024),
                 &rule_book,
+                MockStateMachineFeatures,
+                SemanticRestateVersion::current(),
             )
             .await?;
 

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -560,10 +560,18 @@ where
                 };
 
             // In v1.7.0 we enable by default writing to the journal v2.
-            if !state_machine_features.use_journal_v2_as_default()
-                && !feature_changes.contains(&PartitionFeatureChange::EnableJournalV2)
-            {
+            if !state_machine_features.use_journal_v2_as_default() {
                 feature_changes.push(PartitionFeatureChange::EnableJournalV2);
+            }
+
+            // Opt this partition in to vqueues if the operator has flipped the experimental config
+            // flag on and the FSM hasn't already recorded the opt-in. The FSM update itself
+            // happens via `OnVersionBarrierCommand` once this proposed barrier is applied; we do
+            // not touch the local FSM mirror here.
+            if config.common.experimental.is_vqueues_enabled()
+                && !state_machine_features.is_vqueues_enabled()
+            {
+                feature_changes.push(PartitionFeatureChange::EnableVqueues);
             }
 
             if !feature_changes.is_empty() {
@@ -586,7 +594,7 @@ where
                                 self.partition.key_range.into(),
                             ),
                             human_reason: Some("Apply state-machine feature changes".to_owned()),
-                            feature_changes: feature_changes.iter().map(|c| c.id()).collect(),
+                            feature_changes: feature_changes.into_iter().map(|c| c.id()).collect(),
                         }),
                     )
                     .await?;

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -299,6 +299,7 @@ impl PartitionProcessorBuilder {
             return Err(state_machine::Error::VersionBarrier {
                 required_min_version: min_restate_version,
                 barrier_reason: String::new(),
+                feature_changes: Vec::default(),
             });
         }
 

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -74,6 +74,7 @@ use restate_types::net::partition_processor::{
     PartitionProcessorRpcResponse,
 };
 use restate_types::net::{RpcRequest, ingest};
+use restate_types::partitions::PartitionFeatureChange;
 use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::retries::{RetryPolicy, with_jitter};
 use restate_types::schema::Schema;
@@ -269,7 +270,23 @@ impl PartitionProcessorBuilder {
         let outbox_seq_number = partition_store.get_outbox_seq_number().await?;
         let outbox_head_seq_number = partition_store.get_outbox_head_seq_number().await?;
         let min_restate_version = partition_store.get_min_restate_version().await?;
-        let enabled_features = partition_store.get_state_machine_features().await?;
+        let mut enabled_features = partition_store.get_state_machine_features().await?;
+
+        // for backward compatibility because PartitionFeatureChanges were only introduced with v1.7,
+        // we need to enable journal v2 if the min restate version is >= v1.6.0
+        if !enabled_features.journal_v2
+            && min_restate_version.is_equal_or_newer_than(
+                PartitionFeatureChange::EnableJournalV2.min_required_version(),
+            )
+        {
+            PartitionFeatureChange::EnableJournalV2.apply_to(&mut enabled_features);
+
+            // update the internal storage
+            let mut txn = partition_store.transaction();
+            txn.put_state_machine_features(&enabled_features)?;
+            txn.commit().await?;
+        }
+
         let schema = partition_store.get_schema().await?;
         let rule_book = Arc::new(partition_store.get_rule_book().await?.unwrap_or_default());
 
@@ -722,6 +739,8 @@ where
                                 config,
                                 &mut vqueues,
                                 &self.state_machine.rule_book,
+                                &self.state_machine,
+                                &self.state_machine.min_restate_version,
                             ).await?;
 
                             Span::current().record("is_leader", is_leader);

--- a/crates/worker/src/partition/rpc/pause_invocation.rs
+++ b/crates/worker/src/partition/rpc/pause_invocation.rs
@@ -100,6 +100,15 @@ mod tests {
                 panic!("storage should not be accessed on non-leader");
                 std::future::ready(Ok(InvocationStatus::Free))
             }
+
+            #[allow(unreachable_code)]
+            fn any_non_completed_invocation_in_range(
+                &mut self,
+                _: restate_types::sharding::KeyRange,
+            ) -> impl Future<Output = restate_storage_api::Result<bool>> + Send {
+                panic!("storage should not be accessed on non-leader");
+                std::future::ready(Ok(false))
+            }
         }
 
         let mut storage = NoopStorage;

--- a/crates/worker/src/partition/rpc/restart_as_new_invocation.rs
+++ b/crates/worker/src/partition/rpc/restart_as_new_invocation.rs
@@ -713,6 +713,13 @@ mod tests {
         ) -> impl Future<Output = restate_storage_api::Result<InvocationStatus>> + Send {
             ready(Ok(self.status.clone()))
         }
+
+        fn any_non_completed_invocation_in_range(
+            &mut self,
+            _: restate_types::sharding::KeyRange,
+        ) -> impl Future<Output = restate_storage_api::Result<bool>> + Send {
+            ready(Ok(false))
+        }
     }
 
     #[test(restate_core::test)]

--- a/crates/worker/src/partition/rpc/resume_invocation.rs
+++ b/crates/worker/src/partition/rpc/resume_invocation.rs
@@ -196,6 +196,13 @@ mod tests {
             assert_eq!(*inv_id, self.expected_invocation_id);
             ready(Ok(self.status.clone()))
         }
+
+        fn any_non_completed_invocation_in_range(
+            &mut self,
+            _: restate_types::sharding::KeyRange,
+        ) -> impl Future<Output = restate_storage_api::Result<bool>> + Send {
+            ready(Ok(false))
+        }
     }
 
     #[test(restate_core::test)]

--- a/crates/worker/src/partition/state_machine/entries/mod.rs
+++ b/crates/worker/src/partition/state_machine/entries/mod.rs
@@ -431,21 +431,24 @@ mod tests {
         Header, InvocationResponse, InvocationTarget, JournalCompletionTarget, ResponseResult,
     };
     use restate_types::journal_v2::{CallCommand, CallRequest};
-    use restate_types::{RESTATE_VERSION_1_6_0, SemanticRestateVersion};
+    use restate_types::partitions::{PartitionFeatureChange, PersistedStateMachineFeatures};
     use restate_wal_protocol::v2::{Command, commands};
 
     #[restate_core::test]
     async fn update_journal_and_commands_length() {
-        run_update_journal_and_commands_length(SemanticRestateVersion::unknown()).await;
+        run_update_journal_and_commands_length(PersistedStateMachineFeatures::default()).await;
     }
 
     #[restate_core::test]
     async fn update_journal_and_commands_length_journal_v2_enabled() {
-        run_update_journal_and_commands_length(RESTATE_VERSION_1_6_0.clone()).await;
+        run_update_journal_and_commands_length(PersistedStateMachineFeatures::from_iter([
+            PartitionFeatureChange::EnableJournalV2,
+        ]))
+        .await;
     }
 
-    async fn run_update_journal_and_commands_length(min_restate_version: SemanticRestateVersion) {
-        let mut test_env = TestEnv::create_with_min_restate_version(min_restate_version).await;
+    async fn run_update_journal_and_commands_length(features: PersistedStateMachineFeatures) {
+        let mut test_env = TestEnv::create_with_features(features).await;
         let invocation_id = fixtures::mock_start_invocation(&mut test_env).await;
         fixtures::mock_pinned_deployment_v5(&mut test_env, invocation_id).await;
 

--- a/crates/worker/src/partition/state_machine/entries/notification.rs
+++ b/crates/worker/src/partition/state_machine/entries/notification.rs
@@ -98,8 +98,8 @@ mod tests {
         BuiltInSignal, CommandType, Entry, EntryType, Failure, FailureMetadata, NotificationId,
         Signal, SignalId, SignalResult, SleepCommand, SleepCompletion,
     };
+    use restate_types::partitions::{PartitionFeatureChange, PersistedStateMachineFeatures};
     use restate_types::time::MillisSinceEpoch;
-    use restate_types::{RESTATE_VERSION_1_6_0, SemanticRestateVersion};
     use restate_wal_protocol::timer::TimerKeyValue;
     use restate_wal_protocol::v2::{Command, commands};
     use rstest::rstest;
@@ -148,19 +148,24 @@ mod tests {
 
     #[restate_core::test]
     async fn notify_signal_received_before_pinned_deployment() {
-        run_notify_signal_received_before_pinned_deployment(SemanticRestateVersion::unknown())
-            .await;
+        run_notify_signal_received_before_pinned_deployment(
+            PersistedStateMachineFeatures::default(),
+        )
+        .await;
     }
 
     #[restate_core::test]
     async fn notify_signal_received_before_pinned_deployment_journal_v2_enabled() {
-        run_notify_signal_received_before_pinned_deployment(RESTATE_VERSION_1_6_0.clone()).await;
+        run_notify_signal_received_before_pinned_deployment(
+            PersistedStateMachineFeatures::from_iter([PartitionFeatureChange::EnableJournalV2]),
+        )
+        .await;
     }
 
     async fn run_notify_signal_received_before_pinned_deployment(
-        min_restate_version: SemanticRestateVersion,
+        features: PersistedStateMachineFeatures,
     ) {
-        let mut test_env = TestEnv::create_with_min_restate_version(min_restate_version).await;
+        let mut test_env = TestEnv::create_with_features(features).await;
         let invocation_id = fixtures::mock_start_invocation(&mut test_env).await;
 
         // Send signal notification before pinned deployment

--- a/crates/worker/src/partition/state_machine/lifecycle/cancel.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/cancel.rs
@@ -141,9 +141,9 @@ mod tests {
     use restate_types::journal_v2::{
         CANCEL_NOTIFICATION_ID, CANCEL_SIGNAL, CommandType, Entry, EntryMetadata, EntryType,
     };
+    use restate_types::partitions::{PartitionFeatureChange, PersistedStateMachineFeatures};
     use restate_types::service_protocol::ServiceProtocolVersion;
     use restate_types::time::MillisSinceEpoch;
-    use restate_types::{RESTATE_VERSION_1_6_0, SemanticRestateVersion};
     use restate_wal_protocol::v2::{Command, commands};
     use restate_worker_api::invoker::Effect;
 
@@ -251,7 +251,10 @@ mod tests {
     #[restate_core::test]
     async fn cancel_invoked_invocation_without_pinned_deployment_with_journal_table_v2_default() {
         let mut test_env =
-            TestEnv::create_with_min_restate_version(RESTATE_VERSION_1_6_0.clone()).await;
+            TestEnv::create_with_features(PersistedStateMachineFeatures::from_iter([
+                PartitionFeatureChange::EnableJournalV2,
+            ]))
+            .await;
         let invocation_id = fixtures::mock_start_invocation(&mut test_env).await;
 
         // Send signal notification before pinning the deployment
@@ -286,7 +289,7 @@ mod tests {
     #[restate_core::test]
     async fn cancel_scheduled_invocation_through_notify_signal() -> anyhow::Result<()> {
         Box::pin(run_cancel_scheduled_invocation_through_notify_signal(
-            SemanticRestateVersion::unknown(),
+            PersistedStateMachineFeatures::default(),
         ))
         .await
     }
@@ -295,15 +298,15 @@ mod tests {
     async fn cancel_scheduled_invocation_through_notify_signal_journal_v2_enabled()
     -> anyhow::Result<()> {
         Box::pin(run_cancel_scheduled_invocation_through_notify_signal(
-            RESTATE_VERSION_1_6_0.clone(),
+            PersistedStateMachineFeatures::from_iter([PartitionFeatureChange::EnableJournalV2]),
         ))
         .await
     }
 
     async fn run_cancel_scheduled_invocation_through_notify_signal(
-        min_restate_version: SemanticRestateVersion,
+        features: PersistedStateMachineFeatures,
     ) -> anyhow::Result<()> {
-        let mut test_env = TestEnv::create_with_min_restate_version(min_restate_version).await;
+        let mut test_env = TestEnv::create_with_features(features).await;
 
         let invocation_id = InvocationId::mock_random();
         let rpc_id = PartitionProcessorRpcRequestId::new();
@@ -377,7 +380,7 @@ mod tests {
     #[restate_core::test]
     async fn cancel_inboxed_invocation_through_notify_signal() -> anyhow::Result<()> {
         Box::pin(run_cancel_inboxed_invocation_through_notify_signal(
-            SemanticRestateVersion::unknown(),
+            PersistedStateMachineFeatures::default(),
         ))
         .await
     }
@@ -386,15 +389,15 @@ mod tests {
     async fn cancel_inboxed_invocation_through_notify_signal_journal_v2_enabled()
     -> anyhow::Result<()> {
         Box::pin(run_cancel_inboxed_invocation_through_notify_signal(
-            RESTATE_VERSION_1_6_0.clone(),
+            PersistedStateMachineFeatures::from_iter([PartitionFeatureChange::EnableJournalV2]),
         ))
         .await
     }
 
     async fn run_cancel_inboxed_invocation_through_notify_signal(
-        min_restate_version: SemanticRestateVersion,
+        features: PersistedStateMachineFeatures,
     ) -> anyhow::Result<()> {
-        let mut test_env = TestEnv::create_with_min_restate_version(min_restate_version).await;
+        let mut test_env = TestEnv::create_with_features(features).await;
 
         let invocation_target = InvocationTarget::mock_virtual_object();
         let invocation_id = InvocationId::mock_generate(&invocation_target);

--- a/crates/worker/src/partition/state_machine/lifecycle/restart_as_new.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/restart_as_new.rs
@@ -310,7 +310,6 @@ mod tests {
     use restate_storage_api::invocation_status_table::{
         InFlightInvocationMetadata, InvocationStatusDiscriminants, ReadInvocationStatusTable,
     };
-    use restate_types::RESTATE_VERSION_1_6_0;
     use restate_types::identifiers::{
         DeploymentId, InvocationId, InvocationUuid, PartitionProcessorRpcRequestId,
         WithPartitionKey,
@@ -324,6 +323,7 @@ mod tests {
         CommandType, CompletionType, NotificationType, OutputCommand, OutputResult, Signal,
         SignalId, SignalResult, SleepCommand,
     };
+    use restate_types::partitions::{PartitionFeatureChange, PersistedStateMachineFeatures};
     use restate_types::service_protocol::ServiceProtocolVersion;
     use restate_types::time::MillisSinceEpoch;
     use restate_wal_protocol::timer::TimerKeyValue;
@@ -408,7 +408,10 @@ mod tests {
         // This works only when using journal table v2 as default!
         // The corner case with journal table v1 is handled by the rpc handler instead.
         let mut test_env =
-            TestEnv::create_with_min_restate_version(RESTATE_VERSION_1_6_0.clone()).await;
+            TestEnv::create_with_features(PersistedStateMachineFeatures::from_iter([
+                PartitionFeatureChange::EnableJournalV2,
+            ]))
+            .await;
 
         // Start invocation, then kill it
         let invocation_target = InvocationTarget::mock_virtual_object();

--- a/crates/worker/src/partition/state_machine/lifecycle/suspend.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/suspend.rs
@@ -171,8 +171,8 @@ mod tests {
         SignalResult, SleepCommand, SleepCompletion, UnresolvedFuture, all_completed,
         all_succeeded_or_first_failed, first_completed, first_succeeded_or_all_failed, unknown,
     };
+    use restate_types::partitions::{PartitionFeatureChange, PersistedStateMachineFeatures};
     use restate_types::time::MillisSinceEpoch;
-    use restate_types::{RESTATE_VERSION_1_6_0, SemanticRestateVersion};
     use restate_wal_protocol::timer::TimerKeyValue;
     use restate_wal_protocol::v2::{Command, commands};
     use std::time::{Duration, SystemTime};
@@ -292,16 +292,19 @@ mod tests {
 
     #[restate_core::test]
     async fn suspend_waiting_on_signal() {
-        run_suspend_waiting_on_signal(SemanticRestateVersion::unknown()).await;
+        run_suspend_waiting_on_signal(PersistedStateMachineFeatures::default()).await;
     }
 
     #[restate_core::test]
     async fn suspend_waiting_on_signal_journal_v2_enabled() {
-        run_suspend_waiting_on_signal(RESTATE_VERSION_1_6_0.clone()).await;
+        run_suspend_waiting_on_signal(PersistedStateMachineFeatures::from_iter([
+            PartitionFeatureChange::EnableJournalV2,
+        ]))
+        .await;
     }
 
-    async fn run_suspend_waiting_on_signal(min_restate_version: SemanticRestateVersion) {
-        let mut test_env = TestEnv::create_with_min_restate_version(min_restate_version).await;
+    async fn run_suspend_waiting_on_signal(features: PersistedStateMachineFeatures) {
+        let mut test_env = TestEnv::create_with_features(features).await;
         let invocation_id = fixtures::mock_start_invocation(&mut test_env).await;
         // We don't pin the deployment here, but this should work nevertheless.
 

--- a/crates/worker/src/partition/state_machine/lifecycle/version_barrier.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/version_barrier.rs
@@ -9,7 +9,10 @@
 // by the Apache License, Version 2.0.
 
 use restate_storage_api::fsm_table::WriteFsmTable;
+use restate_storage_api::inbox_table::ReadInboxTable;
+use restate_storage_api::invocation_status_table::ReadInvocationStatusTable;
 use restate_types::partitions::features::PartitionFeatureChange;
+use restate_types::sharding::KeyRange;
 use restate_wal_protocol::control::VersionBarrierCommand;
 
 use crate::debug_if_leader;
@@ -19,10 +22,47 @@ pub struct OnVersionBarrierCommand {
     pub barrier: VersionBarrierCommand,
 }
 
+/// Returns `true` if applying `change` to a partition that holds pre-existing
+/// in-flight data would leave that data inconsistent and therefore requires a
+/// migration step which is not provided by this binary.
+async fn requires_migration_for<S>(
+    change: PartitionFeatureChange,
+    storage: &mut S,
+    partition_key_range: KeyRange,
+) -> Result<bool, restate_storage_api::StorageError>
+where
+    S: ReadInboxTable + ReadInvocationStatusTable,
+{
+    match change {
+        PartitionFeatureChange::EnableVqueues => {
+            // Inbox entries (invocations and state mutations) and any non-Completed
+            // invocation status (which transitively covers held virtual-object locks
+            // and scheduled-invocation timers via the `InvocationStatus::Scheduled`
+            // source-of-truth) must be migrated to vqueue form before vqueues is
+            // enabled. The 1.7.0 binary lacks the migration code; a later server
+            // version provides it.
+            if storage
+                .any_inbox_entry_in_range(partition_key_range)
+                .await?
+            {
+                return Ok(true);
+            }
+            if storage
+                .any_non_completed_invocation_in_range(partition_key_range)
+                .await?
+            {
+                return Ok(true);
+            }
+            Ok(false)
+        }
+        PartitionFeatureChange::EnableJournalV2 => Ok(false),
+    }
+}
+
 impl<'ctx, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>>
     for OnVersionBarrierCommand
 where
-    S: WriteFsmTable,
+    S: WriteFsmTable + ReadInboxTable + ReadInvocationStatusTable,
 {
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
         // Defense-in-depth: every feature change ID carried by the barrier must be known to this
@@ -46,6 +86,31 @@ where
             });
         }
 
+        // Determine which known changes actually flip a feature off->on. Only those
+        // need to run the migration probe; re-applying an already-enabled barrier
+        // stays cheap and idempotent.
+        let mut updated = ctx.enabled_features.clone();
+        let flip_on_changes: Vec<PartitionFeatureChange> = known_changes
+            .iter()
+            .copied()
+            .filter(|change| change.apply_to(&mut updated))
+            .collect();
+
+        // Per-feature migration gate. Atomicity: if any flip-on change requires
+        // migration, the whole barrier fails and the transaction rolls back so no
+        // partial state (incl. min_restate_version) is persisted.
+        let mut needs_migration = Vec::new();
+        for &change in &flip_on_changes {
+            if requires_migration_for(change, ctx.storage, ctx.partition_key_range).await? {
+                needs_migration.push(change);
+            }
+        }
+        if !needs_migration.is_empty() {
+            return Err(Error::MigrationRequired {
+                features: needs_migration,
+            });
+        }
+
         if matches!(
             self.barrier.version.cmp_precedence(ctx.min_restate_version),
             std::cmp::Ordering::Greater,
@@ -62,24 +127,15 @@ where
             //  if it is not prohibitively expensive
         }
 
-        if !known_changes.is_empty() {
-            let mut updated = ctx.enabled_features.clone();
-            for change in &known_changes {
-                change.apply_to(&mut updated);
-            }
-
-            // todo(tillrohrmann) implement logic to enable currently supported features (vqueues)
-
-            if updated != *ctx.enabled_features {
-                ctx.storage.put_state_machine_features(&updated)?;
-                *ctx.enabled_features = updated;
-                debug_if_leader!(
-                    ctx.is_leader,
-                    "Applied state-machine feature changes {:?}; new feature set: {:?}",
-                    known_changes,
-                    ctx.enabled_features
-                );
-            }
+        if updated != *ctx.enabled_features {
+            ctx.storage.put_state_machine_features(&updated)?;
+            *ctx.enabled_features = updated;
+            debug_if_leader!(
+                ctx.is_leader,
+                "Applied state-machine feature changes {:?}; new feature set: {:?}",
+                known_changes,
+                ctx.enabled_features
+            );
         }
 
         Ok(())
@@ -90,14 +146,25 @@ where
 mod tests {
     use googletest::prelude::*;
     use restate_limiter::RuleBook;
+    use restate_storage_api::Transaction;
     use restate_storage_api::fsm_table::ReadFsmTable;
+    use restate_storage_api::inbox_table::{InboxEntry, WriteInboxTable};
+    use restate_storage_api::invocation_status_table::{
+        CompletedInvocation, InFlightInvocationMetadata, InvocationStatus,
+        WriteInvocationStatusTable,
+    };
     use restate_types::SemanticRestateVersion;
-    use restate_types::identifiers::PartitionKey;
+    use restate_types::identifiers::{InvocationId, PartitionKey, ServiceId};
+    use restate_types::invocation::InvocationTarget;
     use restate_types::logs::Keys;
-    use restate_types::partitions::features::PartitionFeatureChange;
+    use restate_types::partitions::features::{
+        PartitionFeatureChange, PersistedStateMachineFeatures,
+    };
     use restate_types::sharding::KeyRange;
+    use restate_types::state_mut::ExternalStateMutation;
     use restate_wal_protocol::control::VersionBarrierCommand;
     use restate_wal_protocol::v2::{Command, commands};
+    use std::collections::HashMap;
 
     use crate::partition::state_machine::StateMachine;
     use crate::partition::state_machine::tests::TestEnv;
@@ -256,6 +323,163 @@ mod tests {
                 .unwrap();
             assert_that!(psf.vqueues, eq(true));
         }
+
+        test_env.shutdown().await;
+    }
+
+    async fn seed_inbox_state_mutation(test_env: &mut TestEnv) {
+        let service_id = ServiceId::new(None, "MyService", "MyKey");
+        let mut tx = test_env.storage().transaction();
+        tx.put_inbox_entry(
+            0,
+            &InboxEntry::StateMutation(ExternalStateMutation {
+                service_id,
+                version: None,
+                state: HashMap::default(),
+            }),
+        )
+        .unwrap();
+        tx.commit().await.unwrap();
+    }
+
+    async fn seed_invoked_status(test_env: &mut TestEnv) {
+        let invocation_id = InvocationId::mock_random();
+        let mut tx = test_env.storage().transaction();
+        tx.put_invocation_status(
+            &invocation_id,
+            &InvocationStatus::Invoked(InFlightInvocationMetadata::mock()),
+        )
+        .unwrap();
+        tx.commit().await.unwrap();
+    }
+
+    async fn seed_completed_status(test_env: &mut TestEnv) {
+        let invocation_target = InvocationTarget::mock_virtual_object();
+        let invocation_id = InvocationId::generate(&invocation_target, None);
+        let mut tx = test_env.storage().transaction();
+        tx.put_invocation_status(
+            &invocation_id,
+            &InvocationStatus::Completed(CompletedInvocation::mock_neo()),
+        )
+        .unwrap();
+        tx.commit().await.unwrap();
+    }
+
+    #[restate_core::test]
+    async fn migration_required_when_inbox_non_empty() {
+        let mut test_env = TestEnv::create_with_state_machine(fresh_state_machine()).await;
+        seed_inbox_state_mutation(&mut test_env).await;
+
+        let result = test_env
+            .apply_fallible(commands::VersionBarrierCommand::test_envelope(barrier(
+                SemanticRestateVersion::current().clone(),
+                vec![PartitionFeatureChange::EnableVqueues.id()],
+            )))
+            .await;
+
+        assert_that!(
+            result,
+            err(pat!(
+                crate::partition::state_machine::Error::MigrationRequired {
+                    features: eq(vec![PartitionFeatureChange::EnableVqueues]),
+                }
+            ))
+        );
+
+        // The feature flag must remain off — the apply transaction rolled back.
+        let psf = test_env
+            .storage()
+            .get_state_machine_features()
+            .await
+            .unwrap();
+        assert_that!(psf.vqueues, eq(false));
+
+        test_env.shutdown().await;
+    }
+
+    #[restate_core::test]
+    async fn migration_required_when_non_completed_invocation_present() {
+        let mut test_env = TestEnv::create_with_state_machine(fresh_state_machine()).await;
+        seed_invoked_status(&mut test_env).await;
+
+        let result = test_env
+            .apply_fallible(commands::VersionBarrierCommand::test_envelope(barrier(
+                SemanticRestateVersion::current().clone(),
+                vec![PartitionFeatureChange::EnableVqueues.id()],
+            )))
+            .await;
+
+        assert_that!(
+            result,
+            err(pat!(
+                crate::partition::state_machine::Error::MigrationRequired {
+                    features: eq(vec![PartitionFeatureChange::EnableVqueues]),
+                }
+            ))
+        );
+
+        let psf = test_env
+            .storage()
+            .get_state_machine_features()
+            .await
+            .unwrap();
+        assert_that!(psf.vqueues, eq(false));
+
+        test_env.shutdown().await;
+    }
+
+    #[restate_core::test]
+    async fn only_completed_invocation_does_not_block_enable() {
+        let mut test_env = TestEnv::create_with_state_machine(fresh_state_machine()).await;
+        seed_completed_status(&mut test_env).await;
+
+        let result = test_env
+            .apply_fallible(commands::VersionBarrierCommand::test_envelope(barrier(
+                SemanticRestateVersion::current().clone(),
+                vec![PartitionFeatureChange::EnableVqueues.id()],
+            )))
+            .await;
+        assert_that!(result, ok(empty()));
+
+        let psf = test_env
+            .storage()
+            .get_state_machine_features()
+            .await
+            .unwrap();
+        assert_that!(psf.vqueues, eq(true));
+
+        test_env.shutdown().await;
+    }
+
+    #[restate_core::test]
+    async fn no_op_reapply_skips_probe() {
+        // Start with vqueues already enabled in the state machine, then seed an
+        // inbox entry that would normally trip the gate. The barrier re-apply must
+        // succeed because the change does not flip a feature off->on.
+        let state_machine = StateMachine::new(
+            0,
+            0,
+            None,
+            KeyRange::FULL,
+            SemanticRestateVersion::unknown(),
+            PersistedStateMachineFeatures {
+                journal_v2: false,
+                vqueues: true,
+            },
+            Default::default(),
+            std::sync::Arc::new(RuleBook::default()),
+            RuleBookCacheHandle::detached(),
+        );
+        let mut test_env = TestEnv::create_with_state_machine(state_machine).await;
+        seed_inbox_state_mutation(&mut test_env).await;
+
+        let result = test_env
+            .apply_fallible(commands::VersionBarrierCommand::test_envelope(barrier(
+                SemanticRestateVersion::current().clone(),
+                vec![PartitionFeatureChange::EnableVqueues.id()],
+            )))
+            .await;
+        assert_that!(result, ok(empty()));
 
         test_env.shutdown().await;
     }

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -225,11 +225,12 @@ impl Debug for StateMachine {
 pub enum Error {
     #[error(
         "partition is blocked; requires an upgrade to restate-server version \
-        {required_min_version} or higher; reason='{barrier_reason}'"
+        {required_min_version} or higher; reason='{barrier_reason}'; feature changes={feature_changes:?}"
     )]
     VersionBarrier {
         required_min_version: SemanticRestateVersion,
         barrier_reason: String,
+        feature_changes: Vec<u16>,
     },
     /// *Since v1.7.0*
     #[error(
@@ -624,6 +625,7 @@ impl<S> StateMachineApplyContext<'_, S> {
                     Err(Error::VersionBarrier {
                         required_min_version: barrier.version,
                         barrier_reason: barrier.human_reason.unwrap_or_default(),
+                        feature_changes: barrier.feature_changes,
                     })
                 }
             }

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -66,7 +66,6 @@ use restate_storage_api::{Result as StorageResult, journal_table};
 use restate_storage_api::{StorageError, journal_table_v2};
 use restate_tracing_instrumentation as instrumentation;
 use restate_types::clock::UniqueTimestamp;
-use restate_types::config::Configuration;
 use restate_types::errors::{
     ALREADY_COMPLETED_INVOCATION_ERROR, CANCELED_INVOCATION_ERROR, GenericError, InvocationError,
     KILLED_INVOCATION_ERROR, NOT_FOUND_INVOCATION_ERROR, NOT_READY_INVOCATION_ERROR,
@@ -97,6 +96,7 @@ use restate_types::journal::enriched::{
     AwakeableEnrichmentResult, CallEnrichmentResult, EnrichedEntryHeader,
 };
 use restate_types::journal::raw::{EntryHeader, RawEntryCodec, RawEntryCodecError};
+use restate_types::journal_v2;
 use restate_types::journal_v2::command::{OutputCommand, OutputResult};
 use restate_types::journal_v2::raw::RawEntry;
 use restate_types::journal_v2::{
@@ -114,7 +114,6 @@ use restate_types::state_mut::StateMutationVersion;
 use restate_types::storage::{StorageDecodeError, StoredRawEntry, StoredRawEntryHeader};
 use restate_types::time::MillisSinceEpoch;
 use restate_types::vqueues::{self, EntryId, VQueueId};
-use restate_types::{RESTATE_VERSION_1_6_0, journal_v2};
 use restate_types::{RestateVersion, SemanticRestateVersion};
 use restate_types::{Versioned, journal::*};
 use restate_util_string::ReString;
@@ -133,17 +132,51 @@ use crate::metric_definitions::{
 use crate::partition::state_machine::lifecycle::OnCancelCommand;
 use crate::partition::types::{InvokerEffectKind, OutboxMessageExt};
 
-trait StateMachineFeatures {
+/// Read-only view of the state-machine features currently enabled for a partition.
+///
+/// Each feature is gated either on the partition's persisted minimum Restate-server version
+/// (`min_restate_version`) or on its persisted opt-in feature set
+/// ([`PersistedStateMachineFeatures`]), depending on what the feature requires. See each method's
+/// doc-comment for the specific gate.
+pub(crate) trait StateMachineFeatures {
     /// Write to journal v2 instead of journal v1 by default. This is a preparational step for
     /// removing the journal v1 after enabling this feature and migrating all unpinned invocations
     /// from journal v1 to journal v2.
     fn use_journal_v2_as_default(&self) -> bool;
+
+    /// Whether vqueue-related code paths are active on this partition.
+    ///
+    /// *Since v1.7.0*
+    fn is_vqueues_enabled(&self) -> bool;
 }
 
-impl StateMachineFeatures for SemanticRestateVersion {
+impl<T: StateMachineFeatures> StateMachineFeatures for &T {
     fn use_journal_v2_as_default(&self) -> bool {
-        // use journal v2 as default if the min Restate version is >= v1.6.0
-        self.is_equal_or_newer_than(&RESTATE_VERSION_1_6_0)
+        (*self).use_journal_v2_as_default()
+    }
+
+    fn is_vqueues_enabled(&self) -> bool {
+        (*self).is_vqueues_enabled()
+    }
+}
+
+impl StateMachineFeatures for StateMachine {
+    fn use_journal_v2_as_default(&self) -> bool {
+        self.enabled_features.journal_v2
+    }
+
+    fn is_vqueues_enabled(&self) -> bool {
+        self.enabled_features.vqueues
+    }
+}
+
+impl<S> StateMachineFeatures for StateMachineApplyContext<'_, S> {
+    fn use_journal_v2_as_default(&self) -> bool {
+        self.enabled_features.journal_v2
+    }
+
+    fn is_vqueues_enabled(&self) -> bool {
+        self.enabled_features.vqueues
     }
 }
 
@@ -952,9 +985,7 @@ impl<S> StateMachineApplyContext<'_, S> {
         // Prepare PreFlightInvocationMetadata structure
         let submit_notification_sink = service_invocation.submit_notification_sink.take();
 
-        let qid = Configuration::pinned()
-            .common
-            .experimental
+        let qid = self
             .is_vqueues_enabled()
             .then_some(VQueue::infer_vqueue_id_from_invocation(
                 service_invocation.partition_key(),
@@ -1002,7 +1033,7 @@ impl<S> StateMachineApplyContext<'_, S> {
         // have a journal v2 created. To handle already existing invocations for which we didn't
         // create the journal yet, there is a separate path in init_journal to create the journal
         // v2. This change has been introduced with v1.6
-        if self.min_restate_version.use_journal_v2_as_default()
+        if self.use_journal_v2_as_default()
             && let PreFlightInvocationArgument::Input(PreFlightInvocationInput {
                 argument,
                 headers,
@@ -1525,7 +1556,7 @@ impl<S> StateMachineApplyContext<'_, S> {
         // the journal v2 by default (setting the min Restate version to v1.6.0). For invocations
         // that are created afterwards, Restate will create the journal in
         // [`StateMachineApplyContext::on_pre_flight_invocation`].
-        if self.min_restate_version.use_journal_v2_as_default() {
+        if self.use_journal_v2_as_default() {
             // Prepare the new entry
             let new_entry: journal_v2::Entry = InputCommand {
                 headers: invocation_input.headers,
@@ -1664,11 +1695,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             + WriteLockTable
             + ReadVQueueTable,
     {
-        if Configuration::pinned()
-            .common
-            .experimental
-            .is_vqueues_enabled()
-        {
+        if self.is_vqueues_enabled() {
             self.vqueue_enqueue_state_mutation(mutation).await?;
         } else {
             let service_status = self

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -37,7 +37,7 @@ use crate::rule_book_cache::RuleBookCacheHandle;
 use restate_service_protocol::codec::ProtobufRawEntryCodec;
 use restate_service_protocol_v4::entry_codec::ServiceProtocolV4Codec;
 use restate_storage_api::fsm_table::WriteFsmTable;
-use restate_storage_api::inbox_table::{InboxEntry, WriteInboxTable};
+use restate_storage_api::inbox_table::{InboxEntry, ReadInboxTable, WriteInboxTable};
 use restate_storage_api::invocation_status_table::{
     CompletedInvocation, InFlightInvocationMetadata, InboxedInvocation, JournalMetadata,
     JournalRetentionPolicy, PreFlightInvocationArgument, PreFlightInvocationInput,
@@ -105,7 +105,7 @@ use restate_types::journal_v2::{
 };
 use restate_types::logs::Lsn;
 use restate_types::message::MessageIndex;
-use restate_types::partitions::features::PersistedStateMachineFeatures;
+use restate_types::partitions::features::{PartitionFeatureChange, PersistedStateMachineFeatures};
 use restate_types::schema::Schema;
 use restate_types::service_protocol::ServiceProtocolVersion;
 use restate_types::sharding::KeyRange;
@@ -240,6 +240,15 @@ pub enum Error {
         unknown_ids: Vec<u16>,
         required_min_version: SemanticRestateVersion,
         barrier_reason: String,
+    },
+    /// *Since v1.7.0*
+    #[error(
+        "partition is blocked; pre-existing in-flight data must be migrated before applying \
+         feature changes {features:?}; consult the Restate documentation for the server version \
+         that supports this migration"
+    )]
+    MigrationRequired {
+        features: Vec<PartitionFeatureChange>,
     },
     #[error("failed to deserialize entry: {0}")]
     Codec(#[from] RawEntryCodecError),
@@ -531,6 +540,7 @@ impl<S> StateMachineApplyContext<'_, S> {
             + WriteTimerTable
             + ReadVirtualObjectStatusTable
             + WriteVirtualObjectStatusTable
+            + ReadInboxTable
             + WriteInboxTable
             + ReadStateTable
             + WriteStateTable

--- a/crates/worker/src/partition/state_machine/tests/delayed_send.rs
+++ b/crates/worker/src/partition/state_machine/tests/delayed_send.rs
@@ -12,22 +12,26 @@ use super::*;
 
 use restate_storage_api::inbox_table::ReadInboxTable;
 use restate_types::invocation::SubmitNotificationSink;
+use restate_types::partitions::PartitionFeatureChange;
 use restate_types::time::MillisSinceEpoch;
 use std::time::{Duration, SystemTime};
 use test_log::test;
 
 #[restate_core::test]
 async fn send_with_delay() {
-    run_send_with_delay(SemanticRestateVersion::unknown()).await
+    run_send_with_delay(PersistedStateMachineFeatures::default()).await
 }
 
 #[restate_core::test]
 async fn send_with_delay_journal_v2_enabled() {
-    run_send_with_delay(RESTATE_VERSION_1_6_0.clone()).await
+    run_send_with_delay(PersistedStateMachineFeatures::from_iter([
+        PartitionFeatureChange::EnableJournalV2,
+    ]))
+    .await
 }
 
-async fn run_send_with_delay(min_restate_version: SemanticRestateVersion) {
-    let mut test_env = TestEnv::create_with_min_restate_version(min_restate_version).await;
+async fn run_send_with_delay(features: PersistedStateMachineFeatures) {
+    let mut test_env = TestEnv::create_with_features(features).await;
 
     let invocation_target = InvocationTarget::mock_service();
     let invocation_id = InvocationId::mock_random();
@@ -122,7 +126,9 @@ async fn send_with_delay_where_experimental_feature_journal_table_v2_is_enabled_
     );
 
     // Now let's update the features
-    test_env.set_min_restate_version(RESTATE_VERSION_1_6_0.clone());
+    test_env.set_enabled_features(PersistedStateMachineFeatures::from_iter([
+        PartitionFeatureChange::EnableJournalV2,
+    ]));
 
     // Now fire the timer
     let actions = test_env

--- a/crates/worker/src/partition/state_machine/tests/kill_cancel.rs
+++ b/crates/worker/src/partition/state_machine/tests/kill_cancel.rs
@@ -25,6 +25,7 @@ use restate_types::invocation::{IngressInvocationResponseSink, TerminationFlavor
 use restate_types::journal::enriched::EnrichedEntryHeader;
 use restate_types::journal_v2::NotificationId;
 use restate_types::journal_v2::UnresolvedFuture;
+use restate_types::partitions::PartitionFeatureChange;
 use restate_types::service_protocol;
 use rstest::rstest;
 use test_log::test;
@@ -32,20 +33,23 @@ use test_log::test;
 #[restate_core::test]
 async fn kill_inboxed_invocation() -> anyhow::Result<()> {
     Box::pin(run_kill_inboxed_invocation(
-        SemanticRestateVersion::unknown(),
+        PersistedStateMachineFeatures::default(),
     ))
     .await
 }
 
 #[restate_core::test]
 async fn kill_inboxed_invocation_journal_v2_enabled() -> anyhow::Result<()> {
-    Box::pin(run_kill_inboxed_invocation(RESTATE_VERSION_1_6_0.clone())).await
+    Box::pin(run_kill_inboxed_invocation(
+        PersistedStateMachineFeatures::from_iter([PartitionFeatureChange::EnableJournalV2]),
+    ))
+    .await
 }
 
 async fn run_kill_inboxed_invocation(
-    min_restate_version: SemanticRestateVersion,
+    features: PersistedStateMachineFeatures,
 ) -> anyhow::Result<()> {
-    let mut test_env = TestEnv::create_with_min_restate_version(min_restate_version).await;
+    let mut test_env = TestEnv::create_with_features(features).await;
 
     let invocation_target = InvocationTarget::mock_virtual_object();
     let invocation_id = InvocationId::mock_generate(&invocation_target);

--- a/crates/worker/src/partition/state_machine/tests/mod.rs
+++ b/crates/worker/src/partition/state_machine/tests/mod.rs
@@ -85,20 +85,18 @@ impl TestEnv {
     }
 
     pub async fn create() -> Self {
-        Self::create_with_min_restate_version(SemanticRestateVersion::unknown()).await
+        Self::create_with_features(PersistedStateMachineFeatures::default()).await
     }
 
-    pub async fn create_with_min_restate_version(
-        min_restate_version: SemanticRestateVersion,
-    ) -> Self {
+    pub async fn create_with_features(features: PersistedStateMachineFeatures) -> Self {
         Self::create_with_state_machine(StateMachine::new(
             0,    /* inbox_seq_number */
             0,    /* outbox_seq_number */
             None, /* outbox_head_seq_number */
             KeyRange::FULL,
-            min_restate_version,
-            PersistedStateMachineFeatures::default(), /* enabled_features */
-            None,                                     /* schema */
+            SemanticRestateVersion::current().clone(),
+            features, /* enabled_features */
+            None,     /* schema */
             Arc::new(RuleBook::default()),
             RuleBookCacheHandle::detached(),
         ))
@@ -312,8 +310,8 @@ impl TestEnv {
         );
     }
 
-    pub fn set_min_restate_version(&mut self, min_restate_version: SemanticRestateVersion) {
-        self.state_machine.min_restate_version = min_restate_version;
+    pub fn set_enabled_features(&mut self, features: PersistedStateMachineFeatures) {
+        self.state_machine.enabled_features = features;
     }
 }
 

--- a/release-notes/unreleased/vqueues/enable-requires-empty-partition.md
+++ b/release-notes/unreleased/vqueues/enable-requires-empty-partition.md
@@ -1,0 +1,45 @@
+# Release Notes: Enabling vqueues requires a partition with no in-flight invocations
+
+## Behavioral Change
+
+### What Changed
+
+When a partition processor receives a `VersionBarrier` command that turns on
+the `EnableVqueues` feature change, it now checks whether the partition holds
+any pre-existing in-flight data. If it does, the partition processor refuses
+to apply the change and surfaces a `MigrationRequired` error that names the
+feature(s) whose application would otherwise leave that data inconsistent.
+
+A partition is considered to hold in-flight data if either of the following is
+true:
+
+- The inbox table contains any entry (queued invocations or state mutations).
+- The invocation status table contains any entry that is not `Completed`
+  (i.e. `Scheduled`, `Inboxed`, `Invoked`, `Suspended`, or `Paused`). This
+  transitively covers held virtual-object locks and any scheduled-invocation
+  timers, since both map back to a non-`Completed` invocation status.
+
+### Why This Matters
+
+Enabling vqueues routes invocations, state mutations, and virtual-object locks
+through a different set of storage tables. Without an explicit migration step,
+pre-existing in-flight data ends up stranded on the legacy code path and
+cannot be progressed once vqueues is on. This release ships the safety gate;
+the migration that rewrites pre-existing in-flight data into vqueue form is
+planned for a later patch release.
+
+### Impact on Users
+
+- **Fresh deployments** and partitions that hold only completed invocations
+  (or no invocations at all) are unaffected — the barrier applies cleanly and
+  vqueues turns on.
+- **Existing deployments with in-flight invocations** that opt into vqueues
+  via `experimental.is_vqueues_enabled` will see the affected partition halt
+  with the `MigrationRequired` error in its logs. No state is lost: the apply
+  transaction rolls back, the partition stays at its pre-apply state, and the
+  same `VersionBarrier` envelope is re-applied automatically once the cluster
+  is rolled to a server version that ships the migration.
+
+### Migration Guidance
+
+If the gate trips, you need to upgrade to a Restate version that supports the migration. It will be at least Restate v1.7.1.


### PR DESCRIPTION
Block the EnableVqueues state-machine feature change from being applied
to a partition that holds pre-existing in-flight data. This binary does
not ship the migration that would rewrite that data into vqueue form,
so applying the change would otherwise leave the data stranded on the
legacy code path.

The gate runs deterministically inside OnVersionBarrierCommand::apply
for any feature change that flips a feature off->on. It probes the
inbox table (catches inbox invocations and state mutations) and the
invocation status table (catches non-Completed entries, which
transitively cover held virtual-object locks and scheduled-invocation
timers via the InvocationStatus::Scheduled source-of-truth). When the
gate trips, the whole barrier fails atomically with the new
Error::MigrationRequired { features } variant; the transaction rolls
back so no partial state (incl. min_restate_version) is persisted, and
the partition halts until rolled to a server version that supports the
migration.