### PR TITLE
Migrate unscoped state and promise tables into scoped variants

### DIFF
--- a/crates/partition-store/src/fsm_table/mod.rs
+++ b/crates/partition-store/src/fsm_table/mod.rs
@@ -8,22 +8,25 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use crate::TableKind::PartitionStateMachine;
+use crate::keys::{EncodeTableKeyPrefix, KeyKind, define_table_key};
+use crate::migrations::SchemaVersion;
+use crate::{
+    PaddedPartitionId, PartitionDb, PartitionStore, PartitionStoreTransaction, StorageAccess,
+};
 use restate_limiter::RuleBook;
-use restate_storage_api::Result;
 use restate_storage_api::fsm_table::{
     CachedEpochMetadata, PartitionDurability, ReadFsmTable, SequenceNumber, WriteFsmTable,
 };
-use restate_storage_api::protobuf_types::PartitionStoreProtobufValue;
+use restate_storage_api::protobuf_types::{PartitionStoreProtobufValue, ProtobufStorageWrapper};
+use restate_storage_api::{Result, StorageError};
 use restate_types::SemanticRestateVersion;
 use restate_types::identifiers::PartitionId;
 use restate_types::logs::Lsn;
 use restate_types::message::MessageIndex;
 use restate_types::partitions::features::PersistedStateMachineFeatures;
 use restate_types::schema::Schema;
