### PR TITLE
[Metrics] Setup 10% sampling for rocksdb-perf operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8135,6 +8135,7 @@ dependencies = [
  "restate-test-util",
  "restate-types",
  "restate-util-bytecount",
+ "restate-util-random",
  "restate-util-string",
  "restate-util-time",
  "restate-workspace-hack",
@@ -8593,6 +8594,13 @@ dependencies = [
  "serde_core",
  "serde_json",
  "serde_with",
+]
+
+[[package]]
+name = "restate-util-random"
+version = "1.7.0-dev"
+dependencies = [
+ "restate-workspace-hack",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ restate-storage-api = { path = "crates/storage-api" }
 restate-storage-query-datafusion = { path = "crates/storage-query-datafusion" }
 restate-sharding = { path = "crates/sharding" }
 restate-util-bytecount = { path = "util/bytecount" }
+restate-util-random = { path = "util/random" }
 restate-util-string = { path = "util/string" }
 restate-util-time = { path = "util/time" }
 restate-test-util = { path = "crates/test-util" }
@@ -326,6 +327,7 @@ debug = true
 
 [profile.dev]
 panic = "unwind"
+split-debuginfo = "unpacked"
 
 [profile.release-lite.package."*"]
 debug = "line-tables-only"

--- a/crates/rocksdb/Cargo.toml
+++ b/crates/rocksdb/Cargo.toml
@@ -16,9 +16,10 @@ restate-workspace-hack = { workspace = true }
 
 restate-core = { workspace = true }
 restate-errors = { workspace = true }
-restate-util-bytecount = { workspace = true, features = ["serde"] }
-restate-util-time = { workspace = true }
 restate-types = { workspace = true }
+restate-util-bytecount = { workspace = true, features = ["serde"] }
+restate-util-random = { workspace = true }
+restate-util-time = { workspace = true }
 
 anyhow = { workspace = true }
 bytes = { workspace = true }

--- a/crates/rocksdb/src/perf.rs
+++ b/crates/rocksdb/src/perf.rs
@@ -11,14 +11,72 @@
 use std::time::Instant;
 
 use metrics::{counter, histogram};
-use restate_types::config::{Configuration, PerfStatsLevel};
 use rocksdb::{PerfContext, PerfMetric};
+
+use restate_types::config::{Configuration, PerfStatsLevel};
+use restate_util_random as rand;
 
 use crate::{
     BLOCK_DECOMPRESS_DURATION, BLOCK_READ_BYTES, BLOCK_READ_DURATION, GET_FROM_MEMTABLE_DURATION,
     NEXT_ON_MEMTABLE, OP_NAME, SEEK_ON_MEMTABLE, TOTAL_DURATION, WRITE_ARTIFICIAL_DELAY_DURATION,
     WRITE_MEMTABLE_DURATION, WRITE_PRE_AND_POST_DURATION, WRITE_WAL_DURATION,
 };
+
+// Sample 10% of rocksdb operations.
+const SAMPLE_RATE: u64 = const { u64::MAX / 10 };
+
+/// This guard is !Send. It must be created and dropped on the same thread since
+/// it's backed by a thread-local in rocksdb.
+pub struct RocksDbPerfGuard(Inner);
+
+static_assertions::assert_not_impl_any!(RocksDbPerfGuard: Send);
+
+impl RocksDbPerfGuard {
+    /// IMPORTANT NOTE: you MUST bind this value with a named variable (f) to ensure
+    /// that the guard is not insta-dropped. Binding to something like `_x = ...` works, just don't
+    /// use the special `_` variable and you'll be fine. Unfortunately, rust/clippy doesn't have a
+    /// mechanism to enforce this at the moment.
+    ///
+    /// This guard should not be used across await points. Stats are thread local.
+    #[must_use]
+    pub fn new(name: &'static str) -> Self {
+        if should_sample() {
+            Self(Inner::Real(RealRocksGuard::new(name)))
+        } else {
+            Self(Inner::Noop)
+        }
+    }
+
+    /// Drops the guard without reporting any metrics.
+    pub fn forget(mut self) {
+        if let Inner::Real(guard) = &mut self.0 {
+            guard.should_report = false;
+        }
+    }
+
+    fn report(&self) {
+        if let Inner::Real(guard) = &self.0 {
+            guard.report();
+        }
+    }
+}
+
+impl Drop for RocksDbPerfGuard {
+    fn drop(&mut self) {
+        if let Inner::Real(guard) = &mut self.0 {
+            rocksdb::perf::set_perf_stats(rocksdb::perf::PerfStatsLevel::Disable);
+            if guard.should_report {
+                // report collected metrics
+                self.report();
+            }
+        }
+    }
+}
+
+#[inline]
+fn should_sample() -> bool {
+    rand::pseudo_random() < SAMPLE_RATE
+}
 
 fn convert_perf_level(input: PerfStatsLevel) -> rocksdb::perf::PerfStatsLevel {
     use rocksdb::perf::PerfStatsLevel as RocksLevel;
@@ -33,42 +91,26 @@ fn convert_perf_level(input: PerfStatsLevel) -> rocksdb::perf::PerfStatsLevel {
     }
 }
 
-/// This guard is !Send. It must be created and dropped on the same thread since
-/// it's backed by a thread-local in rocksdb.
-pub struct RocksDbPerfGuard {
+struct RealRocksGuard {
     start: Instant,
     name: &'static str,
     context: PerfContext,
     should_report: bool,
 }
 
-static_assertions::assert_not_impl_any!(RocksDbPerfGuard: Send);
-
-impl RocksDbPerfGuard {
-    /// IMPORTANT NOTE: you MUST bind this value with a named variable (f) to ensure
-    /// that the guard is not insta-dropped. Binding to something like `_x = ...` works, just don't
-    /// use the special `_` variable and you'll be fine. Unfortunately, rust/clippy doesn't have a
-    /// mechanism to enforce this at the moment.
-    ///
-    /// This guard should not be used across await points. Stats are thread local.
-    #[must_use]
-    pub fn new(name: &'static str) -> Self {
+impl RealRocksGuard {
+    fn new(name: &'static str) -> Self {
         let rocks_level = convert_perf_level(Configuration::pinned().common.rocksdb_perf_level);
         rocksdb::perf::set_perf_stats(rocks_level);
         // Behind the scenes, this "gets" the thread-local perf context and doesn't clear it up.
         let mut context = PerfContext::default();
         context.reset();
-        RocksDbPerfGuard {
+        Self {
             name,
             start: Instant::now(),
             context,
             should_report: true,
         }
-    }
-
-    /// Drops the guard without reporting any metrics.
-    pub fn forget(mut self) {
-        self.should_report = false;
     }
 
     fn report(&self) {
@@ -135,14 +177,9 @@ impl RocksDbPerfGuard {
     }
 }
 
-impl Drop for RocksDbPerfGuard {
-    fn drop(&mut self) {
-        rocksdb::perf::set_perf_stats(rocksdb::perf::PerfStatsLevel::Disable);
-        if self.should_report {
-            // report collected metrics
-            self.report();
-        }
-    }
+enum Inner {
+    Noop,
+    Real(RealRocksGuard),
 }
 
 #[inline]

--- a/util/random/Cargo.toml
+++ b/util/random/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "restate-util-random"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+restate-workspace-hack = { workspace = true }
+
+[lints]
+workspace = true

--- a/util/random/README.md
+++ b/util/random/README.md
@@ -1,0 +1,29 @@
+# restate-util-random
+
+Lightweight, dependency-free pseudo-random utilities for use inside Restate
+crates that need cheap, non-cryptographic randomness (e.g. sampling, shuffling,
+jitter).
+
+The PRNG is a thread-local [xorshift\*] generator, seeded from a process-wide
+counter hashed with `DefaultHasher`. It is **not** cryptographically secure and
+must not be used where unpredictability matters.
+
+[xorshift\*]: https://en.wikipedia.org/wiki/Xorshift#xorshift*
+
+## API
+
+- `pseudo_random() -> u64` — next 64-bit pseudo-random value from the
+  current thread's generator.
+- `psuedo_shuffle<T>(slice: &mut [T])` — in-place Fisher–Yates shuffle using
+  `pseudo_random()`.
+
+## When to use
+
+- Probabilistic sampling on hot paths where a real RNG would be overkill
+  (e.g. `restate-rocksdb` perf-guard sampling).
+- Shuffling small slices when ordering bias is acceptable.
+
+## When NOT to use
+
+- Anything security-sensitive (tokens, nonces, keys). Use a CSPRNG instead.
+- Reproducible randomness across threads — each thread has its own seed.

--- a/util/random/src/lib.rs
+++ b/util/random/src/lib.rs
@@ -1,0 +1,64 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// Design borrowed from futures-rs's random.rs
+use std::{
+    cell::Cell,
+    collections::hash_map::DefaultHasher,
+    hash::Hasher,
+    num::Wrapping,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+/// Based on [Fisher–Yates shuffle].
+///
+/// [Fisher–Yates shuffle]: https://en.wikipedia.org/wiki/Fisher–Yates_shuffle
+pub fn psuedo_shuffle<T>(slice: &mut [T]) {
+    for i in (1..slice.len()).rev() {
+        slice.swap(i, gen_index(i + 1));
+    }
+}
+
+/// Return a value from `0..n`.
+fn gen_index(n: usize) -> usize {
+    (pseudo_random() % n as u64) as usize
+}
+
+/// Pseudorandom number generator based on [xorshift*].
+///
+/// [xorshift*]: https://en.wikipedia.org/wiki/Xorshift#xorshift*
+pub fn pseudo_random() -> u64 {
+    std::thread_local! {
+        static RNG: Cell<Wrapping<u64>> = Cell::new(Wrapping(prng_seed()));
+    }
+
+    fn prng_seed() -> u64 {
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+        // Any non-zero seed will do
+        let mut seed = 0;
+        while seed == 0 {
+            let mut hasher = DefaultHasher::new();
+            hasher.write_usize(COUNTER.fetch_add(1, Ordering::Relaxed));
+            seed = hasher.finish();
+        }
+        seed
+    }
+
+    RNG.with(|rng| {
+        let mut x = rng.get();
+        debug_assert_ne!(x.0, 0);
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        rng.set(x);
+        x.0.wrapping_mul(0x2545_f491_4f6c_dd1d)
+    })
+}


### PR DESCRIPTION

Enabling rocksdb perf sampling on every operation can get costly quickly. In practice, we're interested in the rough magnitude of
the values rather than the precise numbers. This PR sets up rocksdb profiling to be only enabled on 10% of operations by using a fast
thread-local RNG to determine whether to sample or not. The new psuedorandom number number generator is 4x faster than the vanilla
random number generator from `rand` crate on macOS. The strategy is similar to what futures-rs and tokio crates do for their internal shuffling (select!
macro and stream_select!).

Adjacent. The change in Cargo.toml helps speed up dev builds on macOS.
