### PR TITLE
[PartitionStore] Enable use-multi-db-layout for multi-db transition

### DIFF
--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -109,6 +109,7 @@ pub fn spawn_restate(config: Configuration) -> task_center::Handle {
         .into_handle();
 
     let mut prometheus = Prometheus::install(&config.common);
+
     restate_types::config::set_current_config(config);
 
     let mut address_book = AddressBook::new(restate_types::config::node_filepath(""));

--- a/crates/node/src/init.rs
+++ b/crates/node/src/init.rs
@@ -8,9 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::cluster_marker::mark_cluster_as_provisioned;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tracing::{Level, debug, enabled, info, trace, warn};
+
 use restate_core::{MetadataWriter, ShutdownError, TaskCenter, cancellation_token};
 use restate_metadata_store::{MetadataStoreClient, ReadWriteError};
+use restate_types::cluster_marker::ClusterMarker;
 use restate_types::config::Configuration;
 use restate_types::errors::MaybeRetryableError;
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
@@ -19,9 +24,6 @@ use restate_types::nodes_config::{
 };
 use restate_types::retries::RetryPolicy;
 use restate_types::{PlainNodeId, RestateVersion};
-use std::sync::Arc;
-use std::time::{Duration, Instant};
-use tracing::{Level, debug, enabled, info, trace, warn};
 
 #[derive(Debug, thiserror::Error)]
 enum JoinError {
@@ -78,7 +80,7 @@ impl<'a> NodeInit<'a> {
             // If we fail at this point, then we might restart as if the cluster has not been
             // provisioned yet. This is not a problem because the provisioning operation is
             // idempotent.
-            mark_cluster_as_provisioned()?;
+            ClusterMarker::mark_cluster_as_provisioned(nodes_configuration.cluster_fingerprint())?;
         }
 
         // Find my node in nodes configuration.

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -8,7 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod cluster_marker;
 mod failure_detector;
 mod init;
 mod introspection;
@@ -49,6 +48,7 @@ use restate_metadata_server::{
 use restate_metadata_store::{ReadWriteError, WriteError, retry_on_retryable_error};
 use restate_partition_store::PartitionStoreManager;
 use restate_tracing_instrumentation::prometheus_metrics::Prometheus;
+use restate_types::cluster_marker::{ClusterMarker, ClusterValidationError};
 use restate_types::config::{CommonOptions, Configuration};
 use restate_types::errors::IntoMaybeRetryable;
 use restate_types::health::NodeStatus;
@@ -69,7 +69,6 @@ use restate_types::protobuf::common::{
 use restate_types::{GenerationalNodeId, RestateVersion, Version, Versioned};
 
 use self::failure_detector::FailureDetector;
-use crate::cluster_marker::ClusterValidationError;
 use crate::init::NodeInit;
 use crate::network_server::NetworkServer;
 use crate::roles::{AdminRole, IngressRole, WorkerRole};
@@ -175,8 +174,12 @@ impl Node {
         let tc = TaskCenter::current();
         debug_assert!(is_set, "Global metadata was already set");
 
-        let is_provisioned =
-            cluster_marker::validate_and_update_cluster_marker(config.common.cluster_name())?;
+        let marker = ClusterMarker::validate_or_create(
+            config.common.cluster_name(),
+            config.worker.use_multi_db_layout,
+        )?;
+
+        let is_provisioned = marker.provisioned();
 
         // If MetadataServerKind::Local and Role::MetadataServer are configured,
         // we use an in-memory client, ignoring the rest of the client config.
@@ -259,7 +262,8 @@ impl Node {
 
         let bifrost = bifrost_svc.handle();
 
-        let partition_store_manager = PartitionStoreManager::create().await?;
+        let partition_store_manager =
+            PartitionStoreManager::create(marker.uses_multi_db_layout()).await?;
 
         let log_server = if config.has_role(Role::LogServer) {
             Some(

--- a/crates/partition-store/benches/basic_benchmark.rs
+++ b/crates/partition-store/benches/basic_benchmark.rs
@@ -51,7 +51,7 @@ fn basic_writing_reading_benchmark(c: &mut Criterion) {
         //
         // setup
         //
-        let manager = PartitionStoreManager::create()
+        let manager = PartitionStoreManager::create(true)
             .await
             .expect("DB creation succeeds");
         manager

--- a/crates/partition-store/src/migrations.rs
+++ b/crates/partition-store/src/migrations.rs
@@ -165,7 +165,7 @@ mod tests {
     async fn split_returns_independent_sub_contexts() {
         let _clock_guard = ClockUpkeep::start().expect("clock upkeep should start");
         RocksDbManager::init();
-        let manager = PartitionStoreManager::create()
+        let manager = PartitionStoreManager::create(true)
             .await
             .expect("DB storage creation succeeds");
         let store = manager

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -1331,7 +1331,7 @@ mod tests {
     #[restate_core::test]
     async fn concurrent_writes_and_reads() -> googletest::Result<()> {
         let rocksdb = RocksDbManager::init();
-        let partition_store_manager = PartitionStoreManager::create().await?;
+        let partition_store_manager = PartitionStoreManager::create(true).await?;
         let mut partition_store = partition_store_manager
             .open(
                 &Partition::new(

--- a/crates/partition-store/src/partition_store_manager.rs
+++ b/crates/partition-store/src/partition_store_manager.rs
@@ -127,10 +127,11 @@ pub struct PartitionStoreManager {
     snapshots: Snapshots,
     db_cache: AsyncMutex<HashMap<restate_rocksdb::DbName, Weak<RocksDb>>>,
     memory_controller: MemoryController,
+    use_multi_db_layout: bool,
 }
 
 impl PartitionStoreManager {
-    pub async fn create() -> Result<Arc<Self>, BuildError> {
+    pub async fn create(use_multi_db_layout: bool) -> Result<Arc<Self>, BuildError> {
         crate::metric_definitions::describe_metrics();
 
         // Start the memory controller, how do we know when db is dropped?
@@ -144,6 +145,7 @@ impl PartitionStoreManager {
                 .map_err(BuildError::Snapshots)?,
             db_cache: Default::default(),
             memory_controller,
+            use_multi_db_layout,
         });
 
         Ok(psm)
@@ -151,7 +153,7 @@ impl PartitionStoreManager {
 
     async fn open_rocksdb(&self, partition: &Partition) -> Result<Arc<RocksDb>, RocksError> {
         let mut db_cache_guard = self.db_cache.lock().await;
-        let db_name = restate_rocksdb::DbName::from(partition.db_name());
+        let db_name = restate_rocksdb::DbName::from(partition.db_name(self.use_multi_db_layout));
 
         if let Some(db) = db_cache_guard.get(&db_name).and_then(|db| db.upgrade()) {
             return Ok(db);

--- a/crates/partition-store/src/tests/barrier_test.rs
+++ b/crates/partition-store/src/tests/barrier_test.rs
@@ -34,7 +34,7 @@ async fn barrier_fsm() -> googletest::Result<()> {
 
     let rocksdb = RocksDbManager::init();
 
-    let partition_store_manager = PartitionStoreManager::create().await?;
+    let partition_store_manager = PartitionStoreManager::create(true).await?;
 
     let partition = Partition::new(
         PartitionId::MIN,

--- a/crates/partition-store/src/tests/durable_lsn_tracking_test.rs
+++ b/crates/partition-store/src/tests/durable_lsn_tracking_test.rs
@@ -44,7 +44,7 @@ async fn track_latest_applied_lsn() -> googletest::Result<()> {
 
     let rocksdb = RocksDbManager::init();
 
-    let partition_store_manager = PartitionStoreManager::create().await?;
+    let partition_store_manager = PartitionStoreManager::create(true).await?;
 
     let mut partition_store = partition_store_manager.open(&PARTITION, None).await?;
 
@@ -113,7 +113,7 @@ async fn track_latest_applied_lsn() -> googletest::Result<()> {
 async fn partition_durability_fsm() -> googletest::Result<()> {
     let rocksdb = RocksDbManager::init();
 
-    let partition_store_manager = PartitionStoreManager::create().await?;
+    let partition_store_manager = PartitionStoreManager::create(true).await?;
 
     let mut partition_store = partition_store_manager.open(&PARTITION, None).await?;
 

--- a/crates/partition-store/src/tests/migrations_test/migrate_to_locks_table.rs
+++ b/crates/partition-store/src/tests/migrations_test/migrate_to_locks_table.rs
@@ -35,7 +35,7 @@ use crate::{PartitionStore, PartitionStoreManager};
 
 async fn storage_test_environment() -> PartitionStore {
     RocksDbManager::init();
-    let manager = PartitionStoreManager::create()
+    let manager = PartitionStoreManager::create(true)
         .await
         .expect("DB storage creation succeeds");
     manager

--- a/crates/partition-store/src/tests/migrations_test/migrate_to_scoped_promise_table.rs
+++ b/crates/partition-store/src/tests/migrations_test/migrate_to_scoped_promise_table.rs
@@ -34,7 +34,7 @@ use crate::scan::{PhysicalScan, TableScan};
 #[restate_core::test]
 async fn migrate_to_scoped_promise_table_moves_unscoped_promises_to_scoped_table() {
     RocksDbManager::init();
-    let manager = PartitionStoreManager::create()
+    let manager = PartitionStoreManager::create(true)
         .await
         .expect("DB storage creation succeeds");
     let mut rocksdb = manager

--- a/crates/partition-store/src/tests/migrations_test/migrate_to_scoped_state_table.rs
+++ b/crates/partition-store/src/tests/migrations_test/migrate_to_scoped_state_table.rs
@@ -31,7 +31,7 @@ use crate::state_table::{ScopedStateKey, StateKey};
 #[restate_core::test]
 async fn migrate_to_scoped_state_table_moves_unscoped_state_to_scoped_table() {
     RocksDbManager::init();
-    let manager = PartitionStoreManager::create()
+    let manager = PartitionStoreManager::create(true)
         .await
         .expect("DB storage creation succeeds");
     let mut rocksdb = manager

--- a/crates/partition-store/src/tests/mod.rs
+++ b/crates/partition-store/src/tests/mod.rs
@@ -53,7 +53,7 @@ async fn storage_test_environment_with_manager() -> (Arc<PartitionStoreManager>,
     // create a rocksdb storage from options
     //
     RocksDbManager::init();
-    let manager = PartitionStoreManager::create()
+    let manager = PartitionStoreManager::create(true)
         .await
         .expect("DB storage creation succeeds");
     // A single partition store that spans all keys.

--- a/crates/storage-query-datafusion/src/mocks.rs
+++ b/crates/storage-query-datafusion/src/mocks.rs
@@ -205,7 +205,7 @@ impl MockQueryEngine {
     ) -> Self {
         // Prepare Rocksdb
         RocksDbManager::init();
-        let manager = PartitionStoreManager::create()
+        let manager = PartitionStoreManager::create(true)
             .await
             .expect("DB creation succeeds");
         let partition_store = manager

--- a/crates/storage-query-datafusion/src/partition/row.rs
+++ b/crates/storage-query-datafusion/src/partition/row.rs
@@ -25,7 +25,6 @@ pub(crate) fn append_partition_row(
     row.start_key(partition.key_range.start());
     row.end_key(partition.key_range.end());
     row.cf_name(partition.cf_name());
-    row.db_name(partition.db_name());
     let leadership = membership.current_leader();
     if leadership.current_leader.is_valid() {
         row.fmt_leader_gen_node_id(leadership.current_leader);

--- a/crates/storage-query-datafusion/src/partition/schema.rs
+++ b/crates/storage-query-datafusion/src/partition/schema.rs
@@ -30,9 +30,6 @@ define_table!(
         /// The column family name
         cf_name: DataType::Utf8,
 
-        /// The database name
-        db_name: DataType::Utf8,
-
         /// The partition leader generational node id acquired from gossip
         leader_gen_node_id: DataType::Utf8,
 

--- a/crates/types/src/cluster_marker.rs
+++ b/crates/types/src/cluster_marker.rs
@@ -14,8 +14,9 @@ use std::path::Path;
 
 use tracing::debug;
 
-use restate_types::SemanticRestateVersion;
-use restate_types::config::node_filepath;
+use crate::SemanticRestateVersion;
+use crate::config::node_filepath;
+use crate::nodes_config::ClusterFingerprint;
 
 const CLUSTER_MARKER_FILE_NAME: &str = ".cluster-marker";
 const TMP_CLUSTER_MARKER_FILE_NAME: &str = ".tmp-cluster-marker";
@@ -90,6 +91,13 @@ pub enum ClusterValidationError {
         this_version: SemanticRestateVersion,
         data_version: SemanticRestateVersion,
     },
+    #[error(
+        "cluster fingerprint mismatch: data directory belongs to cluster with fingerprint '{persisted}', but the running cluster has fingerprint '{configured}'"
+    )]
+    ClusterFingerprintMismatch {
+        configured: ClusterFingerprint,
+        persisted: ClusterFingerprint,
+    },
 }
 
 /// Marker stored in the Node's working directory with metadata about the cluster it belongs to and
@@ -97,6 +105,9 @@ pub enum ClusterValidationError {
 #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct ClusterMarker {
     cluster_name: String,
+    /// Since v1.7.0. Nodes before this version won't read or write this field.
+    /// V1.7.0 will write this field on provisioning.
+    cluster_fingerprint: Option<ClusterFingerprint>,
     /// The highest version that has operated on the data directory.
     max_version: SemanticRestateVersion,
     /// The most recent version to operate on the data directory.
@@ -105,7 +116,14 @@ pub struct ClusterMarker {
     /// This field should only be updated when updating the `max_version` field.
     min_forward_compatible_version: Option<SemanticRestateVersion>,
     /// True if the cluster is known to be provisioned. Versions < 1.2 don't have this field stored.
-    is_provisioned: Option<bool>,
+    is_provisioned: bool,
+    /// True if the node is using the multi-db layout (db-*).
+    ///
+    /// Nodes older than v1.7.0 cannot detect the layout and will always assume a single-db layout.
+    ///
+    /// *Since v1.7.0*
+    #[serde(default)]
+    use_multi_db_layout: bool,
 }
 
 impl ClusterMarker {
@@ -114,40 +132,67 @@ impl ClusterMarker {
         current_version: SemanticRestateVersion,
         min_forward_compatible_version: SemanticRestateVersion,
         is_provisioned: bool,
+        use_multi_db_layout: bool,
     ) -> Self {
         Self {
             cluster_name,
             max_version: current_version.clone(),
             current_version,
             min_forward_compatible_version: Some(min_forward_compatible_version),
-            is_provisioned: Some(is_provisioned),
+            is_provisioned,
+            use_multi_db_layout,
+            cluster_fingerprint: None,
         }
     }
 }
 
-/// Validates and updates the cluster marker wrt to the currently used Restate version. Returns
-/// whether the cluster was provisioned before.
-pub fn validate_and_update_cluster_marker(
-    cluster_name: &str,
-) -> Result<bool, ClusterValidationError> {
-    let this_version = SemanticRestateVersion::current();
+impl ClusterMarker {
+    /// Validates and updates the cluster marker wrt to the currently used Restate version.
+    pub fn validate_or_create(
+        cluster_name: &str,
+        use_multi_db_layout: bool,
+    ) -> Result<Self, ClusterValidationError> {
+        let this_version = SemanticRestateVersion::current();
 
-    let cluster_marker_filepath = node_filepath(CLUSTER_MARKER_FILE_NAME);
+        let cluster_marker_filepath = node_filepath(CLUSTER_MARKER_FILE_NAME);
 
-    validate_and_update_cluster_marker_inner(
-        cluster_name,
-        this_version,
-        cluster_marker_filepath.as_path(),
-        &COMPATIBILITY_INFORMATION,
-    )
+        validate_and_update_cluster_marker_inner(
+            cluster_name,
+            this_version,
+            cluster_marker_filepath.as_path(),
+            use_multi_db_layout,
+            &COMPATIBILITY_INFORMATION,
+        )
+    }
+
+    /// Marks the cluster as provisioned in the cluster marker
+    pub fn mark_cluster_as_provisioned(
+        fingerprint: Option<ClusterFingerprint>,
+    ) -> Result<(), ClusterValidationError> {
+        let cluster_marker_filepath = node_filepath(CLUSTER_MARKER_FILE_NAME);
+        mark_cluster_as_provisioned_inner(cluster_marker_filepath.as_path(), fingerprint)
+    }
+
+    pub fn provisioned(&self) -> bool {
+        self.is_provisioned
+    }
+
+    pub fn cluster_fingerprint(&self) -> Option<ClusterFingerprint> {
+        self.cluster_fingerprint
+    }
+
+    pub fn uses_multi_db_layout(&self) -> bool {
+        self.use_multi_db_layout
+    }
 }
 
 fn validate_and_update_cluster_marker_inner(
     cluster_name: &str,
     this_version: &SemanticRestateVersion,
     cluster_marker_filepath: &Path,
+    use_multi_db_layout: bool,
     compatibility_information: &CompatibilityInformation,
-) -> Result<bool, ClusterValidationError> {
+) -> Result<ClusterMarker, ClusterValidationError> {
     let mut cluster_marker = if cluster_marker_filepath.exists() {
         read_cluster_marker(cluster_marker_filepath)?
     } else {
@@ -162,6 +207,7 @@ fn validate_and_update_cluster_marker_inner(
                 .min_forward_compatible_version
                 .clone(),
             false,
+            use_multi_db_layout,
         )
     };
 
@@ -215,7 +261,7 @@ fn validate_and_update_cluster_marker_inner(
 
     write_new_cluster_marker(cluster_marker_filepath, &cluster_marker)?;
 
-    Ok(cluster_marker.is_provisioned.unwrap_or_default())
+    Ok(cluster_marker)
 }
 
 fn write_new_cluster_marker(
@@ -278,28 +324,43 @@ fn read_cluster_marker(
         .map_err(ClusterValidationError::Decode)
 }
 
-/// Marks the cluster as provisioned in the cluster marker
-pub fn mark_cluster_as_provisioned() -> Result<(), ClusterValidationError> {
-    let cluster_marker_filepath = node_filepath(CLUSTER_MARKER_FILE_NAME);
-    mark_cluster_as_provisioned_inner(cluster_marker_filepath.as_path())
-}
-
 fn mark_cluster_as_provisioned_inner(
     cluster_marker_filepath: &Path,
+    fingerprint: Option<ClusterFingerprint>,
 ) -> Result<(), ClusterValidationError> {
     let mut cluster_marker = read_cluster_marker(cluster_marker_filepath)?;
-    cluster_marker.is_provisioned = Some(true);
+
+    // Reconcile the persisted fingerprint with the input:
+    // - existing None, input Some  -> adopt input
+    // - existing Some, input Some  -> must match, otherwise error
+    // - existing Some, input None  -> keep existing (older callers may not supply one)
+    // - existing None, input None  -> nothing to do
+    match (cluster_marker.cluster_fingerprint, fingerprint) {
+        (Some(persisted), Some(configured)) if persisted != configured => {
+            return Err(ClusterValidationError::ClusterFingerprintMismatch {
+                configured,
+                persisted,
+            });
+        }
+        (None, Some(input)) => {
+            cluster_marker.cluster_fingerprint = Some(input);
+        }
+        _ => {}
+    }
+
+    cluster_marker.is_provisioned = true;
     write_new_cluster_marker(cluster_marker_filepath, &cluster_marker)
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::SemanticRestateVersion;
     use crate::cluster_marker::{
         CLUSTER_MARKER_FILE_NAME, COMPATIBILITY_INFORMATION, ClusterMarker, ClusterValidationError,
         CompatibilityInformation, mark_cluster_as_provisioned_inner,
         validate_and_update_cluster_marker_inner,
     };
-    use restate_types::SemanticRestateVersion;
+    use crate::nodes_config::ClusterFingerprint;
     use std::fs;
     use std::fs::OpenOptions;
     use std::path::Path;
@@ -341,6 +402,7 @@ mod tests {
             CLUSTER_NAME,
             &current_version,
             file.as_path(),
+            false,
             &TESTING_COMPATIBILITY_INFORMATION,
         )
         .unwrap();
@@ -356,7 +418,9 @@ mod tests {
                 min_forward_compatible_version: Some(
                     TESTING_COMPATIBILITY_INFORMATION.min_forward_compatible_version
                 ),
-                is_provisioned: Some(false),
+                is_provisioned: false,
+                use_multi_db_layout: false,
+                cluster_fingerprint: None,
             }
         )
     }
@@ -374,6 +438,7 @@ mod tests {
                 previous_version,
                 TESTING_COMPATIBILITY_INFORMATION.min_forward_compatible_version,
                 true,
+                false,
             ),
             &file,
         )?;
@@ -382,6 +447,7 @@ mod tests {
             CLUSTER_NAME,
             &current_version,
             &file,
+            false,
             &TESTING_COMPATIBILITY_INFORMATION,
         )?;
 
@@ -396,7 +462,9 @@ mod tests {
                 min_forward_compatible_version: Some(
                     TESTING_COMPATIBILITY_INFORMATION.min_forward_compatible_version
                 ),
-                is_provisioned: Some(true),
+                is_provisioned: true,
+                use_multi_db_layout: false,
+                cluster_fingerprint: None,
             }
         );
         Ok(())
@@ -415,6 +483,7 @@ mod tests {
                 max_version.clone(),
                 TESTING_COMPATIBILITY_INFORMATION.min_forward_compatible_version,
                 false,
+                false,
             ),
             &file,
         )?;
@@ -423,6 +492,7 @@ mod tests {
             CLUSTER_NAME,
             &current_version,
             &file,
+            false,
             &TESTING_COMPATIBILITY_INFORMATION,
         )?;
 
@@ -437,7 +507,9 @@ mod tests {
                 min_forward_compatible_version: Some(
                     TESTING_COMPATIBILITY_INFORMATION.min_forward_compatible_version
                 ),
-                is_provisioned: Some(false),
+                is_provisioned: false,
+                use_multi_db_layout: false,
+                cluster_fingerprint: None,
             }
         );
         Ok(())
@@ -456,6 +528,7 @@ mod tests {
                 max_version,
                 TESTING_COMPATIBILITY_INFORMATION.min_forward_compatible_version,
                 true,
+                false,
             ),
             &file,
         )?;
@@ -464,6 +537,7 @@ mod tests {
             CLUSTER_NAME,
             &current_version,
             &file,
+            false,
             &TESTING_COMPATIBILITY_INFORMATION,
         );
         assert!(matches!(
@@ -486,6 +560,7 @@ mod tests {
                 max_version,
                 SemanticRestateVersion::new(2, 0, 0),
                 true,
+                false,
             ),
             &file,
         )?;
@@ -494,6 +569,7 @@ mod tests {
             CLUSTER_NAME,
             &this_version,
             &file,
+            false,
             &COMPATIBILITY_INFORMATION,
         );
         assert!(matches!(
@@ -515,6 +591,7 @@ mod tests {
                 max_version,
                 SemanticRestateVersion::new(1, 4, 0),
                 true,
+                false,
             ),
             &file,
         )?;
@@ -523,6 +600,7 @@ mod tests {
             CLUSTER_NAME,
             &this_version,
             &file,
+            false,
             &COMPATIBILITY_INFORMATION,
         );
         assert!(matches!(
@@ -545,6 +623,7 @@ mod tests {
                 max_version,
                 TESTING_COMPATIBILITY_INFORMATION.min_forward_compatible_version,
                 false,
+                false,
             ),
             &file,
         )?;
@@ -553,6 +632,7 @@ mod tests {
             CLUSTER_NAME,
             &this_version,
             &file,
+            false,
             &TESTING_COMPATIBILITY_INFORMATION,
         );
         assert!(result.is_ok());
@@ -566,32 +646,56 @@ mod tests {
         let file = dir.path().join(CLUSTER_MARKER_FILE_NAME);
         let version = SemanticRestateVersion::new(2, 2, 6);
 
-        write_cluster_marker(
-            &ClusterMarker::new(
+        let fresh_marker = || {
+            ClusterMarker::new(
                 CLUSTER_NAME.to_owned(),
                 version.clone(),
                 TESTING_COMPATIBILITY_INFORMATION.min_forward_compatible_version,
                 false,
-            ),
-            &file,
-        )?;
+                false,
+            )
+        };
 
-        mark_cluster_as_provisioned_inner(&file)?;
+        let fp_a = ClusterFingerprint::try_from(0xA1A1_A1A1_A1A1_A1A1u64)?;
+        let fp_b = ClusterFingerprint::try_from(0xB2B2_B2B2_B2B2_B2B2u64)?;
 
-        let cluster_marker = read_cluster_marker(file)?;
+        // Case 1: existing None, input Some -> adopt input and become provisioned.
+        write_cluster_marker(&fresh_marker(), &file)?;
+        mark_cluster_as_provisioned_inner(&file, Some(fp_a))?;
+        let marker = read_cluster_marker(&file)?;
+        assert!(marker.is_provisioned);
+        assert_eq!(marker.cluster_fingerprint, Some(fp_a));
 
-        assert_eq!(
-            cluster_marker,
-            ClusterMarker {
-                current_version: version.clone(),
-                max_version: version,
-                cluster_name: CLUSTER_NAME.to_owned(),
-                min_forward_compatible_version: Some(
-                    TESTING_COMPATIBILITY_INFORMATION.min_forward_compatible_version
-                ),
-                is_provisioned: Some(true),
-            }
-        );
+        // Case 2: existing Some, input Some matching -> idempotent, no error.
+        mark_cluster_as_provisioned_inner(&file, Some(fp_a))?;
+        let marker = read_cluster_marker(&file)?;
+        assert!(marker.is_provisioned);
+        assert_eq!(marker.cluster_fingerprint, Some(fp_a));
+
+        // Case 3: existing Some, input None -> keep existing silently.
+        mark_cluster_as_provisioned_inner(&file, None)?;
+        let marker = read_cluster_marker(&file)?;
+        assert!(marker.is_provisioned);
+        assert_eq!(marker.cluster_fingerprint, Some(fp_a));
+
+        // Case 4: existing Some, input Some differing -> error, no mutation.
+        let result = mark_cluster_as_provisioned_inner(&file, Some(fp_b));
+        assert!(matches!(
+            result,
+            Err(ClusterValidationError::ClusterFingerprintMismatch {
+                configured,
+                persisted,
+            }) if configured == fp_b && persisted == fp_a
+        ));
+        let marker = read_cluster_marker(&file)?;
+        assert_eq!(marker.cluster_fingerprint, Some(fp_a));
+
+        // Case 5: existing None, input None -> mark provisioned, fingerprint stays None.
+        write_cluster_marker(&fresh_marker(), &file)?;
+        mark_cluster_as_provisioned_inner(&file, None)?;
+        let marker = read_cluster_marker(&file)?;
+        assert!(marker.is_provisioned);
+        assert_eq!(marker.cluster_fingerprint, None);
 
         Ok(())
     }

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -124,6 +124,19 @@ pub struct WorkerOptions {
     /// partition leader has yet observed the change. Default: 30 s.
     /// *Since v1.7.0*
     pub rule_book_poll_interval: NonZeroFriendlyDuration,
+
+    /// Create a database per partition
+    ///
+    /// This asks the node to create a database per partition. Enabling this is only
+    /// effective for fresh empty nodes. If this was enabled on a node that already has
+    /// the single db layout, the node will continue to use the single db layout.
+    ///
+    /// It's possible in future versions (>=v1.8.0+) to include automatic migration
+    /// facility when enabling this option on a legacy node.
+    /// *Since v1.7.0*
+    #[cfg_attr(feature = "schemars", schemars(skip))]
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub use_multi_db_layout: bool,
 }
 
 impl WorkerOptions {
@@ -185,6 +198,7 @@ impl Default for WorkerOptions {
                 NonZeroUsize::new(256 * 1024 * 1024).unwrap(),
             ),
             rule_book_poll_interval: NonZeroFriendlyDuration::from_secs_unchecked(30),
+            use_multi_db_layout: false,
         }
     }
 }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -26,6 +26,7 @@ pub mod cluster;
 pub mod cluster_state;
 pub mod health;
 
+pub mod cluster_marker;
 pub mod config;
 pub mod config_loader;
 pub mod deployment;

--- a/crates/types/src/nodes_config.rs
+++ b/crates/types/src/nodes_config.rs
@@ -190,6 +190,8 @@ pub struct NodesConfiguration {
     // A unique fingerprint for this cluster. Introduced in v1.3 for forward compatibility. As of
     // v1.6, we expect this cluster fingerprint to be present. Will be used to uniquely identify
     // this cluster instance. The value is None if the nodes configuration is invalid.
+    //
+    // NOTE: This is optional due to the issue described in https://github.com/restatedev/restate/issues/4293
     cluster_fingerprint: Option<ClusterFingerprint>,
     // flexbuffers only supports string-keyed maps :-( --> so we store it as vector of kv pairs
     #[serde_as(as = "serde_with::Seq<(_, _)>")]

--- a/crates/types/src/partition_table.rs
+++ b/crates/types/src/partition_table.rs
@@ -261,7 +261,6 @@ pub struct Partition {
     pub partition_id: PartitionId,
     pub key_range: crate::sharding::KeyRange,
     log_id: Option<LogId>,
-    db_name: Option<DbName>,
     cf_name: Option<CfName>,
 }
 
@@ -271,7 +270,6 @@ impl Partition {
             partition_id,
             key_range,
             log_id: None,
-            db_name: None,
             cf_name: None,
         }
     }
@@ -285,15 +283,13 @@ impl Partition {
             .unwrap_or_else(|| LogId::default_for_partition(self.partition_id))
     }
 
-    pub fn db_name(&self) -> DbName {
+    pub fn db_name(&self, use_multi_db_layout: bool) -> DbName {
         let base = DatabaseKind::PartitionStore.db_name();
-        #[cfg(feature = "multi-db")]
-        return self
-            .db_name
-            .clone()
-            .unwrap_or_else(|| DbName::from(format!("{base}-{}", self.partition_id)));
-        #[cfg(not(feature = "multi-db"))]
-        return self.db_name.clone().unwrap_or_else(|| DbName::from(base));
+        if use_multi_db_layout {
+            DbName::from(format!("{base}-{}", self.partition_id))
+        } else {
+            DbName::from(base)
+        }
     }
 
     pub fn cf_name(&self) -> CfName {
@@ -483,7 +479,7 @@ impl From<PartitionTable> for PartitionTableShadow {
                             log_id: partition.log_id,
                             key_range: partition.key_range,
                             cf_name: partition.cf_name,
-                            db_name: partition.db_name,
+                            db_name: None,
                         };
 
                         (partition_id, partition_shadow)
@@ -514,7 +510,6 @@ impl TryFrom<PartitionTableShadow> for PartitionTable {
                         partition_id,
                         log_id: partition_shadow.log_id,
                         key_range: partition_shadow.key_range,
-                        db_name: partition_shadow.db_name,
                         cf_name: partition_shadow.cf_name,
                     };
 

--- a/crates/types/src/protobuf.rs
+++ b/crates/types/src/protobuf.rs
@@ -87,7 +87,7 @@ pub mod common {
         /// For [`DatabaseKind::PartitionStore`], this returns the base prefix `"db"`.
         /// Individual partition databases may be named `"db-{partition_id}"` in
         /// multi-db mode.
-        pub fn db_name(&self) -> &'static str {
+        pub const fn db_name(&self) -> &'static str {
             match self {
                 DatabaseKind::LogServer => "log-server",
                 DatabaseKind::MetadataServer => "replicated-metadata-server",

--- a/crates/vqueues/src/scheduler/drr.rs
+++ b/crates/vqueues/src/scheduler/drr.rs
@@ -467,7 +467,7 @@ mod tests {
             rocksdb_manager.shutdown().await;
         }));
 
-        let manager = PartitionStoreManager::create()
+        let manager = PartitionStoreManager::create(true)
             .await
             .expect("DB storage creation succeeds");
         manager

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -953,7 +953,7 @@ mod tests {
         let bifrost = Bifrost::init_in_memory(env.metadata_writer).await;
         let replica_set_states = PartitionReplicaSetStates::default();
 
-        let partition_store_manager = PartitionStoreManager::create().await?;
+        let partition_store_manager = PartitionStoreManager::create(true).await?;
 
         let ingress = IngestionClient::new(
             env.networking.clone(),

--- a/crates/worker/src/partition/state_machine/tests/mod.rs
+++ b/crates/worker/src/partition/state_machine/tests/mod.rs
@@ -132,7 +132,7 @@ impl TestEnv {
             "Using RocksDB temp directory {}",
             storage_options.data_dir("db").display()
         );
-        let manager = PartitionStoreManager::create().await.unwrap();
+        let manager = PartitionStoreManager::create(true).await.unwrap();
         let rocksdb_storage = manager
             .open(&Partition::new(PartitionId::MIN, KeyRange::FULL), None)
             .await

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -1595,7 +1595,7 @@ mod tests {
 
         let replica_set_states = PartitionReplicaSetStates::default();
 
-        let partition_store_manager = PartitionStoreManager::create().await?;
+        let partition_store_manager = PartitionStoreManager::create(true).await?;
 
         let ingestion_client = IngestionClient::new(
             env_builder.networking.clone(),

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -238,6 +238,7 @@ fn main() {
             } else {
                 "[default]".to_owned()
             };
+
             info!(
                 node_name = Configuration::pinned().node_name(),
                 config_source = %config_source,

--- a/tools/pp-bench/src/workload.rs
+++ b/tools/pp-bench/src/workload.rs
@@ -96,7 +96,7 @@ pub async fn run(
     // -----------------------------------------------------------------------
     RocksDbManager::init();
 
-    let manager = PartitionStoreManager::create().await?;
+    let manager = PartitionStoreManager::create(true).await?;
     let mut partition_store = manager
         .open(&Partition::new(PartitionId::MIN, KeyRange::FULL), None)
         .await?;


### PR DESCRIPTION

The strategy is to allow nodes to start with `RESTATE_WORKER__USE_MULTI_DB_LAYOUT=true` when empty
and they'll provision their partition store with the multi-db layout. The layout choice is persisted
in the cluster marker and on future runs, it will be used as the source of truth. This makes it safe
to enable this option on all nodes of a cluster safely, only new nodes will respect it.

If/when we need to support a migration from single-db to multi-db layout, we'll trigger this transition
on node startup and update the marker accordingly. This makes the migration compatible with older nodes.


- Persist the database layout choice (single-db vs multi-db) in the cluster
marker on first provisioning, so nodes consistently open partition stores
under the layout the cluster was created with. The layout flag flows from
the `ClusterMarker` returned by `validate_or_create` into
`PartitionStoreManager`, which uses it to compute per-partition `DbName`s.

- All existing tests have been updated to use the new `use_multi_db_layout` to increase confidence.

- Record the cluster fingerprint in the marker on provisioning. Not
consumed yet — lays the groundwork for validating that a node's data
directory belongs to the cluster it is being asked to join.

- Remove the `db_name` field from the sql `partitions`, the field isn't useful in
investigations and will require some plumbing if we want to keep it. I deemed it to be not worth the effort.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4789).
* #4791
* __->__ #4789