-
-use crate::TableKind::PartitionStateMachine;
-use crate::keys::{KeyKind, define_table_key};
-use crate::{PaddedPartitionId, PartitionStore, PartitionStoreTransaction, StorageAccess};
+use restate_types::storage::StorageCodec;
 
 define_table_key!(
     PartitionStateMachine,
@@ -135,6 +138,37 @@ pub(crate) async fn get_storage_version<S: StorageAccess>(
         .map(|opt| opt.map(|s| s.0 as u16).unwrap_or_default())
 }
 
+pub(crate) fn get_storage_version_from_partition_db(db: &PartitionDb) -> Result<SchemaVersion> {
+    let cf = db.cf_handle();
+    let key = create_key(db.partition().partition_id, fsm_variable::STORAGE_VERSION);
+    let sequence_number: Option<SequenceNumber> = db
+        .rocksdb()
+        .inner()
+        .as_raw_db()
+        .get_pinned_cf(cf, key.serialize())
+        .map_err(|err| StorageError::Generic(err.into()))?
+        .map(|value| {
+            let mut slice = value.as_ref();
+            StorageCodec::decode::<
+                ProtobufStorageWrapper<
+                    <SequenceNumber as PartitionStoreProtobufValue>::ProtobufType,
+                >,
+                _,
+            >(&mut slice)
+            .map(|v| v.0.into())
+        })
+        .transpose()
+        .map_err(|err| StorageError::Generic(err.into()))?;
+
+    Ok(if let Some(sequence_number) = sequence_number {
+        u16::try_from(sequence_number.0)
+            .map_err(|_| StorageError::DataIntegrityError)?
+            .try_into()?
+    } else {
+        SchemaVersion::None
+    })
+}
+
 pub(crate) async fn put_storage_version<S: StorageAccess>(
     storage: &mut S,
     partition_id: PartitionId,
@@ -146,6 +180,33 @@ pub(crate) async fn put_storage_version<S: StorageAccess>(
         fsm_variable::STORAGE_VERSION,
         &SequenceNumber::from(last_executed_migration as u64),
     )
+}
+
+/// Append a `STORAGE_VERSION = version` put to `wb`.
+pub(crate) fn append_schema_version_to_wb(
+    cf_handle: &std::sync::Arc<rocksdb::BoundColumnFamily<'_>>,
+    wb: &mut rocksdb::WriteBatch,
+    partition_id: PartitionId,
+    version: SchemaVersion,
+) -> Result<()> {
+    use bytes::BytesMut;
+    use restate_types::storage::StorageCodec;
+
+    let key = create_key(partition_id, fsm_variable::STORAGE_VERSION);
+    let key_buffer = key.serialize();
+
+    let value = SequenceNumber::from(version as u64);
+    let mut value_buffer = BytesMut::new();
+    StorageCodec::encode(
+        &ProtobufStorageWrapper::<<SequenceNumber as PartitionStoreProtobufValue>::ProtobufType>(
+            value.into(),
+        ),
+        &mut value_buffer,
+    )
+    .map_err(|e| restate_storage_api::StorageError::Generic(e.into()))?;
+
+    wb.put_cf(cf_handle, &key_buffer, &value_buffer);
+    Ok(())
 }
 
 pub(crate) fn is_jc_orphan_cleanup_done<S: StorageAccess>(

--- a/crates/partition-store/src/migrations.rs
+++ b/crates/partition-store/src/migrations.rs
@@ -15,18 +15,30 @@ mod migrate_to_scoped_state_table;
 use std::num::NonZeroU16;
 use std::sync::Arc;
 
+use anyhow::Context;
 use bytes::BytesMut;
-use restate_types::sharding::KeyRange;
-use restate_types::sharding::subsharding::ShardPlan;
-use strum::EnumCount;
+use rocksdb::WriteBatch;
+use tracing::debug;
 
-use crate::{PartitionDb, PartitionStore, Result};
 use restate_clock::{AtomicStorage, HlcClock, WallClock};
+use restate_rocksdb::{IoMode, Priority};
 use restate_storage_api::StorageError;
 use restate_types::config::Configuration;
+use restate_types::sharding::KeyRange;
+use restate_types::sharding::subsharding::ShardPlan;
+
+use crate::fsm_table::append_schema_version_to_wb;
+use crate::{PartitionDb, PartitionStore, Result};
+
+use self::migrate_to_scoped_promise_table::{
+    append_delete_promise_data, migrate_to_scoped_promise_table,
+};
+use self::migrate_to_scoped_state_table::{
+    append_delete_state_data, migrate_to_scoped_state_table,
+};
 
 // NOTE: The representation numbers here must be strictly monotonically increasing.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, strum::FromRepr, strum::EnumCount)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, strum::FromRepr)]
 #[repr(u16)]
 pub(crate) enum SchemaVersion {
     /// Before 1.5
@@ -34,10 +46,14 @@ pub(crate) enum SchemaVersion {
     /// Migrations:
     /// * Invocation status V1 -> V2
     V1_5 = 1,
+    /// Migrations:
+    /// * unscoped `state_table` -> scoped `state_table` (with `scope = None`)
+    /// * unscoped `promise_table` -> scoped `promise_table` (with `scope = None`)
+    ///
+    /// Gated by `experimental_enable_migrate_scoped_tables`.
+    /// Since v1.7.0
+    ScopedStateAndPromise = 2,
 }
-
-pub(crate) const LATEST_VERSION: SchemaVersion =
-    SchemaVersion::from_repr((SchemaVersion::COUNT as u16) - 1).unwrap();
 
 impl TryFrom<u16> for SchemaVersion {
     type Error = StorageError;
@@ -54,20 +70,36 @@ impl TryFrom<u16> for SchemaVersion {
 }
 
 impl SchemaVersion {
-    fn next(&self) -> Option<Self> {
-        SchemaVersion::from_repr((*self as u16) + 1)
+    /// Returns `true` once the partition store has migrated the unscoped state
+    /// and promise tables into their scoped variants. After this point all
+    /// state/promise reads and writes use the scoped tables (with
+    /// `scope = None` for entries that were unscoped pre-migration).
+    pub(crate) fn is_scope_migrated(self) -> bool {
+        self >= SchemaVersion::ScopedStateAndPromise
     }
 
-    pub(crate) async fn run_all_migrations(mut self, storage: &mut PartitionStore) -> Result<Self> {
-        while self.next().is_some() {
+    pub(crate) async fn run_migrations_up_to(
+        mut self,
+        target: SchemaVersion,
+        storage: &mut PartitionStore,
+    ) -> Result<Self> {
+        while self < target {
             self = self.do_migration(storage).await?;
         }
         Ok(self)
     }
 
     // Runs the migration for the given schema version and returns the new schema version
-    async fn do_migration(&self, _storage: &mut PartitionStore) -> Result<SchemaVersion> {
-        match self {
+    //
+    // Each migration arm is responsible for atomically (with respect to crashes)
+    // persisting the schema-version bump together with any destructive cleanup
+    // (range deletes, etc.). See the `V1_5` arm for an example: copy passes run
+    // with WAL disabled, then a single final `WriteBatch` (also WAL off)
+    // commits the schema-version put together with the legacy `delete_range_cf`s.
+    // RocksDB's FIFO memtable flush order guarantees that the final batch can
+    // only become durable on SST after the copy writes are already on SST.
+    async fn do_migration(&self, storage: &mut PartitionStore) -> Result<SchemaVersion> {
+        let new_schema_version = match self {
             SchemaVersion::None => {
                 // Version 1.6+ does not support upgrading from pre-1.5
                 // The InvocationStatusV1 migration was removed in 1.6
@@ -78,15 +110,53 @@ impl SchemaVersion {
                 )));
             }
             SchemaVersion::V1_5 => {
-                // todo(tillrohrmann) add migrations for:
-                //  * service_status_table -> locks_table
-                //  * promise_table -> scoped promise_table
-                //  * state_table -> scoped state_table
-                //  * and more
-            }
-        }
+                let config = Configuration::pinned();
+                let key_range = storage.partition_key_range();
+                let partition_id = storage.partition_id();
+                let partition_db = storage.partition_db().clone();
+                let mut ctx = MigrationContext::new(&config, &partition_db, key_range);
+                let new_schema_version = SchemaVersion::ScopedStateAndPromise;
 
-        Ok(SchemaVersion::V1_5)
+                migrate_to_scoped_state_table(&mut ctx)?;
+                migrate_to_scoped_promise_table(&mut ctx)?;
+
+                // Atomic final step: delete legacy ranges + bump schema version
+                // in a single `WriteBatch`. WAL off so the FIFO memtable order
+                // pins the schema bump behind the copy writes — see the
+                // doc-comment on `do_migration` for the durability argument.
+                let cf_handle = partition_db.cf_handle().clone();
+                let mut wb = WriteBatch::default();
+                append_delete_state_data(&ctx, &mut wb);
+                append_delete_promise_data(&ctx, &mut wb);
+                append_schema_version_to_wb(&cf_handle, &mut wb, partition_id, new_schema_version)?;
+
+                let mut opts = rocksdb::WriteOptions::default();
+                opts.disable_wal(true);
+                partition_db
+                    .rocksdb()
+                    .write_batch(
+                        "scoped-state-promise-table-migration",
+                        Priority::High,
+                        IoMode::Default,
+                        opts,
+                        wb,
+                    )
+                    .await
+                    .context("failed to commit scoped-state-and-promise final write batch")
+                    .map_err(StorageError::Generic)?;
+                debug!(
+                    %partition_id,
+                    "Finalized scoped state/promise migration"
+                );
+                new_schema_version
+            }
+            SchemaVersion::ScopedStateAndPromise => {
+                // Latest version, nothing further to do.
+                SchemaVersion::ScopedStateAndPromise
+            }
+        };
+
+        Ok(new_schema_version)
     }
 }
 
@@ -232,7 +302,7 @@ mod tests {
         use crate::fsm_table::put_storage_version;
 
         RocksDbManager::init();
-        let manager = PartitionStoreManager::create()
+        let manager = PartitionStoreManager::create(true)
             .await
             .expect("DB storage creation succeeds");
         let mut store = manager
@@ -271,3 +341,7 @@ mod tests {
         RocksDbManager::get().shutdown().await;
     }
 }
+
+#[cfg(test)]
+#[path = "tests/migrations_test/verify_and_run_migrations.rs"]
+mod verify_and_run_migrations_test;

--- a/crates/partition-store/src/migrations.rs
+++ b/crates/partition-store/src/migrations.rs
@@ -20,14 +20,13 @@ use restate_types::sharding::KeyRange;
 use restate_types::sharding::subsharding::ShardPlan;
 use strum::EnumCount;
 
+use crate::{PartitionDb, PartitionStore, Result};
 use restate_clock::{AtomicStorage, HlcClock, WallClock};
 use restate_storage_api::StorageError;
 use restate_types::config::Configuration;
 
-use crate::{PartitionDb, PartitionStore, Result};
-
 // NOTE: The representation numbers here must be strictly monotonically increasing.
-#[derive(Debug, Eq, PartialEq, strum::FromRepr, strum::EnumCount)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, strum::FromRepr, strum::EnumCount)]
 #[repr(u16)]
 pub(crate) enum SchemaVersion {
     /// Before 1.5
@@ -40,27 +39,34 @@ pub(crate) enum SchemaVersion {
 pub(crate) const LATEST_VERSION: SchemaVersion =
     SchemaVersion::from_repr((SchemaVersion::COUNT as u16) - 1).unwrap();
 
-impl From<u16> for SchemaVersion {
-    fn from(value: u16) -> Self {
-        SchemaVersion::from_repr(value).unwrap_or(SchemaVersion::V1_5)
+impl TryFrom<u16> for SchemaVersion {
+    type Error = StorageError;
+
+    fn try_from(value: u16) -> Result<Self, StorageError> {
+        SchemaVersion::from_repr(value).ok_or_else(|| {
+            StorageError::Generic(anyhow::anyhow!(
+                "unknown partition-store schema version {value}; this binary is older \
+                 than the data it would open. Roll forward to a server version that \
+                 recognizes this schema."
+            ))
+        })
     }
 }
 
 impl SchemaVersion {
-    fn next(self) -> Self {
-        ((self as u16) + 1).into()
+    fn next(&self) -> Option<Self> {
+        SchemaVersion::from_repr((*self as u16) + 1)
     }
 
     pub(crate) async fn run_all_migrations(mut self, storage: &mut PartitionStore) -> Result<Self> {
-        while self != LATEST_VERSION {
-            self.do_migration(storage).await?;
-            self = self.next();
+        while self.next().is_some() {
+            self = self.do_migration(storage).await?;
         }
         Ok(self)
     }
 
-    // Add migrations here!
-    async fn do_migration(&self, _storage: &mut PartitionStore) -> Result<()> {
+    // Runs the migration for the given schema version and returns the new schema version
+    async fn do_migration(&self, _storage: &mut PartitionStore) -> Result<SchemaVersion> {
         match self {
             SchemaVersion::None => {
                 // Version 1.6+ does not support upgrading from pre-1.5
@@ -79,7 +85,8 @@ impl SchemaVersion {
                 //  * and more
             }
         }
-        Ok(())
+
+        Ok(SchemaVersion::V1_5)
     }
 }
 
@@ -217,6 +224,50 @@ mod tests {
         assert_eq!(single_key_ranges, vec![KeyRange::new(42, 42)]);
 
         drop((ctx, left_ctx, right_ctx, single_key_ctx));
+        RocksDbManager::get().shutdown().await;
+    }
+
+    #[restate_core::test]
+    async fn verify_and_run_migrations_rejects_unknown_persisted_version() {
+        use crate::fsm_table::put_storage_version;
+
+        RocksDbManager::init();
+        let manager = PartitionStoreManager::create()
+            .await
+            .expect("DB storage creation succeeds");
+        let mut store = manager
+            .open(
+                &Partition::new(PartitionId::MIN, KeyRange::new(0, PartitionKey::MAX - 1)),
+                None,
+            )
+            .await
+            .expect("DB storage creation succeeds");
+
+        // Seed the FSM with an applied LSN so the empty-partition fast path is skipped,
+        // and a SchemaVersion discriminant that this binary doesn't know.
+        {
+            use restate_storage_api::Transaction;
+            use restate_storage_api::fsm_table::WriteFsmTable;
+            let mut txn = store.transaction();
+            txn.put_applied_lsn(restate_types::logs::Lsn::new(1))
+                .expect("applied lsn write should succeed");
+            txn.commit().await.expect("commit should succeed");
+        }
+        let partition_id = store.partition_id();
+        put_storage_version(&mut store, partition_id, 9999_u16)
+            .await
+            .expect("seeding unknown storage version should succeed");
+
+        let err = store
+            .verify_and_run_migrations()
+            .await
+            .expect_err("unknown schema version should fail verify_and_run_migrations");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("9999") && msg.contains("schema version"),
+            "unexpected error message: {msg}"
+        );
+
         RocksDbManager::get().shutdown().await;
     }
 }

--- a/crates/partition-store/src/migrations/migrate_to_scoped_promise_table.rs
+++ b/crates/partition-store/src/migrations/migrate_to_scoped_promise_table.rs
@@ -22,12 +22,14 @@ use crate::scan::{PhysicalScan, TableScan};
 
 use super::MigrationContext;
 
+/// Length of a `KeyKind | partition_key` prefix.
+const KEY_PREFIX_LEN: usize = KeyKind::SERIALIZED_LENGTH + std::mem::size_of::<PartitionKey>();
+
 /// Scan the unscoped promise table and copy every entry into the scoped
 /// promise table with `scope = None`. The value bytes are copied through
 /// unchanged.
 ///
 /// We use direct rocksdb access because no async operations are needed.
-#[allow(dead_code)]
 pub fn migrate_to_scoped_promise_table(ctx: &mut MigrationContext<'_>) -> Result<(), StorageError> {
     let rocks = ctx.partition_db.rocksdb();
     let key_range = ctx.key_range;
@@ -100,21 +102,19 @@ pub fn migrate_to_scoped_promise_table(ctx: &mut MigrationContext<'_>) -> Result
     Ok(())
 }
 
-/// Deletes the legacy unscoped promise range.
-#[allow(dead_code)]
-pub fn delete_promise_data(ctx: &mut MigrationContext<'_>) -> Result<(), StorageError> {
-    let mut wb = WriteBatch::default();
-    let mut opts = rocksdb::WriteOptions::default();
-    // We disable WAL since bifrost is our durable distributed log.
-    opts.disable_wal(true);
-
-    let mut start_key_buf = [0u8; KeyKind::SERIALIZED_LENGTH + std::mem::size_of::<PartitionKey>()];
+/// Appends a `delete_range_cf` for the legacy unscoped promise range to `wb`.
+///
+/// The caller is responsible for committing `wb`. Bundling the range delete
+/// with the schema-version bump in a single [`WriteBatch`] keeps the two
+/// changes atomic with respect to RocksDB's memtable / SST flush.
+pub fn append_delete_promise_data(ctx: &MigrationContext<'_>, wb: &mut WriteBatch) {
+    let mut start_key_buf = [0u8; KEY_PREFIX_LEN];
     EncodeTableKeyPrefix::serialize_to(
         &PromiseKey::builder().partition_key(ctx.key_range.start()),
         &mut start_key_buf.as_mut(),
     );
 
-    let mut end_key_buf = [0u8; KeyKind::SERIALIZED_LENGTH + std::mem::size_of::<PartitionKey>()];
+    let mut end_key_buf = [0u8; KEY_PREFIX_LEN];
     EncodeTableKeyPrefix::serialize_to(
         &PromiseKey::builder().partition_key(ctx.key_range.end()),
         &mut end_key_buf.as_mut(),
@@ -124,14 +124,6 @@ pub fn delete_promise_data(ctx: &mut MigrationContext<'_>) -> Result<(), Storage
     let success = crate::convert_to_upper_bound(&mut end_key_buf);
     assert!(success, "end key overflowed");
     wb.delete_range_cf(ctx.partition_db.cf_handle(), start_key_buf, end_key_buf);
-
-    ctx.partition_db
-        .rocksdb()
-        .inner()
-        .write_batch(&wb, &opts)
-        .context("failed to write batch")?;
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/partition-store/src/migrations/migrate_to_scoped_state_table.rs
+++ b/crates/partition-store/src/migrations/migrate_to_scoped_state_table.rs
@@ -22,11 +22,13 @@ use crate::state_table::StateKey;
 
 use super::MigrationContext;
 
+/// Length of a `KeyKind | partition_key` prefix.
+const KEY_PREFIX_LEN: usize = KeyKind::SERIALIZED_LENGTH + std::mem::size_of::<PartitionKey>();
+
 /// Scan the unscoped state table and copy every entry into the scoped state
 /// table with `scope = None`. The value bytes are copied through unchanged.
 ///
 /// We use direct rocksdb access because no async operations are needed.
-#[allow(dead_code)]
 pub fn migrate_to_scoped_state_table(ctx: &mut MigrationContext<'_>) -> Result<(), StorageError> {
     let rocks = ctx.partition_db.rocksdb();
     let key_range = ctx.key_range;
@@ -99,21 +101,19 @@ pub fn migrate_to_scoped_state_table(ctx: &mut MigrationContext<'_>) -> Result<(
     Ok(())
 }
 
-/// Deletes the legacy unscoped state range.
-#[allow(dead_code)]
-pub fn delete_state_data(ctx: &mut MigrationContext<'_>) -> Result<(), StorageError> {
-    let mut wb = WriteBatch::default();
-    let mut opts = rocksdb::WriteOptions::default();
-    // We disable WAL since bifrost is our durable distributed log.
-    opts.disable_wal(true);
-
-    let mut start_key_buf = [0u8; KeyKind::SERIALIZED_LENGTH + std::mem::size_of::<PartitionKey>()];
+/// Appends a `delete_range_cf` for the legacy unscoped state range to `wb`.
+///
+/// The caller is responsible for committing `wb`. Bundling the range delete
+/// with the schema-version bump in a single [`WriteBatch`] keeps the two
+/// changes atomic with respect to RocksDB's memtable / SST flush.
+pub fn append_delete_state_data(ctx: &MigrationContext<'_>, wb: &mut WriteBatch) {
+    let mut start_key_buf = [0u8; KEY_PREFIX_LEN];
     EncodeTableKeyPrefix::serialize_to(
         &StateKey::builder().partition_key(ctx.key_range.start()),
         &mut start_key_buf.as_mut(),
     );
 
-    let mut end_key_buf = [0u8; KeyKind::SERIALIZED_LENGTH + std::mem::size_of::<PartitionKey>()];
+    let mut end_key_buf = [0u8; KEY_PREFIX_LEN];
     EncodeTableKeyPrefix::serialize_to(
         &StateKey::builder().partition_key(ctx.key_range.end()),
         &mut end_key_buf.as_mut(),
@@ -123,14 +123,6 @@ pub fn delete_state_data(ctx: &mut MigrationContext<'_>) -> Result<(), StorageEr
     let success = crate::convert_to_upper_bound(&mut end_key_buf);
     assert!(success, "end key overflowed");
     wb.delete_range_cf(ctx.partition_db.cf_handle(), start_key_buf, end_key_buf);
-
-    ctx.partition_db
-        .rocksdb()
-        .inner()
-        .write_batch(&wb, &opts)
-        .context("failed to write batch")?;
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -43,11 +43,11 @@ use restate_types::storage::StorageDecode;
 use restate_types::storage::StorageEncode;
 
 use crate::fsm_table::{
-    get_locally_durable_lsn, get_storage_version, is_jc_orphan_cleanup_done,
-    put_jc_orphan_cleanup_done, put_storage_version,
+    get_locally_durable_lsn, get_storage_version, get_storage_version_from_partition_db,
+    is_jc_orphan_cleanup_done, put_jc_orphan_cleanup_done, put_storage_version,
 };
 use crate::keys::{EncodeTableKey, EncodeTableKeyPrefix, KeyKind};
-use crate::migrations::{LATEST_VERSION, SchemaVersion};
+use crate::migrations::SchemaVersion;
 use crate::partition_db::PartitionDb;
 use crate::scan::PhysicalScan;
 use crate::scan::TableScan;
@@ -197,6 +197,7 @@ impl TableKind {
 
 pub struct PartitionStore {
     db: PartitionDb,
+    schema_version: SchemaVersion,
     key_buffer: BytesMut,
     value_buffer: BytesMut,
 }
@@ -216,6 +217,7 @@ impl Clone for PartitionStore {
     fn clone(&self) -> Self {
         PartitionStore {
             db: self.db.clone(),
+            schema_version: self.schema_version,
             key_buffer: BytesMut::default(),
             value_buffer: BytesMut::default(),
         }
@@ -230,11 +232,20 @@ impl From<PartitionDb> for PartitionStore {
 
 impl PartitionStore {
     pub(crate) fn new(db: PartitionDb) -> Self {
+        let schema_version =
+            get_storage_version_from_partition_db(&db).expect("storage version must exist");
+
         Self {
             db,
+            schema_version,
             key_buffer: BytesMut::new(),
             value_buffer: BytesMut::new(),
         }
+    }
+
+    #[inline]
+    pub(crate) fn schema_version(&self) -> SchemaVersion {
+        self.schema_version
     }
 
     pub fn partition_db(&self) -> &PartitionDb {
@@ -568,6 +579,7 @@ impl PartitionStore {
             key_buffer: &mut self.key_buffer,
             value_buffer: &mut self.value_buffer,
             meta: self.db.partition(),
+            schema_version: self.schema_version,
             snapshot,
         }
     }
@@ -648,29 +660,45 @@ impl PartitionStore {
     }
 
     pub async fn verify_and_run_migrations(&mut self) -> Result<()> {
+        // The target schema version is gated by the operator opt-in. Without
+        // the flag we leave the partition at `V1_5` so a downgrade to a
+        // pre-`ScopedStateAndPromise` binary stays possible. With the flag
+        // enabled we migrate the unscoped state and promise tables into their
+        // scoped variants and bump to `ScopedStateAndPromise`.
+        let target = if Configuration::pinned()
+            .common
+            .experimental
+            .is_migrate_scoped_tables_enabled()
+        {
+            SchemaVersion::ScopedStateAndPromise
+        } else {
+            SchemaVersion::V1_5
+        };
+
         // We assume the partition store to be empty if it does not contain any applied lsn. The
         // reason is that we always commit changes to the partition store via a transaction which
         // also updates the applied lsn field.
         let is_empty = self.get_applied_lsn().await?.is_none();
         if is_empty {
-            put_storage_version(self, self.partition_id(), LATEST_VERSION as u16).await?;
+            put_storage_version(self, self.partition_id(), target as u16).await?;
             // A fresh partition store cannot have orphaned jc index entries, so mark the
             // cleanup as already done to avoid a needless scan on first startup.
             put_jc_orphan_cleanup_done(self, self.partition_id())?;
+            self.schema_version = target;
             return Ok(());
         }
 
         let mut schema_version =
             SchemaVersion::try_from(get_storage_version(self, self.partition_id()).await?)?;
-        if schema_version != LATEST_VERSION {
+        if schema_version < target {
             // We need to run some migrations!
             debug!(
                 "Running storage migration from {:?} to {:?}",
-                schema_version, LATEST_VERSION
+                schema_version, target
             );
-            schema_version = schema_version.run_all_migrations(self).await?;
-            put_storage_version(self, self.partition_id(), schema_version as u16).await?;
+            schema_version = schema_version.run_migrations_up_to(target, self).await?;
         }
+        self.schema_version = schema_version;
 
         Ok(())
     }
@@ -787,6 +815,7 @@ pub struct PartitionStoreTransaction<'a> {
     data_cf_handle: &'a Arc<BoundColumnFamily<'a>>,
     key_buffer: &'a mut BytesMut,
     value_buffer: &'a mut BytesMut,
+    schema_version: SchemaVersion,
     snapshot: Option<SnapshotWithThreadMode<'a, rocksdb::DB>>,
 }
 
@@ -907,6 +936,11 @@ impl PartitionStoreTransaction<'_> {
     #[inline]
     pub(crate) fn partition_id(&self) -> PartitionId {
         self.meta.partition_id
+    }
+
+    #[inline]
+    pub(crate) fn schema_version(&self) -> SchemaVersion {
+        self.schema_version
     }
 
     #[inline]

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -660,8 +660,8 @@ impl PartitionStore {
             return Ok(());
         }
 
-        let mut schema_version: SchemaVersion =
-            get_storage_version(self, self.partition_id()).await?.into();
+        let mut schema_version =
+            SchemaVersion::try_from(get_storage_version(self, self.partition_id()).await?)?;
         if schema_version != LATEST_VERSION {
             // We need to run some migrations!
             debug!(

--- a/crates/partition-store/src/promise_table/mod.rs
+++ b/crates/partition-store/src/promise_table/mod.rs
@@ -13,6 +13,7 @@ use bytestring::ByteString;
 use std::sync::Arc;
 
 use crate::keys::{DecodeTableKey, KeyKind, define_table_key};
+use crate::migrations::SchemaVersion;
 use crate::scan::TableScan;
 use crate::{
     PartitionStore, PartitionStoreTransaction, StorageAccess, TableKind,
@@ -62,14 +63,23 @@ fn create_key(service_id: &ServiceId, key: &ByteString) -> PromiseKey {
     }
 }
 
+/// Returns `true` if the call should use the scoped promise table — either
+/// because the partition store has migrated past
+/// [`SchemaVersion::ScopedStateAndPromise`] (so scope = None entries also live
+/// in the scoped table) or because the [`ServiceId`] carries an explicit scope.
+#[inline]
+fn use_scoped_promise(schema_version: SchemaVersion, service_id: &ServiceId) -> bool {
+    schema_version.is_scope_migrated() || service_id.scope.is_some()
+}
+
 fn get_promise<S: StorageAccess>(
     storage: &mut S,
+    schema_version: SchemaVersion,
     service_id: &ServiceId,
     key: &ByteString,
 ) -> Result<Option<Promise>> {
     let _x = RocksDbPerfGuard::new("get-promise");
-    // todo(tillrohrmann) make dependent on migration status once we migrate old promises to the new scoped table
-    if service_id.scope.is_some() {
+    if use_scoped_promise(schema_version, service_id) {
         // todo(tillrohrmann) remove once ServiceId uses ServiceName and ReString internally
         let service_name = ServiceName::new(&service_id.service_name);
         let service_key = ReString::new(&service_id.key);
@@ -92,12 +102,12 @@ fn get_promise<S: StorageAccess>(
 
 fn put_promise<S: StorageAccess>(
     storage: &mut S,
+    schema_version: SchemaVersion,
     service_id: &ServiceId,
     key: &ByteString,
     metadata: &Promise,
 ) -> Result<()> {
-    // todo(tillrohrmann) make dependent on migration status once we migrate old promises to the new scoped table
-    if service_id.scope.is_some() {
+    if use_scoped_promise(schema_version, service_id) {
         // todo(tillrohrmann) remove once ServiceId uses ServiceName and ReString internally
         let service_name = ServiceName::new(&service_id.service_name);
         let service_key = ReString::new(&service_id.key);
@@ -119,9 +129,12 @@ fn put_promise<S: StorageAccess>(
     }
 }
 
-fn delete_all_promises<S: StorageAccess>(storage: &mut S, service_id: &ServiceId) -> Result<()> {
-    // todo(tillrohrmann) make dependent on migration status once we migrate old promises to the new scoped table
-    if service_id.scope.is_some() {
+fn delete_all_promises<S: StorageAccess>(
+    storage: &mut S,
+    schema_version: SchemaVersion,
+    service_id: &ServiceId,
+) -> Result<()> {
+    if use_scoped_promise(schema_version, service_id) {
         // todo(tillrohrmann) remove once ServiceId uses ServiceName and ReString internally
         let service_name = ServiceName::new(&service_id.service_name);
         let service_key = ReString::new(&service_id.key);
@@ -171,7 +184,7 @@ impl ReadPromiseTable for PartitionStore {
         key: &ByteString,
     ) -> Result<Option<Promise>> {
         self.assert_partition_key(service_id)?;
-        get_promise(self, service_id, key)
+        get_promise(self, self.schema_version(), service_id, key)
     }
 }
 
@@ -188,33 +201,41 @@ impl ScanPromiseTable for PartitionStore {
         // No contention: scans are awaited sequentially.
         let f = Arc::new(parking_lot::Mutex::new(f));
 
-        // todo(tillrohrmann) remove once we migrated the unscoped promises to the scoped promises table
-        let f_unscoped = Arc::clone(&f);
-        let unscoped = self
-            .iterator_for_each(
-                "df-promise",
-                Priority::Low,
-                TableScan::FullScanPartitionKeyRange::<PromiseKey>(range),
-                move |(mut k, mut v)| {
-                    let key = break_on_err(PromiseKey::deserialize_from(&mut k))?;
-                    let metadata = break_on_err(Promise::decode(&mut v))?;
-                    let (partition_key, service_name, service_key, promise_key) = key.split();
-                    let service_id = ServiceId::with_partition_key(
-                        partition_key,
-                        service_name,
-                        break_on_err(ByteString::try_from(service_key).map_err(|e| {
-                            StorageError::Generic(anyhow::anyhow!("Cannot convert to string {e}"))
-                        }))?,
-                    );
-                    f_unscoped.lock()(OwnedPromiseRow {
-                        service_id,
-                        key: promise_key,
-                        metadata,
-                    })
-                    .map_break(Ok)
-                },
+        // Only scan the legacy unscoped table while we may still hold data there.
+        // After migration the range was deleted, so the scoped scan covers everything.
+        let unscoped = if self.schema_version().is_scope_migrated() {
+            None
+        } else {
+            let f_unscoped = Arc::clone(&f);
+            Some(
+                self.iterator_for_each(
+                    "df-promise",
+                    Priority::Low,
+                    TableScan::FullScanPartitionKeyRange::<PromiseKey>(range),
+                    move |(mut k, mut v)| {
+                        let key = break_on_err(PromiseKey::deserialize_from(&mut k))?;
+                        let metadata = break_on_err(Promise::decode(&mut v))?;
+                        let (partition_key, service_name, service_key, promise_key) = key.split();
+                        let service_id = ServiceId::with_partition_key(
+                            partition_key,
+                            service_name,
+                            break_on_err(ByteString::try_from(service_key).map_err(|e| {
+                                StorageError::Generic(anyhow::anyhow!(
+                                    "Cannot convert to string {e}"
+                                ))
+                            }))?,
+                        );
+                        f_unscoped.lock()(OwnedPromiseRow {
+                            service_id,
+                            key: promise_key,
+                            metadata,
+                        })
+                        .map_break(Ok)
+                    },
+                )
+                .map_err(|_| StorageError::OperationalError)?,
             )
-            .map_err(|_| StorageError::OperationalError)?;
+        };
 
         let f_scoped = f;
         let scoped = self
@@ -243,7 +264,9 @@ impl ScanPromiseTable for PartitionStore {
             .map_err(|_| StorageError::OperationalError)?;
 
         Ok(async move {
-            unscoped.await?;
+            if let Some(unscoped) = unscoped {
+                unscoped.await?;
+            }
             scoped.await?;
             Ok(())
         })
@@ -257,7 +280,7 @@ impl ReadPromiseTable for PartitionStoreTransaction<'_> {
         key: &ByteString,
     ) -> Result<Option<Promise>> {
         self.assert_partition_key(service_id)?;
-        get_promise(self, service_id, key)
+        get_promise(self, self.schema_version(), service_id, key)
     }
 }
 
@@ -269,11 +292,11 @@ impl WritePromiseTable for PartitionStoreTransaction<'_> {
         promise: &Promise,
     ) -> Result<()> {
         self.assert_partition_key(service_id)?;
-        put_promise(self, service_id, key, promise)
+        put_promise(self, self.schema_version(), service_id, key, promise)
     }
 
     fn delete_all_promises(&mut self, service_id: &ServiceId) -> Result<()> {
         self.assert_partition_key(service_id)?;
-        delete_all_promises(self, service_id)
+        delete_all_promises(self, self.schema_version(), service_id)
     }
 }

--- a/crates/partition-store/src/state_table/mod.rs
+++ b/crates/partition-store/src/state_table/mod.rs
@@ -31,6 +31,7 @@ use restate_util_string::ReString;
 
 use crate::TableKind::State;
 use crate::keys::{DecodeTableKey, KeyKind, define_table_key};
+use crate::migrations::SchemaVersion;
 use crate::{
     PartitionStore, PartitionStoreTransaction, StorageAccess, TableScan,
     TableScanIterationDecision, break_on_err,
@@ -127,14 +128,23 @@ impl<DB: DBAccess> Iterator for StateEntryIter<'_, DB> {
     }
 }
 
+/// Returns `true` if the call should use the scoped state table — either because
+/// the partition store has migrated past
+/// [`SchemaVersion::ScopedStateAndPromise`] (so scope = None entries also live
+/// in the scoped table) or because the [`ServiceId`] carries an explicit scope.
+#[inline]
+fn use_scoped_state(schema_version: SchemaVersion, service_id: &ServiceId) -> bool {
+    schema_version.is_scope_migrated() || service_id.scope.is_some()
+}
+
 fn put_user_state<S: StorageAccess>(
     storage: &mut S,
+    schema_version: SchemaVersion,
     service_id: &ServiceId,
     state_key: &Bytes,
     state_value: impl AsRef<[u8]>,
 ) -> Result<()> {
-    // todo(tillrohrmann) make dependent on migration status once we migrate old state entries to the new scoped table
-    if service_id.scope.is_some() {
+    if use_scoped_state(schema_version, service_id) {
         //todo(tillrohrmann) remove once ServiceId carries the right types
         let service_name = ServiceName::new(service_id.service_name.as_ref());
         let service_key = ReString::new(&service_id.key);
@@ -158,11 +168,11 @@ fn put_user_state<S: StorageAccess>(
 
 fn delete_user_state<S: StorageAccess>(
     storage: &mut S,
+    schema_version: SchemaVersion,
     service_id: &ServiceId,
     state_key: &Bytes,
 ) -> Result<()> {
-    // todo(tillrohrmann) make dependent on migration status once we migrate old state entries to the new scoped table
-    if service_id.scope.is_some() {
+    if use_scoped_state(schema_version, service_id) {
         //todo(tillrohrmann) remove once ServiceId carries the right types
         let service_name = ServiceName::new(service_id.service_name.as_ref());
         let service_key = ReString::new(&service_id.key);
@@ -184,9 +194,12 @@ fn delete_user_state<S: StorageAccess>(
     }
 }
 
-fn delete_all_user_state<S: StorageAccess>(storage: &mut S, service_id: &ServiceId) -> Result<()> {
-    // todo(tillrohrmann) make dependent on migration status once we migrate old state entries to the new scoped table
-    if service_id.scope.is_some() {
+fn delete_all_user_state<S: StorageAccess>(
+    storage: &mut S,
+    schema_version: SchemaVersion,
+    service_id: &ServiceId,
+) -> Result<()> {
+    if use_scoped_state(schema_version, service_id) {
         //todo(tillrohrmann) remove once ServiceId carries the right types
         let service_name = ServiceName::new(service_id.service_name.as_ref());
         let service_key = ReString::new(&service_id.key);
@@ -231,12 +244,12 @@ fn delete_all_user_state<S: StorageAccess>(storage: &mut S, service_id: &Service
 
 fn get_user_state<S: StorageAccess>(
     storage: &mut S,
+    schema_version: SchemaVersion,
     service_id: &ServiceId,
     state_key: &Bytes,
 ) -> Result<Option<Bytes>> {
     let _x = RocksDbPerfGuard::new("get-user-state");
-    // todo(tillrohrmann) make dependent on migration status once we migrate old state entries to the new scoped table
-    if service_id.scope.is_some() {
+    if use_scoped_state(schema_version, service_id) {
         //todo(tillrohrmann) remove once ServiceId carries the right types
         let service_name = ServiceName::new(service_id.service_name.as_ref());
         let service_key = ReString::new(&service_id.key);
@@ -260,12 +273,12 @@ fn get_user_state<S: StorageAccess>(
 
 fn get_all_user_states_for_service<'a, S: StorageAccess>(
     storage: &'a S,
+    schema_version: SchemaVersion,
     service_id: &ServiceId,
 ) -> Result<StateEntryIter<'a, S::DBAccess<'a>>> {
     let _x = RocksDbPerfGuard::new("get-all-user-state-iter-setup");
 
-    // todo(tillrohrmann) make dependent on migration status once we migrate old state entries to the new scoped table
-    if service_id.scope.is_some() {
+    if use_scoped_state(schema_version, service_id) {
         //todo(tillrohrmann) remove once ServiceId carries the right types
         let service_name = ServiceName::new(service_id.service_name.as_ref());
         let service_key = ReString::new(&service_id.key);
@@ -303,7 +316,7 @@ impl ReadStateTable for PartitionStore {
         state_key: &Bytes,
     ) -> Result<Option<Bytes>> {
         self.assert_partition_key(service_id)?;
-        get_user_state(self, service_id, state_key)
+        get_user_state(self, self.schema_version(), service_id, state_key)
     }
 
     fn get_all_user_states_for_service<'a>(
@@ -312,7 +325,9 @@ impl ReadStateTable for PartitionStore {
     ) -> Result<impl Stream<Item = Result<(Bytes, Bytes)>> + Send + 'a> {
         self.assert_partition_key(service_id)?;
         Ok(stream::iter(get_all_user_states_for_service(
-            self, service_id,
+            self,
+            self.schema_version(),
+            service_id,
         )?))
     }
 
@@ -327,7 +342,7 @@ impl ReadStateTable for PartitionStore {
         + 'a,
     > {
         self.assert_partition_key(service_id)?;
-        let iter = get_all_user_states_for_service(self, service_id)?;
+        let iter = get_all_user_states_for_service(self, self.schema_version(), service_id)?;
         Ok(budgeted_state_stream(iter, budget))
     }
 }
@@ -345,22 +360,28 @@ impl ScanStateTable for PartitionStore {
         // No contention: scans are awaited sequentially.
         let f = Arc::new(parking_lot::Mutex::new(f));
 
-        // todo(tillrohrmann) remove once we migrated the unscoped state entries to the scoped state entries table
-        let f_unscoped = Arc::clone(&f);
-        let unscoped = self
-            .iterator_for_each(
-                "df-user-state",
-                Priority::Low,
-                TableScan::FullScanPartitionKeyRange::<StateKey>(range),
-                move |(mut key, value)| {
-                    let row_key = break_on_err(StateKey::deserialize_from(&mut key))?;
-                    let (partition_key, service_name, service_key, state_key) = row_key.split();
-                    let service_id =
-                        ServiceId::from_parts(partition_key, service_name, service_key);
-                    f_unscoped.lock()((service_id, state_key, value)).map_break(Ok)
-                },
+        // Only scan the legacy unscoped table while we may still hold data there.
+        // After migration the range was deleted, so the scoped scan covers everything.
+        let unscoped = if self.schema_version().is_scope_migrated() {
+            None
+        } else {
+            let f_unscoped = Arc::clone(&f);
+            Some(
+                self.iterator_for_each(
+                    "df-user-state",
+                    Priority::Low,
+                    TableScan::FullScanPartitionKeyRange::<StateKey>(range),
+                    move |(mut key, value)| {
+                        let row_key = break_on_err(StateKey::deserialize_from(&mut key))?;
+                        let (partition_key, service_name, service_key, state_key) = row_key.split();
+                        let service_id =
+                            ServiceId::from_parts(partition_key, service_name, service_key);
+                        f_unscoped.lock()((service_id, state_key, value)).map_break(Ok)
+                    },
+                )
+                .map_err(|_| StorageError::OperationalError)?,
             )
-            .map_err(|_| StorageError::OperationalError)?;
+        };
 
         let f_scoped = f;
         let scoped = self
@@ -383,7 +404,9 @@ impl ScanStateTable for PartitionStore {
             .map_err(|_| StorageError::OperationalError)?;
 
         Ok(async move {
-            unscoped.await?;
+            if let Some(unscoped) = unscoped {
+                unscoped.await?;
+            }
             scoped.await?;
             Ok(())
         })
@@ -397,7 +420,7 @@ impl ReadStateTable for PartitionStoreTransaction<'_> {
         state_key: &Bytes,
     ) -> Result<Option<Bytes>> {
         self.assert_partition_key(service_id)?;
-        get_user_state(self, service_id, state_key)
+        get_user_state(self, self.schema_version(), service_id, state_key)
     }
 
     fn get_all_user_states_for_service<'a>(
@@ -406,7 +429,9 @@ impl ReadStateTable for PartitionStoreTransaction<'_> {
     ) -> Result<impl Stream<Item = Result<(Bytes, Bytes)>> + Send + 'a> {
         self.assert_partition_key(service_id)?;
         Ok(stream::iter(get_all_user_states_for_service(
-            self, service_id,
+            self,
+            self.schema_version(),
+            service_id,
         )?))
     }
 
@@ -421,7 +446,7 @@ impl ReadStateTable for PartitionStoreTransaction<'_> {
         + 'a,
     > {
         self.assert_partition_key(service_id)?;
-        let iter = get_all_user_states_for_service(self, service_id)?;
+        let iter = get_all_user_states_for_service(self, self.schema_version(), service_id)?;
         Ok(budgeted_state_stream(iter, budget))
     }
 }
@@ -434,17 +459,23 @@ impl WriteStateTable for PartitionStoreTransaction<'_> {
         state_value: impl AsRef<[u8]>,
     ) -> Result<()> {
         self.assert_partition_key(service_id)?;
-        put_user_state(self, service_id, state_key, state_value)
+        put_user_state(
+            self,
+            self.schema_version(),
+            service_id,
+            state_key,
+            state_value,
+        )
     }
 
     fn delete_user_state(&mut self, service_id: &ServiceId, state_key: &Bytes) -> Result<()> {
         self.assert_partition_key(service_id)?;
-        delete_user_state(self, service_id, state_key)
+        delete_user_state(self, self.schema_version(), service_id, state_key)
     }
 
     fn delete_all_user_state(&mut self, service_id: &ServiceId) -> Result<()> {
         self.assert_partition_key(service_id)?;
-        delete_all_user_state(self, service_id)
+        delete_all_user_state(self, self.schema_version(), service_id)
     }
 }
 

--- a/crates/partition-store/src/tests/migrations_test/migrate_to_scoped_promise_table.rs
+++ b/crates/partition-store/src/tests/migrations_test/migrate_to_scoped_promise_table.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 
 use bytes::BytesMut;
 use bytestring::ByteString;
+use rocksdb::WriteBatch;
 
 use restate_rocksdb::RocksDbManager;
 use restate_storage_api::Transaction;
@@ -89,8 +90,16 @@ async fn migrate_to_scoped_promise_table_moves_unscoped_promises_to_scoped_table
     );
     migrate_to_scoped_promise_table::migrate_to_scoped_promise_table(&mut ctx)
         .expect("migration should succeed");
-    migrate_to_scoped_promise_table::delete_promise_data(&mut ctx)
-        .expect("promise cleanup should succeed");
+    let mut wb = WriteBatch::default();
+    migrate_to_scoped_promise_table::append_delete_promise_data(&ctx, &mut wb);
+    let mut opts = rocksdb::WriteOptions::default();
+    opts.disable_wal(true);
+    rocksdb
+        .partition_db()
+        .rocksdb()
+        .inner()
+        .write_batch(&wb, &opts)
+        .expect("delete-range write batch should commit");
 
     // The legacy `b"pr"` range must be empty after cleanup.
     let mut arena = BytesMut::new();

--- a/crates/partition-store/src/tests/migrations_test/migrate_to_scoped_state_table.rs
+++ b/crates/partition-store/src/tests/migrations_test/migrate_to_scoped_state_table.rs
@@ -11,6 +11,7 @@
 use std::collections::HashMap;
 
 use bytes::{Bytes, BytesMut};
+use rocksdb::WriteBatch;
 
 use restate_rocksdb::RocksDbManager;
 use restate_storage_api::Transaction;
@@ -77,8 +78,16 @@ async fn migrate_to_scoped_state_table_moves_unscoped_state_to_scoped_table() {
     );
     migrate_to_scoped_state_table::migrate_to_scoped_state_table(&mut ctx)
         .expect("migration should succeed");
-    migrate_to_scoped_state_table::delete_state_data(&mut ctx)
-        .expect("state cleanup should succeed");
+    let mut wb = WriteBatch::default();
+    migrate_to_scoped_state_table::append_delete_state_data(&ctx, &mut wb);
+    let mut opts = rocksdb::WriteOptions::default();
+    opts.disable_wal(true);
+    rocksdb
+        .partition_db()
+        .rocksdb()
+        .inner()
+        .write_batch(&wb, &opts)
+        .expect("delete-range write batch should commit");
 
     // The legacy `b"st"` range must be empty after cleanup.
     let mut arena = BytesMut::new();

--- a/crates/partition-store/src/tests/migrations_test/verify_and_run_migrations.rs
+++ b/crates/partition-store/src/tests/migrations_test/verify_and_run_migrations.rs
@@ -1,0 +1,300 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! End-to-end tests for the V1_5 → ScopedStateAndPromise migration. Exercises
+//! `verify_and_run_migrations` with and without the experimental opt-in.
+
+use bytes::{Bytes, BytesMut};
+use bytestring::ByteString;
+
+use restate_rocksdb::RocksDbManager;
+use restate_storage_api::Transaction;
+use restate_storage_api::fsm_table::WriteFsmTable;
+use restate_storage_api::promise_table::{
+    Promise, PromiseState, ReadPromiseTable, WritePromiseTable,
+};
+use restate_storage_api::state_table::{ReadStateTable, WriteStateTable};
+use restate_types::config::{Configuration, set_current_config};
+use restate_types::identifiers::{PartitionId, PartitionKey, ServiceId};
+use restate_types::logs::Lsn;
+use restate_types::partitions::Partition;
+use restate_types::sharding::KeyRange;
+
+use crate::PartitionStoreManager;
+use crate::fsm_table::put_storage_version;
+use crate::keys::DecodeTableKey;
+use crate::migrations::SchemaVersion;
+use crate::promise_table::{PromiseKey, ScopedPromiseKey};
+use crate::scan::{PhysicalScan, TableScan};
+use crate::state_table::{ScopedStateKey, StateKey};
+
+fn with_migrate_scoped_tables(enabled: bool) {
+    let mut config = Configuration::default();
+    config
+        .common
+        .experimental
+        .set_migrate_scoped_tables(enabled);
+    set_current_config(config);
+}
+
+async fn seed_unscoped_data(
+    store: &mut crate::PartitionStore,
+) -> (Vec<(ServiceId, Bytes)>, Vec<ServiceId>) {
+    let service_ids = crate::migrations::tests::distinct_service_ids(3);
+    let state_entries: Vec<(ServiceId, Bytes)> = service_ids
+        .iter()
+        .map(|sid| (sid.clone(), Bytes::from_static(b"k1")))
+        .collect();
+
+    let mut txn = store.transaction();
+    for (service_id, state_key) in &state_entries {
+        txn.put_user_state(service_id, state_key, Bytes::from_static(b"v1"))
+            .expect("state write should succeed");
+    }
+    for service_id in &service_ids {
+        txn.put_promise(
+            service_id,
+            &ByteString::from_static("p"),
+            &Promise {
+                state: PromiseState::NotCompleted(vec![]),
+            },
+        )
+        .expect("promise write should succeed");
+    }
+    txn.put_applied_lsn(Lsn::from(1)).expect("lsn write");
+    txn.commit().await.expect("commit should succeed");
+
+    (state_entries, service_ids)
+}
+
+fn count_legacy_state(store: &crate::PartitionStore) -> usize {
+    let mut arena = BytesMut::new();
+    let mut it = store
+        .partition_db()
+        .scan(PhysicalScan::from(
+            TableScan::FullScanPartitionKeyRange::<StateKey>(store.partition_key_range()),
+            &mut arena,
+        ))
+        .expect("scan legacy state");
+    it.seek_to_first();
+    let mut n = 0;
+    while it.valid() {
+        n += 1;
+        it.next();
+    }
+    n
+}
+
+fn count_legacy_promise(store: &crate::PartitionStore) -> usize {
+    let mut arena = BytesMut::new();
+    let mut it = store
+        .partition_db()
+        .scan(PhysicalScan::from(
+            TableScan::FullScanPartitionKeyRange::<PromiseKey>(store.partition_key_range()),
+            &mut arena,
+        ))
+        .expect("scan legacy promise");
+    it.seek_to_first();
+    let mut n = 0;
+    while it.valid() {
+        n += 1;
+        it.next();
+    }
+    n
+}
+
+fn count_scoped_state(store: &crate::PartitionStore) -> usize {
+    let mut arena = BytesMut::new();
+    let mut it = store
+        .partition_db()
+        .scan(PhysicalScan::from(
+            TableScan::FullScanPartitionKeyRange::<ScopedStateKey>(store.partition_key_range()),
+            &mut arena,
+        ))
+        .expect("scan scoped state");
+    it.seek_to_first();
+    let mut n = 0;
+    while it.valid() {
+        let (mut key, _) = it.item().unwrap();
+        let scoped = ScopedStateKey::deserialize_from(&mut key).unwrap();
+        let (_pk, scope, _name, _key, _state_key) = scoped.split();
+        assert_eq!(scope, None, "migrated state must have scope = None");
+        n += 1;
+        it.next();
+    }
+    n
+}
+
+fn count_scoped_promise(store: &crate::PartitionStore) -> usize {
+    let mut arena = BytesMut::new();
+    let mut it = store
+        .partition_db()
+        .scan(PhysicalScan::from(
+            TableScan::FullScanPartitionKeyRange::<ScopedPromiseKey>(store.partition_key_range()),
+            &mut arena,
+        ))
+        .expect("scan scoped promise");
+    it.seek_to_first();
+    let mut n = 0;
+    while it.valid() {
+        let (mut key, _) = it.item().unwrap();
+        let scoped = ScopedPromiseKey::deserialize_from(&mut key).unwrap();
+        let (_pk, scope, _name, _key, _pkey) = scoped.split();
+        assert_eq!(scope, None, "migrated promise must have scope = None");
+        n += 1;
+        it.next();
+    }
+    n
+}
+
+#[restate_core::test]
+async fn flag_off_keeps_partition_at_v1_5() {
+    with_migrate_scoped_tables(false);
+    RocksDbManager::init();
+    let manager = PartitionStoreManager::create(true)
+        .await
+        .expect("manager create");
+    let mut store = manager
+        .open(
+            &Partition::new(PartitionId::MIN, KeyRange::new(0, PartitionKey::MAX - 1)),
+            None,
+        )
+        .await
+        .expect("open");
+
+    let (_state_entries, _service_ids) = seed_unscoped_data(&mut store).await;
+    // Stamp the FSM as V1_5 so verify_and_run_migrations takes the migration path
+    // rather than the empty-partition fast path.
+    let partition_id = store.partition_id();
+    put_storage_version(&mut store, partition_id, SchemaVersion::V1_5 as u16)
+        .await
+        .expect("seed V1_5");
+
+    let legacy_state_before = count_legacy_state(&store);
+    let legacy_promise_before = count_legacy_promise(&store);
+    assert!(legacy_state_before > 0);
+    assert!(legacy_promise_before > 0);
+
+    store
+        .verify_and_run_migrations()
+        .await
+        .expect("verify with flag off");
+
+    assert_eq!(store.schema_version(), SchemaVersion::V1_5);
+    assert_eq!(count_legacy_state(&store), legacy_state_before);
+    assert_eq!(count_legacy_promise(&store), legacy_promise_before);
+    assert_eq!(count_scoped_state(&store), 0);
+    assert_eq!(count_scoped_promise(&store), 0);
+
+    RocksDbManager::get().shutdown().await;
+}
+
+#[restate_core::test]
+async fn flag_on_migrates_and_bumps_version() {
+    with_migrate_scoped_tables(true);
+    RocksDbManager::init();
+    let manager = PartitionStoreManager::create(true)
+        .await
+        .expect("manager create");
+    let mut store = manager
+        .open(
+            &Partition::new(PartitionId::MIN, KeyRange::new(0, PartitionKey::MAX - 1)),
+            None,
+        )
+        .await
+        .expect("open");
+
+    // Switch the flag back off so that seeding via WriteStateTable hits the legacy table.
+    with_migrate_scoped_tables(false);
+    let (state_entries, service_ids) = seed_unscoped_data(&mut store).await;
+    let partition_id = store.partition_id();
+    put_storage_version(&mut store, partition_id, SchemaVersion::V1_5 as u16)
+        .await
+        .expect("seed V1_5");
+    // Sanity: data really landed in the legacy tables.
+    assert_eq!(count_legacy_state(&store), state_entries.len());
+    assert_eq!(count_legacy_promise(&store), service_ids.len());
+
+    // Now turn the flag back on and run migrations.
+    with_migrate_scoped_tables(true);
+    store
+        .verify_and_run_migrations()
+        .await
+        .expect("verify with flag on");
+
+    assert_eq!(store.schema_version(), SchemaVersion::ScopedStateAndPromise);
+    assert_eq!(count_legacy_state(&store), 0);
+    assert_eq!(count_legacy_promise(&store), 0);
+    assert_eq!(count_scoped_state(&store), state_entries.len());
+    assert_eq!(count_scoped_promise(&store), service_ids.len());
+
+    // Reads via the public API (scope = None) hit the scoped table now.
+    for (service_id, state_key) in &state_entries {
+        let v = store
+            .get_user_state(service_id, state_key)
+            .await
+            .expect("get state");
+        assert_eq!(v, Some(Bytes::from_static(b"v1")));
+    }
+    for service_id in &service_ids {
+        let p = store
+            .get_promise(service_id, &ByteString::from_static("p"))
+            .await
+            .expect("get promise");
+        assert!(p.is_some());
+    }
+
+    // Idempotency: a second verify is a no-op.
+    store
+        .verify_and_run_migrations()
+        .await
+        .expect("second verify");
+    assert_eq!(store.schema_version(), SchemaVersion::ScopedStateAndPromise);
+    assert_eq!(count_legacy_state(&store), 0);
+    assert_eq!(count_scoped_state(&store), state_entries.len());
+
+    RocksDbManager::get().shutdown().await;
+}
+
+#[restate_core::test]
+async fn flag_on_writes_post_migration_land_in_scoped() {
+    with_migrate_scoped_tables(true);
+    RocksDbManager::init();
+    let manager = PartitionStoreManager::create(true)
+        .await
+        .expect("manager create");
+    let mut store = manager
+        .open(
+            &Partition::new(PartitionId::MIN, KeyRange::new(0, PartitionKey::MAX - 1)),
+            None,
+        )
+        .await
+        .expect("open");
+
+    // Empty partition + flag on → fast path initializes at ScopedStateAndPromise.
+    store
+        .verify_and_run_migrations()
+        .await
+        .expect("verify fresh");
+    assert_eq!(store.schema_version(), SchemaVersion::ScopedStateAndPromise);
+
+    let service_id = ServiceId::new(None, "svc", "k");
+    {
+        let mut txn = store.transaction();
+        txn.put_user_state(&service_id, &Bytes::from_static(b"key"), b"value")
+            .expect("write state");
+        txn.commit().await.expect("commit");
+    }
+
+    assert_eq!(count_legacy_state(&store), 0);
+    assert_eq!(count_scoped_state(&store), 1);
+
+    RocksDbManager::get().shutdown().await;
+}

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -605,6 +605,19 @@ experimental! {
     ///
     /// Since v1.7.0
     unique_random_seeds,
+
+    /// # Migrate the unscoped state and promise tables into their scoped variants
+    ///
+    /// When enabled, partition stores migrate every entry of the legacy unscoped
+    /// state and promise tables into their scoped variants (with `scope = None`)
+    /// on open, and route all subsequent state/promise reads and writes through
+    /// the scoped tables.
+    ///
+    /// Once enabled, you **cannot** roll back to a Restate-server version that
+    /// did not yet recognize the resulting on-disk schema version.
+    ///
+    /// Since v1.7.0
+    migrate_scoped_tables,
 }
 
 serde_with::with_prefix!(pub prefix_tokio_console "tokio_console_");

--- a/release-notes/unreleased/vqueues/migrate-scoped-state-and-promise.md
+++ b/release-notes/unreleased/vqueues/migrate-scoped-state-and-promise.md
@@ -1,0 +1,34 @@
+# Release Notes: Migrate the unscoped state and promise tables into their scoped variants
+
+## Behavioral Change
+
+### What Changed
+
+A new experimental opt-in, `experimental.migrate_scoped_tables`, switches each
+local partition store onto the scoped state and promise tables. When the flag
+is enabled, the partition processor runs a one-time, per-partition migration on
+open that:
+
+- Copies every row of the legacy unscoped state table (`KeyKind::State`) into
+  the scoped state table (`KeyKind::ScopedState`) with `scope = None`.
+- Copies every row of the legacy unscoped promise table (`KeyKind::Promise`)
+  into the scoped promise table (`KeyKind::ScopedPromise`) with `scope = None`.
+- Range-deletes the legacy unscoped ranges and bumps the on-disk schema version
+  to `ScopedStateAndPromise` in a single atomic write batch.
+
+After the migration runs, all state and promise reads and writes on the
+partition use the scoped tables exclusively, including for services with
+`scope = None`.
+
+### Impact on Users
+
+- **Default behavior is unchanged.** With
+  `experimental.migrate_scoped_tables = false` (the default), partition stores
+  keep the existing mixed-mode layout: services with an explicit scope already
+  write to the scoped tables, while services without a scope continue to write
+  to the legacy unscoped tables. Downgrades remain possible.
+- **Opting in** (`experimental.migrate_scoped_tables = true`) triggers the
+  migration on the next partition open. Once a partition has reached
+  `ScopedStateAndPromise`, it cannot be downgraded to a server version that
+  does not recognize the new schema version — the older binary will refuse to
+  open the partition.


### PR DESCRIPTION
The migration logic for moving rows out of the legacy `KeyKind::State`
and `KeyKind::Promise` tables into their `ScopedState` / `ScopedPromise`
counterparts already existed but was unreachable. This change wires it
into the partition store and gates it behind a new experimental opt-in
so the schema bump does not happen implicitly on upgrade.

When `experimental.migrate_scoped_tables` is enabled, the partition
processor's first `verify_and_run_migrations` call:

  1. copies every legacy row into the scoped table with `scope = None`,
  2. commits a single WAL-off `WriteBatch` that range-deletes both legacy
     ranges and writes `SchemaVersion::ScopedStateAndPromise` to the FSM.

RocksDB's FIFO memtable flush order against the partition's CF
guarantees that the schema bump can only become durable on SST after the
copy writes are also on SST. The copy step is naturally idempotent, so
a crash anywhere in the migration recovers cleanly on the next start-up.

Once the migration completes, the in-memory `schema_version` field on
`PartitionStore` (and the copy on `PartitionStoreTransaction` captured
at txn-create time) routes every state/promise read and write through
the scoped tables — `scope = None` and explicitly-scoped services share
the same code path. The data-fusion full scans skip the legacy table
once the partition is past `ScopedStateAndPromise`.

This fixes #4792.