### PR TITLE
Expose partition-store StorageVersion via partition state

### DIFF
--- a/crates/partition-store/src/fsm_table/mod.rs
+++ b/crates/partition-store/src/fsm_table/mod.rs
@@ -10,7 +10,7 @@
 
 use crate::TableKind::PartitionStateMachine;
 use crate::keys::{EncodeTableKeyPrefix, KeyKind, define_table_key};
-use crate::migrations::SchemaVersion;
+use crate::migrations::StorageVersion;
 use crate::{
     PaddedPartitionId, PartitionDb, PartitionStore, PartitionStoreTransaction, StorageAccess,
 };
@@ -138,7 +138,7 @@ pub(crate) async fn get_storage_version<S: StorageAccess>(
         .map(|opt| opt.map(|s| s.0 as u16).unwrap_or_default())
 }
 
-pub(crate) fn get_storage_version_from_partition_db(db: &PartitionDb) -> Result<SchemaVersion> {
+pub(crate) fn get_storage_version_from_partition_db(db: &PartitionDb) -> Result<StorageVersion> {
     let cf = db.cf_handle();
     let key = create_key(db.partition().partition_id, fsm_variable::STORAGE_VERSION);
     let sequence_number: Option<SequenceNumber> = db
@@ -165,7 +165,7 @@ pub(crate) fn get_storage_version_from_partition_db(db: &PartitionDb) -> Result<
             .map_err(|_| StorageError::DataIntegrityError)?
             .try_into()?
     } else {
-        SchemaVersion::None
+        StorageVersion::None
     })
 }
 
@@ -183,11 +183,11 @@ pub(crate) async fn put_storage_version<S: StorageAccess>(
 }
 
 /// Append a `STORAGE_VERSION = version` put to `wb`.
