### PR TITLE
Raise default invoker memory limit to 1.5 GiB

### DIFF
--- a/crates/invoker-impl/src/error.rs
+++ b/crates/invoker-impl/src/error.rs
@@ -212,10 +212,16 @@ pub(crate) struct InvocationMemoryExhausted {
 
 impl fmt::Display for InvocationMemoryExhausted {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let hint = match self.kind {
+            OutOfMemoryKind::PoolExhausted => "consider increasing 'worker.invoker.memory-limit'",
+            OutOfMemoryKind::UpperBoundExceeded => {
+                "consider increasing 'worker.invoker.per-invocation-memory-limit'"
+            }
+        };
         write!(
             f,
-            "memory budget exhausted ({}) while {}: needed {}",
-            self.kind, self.context, self.needed,
+            "memory budget exhausted ({}) while {}: needed {}; {}",
+            self.kind, self.context, self.needed, hint,
         )
     }
 }

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -536,7 +536,7 @@ impl Default for InvokerOptions {
             invocation_throttling: None,
             action_throttling: None,
             memory_limit: NonZeroByteCount::new(
-                NonZeroUsize::new(256 * 1024 * 1024).unwrap(), // 256 MiB
+                NonZeroUsize::new(1536 * 1024 * 1024).unwrap(), // 1.5 GiB
             ),
             per_invocation_memory_limit: None,
             per_invocation_initial_memory: DEFAULT_PER_INVOCATION_INITIAL_MEMORY,

--- a/release-notes/unreleased/4354-invoker-memory-pool.md
+++ b/release-notes/unreleased/4354-invoker-memory-pool.md
@@ -12,7 +12,7 @@ payloads.
 
 Key aspects of the new memory model:
 
-- **Global memory pool**: A shared budget (`worker.invoker.memory-limit`, default **256 MiB**)
+- **Global memory pool**: A shared budget (`worker.invoker.memory-limit`, default **1.5 GiB**)
   limits the total invoker memory across all partitions on a node.
 
 - **Per-invocation budgets**: Each invocation receives a budget capped at
@@ -60,8 +60,8 @@ Three new configuration options control the memory pool:
 # Global memory budget shared across all invocations on this node.
 # Controls how much memory can be used for in-flight journal entries, state,
 # and protocol messages sent from the invoker to service deployments.
-# Default: "256MB"
-memory-limit = "256MB"
+# Default: "1.5GB"
+memory-limit = "1.5GB"
 
 # Maximum memory a single invocation may use for its outbound data.
 # Defaults to message-size-limit if unset. Clamped at message-size-limit.
@@ -90,7 +90,7 @@ per-invocation-initial-memory = "32KB"
 ### Impact on Users
 
 - **Most users will see no change**: The defaults are generous enough for typical workloads.
-  The global pool (256 MiB) can support thousands of concurrent invocations with normal-sized
+  The global pool (1.5 GiB) can support thousands of concurrent invocations with normal-sized
   payloads.
 
 - **Users processing very large payloads or state**: Invocations that send data exceeding the
@@ -128,7 +128,7 @@ The global memory pool may be the bottleneck. Either:
 1. Increase the global pool:
    ```toml
    [worker.invoker]
-   memory-limit = "512MB"
+   memory-limit = "2GB"
    ```
 2. Decrease the initial per-invocation reservation to allow more concurrent invocations:
    ```toml


### PR DESCRIPTION
The previous 256 MiB default produced spurious 'pool exhausted' retries under modest bursts. The invoker pool now sits alongside the existing memory budgets — RocksDB 2 GiB (common.rs:839), query engine 1 GiB (query_engine.rs:59), Bifrost record cache 250 MiB (bifrost.rs:167) — leaving headroom for the unaccounted inbound path (incoming journal entries) and other consumers like the network layer, so the combined footprint still fits within an 8 GiB process limit.

Also extend the InvocationMemoryExhausted error to point operators at the relevant config knob ('worker.invoker.memory-limit' for pool exhaustion, 'worker.invoker.per-invocation-memory-limit' for upper- bound hits), as suggested on the issue.

Closes #4801