### PR TITLE
Expose enabled state-machine features on partition state

### DIFF
--- a/crates/storage-query-datafusion/src/partition_state/row.rs
+++ b/crates/storage-query-datafusion/src/partition_state/row.rs
@@ -66,4 +66,6 @@ pub(crate) fn append_partition_row(
     if let Some(version) = state.last_applied_schema_version {
         row.applied_schema_version(u32::from(version));
     }
+
+    row.enabled_features(state.enabled_features.enabled_names().map(Some));
 }

--- a/crates/storage-query-datafusion/src/partition_state/schema.rs
+++ b/crates/storage-query-datafusion/src/partition_state/schema.rs
@@ -62,5 +62,9 @@ define_table!(
 
         /// Version of the schema currently applied by the partition processor
         applied_schema_version: DataType::UInt32,
+
+        /// State-machine features currently enabled on the partition processor.
+        /// Query membership with `array_has(enabled_features, 'vqueues')`.
+        enabled_features: Utf8List,
     )
 );

--- a/crates/storage-query-datafusion/src/table_macro.rs
+++ b/crates/storage-query-datafusion/src/table_macro.rs
@@ -49,6 +49,9 @@ macro_rules! define_builder {
     (LargeUtf8List) => {
         ::datafusion::arrow::array::ListBuilder<::datafusion::arrow::array::LargeStringBuilder>
     };
+    (Utf8List) => {
+        ::datafusion::arrow::array::ListBuilder<::datafusion::arrow::array::StringBuilder>
+    };
 }
 
 pub(crate) trait BuilderCapacity: datafusion::arrow::array::ArrayBuilder {
@@ -277,6 +280,9 @@ macro_rules! define_primitive_trait {
     (LargeUtf8List) => {
         impl IntoIterator<Item = Option<impl AsRef<str>>>
     };
+    (Utf8List) => {
+        impl IntoIterator<Item = Option<impl AsRef<str>>>
+    };
 }
 
 pub static TIMEZONE_UTC: std::sync::LazyLock<std::sync::Arc<str>> =
@@ -326,6 +332,11 @@ macro_rules! define_data_type {
             ::datafusion::common::arrow::datatypes::Field::new("item", DataType::LargeUtf8, true),
         ))
     };
+    (Utf8List) => {
+        DataType::List(::datafusion::common::arrow::datatypes::FieldRef::new(
+            ::datafusion::common::arrow::datatypes::Field::new("item", DataType::Utf8, true),
+        ))
+    };
 }
 
 #[cfg(feature = "table_docs")]
@@ -364,6 +375,9 @@ macro_rules! document_type {
         "UInt32 List"
     };
     (LargeUtf8List) => {
+        "Utf8 List"
+    };
+    (Utf8List) => {
         "Utf8 List"
     };
 }

--- a/crates/types/protobuf/restate/cluster.proto
+++ b/crates/types/protobuf/restate/cluster.proto
@@ -74,6 +74,10 @@ message PartitionProcessorStatus {
   optional restate.common.Lsn target_tail_lsn = 11;
   optional restate.common.Version last_applied_rule_book_version = 13;
   optional restate.common.Version last_applied_schema_version = 14;
+  // Names of state-machine features currently enabled on this partition
+  // processor. Carried as strings so that older clients can render feature
+  // names they don't recognise.
+  repeated string enabled_features = 15;
 }
 
 message ReplicationProperty { string replication_property = 1; }

--- a/crates/types/src/cluster/cluster_state.rs
+++ b/crates/types/src/cluster/cluster_state.rs
@@ -18,6 +18,7 @@ use restate_encoding::NetSerde;
 
 use crate::identifiers::{LeaderEpoch, PartitionId};
 use crate::logs::Lsn;
+use crate::partitions::features::PersistedStateMachineFeatures;
 use crate::time::MillisSinceEpoch;
 use crate::{GenerationalNodeId, PlainNodeId, Version};
 