-pub(crate) fn append_schema_version_to_wb(
+pub(crate) fn append_storage_version_to_wb(
     cf_handle: &std::sync::Arc<rocksdb::BoundColumnFamily<'_>>,
     wb: &mut rocksdb::WriteBatch,
     partition_id: PartitionId,
-    version: SchemaVersion,
+    version: StorageVersion,
 ) -> Result<()> {
     use bytes::BytesMut;
     use restate_types::storage::StorageCodec;

--- a/crates/partition-store/src/fsm_table/mod.rs
+++ b/crates/partition-store/src/fsm_table/mod.rs
@@ -10,7 +10,6 @@
 
 use crate::TableKind::PartitionStateMachine;
 use crate::keys::{EncodeTableKeyPrefix, KeyKind, define_table_key};
-use crate::migrations::StorageVersion;
 use crate::{
     PaddedPartitionId, PartitionDb, PartitionStore, PartitionStoreTransaction, StorageAccess,
 };
@@ -24,6 +23,7 @@ use restate_types::SemanticRestateVersion;
 use restate_types::identifiers::PartitionId;
 use restate_types::logs::Lsn;
 use restate_types::message::MessageIndex;
+use restate_types::partitions::StorageVersion;
 use restate_types::partitions::features::PersistedStateMachineFeatures;
 use restate_types::schema::Schema;
 use restate_types::storage::StorageCodec;
@@ -133,9 +133,18 @@ pub async fn get_locally_durable_lsn(partition_store: &mut PartitionStore) -> Re
 pub(crate) async fn get_storage_version<S: StorageAccess>(
     storage: &mut S,
     partition_id: PartitionId,
-) -> Result<u16> {
-    get::<SequenceNumber, _>(storage, partition_id, fsm_variable::STORAGE_VERSION)
-        .map(|opt| opt.map(|s| s.0 as u16).unwrap_or_default())
+) -> Result<StorageVersion> {
+    get::<SequenceNumber, _>(storage, partition_id, fsm_variable::STORAGE_VERSION).and_then(|opt| {
+        let storage_version = if let Some(seq_number) = opt {
+            StorageVersion::try_from(
+                u16::try_from(seq_number.0).map_err(|_| StorageError::DataIntegrityError)?,
+            )?
+        } else {
+            StorageVersion::None
+        };
+
+        Ok(storage_version)
+    })
 }
 
 pub(crate) fn get_storage_version_from_partition_db(db: &PartitionDb) -> Result<StorageVersion> {
@@ -161,9 +170,8 @@ pub(crate) fn get_storage_version_from_partition_db(db: &PartitionDb) -> Result<
         .map_err(|err| StorageError::Generic(err.into()))?;
 
     Ok(if let Some(sequence_number) = sequence_number {
-        u16::try_from(sequence_number.0)
-            .map_err(|_| StorageError::DataIntegrityError)?
-            .try_into()?
+        let raw = u16::try_from(sequence_number.0).map_err(|_| StorageError::DataIntegrityError)?;
+        StorageVersion::try_from(raw)?
     } else {
         StorageVersion::None
     })

--- a/crates/partition-store/src/migrations.rs
+++ b/crates/partition-store/src/migrations.rs
@@ -24,6 +24,7 @@ use restate_clock::{AtomicStorage, HlcClock, WallClock};
 use restate_rocksdb::{IoMode, Priority};
 use restate_storage_api::StorageError;
 use restate_types::config::Configuration;
+use restate_types::partitions::StorageVersion;
 use restate_types::sharding::KeyRange;
 use restate_types::sharding::subsharding::ShardPlan;
 
@@ -37,132 +38,92 @@ use self::migrate_to_scoped_state_table::{
     append_delete_state_data, migrate_to_scoped_state_table,
 };
 
-// NOTE: The representation numbers here must be strictly monotonically increasing.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, strum::FromRepr)]
-#[repr(u16)]
-pub enum StorageVersion {
-    /// Before 1.5
-    None = 0,
-    /// Migrations:
-    /// * Invocation status V1 -> V2
-    V1_5 = 1,
-    /// Migrations:
-    /// * unscoped `state_table` -> scoped `state_table` (with `scope = None`)
-    /// * unscoped `promise_table` -> scoped `promise_table` (with `scope = None`)
-    ///
-    /// Gated by `experimental_enable_migrate_scoped_tables`.
-    /// Since v1.7.0
-    ScopedStateAndPromise = 2,
+/// Runs the migrations needed to transition the [`StorageVersion`] from current to the target
+/// storage version. A failure can leave the storage version at any valid version between current
+/// and target.
+pub async fn run_migrations_up_to(
+    mut current: StorageVersion,
+    target: StorageVersion,
+    storage: &mut PartitionStore,
+) -> Result<StorageVersion> {
+    while current < target {
+        current = do_migration(current, storage).await?;
+    }
+    Ok(current)
 }
 
-impl TryFrom<u16> for StorageVersion {
-    type Error = StorageError;
-
-    fn try_from(value: u16) -> Result<Self, StorageError> {
-        StorageVersion::from_repr(value).ok_or_else(|| {
-            StorageError::Generic(anyhow::anyhow!(
-                "unknown partition-store storage version {value}; this binary is older \
-                 than the data it would open. Roll forward to a server version that \
-                 recognizes this storage version."
-            ))
-        })
-    }
-}
-
-impl StorageVersion {
-    /// Returns `true` once the partition store has migrated the unscoped state
-    /// and promise tables into their scoped variants. After this point all
-    /// state/promise reads and writes use the scoped tables (with
-    /// `scope = None` for entries that were unscoped pre-migration).
-    pub(crate) fn is_scope_migrated(self) -> bool {
-        self >= StorageVersion::ScopedStateAndPromise
-    }
-
-    pub(crate) async fn run_migrations_up_to(
-        mut self,
-        target: StorageVersion,
-        storage: &mut PartitionStore,
-    ) -> Result<Self> {
-        while self < target {
-            self = self.do_migration(storage).await?;
+/// Runs the migration for the given storage version and returns the new
+/// storage version.
+///
+/// Each migration arm is responsible for atomically (with respect to crashes)
+/// persisting the storage-version bump together with any destructive cleanup
+/// (range deletes, etc.). See the `V1_5` arm for an example: copy passes run
+/// with WAL disabled, then a single final `WriteBatch` (also WAL off)
+/// commits the storage-version put together with the legacy `delete_range_cf`s.
+/// RocksDB's FIFO memtable flush order guarantees that the final batch can
+/// only become durable on SST after the copy writes are already on SST.
+async fn do_migration(
+    current: StorageVersion,
+    storage: &mut PartitionStore,
+) -> Result<StorageVersion> {
+    let new_storage_version = match current {
+        StorageVersion::None => {
+            // Version 1.6+ does not support upgrading from pre-1.5
+            // The InvocationStatusV1 migration was removed in 1.6
+            return Err(StorageError::Generic(anyhow::anyhow!(
+                "Cannot upgrade from version <1.5 directly to 1.6 or later. \
+                 Please upgrade to version 1.5 first, which will migrate your data, \
+                 and then upgrade to 1.6+"
+            )));
         }
-        Ok(self)
-    }
+        StorageVersion::V1_5 => {
+            let config = Configuration::pinned();
+            let key_range = storage.partition_key_range();
+            let partition_id = storage.partition_id();
+            let partition_db = storage.partition_db().clone();
+            let mut ctx = MigrationContext::new(&config, &partition_db, key_range);
+            let new_storage_version = StorageVersion::ScopedStateAndPromise;
 
-    // Runs the migration for the given schema version and returns the new schema version
-    //
-    // Each migration arm is responsible for atomically (with respect to crashes)
-    // persisting the schema-version bump together with any destructive cleanup
-    // (range deletes, etc.). See the `V1_5` arm for an example: copy passes run
-    // with WAL disabled, then a single final `WriteBatch` (also WAL off)
-    // commits the schema-version put together with the legacy `delete_range_cf`s.
-    // RocksDB's FIFO memtable flush order guarantees that the final batch can
-    // only become durable on SST after the copy writes are already on SST.
-    async fn do_migration(&self, storage: &mut PartitionStore) -> Result<StorageVersion> {
-        let new_storage_version = match self {
-            StorageVersion::None => {
-                // Version 1.6+ does not support upgrading from pre-1.5
-                // The InvocationStatusV1 migration was removed in 1.6
-                return Err(StorageError::Generic(anyhow::anyhow!(
-                    "Cannot upgrade from version <1.5 directly to 1.6 or later. \
-                     Please upgrade to version 1.5 first, which will migrate your data, \
-                     and then upgrade to 1.6+"
-                )));
-            }
-            StorageVersion::V1_5 => {
-                let config = Configuration::pinned();
-                let key_range = storage.partition_key_range();
-                let partition_id = storage.partition_id();
-                let partition_db = storage.partition_db().clone();
-                let mut ctx = MigrationContext::new(&config, &partition_db, key_range);
-                let new_storage_version = StorageVersion::ScopedStateAndPromise;
+            migrate_to_scoped_state_table(&mut ctx)?;
+            migrate_to_scoped_promise_table(&mut ctx)?;
 
-                migrate_to_scoped_state_table(&mut ctx)?;
-                migrate_to_scoped_promise_table(&mut ctx)?;
+            // Atomic final step: delete legacy ranges + bump storage version
+            // in a single `WriteBatch`. WAL off so the FIFO memtable order
+            // pins the version bump behind the copy writes — see the
+            // doc-comment on `do_migration` for the durability argument.
+            let cf_handle = partition_db.cf_handle().clone();
+            let mut wb = WriteBatch::default();
+            append_delete_state_data(&ctx, &mut wb);
+            append_delete_promise_data(&ctx, &mut wb);
+            append_storage_version_to_wb(&cf_handle, &mut wb, partition_id, new_storage_version)?;
 
-                // Atomic final step: delete legacy ranges + bump schema version
-                // in a single `WriteBatch`. WAL off so the FIFO memtable order
-                // pins the schema bump behind the copy writes — see the
-                // doc-comment on `do_migration` for the durability argument.
-                let cf_handle = partition_db.cf_handle().clone();
-                let mut wb = WriteBatch::default();
-                append_delete_state_data(&ctx, &mut wb);
-                append_delete_promise_data(&ctx, &mut wb);
-                append_storage_version_to_wb(
-                    &cf_handle,
-                    &mut wb,
-                    partition_id,
-                    new_storage_version,
-                )?;
+            let mut opts = rocksdb::WriteOptions::default();
+            opts.disable_wal(true);
+            partition_db
+                .rocksdb()
+                .write_batch(
+                    "scoped-state-promise-table-migration",
+                    Priority::High,
+                    IoMode::Default,
+                    opts,
+                    wb,
+                )
+                .await
+                .context("failed to commit scoped-state-and-promise final write batch")
+                .map_err(StorageError::Generic)?;
+            debug!(
+                %partition_id,
+                "Finalized scoped state/promise migration"
+            );
+            new_storage_version
+        }
+        StorageVersion::ScopedStateAndPromise => {
+            // Latest version, nothing further to do.
+            StorageVersion::ScopedStateAndPromise
+        }
+    };
 
-                let mut opts = rocksdb::WriteOptions::default();
-                opts.disable_wal(true);
-                partition_db
-                    .rocksdb()
-                    .write_batch(
-                        "scoped-state-promise-table-migration",
-                        Priority::High,
-                        IoMode::Default,
-                        opts,
-                        wb,
-                    )
-                    .await
-                    .context("failed to commit scoped-state-and-promise final write batch")
-                    .map_err(StorageError::Generic)?;
-                debug!(
-                    %partition_id,
-                    "Finalized scoped state/promise migration"
-                );
-                new_storage_version
-            }
-            StorageVersion::ScopedStateAndPromise => {
-                // Latest version, nothing further to do.
-                StorageVersion::ScopedStateAndPromise
-            }
-        };
-
-        Ok(new_storage_version)
-    }
+    Ok(new_storage_version)
 }
 
 #[allow(dead_code)]

--- a/crates/partition-store/src/migrations.rs
+++ b/crates/partition-store/src/migrations.rs
@@ -27,7 +27,7 @@ use restate_types::config::Configuration;
 use restate_types::sharding::KeyRange;
 use restate_types::sharding::subsharding::ShardPlan;
 
-use crate::fsm_table::append_schema_version_to_wb;
+use crate::fsm_table::append_storage_version_to_wb;
 use crate::{PartitionDb, PartitionStore, Result};
 
 use self::migrate_to_scoped_promise_table::{
@@ -40,7 +40,7 @@ use self::migrate_to_scoped_state_table::{
 // NOTE: The representation numbers here must be strictly monotonically increasing.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, strum::FromRepr)]
 #[repr(u16)]
-pub(crate) enum SchemaVersion {
+pub enum StorageVersion {
     /// Before 1.5
     None = 0,
     /// Migrations:
@@ -55,32 +55,32 @@ pub(crate) enum SchemaVersion {
     ScopedStateAndPromise = 2,
 }
 
-impl TryFrom<u16> for SchemaVersion {
+impl TryFrom<u16> for StorageVersion {
     type Error = StorageError;
 
     fn try_from(value: u16) -> Result<Self, StorageError> {
-        SchemaVersion::from_repr(value).ok_or_else(|| {
+        StorageVersion::from_repr(value).ok_or_else(|| {
             StorageError::Generic(anyhow::anyhow!(
-                "unknown partition-store schema version {value}; this binary is older \
+                "unknown partition-store storage version {value}; this binary is older \
                  than the data it would open. Roll forward to a server version that \
-                 recognizes this schema."
+                 recognizes this storage version."
             ))
         })
     }
 }
 
-impl SchemaVersion {
+impl StorageVersion {
     /// Returns `true` once the partition store has migrated the unscoped state
     /// and promise tables into their scoped variants. After this point all
     /// state/promise reads and writes use the scoped tables (with
     /// `scope = None` for entries that were unscoped pre-migration).
     pub(crate) fn is_scope_migrated(self) -> bool {
-        self >= SchemaVersion::ScopedStateAndPromise
+        self >= StorageVersion::ScopedStateAndPromise
     }
 
     pub(crate) async fn run_migrations_up_to(
         mut self,
-        target: SchemaVersion,
+        target: StorageVersion,
         storage: &mut PartitionStore,
     ) -> Result<Self> {
         while self < target {
@@ -98,9 +98,9 @@ impl SchemaVersion {
     // commits the schema-version put together with the legacy `delete_range_cf`s.
     // RocksDB's FIFO memtable flush order guarantees that the final batch can
     // only become durable on SST after the copy writes are already on SST.
-    async fn do_migration(&self, storage: &mut PartitionStore) -> Result<SchemaVersion> {
-        let new_schema_version = match self {
-            SchemaVersion::None => {
+    async fn do_migration(&self, storage: &mut PartitionStore) -> Result<StorageVersion> {
+        let new_storage_version = match self {
+            StorageVersion::None => {
                 // Version 1.6+ does not support upgrading from pre-1.5
                 // The InvocationStatusV1 migration was removed in 1.6
                 return Err(StorageError::Generic(anyhow::anyhow!(
@@ -109,13 +109,13 @@ impl SchemaVersion {
                      and then upgrade to 1.6+"
                 )));
             }
-            SchemaVersion::V1_5 => {
+            StorageVersion::V1_5 => {
                 let config = Configuration::pinned();
                 let key_range = storage.partition_key_range();
                 let partition_id = storage.partition_id();
                 let partition_db = storage.partition_db().clone();
                 let mut ctx = MigrationContext::new(&config, &partition_db, key_range);
-                let new_schema_version = SchemaVersion::ScopedStateAndPromise;
+                let new_storage_version = StorageVersion::ScopedStateAndPromise;
 
                 migrate_to_scoped_state_table(&mut ctx)?;
                 migrate_to_scoped_promise_table(&mut ctx)?;
@@ -128,7 +128,12 @@ impl SchemaVersion {
                 let mut wb = WriteBatch::default();
                 append_delete_state_data(&ctx, &mut wb);
                 append_delete_promise_data(&ctx, &mut wb);
-                append_schema_version_to_wb(&cf_handle, &mut wb, partition_id, new_schema_version)?;
+                append_storage_version_to_wb(
+                    &cf_handle,
+                    &mut wb,
+                    partition_id,
+                    new_storage_version,
+                )?;
 
                 let mut opts = rocksdb::WriteOptions::default();
                 opts.disable_wal(true);
@@ -148,15 +153,15 @@ impl SchemaVersion {
                     %partition_id,
                     "Finalized scoped state/promise migration"
                 );
-                new_schema_version
+                new_storage_version
             }
-            SchemaVersion::ScopedStateAndPromise => {
+            StorageVersion::ScopedStateAndPromise => {
                 // Latest version, nothing further to do.
-                SchemaVersion::ScopedStateAndPromise
+                StorageVersion::ScopedStateAndPromise
             }
         };
 
-        Ok(new_schema_version)
+        Ok(new_storage_version)
     }
 }
 
@@ -314,7 +319,7 @@ mod tests {
             .expect("DB storage creation succeeds");
 
         // Seed the FSM with an applied LSN so the empty-partition fast path is skipped,
-        // and a SchemaVersion discriminant that this binary doesn't know.
+        // and a StorageVersion discriminant that this binary doesn't know.
         {
             use restate_storage_api::Transaction;
             use restate_storage_api::fsm_table::WriteFsmTable;
@@ -331,10 +336,10 @@ mod tests {
         let err = store
             .verify_and_run_migrations()
             .await
-            .expect_err("unknown schema version should fail verify_and_run_migrations");
+            .expect_err("unknown storage version should fail verify_and_run_migrations");
         let msg = err.to_string();
         assert!(
-            msg.contains("9999") && msg.contains("schema version"),
+            msg.contains("9999") && msg.contains("storage version"),
             "unexpected error message: {msg}"
         );
 

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -42,12 +42,14 @@ use restate_types::storage::StorageCodec;
 use restate_types::storage::StorageDecode;
 use restate_types::storage::StorageEncode;
 
+use restate_types::partitions::StorageVersion;
+
 use crate::fsm_table::{
     get_locally_durable_lsn, get_storage_version, get_storage_version_from_partition_db,
     is_jc_orphan_cleanup_done, put_jc_orphan_cleanup_done, put_storage_version,
 };
 use crate::keys::{EncodeTableKey, EncodeTableKeyPrefix, KeyKind};
-use crate::migrations::StorageVersion;
+use crate::migrations::run_migrations_up_to;
 use crate::partition_db::PartitionDb;
 use crate::scan::PhysicalScan;
 use crate::scan::TableScan;
@@ -688,15 +690,14 @@ impl PartitionStore {
             return Ok(());
         }
 
-        let mut storage_version =
-            StorageVersion::try_from(get_storage_version(self, self.partition_id()).await?)?;
+        let mut storage_version = get_storage_version(self, self.partition_id()).await?;
         if storage_version < target {
             // We need to run some migrations!
             debug!(
                 "Running storage migration from {:?} to {:?}",
                 storage_version, target
             );
-            storage_version = storage_version.run_migrations_up_to(target, self).await?;
+            storage_version = run_migrations_up_to(storage_version, target, self).await?;
         }
         self.storage_version = storage_version;
 

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -47,7 +47,7 @@ use crate::fsm_table::{
     is_jc_orphan_cleanup_done, put_jc_orphan_cleanup_done, put_storage_version,
 };
 use crate::keys::{EncodeTableKey, EncodeTableKeyPrefix, KeyKind};
-use crate::migrations::SchemaVersion;
+use crate::migrations::StorageVersion;
 use crate::partition_db::PartitionDb;
 use crate::scan::PhysicalScan;
 use crate::scan::TableScan;
@@ -197,7 +197,7 @@ impl TableKind {
 
 pub struct PartitionStore {
     db: PartitionDb,
-    schema_version: SchemaVersion,
+    storage_version: StorageVersion,
     key_buffer: BytesMut,
     value_buffer: BytesMut,
 }
@@ -217,7 +217,7 @@ impl Clone for PartitionStore {
     fn clone(&self) -> Self {
         PartitionStore {
             db: self.db.clone(),
-            schema_version: self.schema_version,
+            storage_version: self.storage_version,
             key_buffer: BytesMut::default(),
             value_buffer: BytesMut::default(),
         }
@@ -232,20 +232,20 @@ impl From<PartitionDb> for PartitionStore {
 
 impl PartitionStore {
     pub(crate) fn new(db: PartitionDb) -> Self {
-        let schema_version =
+        let storage_version =
             get_storage_version_from_partition_db(&db).expect("storage version must exist");
 
         Self {
             db,
-            schema_version,
+            storage_version,
             key_buffer: BytesMut::new(),
             value_buffer: BytesMut::new(),
         }
     }
 
     #[inline]
-    pub(crate) fn schema_version(&self) -> SchemaVersion {
-        self.schema_version
+    pub fn storage_version(&self) -> StorageVersion {
+        self.storage_version
     }
 
     pub fn partition_db(&self) -> &PartitionDb {
@@ -579,7 +579,7 @@ impl PartitionStore {
             key_buffer: &mut self.key_buffer,
             value_buffer: &mut self.value_buffer,
             meta: self.db.partition(),
-            schema_version: self.schema_version,
+            storage_version: self.storage_version,
             snapshot,
         }
     }
@@ -670,9 +670,9 @@ impl PartitionStore {
             .experimental
             .is_migrate_scoped_tables_enabled()
         {
-            SchemaVersion::ScopedStateAndPromise
+            StorageVersion::ScopedStateAndPromise
         } else {
-            SchemaVersion::V1_5
+            StorageVersion::V1_5
         };
 
         // We assume the partition store to be empty if it does not contain any applied lsn. The
@@ -684,21 +684,21 @@ impl PartitionStore {
             // A fresh partition store cannot have orphaned jc index entries, so mark the
             // cleanup as already done to avoid a needless scan on first startup.
             put_jc_orphan_cleanup_done(self, self.partition_id())?;
-            self.schema_version = target;
+            self.storage_version = target;
             return Ok(());
         }
 
-        let mut schema_version =
-            SchemaVersion::try_from(get_storage_version(self, self.partition_id()).await?)?;
-        if schema_version < target {
+        let mut storage_version =
+            StorageVersion::try_from(get_storage_version(self, self.partition_id()).await?)?;
+        if storage_version < target {
             // We need to run some migrations!
             debug!(
                 "Running storage migration from {:?} to {:?}",
-                schema_version, target
+                storage_version, target
             );
-            schema_version = schema_version.run_migrations_up_to(target, self).await?;
+            storage_version = storage_version.run_migrations_up_to(target, self).await?;
         }
-        self.schema_version = schema_version;
+        self.storage_version = storage_version;
 
         Ok(())
     }
@@ -815,7 +815,7 @@ pub struct PartitionStoreTransaction<'a> {
     data_cf_handle: &'a Arc<BoundColumnFamily<'a>>,
     key_buffer: &'a mut BytesMut,
     value_buffer: &'a mut BytesMut,
-    schema_version: SchemaVersion,
+    storage_version: StorageVersion,
     snapshot: Option<SnapshotWithThreadMode<'a, rocksdb::DB>>,
 }
 
@@ -939,8 +939,8 @@ impl PartitionStoreTransaction<'_> {
     }
 
     #[inline]
-    pub(crate) fn schema_version(&self) -> SchemaVersion {
-        self.schema_version
+    pub(crate) fn storage_version(&self) -> StorageVersion {
+        self.storage_version
     }
 
     #[inline]

--- a/crates/partition-store/src/promise_table/mod.rs
+++ b/crates/partition-store/src/promise_table/mod.rs
@@ -13,7 +13,7 @@ use bytestring::ByteString;
 use std::sync::Arc;
 
 use crate::keys::{DecodeTableKey, KeyKind, define_table_key};
-use crate::migrations::SchemaVersion;
+use crate::migrations::StorageVersion;
 use crate::scan::TableScan;
 use crate::{
     PartitionStore, PartitionStoreTransaction, StorageAccess, TableKind,
@@ -65,21 +65,21 @@ fn create_key(service_id: &ServiceId, key: &ByteString) -> PromiseKey {
 
 /// Returns `true` if the call should use the scoped promise table — either
 /// because the partition store has migrated past
-/// [`SchemaVersion::ScopedStateAndPromise`] (so scope = None entries also live
+/// [`StorageVersion::ScopedStateAndPromise`] (so scope = None entries also live
 /// in the scoped table) or because the [`ServiceId`] carries an explicit scope.
 #[inline]
-fn use_scoped_promise(schema_version: SchemaVersion, service_id: &ServiceId) -> bool {
-    schema_version.is_scope_migrated() || service_id.scope.is_some()
+fn use_scoped_promise(storage_version: StorageVersion, service_id: &ServiceId) -> bool {
+    storage_version.is_scope_migrated() || service_id.scope.is_some()
 }
 
 fn get_promise<S: StorageAccess>(
     storage: &mut S,
-    schema_version: SchemaVersion,
+    storage_version: StorageVersion,
     service_id: &ServiceId,
     key: &ByteString,
 ) -> Result<Option<Promise>> {
     let _x = RocksDbPerfGuard::new("get-promise");
-    if use_scoped_promise(schema_version, service_id) {
+    if use_scoped_promise(storage_version, service_id) {
         // todo(tillrohrmann) remove once ServiceId uses ServiceName and ReString internally
         let service_name = ServiceName::new(&service_id.service_name);
         let service_key = ReString::new(&service_id.key);
@@ -102,12 +102,12 @@ fn get_promise<S: StorageAccess>(
 
 fn put_promise<S: StorageAccess>(
     storage: &mut S,
-    schema_version: SchemaVersion,
+    storage_version: StorageVersion,
     service_id: &ServiceId,
     key: &ByteString,
     metadata: &Promise,
 ) -> Result<()> {
-    if use_scoped_promise(schema_version, service_id) {
+    if use_scoped_promise(storage_version, service_id) {
         // todo(tillrohrmann) remove once ServiceId uses ServiceName and ReString internally
         let service_name = ServiceName::new(&service_id.service_name);
         let service_key = ReString::new(&service_id.key);
@@ -131,10 +131,10 @@ fn put_promise<S: StorageAccess>(
 
 fn delete_all_promises<S: StorageAccess>(
     storage: &mut S,
-    schema_version: SchemaVersion,
+    storage_version: StorageVersion,
     service_id: &ServiceId,
 ) -> Result<()> {
-    if use_scoped_promise(schema_version, service_id) {
+    if use_scoped_promise(storage_version, service_id) {
         // todo(tillrohrmann) remove once ServiceId uses ServiceName and ReString internally
         let service_name = ServiceName::new(&service_id.service_name);
         let service_key = ReString::new(&service_id.key);
@@ -184,7 +184,7 @@ impl ReadPromiseTable for PartitionStore {
         key: &ByteString,
     ) -> Result<Option<Promise>> {
         self.assert_partition_key(service_id)?;
-        get_promise(self, self.schema_version(), service_id, key)
+        get_promise(self, self.storage_version(), service_id, key)
     }
 }
 
@@ -203,7 +203,7 @@ impl ScanPromiseTable for PartitionStore {
 
         // Only scan the legacy unscoped table while we may still hold data there.
         // After migration the range was deleted, so the scoped scan covers everything.
-        let unscoped = if self.schema_version().is_scope_migrated() {
+        let unscoped = if self.storage_version().is_scope_migrated() {
             None
         } else {
             let f_unscoped = Arc::clone(&f);
@@ -280,7 +280,7 @@ impl ReadPromiseTable for PartitionStoreTransaction<'_> {
         key: &ByteString,
     ) -> Result<Option<Promise>> {
         self.assert_partition_key(service_id)?;
-        get_promise(self, self.schema_version(), service_id, key)
+        get_promise(self, self.storage_version(), service_id, key)
     }
 }
 
@@ -292,11 +292,11 @@ impl WritePromiseTable for PartitionStoreTransaction<'_> {
         promise: &Promise,
     ) -> Result<()> {
         self.assert_partition_key(service_id)?;
-        put_promise(self, self.schema_version(), service_id, key, promise)
+        put_promise(self, self.storage_version(), service_id, key, promise)
     }
 
     fn delete_all_promises(&mut self, service_id: &ServiceId) -> Result<()> {
         self.assert_partition_key(service_id)?;
-        delete_all_promises(self, self.schema_version(), service_id)
+        delete_all_promises(self, self.storage_version(), service_id)
     }
 }

--- a/crates/partition-store/src/promise_table/mod.rs
+++ b/crates/partition-store/src/promise_table/mod.rs
@@ -13,7 +13,6 @@ use bytestring::ByteString;
 use std::sync::Arc;
 
 use crate::keys::{DecodeTableKey, KeyKind, define_table_key};
-use crate::migrations::StorageVersion;
 use crate::scan::TableScan;
 use crate::{
     PartitionStore, PartitionStoreTransaction, StorageAccess, TableKind,
@@ -26,6 +25,7 @@ use restate_storage_api::promise_table::{
 use restate_storage_api::protobuf_types::PartitionStoreProtobufValue;
 use restate_storage_api::{Result, StorageError};
 use restate_types::identifiers::{PartitionKey, ServiceId, WithPartitionKey};
+use restate_types::partitions::StorageVersion;
 use restate_types::sharding::KeyRange;
 use restate_types::{Scope, ServiceName};
 use restate_util_string::ReString;

--- a/crates/partition-store/src/state_table/mod.rs
+++ b/crates/partition-store/src/state_table/mod.rs
@@ -31,11 +31,11 @@ use restate_util_string::ReString;
 
 use crate::TableKind::State;
 use crate::keys::{DecodeTableKey, KeyKind, define_table_key};
-use crate::migrations::StorageVersion;
 use crate::{
     PartitionStore, PartitionStoreTransaction, StorageAccess, TableScan,
     TableScanIterationDecision, break_on_err,
 };
+use restate_types::partitions::StorageVersion;
 
 define_table_key!(
     State,

--- a/crates/partition-store/src/state_table/mod.rs
+++ b/crates/partition-store/src/state_table/mod.rs
@@ -31,7 +31,7 @@ use restate_util_string::ReString;
 
 use crate::TableKind::State;
 use crate::keys::{DecodeTableKey, KeyKind, define_table_key};
-use crate::migrations::SchemaVersion;
+use crate::migrations::StorageVersion;
 use crate::{
     PartitionStore, PartitionStoreTransaction, StorageAccess, TableScan,
     TableScanIterationDecision, break_on_err,
@@ -130,21 +130,21 @@ impl<DB: DBAccess> Iterator for StateEntryIter<'_, DB> {
 
 /// Returns `true` if the call should use the scoped state table — either because
 /// the partition store has migrated past
-/// [`SchemaVersion::ScopedStateAndPromise`] (so scope = None entries also live
+/// [`StorageVersion::ScopedStateAndPromise`] (so scope = None entries also live
 /// in the scoped table) or because the [`ServiceId`] carries an explicit scope.
 #[inline]
-fn use_scoped_state(schema_version: SchemaVersion, service_id: &ServiceId) -> bool {
-    schema_version.is_scope_migrated() || service_id.scope.is_some()
+fn use_scoped_state(storage_version: StorageVersion, service_id: &ServiceId) -> bool {
+    storage_version.is_scope_migrated() || service_id.scope.is_some()
 }
 
 fn put_user_state<S: StorageAccess>(
     storage: &mut S,
-    schema_version: SchemaVersion,
+    storage_version: StorageVersion,
     service_id: &ServiceId,
     state_key: &Bytes,
     state_value: impl AsRef<[u8]>,
 ) -> Result<()> {
-    if use_scoped_state(schema_version, service_id) {
+    if use_scoped_state(storage_version, service_id) {
         //todo(tillrohrmann) remove once ServiceId carries the right types
         let service_name = ServiceName::new(service_id.service_name.as_ref());
         let service_key = ReString::new(&service_id.key);
@@ -168,11 +168,11 @@ fn put_user_state<S: StorageAccess>(
 
 fn delete_user_state<S: StorageAccess>(
     storage: &mut S,
-    schema_version: SchemaVersion,
+    storage_version: StorageVersion,
     service_id: &ServiceId,
     state_key: &Bytes,
 ) -> Result<()> {
-    if use_scoped_state(schema_version, service_id) {
+    if use_scoped_state(storage_version, service_id) {
         //todo(tillrohrmann) remove once ServiceId carries the right types
         let service_name = ServiceName::new(service_id.service_name.as_ref());
         let service_key = ReString::new(&service_id.key);
@@ -196,10 +196,10 @@ fn delete_user_state<S: StorageAccess>(
 
 fn delete_all_user_state<S: StorageAccess>(
     storage: &mut S,
-    schema_version: SchemaVersion,
+    storage_version: StorageVersion,
     service_id: &ServiceId,
 ) -> Result<()> {
-    if use_scoped_state(schema_version, service_id) {
+    if use_scoped_state(storage_version, service_id) {
         //todo(tillrohrmann) remove once ServiceId carries the right types
         let service_name = ServiceName::new(service_id.service_name.as_ref());
         let service_key = ReString::new(&service_id.key);
@@ -244,12 +244,12 @@ fn delete_all_user_state<S: StorageAccess>(
 
 fn get_user_state<S: StorageAccess>(
     storage: &mut S,
-    schema_version: SchemaVersion,
+    storage_version: StorageVersion,
     service_id: &ServiceId,
     state_key: &Bytes,
 ) -> Result<Option<Bytes>> {
     let _x = RocksDbPerfGuard::new("get-user-state");
-    if use_scoped_state(schema_version, service_id) {
+    if use_scoped_state(storage_version, service_id) {
         //todo(tillrohrmann) remove once ServiceId carries the right types
         let service_name = ServiceName::new(service_id.service_name.as_ref());
         let service_key = ReString::new(&service_id.key);
@@ -273,12 +273,12 @@ fn get_user_state<S: StorageAccess>(
 
 fn get_all_user_states_for_service<'a, S: StorageAccess>(
     storage: &'a S,
-    schema_version: SchemaVersion,
+    storage_version: StorageVersion,
     service_id: &ServiceId,
 ) -> Result<StateEntryIter<'a, S::DBAccess<'a>>> {
     let _x = RocksDbPerfGuard::new("get-all-user-state-iter-setup");
 
-    if use_scoped_state(schema_version, service_id) {
+    if use_scoped_state(storage_version, service_id) {
         //todo(tillrohrmann) remove once ServiceId carries the right types
         let service_name = ServiceName::new(service_id.service_name.as_ref());
         let service_key = ReString::new(&service_id.key);
@@ -316,7 +316,7 @@ impl ReadStateTable for PartitionStore {
         state_key: &Bytes,
     ) -> Result<Option<Bytes>> {
         self.assert_partition_key(service_id)?;
-        get_user_state(self, self.schema_version(), service_id, state_key)
+        get_user_state(self, self.storage_version(), service_id, state_key)
     }
 
     fn get_all_user_states_for_service<'a>(
@@ -326,7 +326,7 @@ impl ReadStateTable for PartitionStore {
         self.assert_partition_key(service_id)?;
         Ok(stream::iter(get_all_user_states_for_service(
             self,
-            self.schema_version(),
+            self.storage_version(),
             service_id,
         )?))
     }
@@ -342,7 +342,7 @@ impl ReadStateTable for PartitionStore {
         + 'a,
     > {
         self.assert_partition_key(service_id)?;
-        let iter = get_all_user_states_for_service(self, self.schema_version(), service_id)?;
+        let iter = get_all_user_states_for_service(self, self.storage_version(), service_id)?;
         Ok(budgeted_state_stream(iter, budget))
     }
 }
@@ -362,7 +362,7 @@ impl ScanStateTable for PartitionStore {
 
         // Only scan the legacy unscoped table while we may still hold data there.
         // After migration the range was deleted, so the scoped scan covers everything.
-        let unscoped = if self.schema_version().is_scope_migrated() {
+        let unscoped = if self.storage_version().is_scope_migrated() {
             None
         } else {
             let f_unscoped = Arc::clone(&f);
@@ -420,7 +420,7 @@ impl ReadStateTable for PartitionStoreTransaction<'_> {
         state_key: &Bytes,
     ) -> Result<Option<Bytes>> {
         self.assert_partition_key(service_id)?;
-        get_user_state(self, self.schema_version(), service_id, state_key)
+        get_user_state(self, self.storage_version(), service_id, state_key)
     }
 
     fn get_all_user_states_for_service<'a>(
@@ -430,7 +430,7 @@ impl ReadStateTable for PartitionStoreTransaction<'_> {
         self.assert_partition_key(service_id)?;
         Ok(stream::iter(get_all_user_states_for_service(
             self,
-            self.schema_version(),
+            self.storage_version(),
             service_id,
         )?))
     }
@@ -446,7 +446,7 @@ impl ReadStateTable for PartitionStoreTransaction<'_> {
         + 'a,
     > {
         self.assert_partition_key(service_id)?;
-        let iter = get_all_user_states_for_service(self, self.schema_version(), service_id)?;
+        let iter = get_all_user_states_for_service(self, self.storage_version(), service_id)?;
         Ok(budgeted_state_stream(iter, budget))
     }
 }
@@ -461,7 +461,7 @@ impl WriteStateTable for PartitionStoreTransaction<'_> {
         self.assert_partition_key(service_id)?;
         put_user_state(
             self,
-            self.schema_version(),
+            self.storage_version(),
             service_id,
             state_key,
             state_value,
@@ -470,12 +470,12 @@ impl WriteStateTable for PartitionStoreTransaction<'_> {
 
     fn delete_user_state(&mut self, service_id: &ServiceId, state_key: &Bytes) -> Result<()> {
         self.assert_partition_key(service_id)?;
-        delete_user_state(self, self.schema_version(), service_id, state_key)
+        delete_user_state(self, self.storage_version(), service_id, state_key)
     }
 
     fn delete_all_user_state(&mut self, service_id: &ServiceId) -> Result<()> {
         self.assert_partition_key(service_id)?;
-        delete_all_user_state(self, self.schema_version(), service_id)
+        delete_all_user_state(self, self.storage_version(), service_id)
     }
 }
 

--- a/crates/partition-store/src/tests/migrations_test/verify_and_run_migrations.rs
+++ b/crates/partition-store/src/tests/migrations_test/verify_and_run_migrations.rs
@@ -30,10 +30,10 @@ use restate_types::sharding::KeyRange;
 use crate::PartitionStoreManager;
 use crate::fsm_table::put_storage_version;
 use crate::keys::DecodeTableKey;
-use crate::migrations::StorageVersion;
 use crate::promise_table::{PromiseKey, ScopedPromiseKey};
 use crate::scan::{PhysicalScan, TableScan};
 use crate::state_table::{ScopedStateKey, StateKey};
+use restate_types::partitions::StorageVersion;
 
 fn with_migrate_scoped_tables(enabled: bool) {
     let mut config = Configuration::default();

--- a/crates/partition-store/src/tests/migrations_test/verify_and_run_migrations.rs
+++ b/crates/partition-store/src/tests/migrations_test/verify_and_run_migrations.rs
@@ -30,7 +30,7 @@ use restate_types::sharding::KeyRange;
 use crate::PartitionStoreManager;
 use crate::fsm_table::put_storage_version;
 use crate::keys::DecodeTableKey;
-use crate::migrations::SchemaVersion;
+use crate::migrations::StorageVersion;
 use crate::promise_table::{PromiseKey, ScopedPromiseKey};
 use crate::scan::{PhysicalScan, TableScan};
 use crate::state_table::{ScopedStateKey, StateKey};
@@ -173,7 +173,7 @@ async fn flag_off_keeps_partition_at_v1_5() {
     // Stamp the FSM as V1_5 so verify_and_run_migrations takes the migration path
     // rather than the empty-partition fast path.
     let partition_id = store.partition_id();
-    put_storage_version(&mut store, partition_id, SchemaVersion::V1_5 as u16)
+    put_storage_version(&mut store, partition_id, StorageVersion::V1_5 as u16)
         .await
         .expect("seed V1_5");
 
@@ -187,7 +187,7 @@ async fn flag_off_keeps_partition_at_v1_5() {
         .await
         .expect("verify with flag off");
 
-    assert_eq!(store.schema_version(), SchemaVersion::V1_5);
+    assert_eq!(store.storage_version(), StorageVersion::V1_5);
     assert_eq!(count_legacy_state(&store), legacy_state_before);
     assert_eq!(count_legacy_promise(&store), legacy_promise_before);
     assert_eq!(count_scoped_state(&store), 0);
@@ -215,7 +215,7 @@ async fn flag_on_migrates_and_bumps_version() {
     with_migrate_scoped_tables(false);
     let (state_entries, service_ids) = seed_unscoped_data(&mut store).await;
     let partition_id = store.partition_id();
-    put_storage_version(&mut store, partition_id, SchemaVersion::V1_5 as u16)
+    put_storage_version(&mut store, partition_id, StorageVersion::V1_5 as u16)
         .await
         .expect("seed V1_5");
     // Sanity: data really landed in the legacy tables.
@@ -229,7 +229,10 @@ async fn flag_on_migrates_and_bumps_version() {
         .await
         .expect("verify with flag on");
 
-    assert_eq!(store.schema_version(), SchemaVersion::ScopedStateAndPromise);
+    assert_eq!(
+        store.storage_version(),
+        StorageVersion::ScopedStateAndPromise
+    );
     assert_eq!(count_legacy_state(&store), 0);
     assert_eq!(count_legacy_promise(&store), 0);
     assert_eq!(count_scoped_state(&store), state_entries.len());
@@ -256,7 +259,10 @@ async fn flag_on_migrates_and_bumps_version() {
         .verify_and_run_migrations()
         .await
         .expect("second verify");
-    assert_eq!(store.schema_version(), SchemaVersion::ScopedStateAndPromise);
+    assert_eq!(
+        store.storage_version(),
+        StorageVersion::ScopedStateAndPromise
+    );
     assert_eq!(count_legacy_state(&store), 0);
     assert_eq!(count_scoped_state(&store), state_entries.len());
 
@@ -283,7 +289,10 @@ async fn flag_on_writes_post_migration_land_in_scoped() {
         .verify_and_run_migrations()
         .await
         .expect("verify fresh");
-    assert_eq!(store.schema_version(), SchemaVersion::ScopedStateAndPromise);
+    assert_eq!(
+        store.storage_version(),
+        StorageVersion::ScopedStateAndPromise
+    );
 
     let service_id = ServiceId::new(None, "svc", "k");
     {

--- a/crates/storage-api/src/lib.rs
+++ b/crates/storage-api/src/lib.rs
@@ -11,6 +11,7 @@
 use std::future::Future;
 
 use restate_memory::{NonZeroByteCount, OutOfMemory, OutOfMemoryKind};
+use restate_types::partitions::UnknownStorageVersion;
 
 /// Storage error
 #[derive(Debug, thiserror::Error)]
@@ -29,6 +30,8 @@ pub enum StorageError {
     SnapshotExport(anyhow::Error),
     #[error("precondition failed: {0}")]
     PreconditionFailed(anyhow::Error),
+    #[error(transparent)]
+    UnknownStorageVersion(#[from] UnknownStorageVersion),
 }
 
 pub type Result<T, E = StorageError> = std::result::Result<T, E>;

--- a/crates/storage-query-datafusion/src/partition_state/row.rs
+++ b/crates/storage-query-datafusion/src/partition_state/row.rs
@@ -68,4 +68,8 @@ pub(crate) fn append_partition_row(
     }
 
     row.enabled_features(state.enabled_features.enabled_names().map(Some));
+
+    if let Some(version) = state.storage_version {
+        row.storage_version(u32::from(version));
+    }
 }

--- a/crates/storage-query-datafusion/src/partition_state/row.rs
+++ b/crates/storage-query-datafusion/src/partition_state/row.rs
@@ -70,6 +70,6 @@ pub(crate) fn append_partition_row(
     row.enabled_features(state.enabled_features.enabled_names().map(Some));
 
     if let Some(version) = state.storage_version {
-        row.storage_version(u32::from(version));
+        row.storage_version(version as u32);
     }
 }

--- a/crates/storage-query-datafusion/src/partition_state/schema.rs
+++ b/crates/storage-query-datafusion/src/partition_state/schema.rs
@@ -66,5 +66,9 @@ define_table!(
         /// State-machine features currently enabled on the partition processor.
         /// Query membership with `array_has(enabled_features, 'vqueues')`.
         enabled_features: Utf8List,
+
+        /// Partition-store on-disk storage version (StorageVersion discriminant).
+        /// Set once on partition open.
+        storage_version: DataType::UInt32,
     )
 );

--- a/crates/types/protobuf/restate/cluster.proto
+++ b/crates/types/protobuf/restate/cluster.proto
@@ -78,6 +78,8 @@ message PartitionProcessorStatus {
   // processor. Carried as strings so that older clients can render feature
   // names they don't recognise.
   repeated string enabled_features = 15;
+  // Partition-store on-disk storage version (StorageVersion discriminant).
+  optional uint32 storage_version = 16;
 }
 
 message ReplicationProperty { string replication_property = 1; }

--- a/crates/types/src/cluster/cluster_state.rs
+++ b/crates/types/src/cluster/cluster_state.rs
@@ -18,6 +18,7 @@ use restate_encoding::NetSerde;
 
 use crate::identifiers::{LeaderEpoch, PartitionId};
 use crate::logs::Lsn;
+use crate::partitions::StorageVersion;
 use crate::partitions::features::PersistedStateMachineFeatures;
 use crate::time::MillisSinceEpoch;
 use crate::{GenerationalNodeId, PlainNodeId, Version};
@@ -225,7 +226,12 @@ pub struct PartitionProcessorStatus {
     /// Partition-store on-disk storage version (StorageVersion discriminant).
     /// Set once on partition open by `verify_and_run_migrations`.
     #[bilrost(16)]
-    pub storage_version: Option<u16>,
+    #[into_prost(map = "storage_version_to_u32")]
+    pub storage_version: Option<StorageVersion>,
+}
+
+fn storage_version_to_u32(v: StorageVersion) -> u32 {
+    v as u32
 }
 
 fn enabled_features_to_proto(f: &PersistedStateMachineFeatures) -> Vec<String> {

--- a/crates/types/src/cluster/cluster_state.rs
+++ b/crates/types/src/cluster/cluster_state.rs
@@ -222,6 +222,10 @@ pub struct PartitionProcessorStatus {
     #[into_prost(map = "enabled_features_to_proto", map_by_ref)]
     #[bilrost(15)]
     pub enabled_features: PersistedStateMachineFeatures,
+    /// Partition-store on-disk storage version (StorageVersion discriminant).
+    /// Set once on partition open by `verify_and_run_migrations`.
+    #[bilrost(16)]
+    pub storage_version: Option<u16>,
 }
 
 fn enabled_features_to_proto(f: &PersistedStateMachineFeatures) -> Vec<String> {
@@ -246,6 +250,7 @@ impl Default for PartitionProcessorStatus {
             last_applied_rule_book_version: None,
             last_applied_schema_version: None,
             enabled_features: PersistedStateMachineFeatures::default(),
+            storage_version: None,
         }
     }
 }

--- a/crates/types/src/partitions.rs
+++ b/crates/types/src/partitions.rs
@@ -12,12 +12,14 @@ mod configuration;
 pub mod features;
 pub mod leadership_policy;
 pub mod state;
+mod storage_version;
 
 use crate::PlainNodeId;
 use crate::nodes_config::{NodeConfig, Role, WorkerState};
 pub use configuration::*;
 pub use features::*;
 pub use leadership_policy::*;
+pub use storage_version::{StorageVersion, UnknownStorageVersion};
 // re-exports of partition-related types in preparation for moving them under this module
 pub use super::epoch::*;
 pub use super::partition_table::*;

--- a/crates/types/src/partitions/storage_version.rs
+++ b/crates/types/src/partitions/storage_version.rs
@@ -1,0 +1,114 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! On-disk storage version of the partition store.
+//!
+//! Persisted in the FSM under `fsm_variable::STORAGE_VERSION`, mirrored in
+//! memory on the `PartitionStore`, and surfaced through
+//! `PartitionProcessorStatus::storage_version` so cluster-wide observers
+//! (e.g. `restatectl partition ls`) can read it without inspecting node
+//! logs.
+
+use restate_encoding::NetSerde;
+
+/// On-disk storage version of the partition store.
+///
+/// NOTE: The representation numbers here must be strictly monotonically
+/// increasing; the migration loop in `restate-partition-store` advances the
+/// version one discriminant at a time. Re-using a discriminant — or skipping
+/// one — would break that loop.
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    bilrost::Enumeration,
+    NetSerde,
+    strum::FromRepr,
+)]
+#[repr(u16)]
+pub enum StorageVersion {
+    /// Before 1.5
+    #[default]
+    None = 0,
+    /// Migrations:
+    /// * Invocation status V1 -> V2
+    V1_5 = 1,
+    /// Migrations:
+    /// * unscoped `state_table` -> scoped `state_table` (with `scope = None`)
+    /// * unscoped `promise_table` -> scoped `promise_table` (with `scope = None`)
+    ///
+    /// Gated by `experimental_enable_migrate_scoped_tables`.
+    /// Since v1.7.0
+    ScopedStateAndPromise = 2,
+}
+
+impl StorageVersion {
+    /// Returns `true` once the partition store has migrated the unscoped state
+    /// and promise tables into their scoped variants. After this point all
+    /// state/promise reads and writes use the scoped tables (with
+    /// `scope = None` for entries that were unscoped pre-migration).
+    pub fn is_scope_migrated(self) -> bool {
+        self >= StorageVersion::ScopedStateAndPromise
+    }
+}
+
+/// Error returned when a discriminant cannot be mapped to a known
+/// [`StorageVersion`]. Wraps the raw value so the caller can report it.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, thiserror::Error)]
+#[error(
+    "unknown partition-store storage version {0}; this binary is older than \
+     the data it would open. Roll forward to a server version that recognizes \
+     this storage version."
+)]
+pub struct UnknownStorageVersion(pub u16);
+
+impl TryFrom<u16> for StorageVersion {
+    type Error = UnknownStorageVersion;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        StorageVersion::from_repr(value).ok_or(UnknownStorageVersion(value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_from_round_trips_known_variants() {
+        for known in [
+            StorageVersion::None,
+            StorageVersion::V1_5,
+            StorageVersion::ScopedStateAndPromise,
+        ] {
+            assert_eq!(StorageVersion::try_from(known as u16).unwrap(), known);
+        }
+    }
+
+    #[test]
+    fn try_from_rejects_unknown_value() {
+        let err = StorageVersion::try_from(9999_u16).unwrap_err();
+        assert_eq!(err.0, 9999);
+        let msg = err.to_string();
+        assert!(msg.contains("9999") && msg.contains("storage version"));
+    }
+
+    #[test]
+    fn is_scope_migrated_only_for_scoped_state_and_promise() {
+        assert!(!StorageVersion::None.is_scope_migrated());
+        assert!(!StorageVersion::V1_5.is_scope_migrated());
+        assert!(StorageVersion::ScopedStateAndPromise.is_scope_migrated());
+    }
+}

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -243,7 +243,7 @@ impl PartitionProcessorBuilder {
 
         let last_applied_log_lsn_watch = watch::Sender::new(Lsn::INVALID);
         // The storage version does not change after having opened the partition store
-        status.storage_version = Some(partition_store.storage_version() as u16);
+        status.storage_version = Some(partition_store.storage_version());
 
         Ok(PartitionProcessor {
             key_filter: KeyFilter::Within(partition_store.partition_key_range().into()),

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -184,7 +184,7 @@ impl PartitionProcessorBuilder {
             target_leader_state_rx,
             network_svc_rx: rpc_rx,
             status_watch_tx,
-            status,
+            mut status,
             invoker_capacity,
             leader_handles_registry,
             rule_book_cache,
@@ -242,6 +242,8 @@ impl PartitionProcessorBuilder {
         );
 
         let last_applied_log_lsn_watch = watch::Sender::new(Lsn::INVALID);
+        // The storage version does not change after having opened the partition store
+        status.storage_version = Some(partition_store.storage_version() as u16);
 
         Ok(PartitionProcessor {
             key_filter: KeyFilter::Within(partition_store.partition_key_range().into()),

--- a/release-notes/unreleased/vqueues/migrate-scoped-state-and-promise.md
+++ b/release-notes/unreleased/vqueues/migrate-scoped-state-and-promise.md
@@ -13,7 +13,7 @@ open that:
   the scoped state table (`KeyKind::ScopedState`) with `scope = None`.
 - Copies every row of the legacy unscoped promise table (`KeyKind::Promise`)
   into the scoped promise table (`KeyKind::ScopedPromise`) with `scope = None`.
-- Range-deletes the legacy unscoped ranges and bumps the on-disk schema version
+- Range-deletes the legacy unscoped ranges and bumps the on-disk storage version
   to `ScopedStateAndPromise` in a single atomic write batch.
 
 After the migration runs, all state and promise reads and writes on the
@@ -30,5 +30,13 @@ partition use the scoped tables exclusively, including for services with
 - **Opting in** (`experimental.migrate_scoped_tables = true`) triggers the
   migration on the next partition open. Once a partition has reached
   `ScopedStateAndPromise`, it cannot be downgraded to a server version that
-  does not recognize the new schema version — the older binary will refuse to
+  does not recognize the new storage version — the older binary will refuse to
   open the partition.
+
+### Observing the Storage Version
+
+The current storage version of each local partition is now surfaced as the
+`storage_version` column in the `partition_state` SQL table and as the
+`STORAGE` column in `restatectl partition ls`. Operators can check at a glance
+whether a partition has reached `ScopedStateAndPromise` (value `2`) or still
+sits on `V1_5` (value `1`).

--- a/tools/restatectl/src/commands/partition/list.rs
+++ b/tools/restatectl/src/commands/partition/list.rs
@@ -229,7 +229,7 @@ pub async fn list_partitions(
                     processor
                         .status
                         .storage_version
-                        .map(|v| v.to_string())
+                        .map(|v| (v as u16).to_string())
                         .unwrap_or_else(|| "-".to_owned()),
                 ),
                 Cell::new(

--- a/tools/restatectl/src/commands/partition/list.rs
+++ b/tools/restatectl/src/commands/partition/list.rs
@@ -119,6 +119,7 @@ pub async fn list_partitions(
         "DURABLE",
         "ARCHIVED",
         "LSN-LAG",
+        "STORAGE",
         "SCHEMA",
         "RULE-BOOK",
         "FEATURES",
@@ -222,6 +223,13 @@ pub async fn list_partitions(
                             // (tail - 1) - applied_lsn = tail - (applied_lsn + 1)
                             tail.value.saturating_sub(applied.value + 1).to_string()
                         })
+                        .unwrap_or_else(|| "-".to_owned()),
+                ),
+                Cell::new(
+                    processor
+                        .status
+                        .storage_version
+                        .map(|v| v.to_string())
                         .unwrap_or_else(|| "-".to_owned()),
                 ),
                 Cell::new(


### PR DESCRIPTION
Rename the partition-store-internal `SchemaVersion` to `StorageVersion`
to disambiguate it from the user-services schema version that already
travels as `last_applied_schema_version` on `PartitionProcessorStatus`.
The on-disk FSM variable was already named `STORAGE_VERSION`; the enum
name now matches.

Surface the value through the partition-state pipeline so operators can
confirm a migration has landed without grepping logs:

- Add `storage_version: Option<u32>` to `PartitionProcessorStatus`
  (proto field 15) and populate it from the cached
  `PartitionStore::storage_version_u16()` in the worker's status-refresh
  block.
- Add a `storage_version` column to the `partition_state` SQL table and
  populate it from the new status field.
- Add a `STORAGE` column to `restatectl partition ls`, placed between
  `LSN-LAG` and `SCHEMA`.