### PR TITLE
Gate Kafka scope/limit-key headers behind an experimental flag (#4797)

### DIFF
--- a/crates/ingress-kafka/src/builder.rs
+++ b/crates/ingress-kafka/src/builder.rs
@@ -90,13 +90,21 @@ impl EnvelopeBuilder {
         };
 
         let headers = Self::generate_events_attributes(&msg, &self.subscription_id);
-        let (scope, limit_key) = extract_scope_limit_key(&msg).map_err(|err| Error::Event {
-            subscription: self.subscription_id.clone(),
-            topic: msg.topic().to_string(),
-            partition: msg.partition(),
-            offset: msg.offset(),
-            cause: anyhow::anyhow!("invalid scope value in x-restate-scope header: {err}"),
-        })?;
+        let (scope, limit_key) = if restate_types::config::Configuration::pinned()
+            .common
+            .experimental
+            .is_kafka_scope_enabled()
+        {
+            extract_scope_limit_key(&msg).map_err(|err| Error::Event {
+                subscription: self.subscription_id.clone(),
+                topic: msg.topic().to_string(),
+                partition: msg.partition(),
+                offset: msg.offset(),
+                cause: anyhow::anyhow!("invalid scope value in x-restate-scope header: {err}"),
+            })?
+        } else {
+            (None, LimitKey::None)
+        };
 
         let dedup = DedupInformation::producer(producer_id, msg.offset() as u64);
 

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -626,6 +626,15 @@ experimental! {
     ///
     /// Since v1.7.0
     scoped_virtual_objects,
+
+    /// # Enables Kafka header support for scoped invocations
+    ///
+    /// When enabled, Kafka subscriptions read `x-restate-scope` and
+    /// `x-restate-limit-key` record headers to drive vqueue scope and
+    /// hierarchical limit-key routing. Requires `vqueues` to also be enabled.
+    ///
+    /// Since v1.7.0
+    kafka_scope,
 }
 
 serde_with::with_prefix!(pub prefix_tokio_console "tokio_console_");

--- a/release-notes/unreleased/vqueues/kafka-scope-limit-key.md
+++ b/release-notes/unreleased/vqueues/kafka-scope-limit-key.md
@@ -8,9 +8,28 @@ Kafka subscription-triggered invocations can now carry scope and limit-key
 information via Kafka record headers. This enables vqueue-based concurrency
 control for Kafka-ingested invocations.
 
+This feature is gated behind the `kafka-scope` experimental flag (which in
+turn requires `vqueues`). When the flag is disabled, the headers are not
+inspected.
+
 ### How to Use
 
-Set the following Kafka record headers on your producer:
+Enable the flag in your configuration:
+
+```toml
+[common.experimental]
+enable-vqueues = true
+enable-kafka-scope = true
+```
+
+Or via environment variables:
+
+```
+RESTATE_COMMON_EXPERIMENTAL_ENABLE_VQUEUES=true
+RESTATE_COMMON_EXPERIMENTAL_ENABLE_KAFKA_SCOPE=true
+```
+
+Then, set the following Kafka record headers on your producer:
 
 - **`x-restate-scope`**: The scope string for the invocation. When present, determines the partition key and acts as a namespace for virtual object instances.
 - **`x-restate-limit-key`**: The limit key for hierarchical concurrency/rate limiting. Format: `"level1"` or `"level1/level2"`. Only valid when `restate-scope` is also set.
@@ -26,5 +45,5 @@ producer.send(record);
 
 ### Impact on Users
 
-- **Existing deployments**: No impact. Kafka records without these headers continue to work as before (no scope, no limit key).
-- **New usage**: Users who want to leverage vqueue concurrency control for Kafka-ingested invocations can now set these headers on their Kafka records.
+- **Existing deployments**: No impact. The feature is off by default; Kafka records (with or without these headers) continue to work as before.
+- **New usage**: Contributors who want to experiment with vqueue concurrency control for Kafka-ingested invocations can enable the `kafka-scope` experimental flag and set these headers on their Kafka records.


### PR DESCRIPTION
Introduce a new `kafka_scope` experimental flag (TOML key `experimental-enable-kafka-scope`) that gates extraction of the `x-restate-scope` and `x-restate-limit-key` headers from Kafka records. When the flag is disabled, the headers are not inspected and the resulting invocation carries no scope or limit-key. Scoped invocations still additionally require `vqueues` to be enabled.

Keeps the feature available for contributors while not exposing scope support to regular users until the design is finalised.