### PR TITLE
Gate scoped Virtual Objects behind experimental flag

### DIFF
--- a/crates/ingress-http/src/handler/error.rs
+++ b/crates/ingress-http/src/handler/error.rs
@@ -66,6 +66,8 @@ pub(crate) enum HandlerError {
     InvalidLimitKey(String),
     #[error("scoped invocations require vqueues to be enabled")]
     ScopeRequiresVQueues,
+    #[error("scope is not supported for Virtual Object targets")]
+    ScopedVirtualObjectNotSupported,
     #[error("not implemented")]
     NotImplemented,
     #[error("bad header {0}: {1:?}")]
@@ -157,7 +159,8 @@ impl HandlerError {
             | HandlerError::InvalidLimitKey(_)
             | HandlerError::BadScopeValue(_)
             | HandlerError::BadPath(_)
-            | HandlerError::ScopeRequiresVQueues => StatusCode::BAD_REQUEST,
+            | HandlerError::ScopeRequiresVQueues
+            | HandlerError::ScopedVirtualObjectNotSupported => StatusCode::BAD_REQUEST,
             HandlerError::DispatcherError(_) => {
                 // TODO add more distinctions between different dispatcher errors (unavailable, etc)
                 StatusCode::INTERNAL_SERVER_ERROR

--- a/crates/ingress-http/src/handler/service_handler.rs
+++ b/crates/ingress-http/src/handler/service_handler.rs
@@ -164,6 +164,20 @@ where
             return Err(HandlerError::ScopeRequiresVQueues);
         }
 
+        // Scoped Virtual Objects are gated behind an experimental flag
+        if scope.is_some()
+            && matches!(
+                invocation_target_meta.target_ty,
+                InvocationTargetType::VirtualObject(_)
+            )
+            && !Configuration::pinned()
+                .common
+                .experimental
+                .is_scoped_virtual_objects_enabled()
+        {
+            return Err(HandlerError::ScopedVirtualObjectNotSupported);
+        }
+
         // Craft Invocation Target and Id
         let invocation_target = if let TargetType::Keyed { key } = target {
             match invocation_target_meta.target_ty {

--- a/crates/ingress-http/src/handler/tests.rs
+++ b/crates/ingress-http/src/handler/tests.rs
@@ -26,6 +26,7 @@ use tracing_test::traced_test;
 
 use restate_core::TestCoreEnv;
 use restate_test_util::{assert, assert_eq};
+use restate_types::config::{Configuration, set_current_config};
 use restate_types::identifiers::{IdempotencyId, InvocationId, ServiceId, WithInvocationId};
 use restate_types::invocation::client::{
     AttachInvocationResponse, GetInvocationOutputResponse, InvocationOutput,
@@ -1471,4 +1472,101 @@ async fn output_by_target_with_workflow() {
     let response_bytes = response.into_body().collect().await.unwrap().to_bytes();
     let response_value: GreetingResponse = serde_json::from_slice(&response_bytes).unwrap();
     assert_eq!(response_value.greeting, "done");
+}
+
+fn set_experimental_flags(vqueues: bool, scoped_virtual_objects: bool) {
+    let mut config = Configuration::default();
+    config.common.experimental.set_vqueues(vqueues);
+    config
+        .common
+        .experimental
+        .set_scoped_virtual_objects(scoped_virtual_objects);
+    set_current_config(config);
+}
+
+#[restate_core::test]
+#[traced_test]
+async fn scoped_virtual_object_rejected_when_flag_off() {
+    set_experimental_flags(true, false);
+
+    // Scoped VO call rejected
+    let response = handle(
+        hyper::Request::builder()
+            .uri("http://localhost/restate/scope/sc1/call/greeter.GreeterObject/my-key/greet")
+            .method(Method::POST)
+            .header("content-type", "application/json")
+            .body(Full::new(Bytes::from_static(b"{}")))
+            .unwrap(),
+        MockRequestDispatcher::default(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    // Scoped service call passes through (not gated)
+    let mut mock_dispatcher = MockRequestDispatcher::default();
+    mock_dispatcher
+        .expect_call()
+        .return_once(|invocation_request| {
+            assert!(invocation_request.header.target.scope().is_some());
+            ready(Ok(InvocationOutput {
+                request_id: Default::default(),
+                invocation_id: Some(invocation_request.invocation_id()),
+                completion_expiry_time: None,
+                response: InvocationOutputResponse::Success(
+                    invocation_request.header.target.clone(),
+                    Bytes::new(),
+                ),
+            }))
+            .boxed()
+        });
+    let response = handle(
+        hyper::Request::builder()
+            .uri("http://localhost/restate/scope/sc1/call/greeter.Greeter/greet")
+            .method(Method::POST)
+            .header("content-type", "application/json")
+            .body(Full::new(Bytes::from_static(b"{}")))
+            .unwrap(),
+        mock_dispatcher,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[restate_core::test]
+#[traced_test]
+async fn scoped_virtual_object_allowed_when_flag_on() {
+    set_experimental_flags(true, true);
+
+    let mut mock_dispatcher = MockRequestDispatcher::default();
+    mock_dispatcher
+        .expect_call()
+        .return_once(|invocation_request| {
+            assert!(invocation_request.header.target.scope().is_some());
+            assert_eq!(
+                invocation_request.header.target.service_name(),
+                "greeter.GreeterObject"
+            );
+            ready(Ok(InvocationOutput {
+                request_id: Default::default(),
+                invocation_id: Some(invocation_request.invocation_id()),
+                completion_expiry_time: None,
+                response: InvocationOutputResponse::Success(
+                    invocation_request.header.target.clone(),
+                    Bytes::new(),
+                ),
+            }))
+            .boxed()
+        });
+
+    let response = handle(
+        hyper::Request::builder()
+            .uri("http://localhost/restate/scope/sc1/call/greeter.GreeterObject/my-key/greet")
+            .method(Method::POST)
+            .header("content-type", "application/json")
+            .body(Full::new(Bytes::from_static(b"{}")))
+            .unwrap(),
+        mock_dispatcher,
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
 }

--- a/crates/ingress-kafka/src/builder.rs
+++ b/crates/ingress-kafka/src/builder.rs
@@ -263,6 +263,17 @@ impl InvocationBuilder {
             bail!("Scoped invocations require experimental vqueues to be enabled");
         }
 
+        // Validate: scoped Virtual Objects are gated behind an experimental flag
+        if invocation_target.scope().is_some()
+            && matches!(invocation_target, InvocationTarget::VirtualObject { .. })
+            && !restate_types::config::Configuration::pinned()
+                .common
+                .experimental
+                .is_scoped_virtual_objects_enabled()
+        {
+            bail!("scope is not supported for Virtual Object targets");
+        }
+
         // Validate: limit_key requires scope
         if !limit_key.is_empty() && invocation_target.scope().is_none() {
             bail!("limit-key requires a scope to be set");

--- a/crates/invoker-impl/src/error.rs
+++ b/crates/invoker-impl/src/error.rs
@@ -394,6 +394,8 @@ pub(crate) enum CommandPreconditionError {
     InvalidLimitKey,
     #[error("limit_key was provided without a scope")]
     LimitKeyWithoutScope,
+    #[error("scope is not supported for Virtual Object targets")]
+    ScopedVirtualObjectNotSupported,
     #[error("invalid scope: {0}")]
     InvalidScope(RestrictedValueError),
     #[error("invalid invocation id {0}: {1}")]

--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
@@ -1576,6 +1576,16 @@ fn resolve_call_request(
         return Err(CommandPreconditionError::LimitKeyWithoutScope);
     }
 
+    if invocation_target.scope().is_some()
+        && matches!(meta.target_ty, InvocationTargetType::VirtualObject(_))
+        && !restate_types::config::Configuration::pinned()
+            .common
+            .experimental
+            .is_scoped_virtual_objects_enabled()
+    {
+        return Err(CommandPreconditionError::ScopedVirtualObjectNotSupported);
+    }
+
     let invocation_retention = meta.compute_retention(idempotency_key.is_some());
     let invocation_id = InvocationId::generate(&invocation_target, idempotency_key);
 

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -618,6 +618,14 @@ experimental! {
     ///
     /// Since v1.7.0
     migrate_scoped_tables,
+
+    /// # Allow scope on Virtual Object targets
+    ///
+    /// Scoped Virtual Objects are not officially supported in v1.7. Requires
+    /// `vqueues` to be enabled as well.
+    ///
+    /// Since v1.7.0
+    scoped_virtual_objects,
 }
 
 serde_with::with_prefix!(pub prefix_tokio_console "tokio_console_");


### PR DESCRIPTION
Scoped Virtual Objects are not officially supported in v1.7. Reject scope on VirtualObject targets at HTTP ingress, Kafka ingress, and invoker unless the new `scoped_virtual_objects` experimental flag is enabled. Scoped Services and scoped Workflows are unaffected.

Closes #4796