### PR TITLE
Shut down task center before RocksDbManager in lifecycle test

### DIFF
--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -1675,6 +1675,7 @@ mod tests {
             version = version.next();
         }
 
+        TaskCenter::shutdown_node("test completed", 0).await;
         RocksDbManager::get().shutdown().await;
         Ok(())
     }


### PR DESCRIPTION
proper_partition_processor_lifecycle was racy: the test called RocksDbManager::get().shutdown() while the partition-processor-manager task was still alive and able to spawn a fresh processor whose open ran concurrently with env teardown, causing a SIGSEGV. Match the convention used by other rocksdb-touching tests and cancel task center first.

Fixes #4790