@@ -215,6 +216,16 @@ pub struct PartitionProcessorStatus {
     /// `None` until the first schema is observed.
     #[bilrost(14)]
     pub last_applied_schema_version: Option<Version>,
+    /// State-machine features currently enabled on this partition processor.
+    /// Translated to a list of names at the protobuf boundary so older clients
+    /// can render unknown feature names without code changes.
+    #[into_prost(map = "enabled_features_to_proto", map_by_ref)]
+    #[bilrost(15)]
+    pub enabled_features: PersistedStateMachineFeatures,
+}
+
+fn enabled_features_to_proto(f: &PersistedStateMachineFeatures) -> Vec<String> {
+    f.enabled_names().map(String::from).collect()
 }
 
 impl Default for PartitionProcessorStatus {
@@ -234,6 +245,7 @@ impl Default for PartitionProcessorStatus {
             target_tail_lsn: None,
             last_applied_rule_book_version: None,
             last_applied_schema_version: None,
+            enabled_features: PersistedStateMachineFeatures::default(),
         }
     }
 }

--- a/crates/types/src/partitions/features.rs
+++ b/crates/types/src/partitions/features.rs
@@ -10,6 +10,8 @@
 
 use bytes::BytesMut;
 
+use restate_encoding::NetSerde;
+
 use crate::storage::{
     StorageCodecKind, StorageDecode, StorageDecodeError, StorageEncode, StorageEncodeError, decode,
     encode,
@@ -86,9 +88,22 @@ impl PartitionFeatureChange {
 /// behavior makes existing FSM data forward-compatible (new fields default to
 /// `false`).
 ///
+/// # Important
+/// When adding new fields to this struct, update [`PersistedStateMachineFeatures::enabled_names`]
+/// accordingly.
+///
 /// *Since v1.7.0*
 #[derive(
-    Debug, Clone, Default, PartialEq, Eq, bilrost::Message, serde::Serialize, serde::Deserialize,
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    PartialEq,
+    Eq,
+    bilrost::Message,
+    NetSerde,
+    serde::Serialize,
+    serde::Deserialize,
 )]
 pub struct PersistedStateMachineFeatures {
     /// Journal v2 should be used by this partition.
@@ -106,6 +121,21 @@ pub struct PersistedStateMachineFeatures {
     /// *Since v1.7.0*
     #[bilrost(tag(3))]
     pub unique_random_seeds: bool,
+}
+
+impl PersistedStateMachineFeatures {
+    /// Names of features currently enabled, in declaration order.
+    ///
+    /// Adding a new feature requires adding one entry here.
+    pub fn enabled_names(&self) -> impl Iterator<Item = &'static str> + '_ {
+        [
+            self.journal_v2.then_some("journal_v2"),
+            self.vqueues.then_some("vqueues"),
+            self.unique_random_seeds.then_some("unique_random_seeds"),
+        ]
+        .into_iter()
+        .flatten()
+    }
 }
 
 impl StorageEncode for PersistedStateMachineFeatures {
@@ -165,6 +195,27 @@ mod tests {
         PartitionFeatureChange::EnableUniqueRandomSeeds.apply_to(&mut features);
         assert!(features.vqueues);
         assert!(features.unique_random_seeds);
+    }
+
+    #[test]
+    fn enabled_names_reflects_set_flags() {
+        let mut features = PersistedStateMachineFeatures::default();
+        assert_eq!(
+            features.enabled_names().collect::<Vec<_>>(),
+            Vec::<&str>::new()
+        );
+
+        features.vqueues = true;
+        assert_eq!(
+            features.enabled_names().collect::<Vec<_>>(),
+            vec!["vqueues"]
+        );
+
+        features.journal_v2 = true;
+        assert_eq!(
+            features.enabled_names().collect::<Vec<_>>(),
+            vec!["journal_v2", "vqueues"],
+        );
     }
 
     #[test]

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -657,6 +657,7 @@ where
                         (rule_book_version >= Version::MIN).then_some(rule_book_version);
                     self.status.last_applied_schema_version =
                         self.state_machine.schema.as_ref().map(Versioned::version);
+                    self.status.enabled_features = self.state_machine.enabled_features;
                     self.status_watch_tx.send_modify(|old| {
                         old.clone_from(&self.status);
                         old.updated_at = MillisSinceEpoch::now();

--- a/crates/worker/src/partition/state_machine/lifecycle/version_barrier.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/version_barrier.rs
@@ -93,7 +93,7 @@ where
         // Determine which known changes actually flip a feature off->on. Only those
         // need to run the migration probe; re-applying an already-enabled barrier
         // stays cheap and idempotent.
-        let mut updated = ctx.enabled_features.clone();
+        let mut updated = *ctx.enabled_features;
         let flip_on_changes: Vec<PartitionFeatureChange> = known_changes
             .iter()
             .copied()

--- a/release-notes/unreleased/expose-partition-processor-features.md
+++ b/release-notes/unreleased/expose-partition-processor-features.md
@@ -1,0 +1,34 @@
+# Release Notes: Expose active partition processor features
+
+## New Feature
+
+### What Changed
+The set of state-machine features currently enabled on each partition processor is now
+observable through `restatectl` and the `partition_state` SQL system table.
+
+- `restatectl partition list` shows a new `FEATURES` column listing the enabled feature
+  names (comma-separated), or `-` when no features are enabled.
+- The `partition_state` table gains a new `enabled_features` column of type `List<Utf8>`,
+  queryable with the standard DataFusion array functions.
+
+The information is surfaced via a new `repeated string enabled_features` field on
+`PartitionProcessorStatus`. Carrying feature names as strings (rather than typed
+booleans) means older `restatectl` clients can render features they don't recognise.
+
+### Usage
+```sql
+-- Is vqueues enabled on partition 0?
+SELECT array_has(enabled_features, 'vqueues') AS vqueues_enabled
+FROM partition_state
+WHERE partition_id = 0;
+
+-- Which partitions have vqueues enabled?
+SELECT partition_id
+FROM partition_state
+WHERE array_has(enabled_features, 'vqueues');
+
+-- Partitions with no features enabled
+SELECT partition_id
+FROM partition_state
+WHERE cardinality(enabled_features) = 0;
+```

--- a/tools/restatectl/src/commands/partition/list.rs
+++ b/tools/restatectl/src/commands/partition/list.rs
@@ -91,11 +91,11 @@ pub async fn list_partitions(
                         .as_ref()
                         .expect("alive partition has a node id");
                     let host_node = GenerationalNodeId::from(*host);
+                    let leadership_epoch =
+                        status.last_observed_leader_epoch.unwrap_or_default().value;
                     let details = PartitionListEntry { host_node, status };
                     partitions.push((partition_id, details));
 
-                    let leadership_epoch =
-                        status.last_observed_leader_epoch.unwrap_or_default().value;
                     max_epoch_per_partition
                         .entry(partition_id)
                         .and_modify(|existing| {
@@ -121,6 +121,7 @@ pub async fn list_partitions(
         "LSN-LAG",
         "SCHEMA",
         "RULE-BOOK",
+        "FEATURES",
         "UPDATED",
     ]);
 
@@ -237,6 +238,11 @@ pub async fn list_partitions(
                         .map(|v| Version::from(v).to_string())
                         .unwrap_or_else(|| "-".to_owned()),
                 ),
+                Cell::new(if processor.status.enabled_features.is_empty() {
+                    "-".to_owned()
+                } else {
+                    processor.status.enabled_features.join(",")
+                }),
                 render_as_duration(processor.status.updated_at, Tense::Past),
             ]);
         });


### PR DESCRIPTION
Surface the applied PersistedStateMachineFeatures via PartitionProcessorStatus as a list of feature names, rendered through a new FEATURES column in 'restatectl partition list' and an enabled_features List<Utf8> column on the partition_state system table. Carrying the wire shape as repeated strings keeps older restatectl clients forward-compatible with feature names they don't know.

Adds Utf8List support to the storage-query table macro alongside the existing LargeUtf8List.