### PR TITLE
Improved partition placement strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6334,6 +6334,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "placement-sim"
+version = "1.7.3-dev"
+dependencies = [
+ "restate-workspace-hack",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "benchmarks",
     "tools/bifrost-benchpress",
     "tools/logserver-bench",
+    "tools/placement-sim",
     "tools/pp-bench",
     "tools/mock-service-endpoint",
     "tools/restate-doctor",

--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -8,13 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::cmp::Ordering;
+use std::cmp::{Ordering, Reverse};
 use std::collections::BTreeMap;
 use std::collections::hash_map::Entry;
 
-use ahash::HashMap;
+use ahash::{HashMap, HashMapExt};
 use futures::{StreamExt, TryStreamExt};
-use tracing::{debug, info, trace};
+use tracing::{debug, info, trace, warn};
 
 use restate_core::network::{NetworkSender as _, Networking, Swimlane, TransportConnect};
 use restate_core::{Metadata, MetadataWriter, ShutdownError, SyncError, TaskCenter, TaskKind};
@@ -23,8 +23,10 @@ use restate_metadata_store::{
 };
 use restate_types::cluster::cluster_state::LegacyClusterState;
 use restate_types::cluster_state::ClusterState;
+use restate_types::config::Configuration;
 use restate_types::epoch::EpochMetadata;
 use restate_types::identifiers::PartitionId;
+use restate_types::locality::LocationScope;
 use restate_types::metadata_store::keys::partition_processor_epoch_key;
 use restate_types::net::partition_processor_manager::{
     ControlProcessor, ControlProcessors, ProcessorCommand,
@@ -39,7 +41,10 @@ use restate_types::partitions::{PartitionConfiguration, worker_candidate_filter}
 use restate_types::replication::balanced_spread_selector::{
     BalancedSpreadSelector, SelectorOptions,
 };
-use restate_types::replication::{NodeSet, ReplicationProperty};
+use restate_types::replication::{
+    DEFAULT_LOAD_BALANCING_TOP_N, NodeSet, ReplicationProperty, extend_top_n_load_balanced,
+    hash_node_id,
+};
 use restate_types::{NodeId, PlainNodeId, Version, Versioned};
 
 #[derive(Debug, thiserror::Error)]
@@ -164,6 +169,302 @@ pub struct Scheduler<T> {
     partitions: HashMap<PartitionId, PartitionState>,
     replica_set_states: PartitionReplicaSetStates,
     cluster_state: ClusterState,
+}
+
+fn experimental_balanced_placement_enabled() -> bool {
+    Configuration::pinned()
+        .common
+        .experimental_placement_strategy
+        .is_balanced_v2()
+}
+
+fn experimental_rebalances_when_healthy() -> bool {
+    Configuration::pinned()
+        .common
+        .experimental_placement_rebalance_mode
+        .rebalances_when_healthy()
+}
+
+fn supports_balanced_placement(replication: &ReplicationProperty) -> bool {
+    replication.copies_at_scope(LocationScope::Region).is_none()
+        && replication.copies_at_scope(LocationScope::Zone).is_none()
+}
+
+fn alive_worker_candidates(
+    nodes_config: &NodesConfiguration,
+    cluster_state: &ClusterState,
+) -> Vec<PlainNodeId> {
+    nodes_config
+        .iter()
+        .filter(|(node_id, node_config)| {
+            worker_candidate_filter(*node_id, node_config)
+                && cluster_state.is_alive((*node_id).into())
+        })
+        .map(|(node_id, _)| node_id)
+        .collect()
+}
+
+fn all_worker_candidates_alive(
+    nodes_config: &NodesConfiguration,
+    cluster_state: &ClusterState,
+) -> bool {
+    nodes_config
+        .iter()
+        .filter(|(node_id, node_config)| worker_candidate_filter(*node_id, node_config))
+        .all(|(node_id, _)| cluster_state.is_alive(node_id.into()))
+}
+
+fn select_replica_overlap_anchor(
+    partition_id: PartitionId,
+    current: &PartitionConfiguration,
+    planned: &NodeSet,
+    candidates: &[PlainNodeId],
+    legacy_cluster_state: &LegacyClusterState,
+    replica_loads: &HashMap<PlainNodeId, usize>,
+) -> Option<PlainNodeId> {
+    if current
+        .replica_set()
+        .iter()
+        .filter(|node_id| candidates.contains(node_id))
+        .any(|node_id| {
+            planned.contains(*node_id)
+                && legacy_cluster_state.is_partition_processor_active(&partition_id, node_id)
+        })
+    {
+        return None;
+    }
+
+    if let Some(active) = current
+        .replica_set()
+        .iter()
+        .copied()
+        .filter(|node_id| candidates.contains(node_id))
+        .filter(|node_id| {
+            legacy_cluster_state.is_partition_processor_active(&partition_id, node_id)
+        })
+        .min_by_key(|node_id| {
+            (
+                replica_loads.get(node_id).copied().unwrap_or_default(),
+                Reverse(hash_node_id(u64::from(partition_id), *node_id)),
+                u32::from(*node_id),
+            )
+        })
+    {
+        return Some(active);
+    }
+
+    if current
+        .replica_set()
+        .iter()
+        .any(|node_id| planned.contains(*node_id))
+    {
+        return None;
+    }
+
+    current
+        .replica_set()
+        .iter()
+        .copied()
+        .filter(|node_id| candidates.contains(node_id))
+        .min_by_key(|node_id| {
+            (
+                replica_loads.get(node_id).copied().unwrap_or_default(),
+                Reverse(hash_node_id(u64::from(partition_id), *node_id)),
+                u32::from(*node_id),
+            )
+        })
+}
+
+fn plan_balanced_partition_placements(
+    partitions: &HashMap<PartitionId, PartitionState>,
+    nodes_config: &NodesConfiguration,
+    partition_table: &PartitionTable,
+    cluster_state: &ClusterState,
+    legacy_cluster_state: &LegacyClusterState,
+    partition_replication: &ReplicationProperty,
+) -> Option<HashMap<PartitionId, PartitionConfiguration>> {
+    if !supports_balanced_placement(partition_replication) {
+        warn!(
+            replication = %partition_replication,
+            "Experimental balanced partition placement only supports flat replication; falling back to legacy placement"
+        );
+        return None;
+    }
+
+    let candidates = alive_worker_candidates(nodes_config, cluster_state);
+    let target_size = partition_replication.num_copies() as usize;
+    if candidates.len() < target_size {
+        warn!(
+            candidates = candidates.len(),
+            target_size,
+            "Experimental balanced partition placement has too few alive worker candidates; falling back to legacy placement"
+        );
+        return None;
+    }
+
+    let rebalance = experimental_rebalances_when_healthy()
+        && all_worker_candidates_alive(nodes_config, cluster_state);
+    let mut replica_loads = HashMap::<PlainNodeId, usize>::default();
+    let mut plan = HashMap::with_capacity(partition_table.num_partitions() as usize);
+
+    for partition_id in partition_table.iter_ids().copied() {
+        let mut selected = NodeSet::new();
+        if !rebalance
+            && let Some(existing) = partitions
+                .get(&partition_id)
+                .map(|state| state.next.as_ref().unwrap_or(&state.current))
+            && existing.replication() == partition_replication
+        {
+            selected = existing
+                .replica_set()
+                .iter()
+                .copied()
+                .filter(|node_id| candidates.contains(node_id))
+                .collect();
+        }
+
+        let mut replica_set = extend_top_n_load_balanced(
+            candidates.iter().copied(),
+            u64::from(partition_id),
+            target_size,
+            selected,
+            DEFAULT_LOAD_BALANCING_TOP_N,
+            |node_id| replica_loads.get(&node_id).copied().unwrap_or_default(),
+        )
+        .expect("candidate and target sizes were validated");
+
+        // Avoid replacing every known partition processor at once. Prefer an active current replica
+        // that can seed a cold replacement from local state; a disjoint set may need a full snapshot.
+        if let Some(anchor) = partitions.get(&partition_id).and_then(|state| {
+            select_replica_overlap_anchor(
+                partition_id,
+                &state.current,
+                &replica_set,
+                &candidates,
+                legacy_cluster_state,
+                &replica_loads,
+            )
+        }) {
+            replica_set = extend_top_n_load_balanced(
+                candidates.iter().copied(),
+                u64::from(partition_id),
+                target_size,
+                NodeSet::from_single(anchor),
+                DEFAULT_LOAD_BALANCING_TOP_N,
+                |node_id| replica_loads.get(&node_id).copied().unwrap_or_default(),
+            )
+            .expect("the retained replica is an eligible candidate");
+        }
+
+        for node_id in replica_set.iter().copied() {
+            *replica_loads.entry(node_id).or_default() += 1;
+        }
+
+        plan.insert(
+            partition_id,
+            PartitionConfiguration::new(
+                partition_replication.clone(),
+                replica_set,
+                HashMap::default(),
+            ),
+        );
+    }
+
+    Some(plan)
+}
+
+fn ensure_balanced_leaders(
+    partitions: &mut HashMap<PartitionId, PartitionState>,
+    cluster_state: &ClusterState,
+    legacy_cluster_state: &LegacyClusterState,
+    nodes_config: &NodesConfiguration,
+    partition_table: &PartitionTable,
+) {
+    let mut leader_loads = HashMap::<PlainNodeId, usize>::default();
+
+    for partition_id in partition_table.iter_ids() {
+        let Some(partition) = partitions.get_mut(partition_id) else {
+            continue;
+        };
+        if partition.leadership_policy.freeze.is_some() {
+            if let Some(leader) = partition.target_leader {
+                *leader_loads.entry(leader).or_default() += 1;
+            }
+            continue;
+        }
+
+        let Some(leader) = select_balanced_leader(
+            partition_id,
+            partition,
+            cluster_state,
+            legacy_cluster_state,
+            nodes_config,
+            &leader_loads,
+        ) else {
+            continue;
+        };
+
+        *leader_loads.entry(leader).or_default() += 1;
+        if partition.target_leader != Some(leader) {
+            debug!(
+                "Selecting node {} as partition processor leader for partition {partition_id}",
+                leader
+            );
+            partition.target_leader = Some(leader);
+        }
+    }
+}
+
+fn select_balanced_leader(
+    partition_id: &PartitionId,
+    partition: &PartitionState,
+    cluster_state: &ClusterState,
+    legacy_cluster_state: &LegacyClusterState,
+    nodes_config: &NodesConfiguration,
+    leader_loads: &HashMap<PlainNodeId, usize>,
+) -> Option<PlainNodeId> {
+    let affinity = partition.leadership_policy.affinity.as_ref();
+    partition
+        .current
+        .replica_set()
+        .iter()
+        .copied()
+        .filter(|node_id| cluster_state.is_alive(NodeId::from(*node_id)))
+        .min_by_key(|node_id| {
+            let has_affinity =
+                affinity.is_some_and(|a| matches_affinity(*node_id, a, nodes_config));
+            let is_caught_up =
+                legacy_cluster_state.is_partition_processor_active(partition_id, node_id);
+            let readiness_rank = match (has_affinity, is_caught_up) {
+                (true, true) => 0u8,
+                (false, true) => 1,
+                (true, false) => 2,
+                (false, false) => 3,
+            };
+            (
+                readiness_rank,
+                leader_loads.get(node_id).copied().unwrap_or_default(),
+                Reverse(hash_node_id(u64::from(*partition_id), *node_id)),
+                u32::from(*node_id),
+            )
+        })
+}
+
+fn requires_reconfiguration_to(
+    partition_state: &PartitionState,
+    default_replication: &ReplicationProperty,
+    planned: &PartitionConfiguration,
+) -> bool {
+    if let Some(next) = partition_state.next.as_ref() {
+        next.replication() != default_replication
+            || !next.replica_set().is_equivalent(planned.replica_set())
+    } else {
+        partition_state.current.replication() != default_replication
+            || !partition_state
+                .current
+                .replica_set()
+                .is_equivalent(planned.replica_set())
+    }
 }
 
 /// The scheduler is responsible for assigning partition processors to nodes and to electing
@@ -325,6 +626,20 @@ impl<T: TransportConnect> Scheduler<T> {
         nodes_config: &NodesConfiguration,
         partition_table: &PartitionTable,
     ) {
+        let partition_replication = partition_table.replication_property(nodes_config);
+        if experimental_balanced_placement_enabled()
+            && supports_balanced_placement(&partition_replication)
+        {
+            ensure_balanced_leaders(
+                &mut self.partitions,
+                cluster_state,
+                legacy_cluster_state,
+                nodes_config,
+                partition_table,
+            );
+            return;
+        }
+
         for partition_id in partition_table.iter_ids() {
             // select the leader based on the observed cluster state
             self.select_leader(
@@ -343,29 +658,62 @@ impl<T: TransportConnect> Scheduler<T> {
         nodes_config: &NodesConfiguration,
         partition_table: &PartitionTable,
     ) -> Result<(), Error> {
+        let partition_replication = partition_table.replication_property(nodes_config);
+        let balanced_plan = if experimental_balanced_placement_enabled() {
+            plan_balanced_partition_placements(
+                &self.partitions,
+                nodes_config,
+                partition_table,
+                cluster_state,
+                legacy_cluster_state,
+                &partition_replication,
+            )
+        } else {
+            None
+        };
+        let use_balanced_placement = balanced_plan.is_some();
+
         for partition_id in partition_table.iter_ids().copied() {
             let entry = self.partitions.entry(partition_id);
 
             // make sure that we have a valid partition processor configuration
             let mut occupied_entry = match entry {
                 Entry::Occupied(mut entry) if entry.get().current.is_valid() => {
-                    let partition_replication = partition_table.replication_property(nodes_config);
-                    if Self::requires_reconfiguration(
-                        partition_id,
-                        entry.get(),
-                        &partition_replication,
-                        nodes_config,
-                        &self.cluster_state,
-                    ) {
+                    let planned = balanced_plan
+                        .as_ref()
+                        .and_then(|plan| plan.get(&partition_id));
+                    let requires_reconfiguration = planned
+                        .map(|planned| {
+                            requires_reconfiguration_to(
+                                entry.get(),
+                                &partition_replication,
+                                planned,
+                            )
+                        })
+                        .unwrap_or_else(|| {
+                            Self::requires_reconfiguration(
+                                partition_id,
+                                entry.get(),
+                                &partition_replication,
+                                nodes_config,
+                                &self.cluster_state,
+                            )
+                        });
+
+                    if requires_reconfiguration {
                         trace!("Partition {} requires reconfiguration", partition_id);
 
-                        if let Some(next) = Self::choose_partition_configuration(
-                            partition_id,
-                            nodes_config,
-                            partition_replication,
-                            NodeSet::new(),
-                            &self.cluster_state,
-                        ) {
+                        let next = planned.cloned().or_else(|| {
+                            Self::choose_partition_configuration(
+                                partition_id,
+                                nodes_config,
+                                partition_replication.clone(),
+                                NodeSet::new(),
+                                &self.cluster_state,
+                            )
+                        });
+
+                        if let Some(next) = next {
                             let partition_configuration_update =
                                 Self::reconfigure_partition_configuration(
                                     self.metadata_writer.raw_metadata_store_client(),
@@ -396,16 +744,21 @@ impl<T: TransportConnect> Scheduler<T> {
                     entry
                 }
                 entry => {
-                    let partition_replication = partition_table.replication_property(nodes_config);
-
                     // no or no valid current configuration, pick a valid configuration
-                    if let Some(current) = Self::choose_partition_configuration(
-                        partition_id,
-                        nodes_config,
-                        partition_replication.clone(),
-                        NodeSet::default(),
-                        &self.cluster_state,
-                    ) {
+                    let current = balanced_plan
+                        .as_ref()
+                        .and_then(|plan| plan.get(&partition_id))
+                        .cloned()
+                        .or_else(|| {
+                            Self::choose_partition_configuration(
+                                partition_id,
+                                nodes_config,
+                                partition_replication.clone(),
+                                NodeSet::default(),
+                                &self.cluster_state,
+                            )
+                        });
+                    if let Some(current) = current {
                         let occupied_entry = entry.insert_entry(
                             Self::store_initial_partition_configuration(
                                 self.metadata_writer.raw_metadata_store_client(),
@@ -455,12 +808,24 @@ impl<T: TransportConnect> Scheduler<T> {
                 }
             }
 
-            // select the leader based on the observed cluster state
-            self.select_leader(
-                &partition_id,
+            if !use_balanced_placement {
+                // select the leader based on the observed cluster state
+                self.select_leader(
+                    &partition_id,
+                    cluster_state,
+                    legacy_cluster_state,
+                    nodes_config,
+                );
+            }
+        }
+
+        if use_balanced_placement {
+            ensure_balanced_leaders(
+                &mut self.partitions,
                 cluster_state,
                 legacy_cluster_state,
                 nodes_config,
+                partition_table,
             );
         }
 
@@ -942,5 +1307,372 @@ fn matches_affinity(
                     .shares_domain_with(location, location.smallest_defined_scope())
             })
             .unwrap_or(false),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use restate_types::cluster::cluster_state::{
+        AliveNode, NodeState as LegacyNodeState, PartitionProcessorStatus, ReplayStatus,
+    };
+    use restate_types::cluster_state::NodeState;
+    use restate_types::nodes_config::{Role, WorkerConfig, WorkerState};
+    use restate_types::partition_table::PartitionReplication;
+    use restate_types::time::MillisSinceEpoch;
+    use restate_types::{GenerationalNodeId, RestateVersion};
+
+    use super::*;
+
+    fn node_id(id: u32) -> PlainNodeId {
+        PlainNodeId::new(id)
+    }
+
+    fn node_index(node_id: PlainNodeId) -> usize {
+        usize::try_from(u32::from(node_id) - 1).expect("node id should fit into usize")
+    }
+
+    fn worker_node(id: u32) -> NodeConfig {
+        NodeConfig::builder()
+            .name(format!("node-{id}"))
+            .current_generation(GenerationalNodeId::new(id, 1))
+            .address(format!("unix:/tmp/scheduler-test-{id}").parse().unwrap())
+            .roles(Role::Worker.into())
+            .worker_config(WorkerConfig {
+                worker_state: WorkerState::Active,
+            })
+            .binary_version(RestateVersion::current())
+            .build()
+    }
+
+    fn active_worker_nodes(count: u32) -> NodesConfiguration {
+        let mut nodes_config = NodesConfiguration::new_for_testing();
+        for id in 1..=count {
+            nodes_config.upsert_node(worker_node(id));
+        }
+        nodes_config
+    }
+
+    fn alive_cluster_state(count: u32) -> ClusterState {
+        cluster_state_with_alive_nodes(1..=count)
+    }
+
+    fn cluster_state_with_alive_nodes(alive_nodes: impl IntoIterator<Item = u32>) -> ClusterState {
+        let cluster_state = ClusterState::default();
+        let mut updater = cluster_state.clone().updater();
+        for id in alive_nodes {
+            updater.upsert_node_state(GenerationalNodeId::new(id, 1), NodeState::Alive);
+        }
+        cluster_state
+    }
+
+    fn partition_table(partitions: u16, replication: ReplicationProperty) -> PartitionTable {
+        let mut builder =
+            PartitionTable::with_equally_sized_partitions(Version::MIN, partitions).into_builder();
+        builder.set_partition_replication(PartitionReplication::Limit(replication));
+        builder.build()
+    }
+
+    fn load_range(loads: &[usize]) -> usize {
+        loads.iter().max().unwrap() - loads.iter().min().unwrap()
+    }
+
+    fn partition_states_from_plan(
+        plan: &HashMap<PartitionId, PartitionConfiguration>,
+    ) -> HashMap<PartitionId, PartitionState> {
+        plan.iter()
+            .map(|(partition_id, configuration)| {
+                (
+                    *partition_id,
+                    PartitionState::new(configuration.clone(), None, LeadershipPolicy::default()),
+                )
+            })
+            .collect()
+    }
+
+    fn count_changed_replica_sets(
+        left: &HashMap<PartitionId, PartitionConfiguration>,
+        right: &HashMap<PartitionId, PartitionConfiguration>,
+    ) -> usize {
+        left.iter()
+            .filter(|(partition_id, left)| {
+                right
+                    .get(partition_id)
+                    .is_some_and(|right| !left.replica_set().is_equivalent(right.replica_set()))
+            })
+            .count()
+    }
+
+    fn count_replica_sets_containing(
+        plan: &HashMap<PartitionId, PartitionConfiguration>,
+        node_id: PlainNodeId,
+    ) -> usize {
+        plan.values()
+            .filter(|configuration| configuration.replica_set().contains(node_id))
+            .count()
+    }
+
+    fn legacy_cluster_state_with_active_processor(
+        partition_id: PartitionId,
+        active_node: PlainNodeId,
+    ) -> LegacyClusterState {
+        let status = PartitionProcessorStatus {
+            replay_status: ReplayStatus::Active,
+            ..PartitionProcessorStatus::default()
+        };
+
+        let mut state = LegacyClusterState::empty();
+        state.nodes.insert(
+            active_node,
+            LegacyNodeState::Alive(AliveNode {
+                last_heartbeat_at: MillisSinceEpoch::now(),
+                generational_node_id: GenerationalNodeId::new(u32::from(active_node), 1),
+                partitions: [(partition_id, status)].into_iter().collect(),
+                uptime: Duration::ZERO,
+            }),
+        );
+        state
+    }
+
+    #[test]
+    fn balanced_partition_plan_spreads_replica_load() {
+        let nodes_config = active_worker_nodes(5);
+        let cluster_state = alive_cluster_state(5);
+        let replication = ReplicationProperty::new_unchecked(3);
+        let partition_table = partition_table(200, replication.clone());
+
+        let plan = plan_balanced_partition_placements(
+            &HashMap::default(),
+            &nodes_config,
+            &partition_table,
+            &cluster_state,
+            &LegacyClusterState::empty(),
+            &replication,
+        )
+        .expect("balanced placement should be supported");
+
+        assert_eq!(plan.len(), 200);
+        let mut loads = vec![0; 5];
+        for configuration in plan.values() {
+            assert_eq!(configuration.replica_set().len(), 3);
+            for node_id in configuration.replica_set().iter().copied() {
+                loads[node_index(node_id)] += 1;
+            }
+        }
+        assert!(
+            load_range(&loads) <= 1,
+            "replica load should be near-ideal: {loads:?}"
+        );
+    }
+
+    #[test]
+    fn balanced_partition_plan_repairs_down_node_without_cascading_churn() {
+        let nodes_config = active_worker_nodes(5);
+        let replication = ReplicationProperty::new_unchecked(3);
+        let partition_table = partition_table(200, replication.clone());
+
+        let all_alive = alive_cluster_state(5);
+        let initial = plan_balanced_partition_placements(
+            &HashMap::default(),
+            &nodes_config,
+            &partition_table,
+            &all_alive,
+            &LegacyClusterState::empty(),
+            &replication,
+        )
+        .expect("balanced placement should be supported");
+        let partitions_with_down_node = count_replica_sets_containing(&initial, node_id(5));
+
+        let node_down = cluster_state_with_alive_nodes(1..=4);
+        let repaired = plan_balanced_partition_placements(
+            &partition_states_from_plan(&initial),
+            &nodes_config,
+            &partition_table,
+            &node_down,
+            &LegacyClusterState::empty(),
+            &replication,
+        )
+        .expect("balanced placement should be supported");
+        let repaired_changes = count_changed_replica_sets(&initial, &repaired);
+
+        let restored = plan_balanced_partition_placements(
+            &partition_states_from_plan(&repaired),
+            &nodes_config,
+            &partition_table,
+            &all_alive,
+            &LegacyClusterState::empty(),
+            &replication,
+        )
+        .expect("balanced placement should be supported");
+        let restored_changes = count_changed_replica_sets(&initial, &restored);
+        let up_transition_changes = count_changed_replica_sets(&repaired, &restored);
+
+        assert_eq!(initial.len(), 200);
+        assert_eq!(repaired.len(), 200);
+        assert_eq!(restored.len(), 200);
+        assert_eq!(repaired_changes, partitions_with_down_node);
+        assert_eq!(restored_changes, 0);
+        assert_eq!(up_transition_changes, partitions_with_down_node);
+    }
+
+    #[test]
+    fn balanced_partition_plan_retains_a_current_replica() {
+        let nodes_config = active_worker_nodes(5);
+        let cluster_state = alive_cluster_state(5);
+        let legacy_cluster_state = LegacyClusterState::empty();
+        let replication = ReplicationProperty::new_unchecked(2);
+        let partition_table = partition_table(200, replication.clone());
+
+        let ideal = plan_balanced_partition_placements(
+            &HashMap::default(),
+            &nodes_config,
+            &partition_table,
+            &cluster_state,
+            &legacy_cluster_state,
+            &replication,
+        )
+        .expect("balanced placement should be supported");
+        let current = ideal
+            .iter()
+            .map(|(partition_id, configuration)| {
+                let replica_set = (1..=5)
+                    .map(node_id)
+                    .filter(|node_id| !configuration.replica_set().contains(*node_id))
+                    .take(2)
+                    .collect();
+                (
+                    *partition_id,
+                    PartitionState::new(
+                        PartitionConfiguration::new(
+                            replication.clone(),
+                            replica_set,
+                            HashMap::default(),
+                        ),
+                        None,
+                        LeadershipPolicy::default(),
+                    ),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+
+        let plan = plan_balanced_partition_placements(
+            &current,
+            &nodes_config,
+            &partition_table,
+            &cluster_state,
+            &legacy_cluster_state,
+            &replication,
+        )
+        .expect("balanced placement should be supported");
+
+        let mut loads = vec![0; 5];
+        for (partition_id, configuration) in &plan {
+            let current_replica_set = current[partition_id].current.replica_set();
+            assert!(
+                configuration
+                    .replica_set()
+                    .iter()
+                    .any(|node_id| current_replica_set.contains(*node_id)),
+                "partition {partition_id} lost every current replica"
+            );
+            for node_id in configuration.replica_set().iter().copied() {
+                loads[node_index(node_id)] += 1;
+            }
+        }
+        assert!(
+            load_range(&loads) <= 1,
+            "replica load should remain near-ideal: {loads:?}"
+        );
+    }
+
+    #[test]
+    fn replica_overlap_prefers_a_warm_current_processor() {
+        let partition_id = PartitionId::from(1);
+        let replication = ReplicationProperty::new_unchecked(2);
+        let current = PartitionConfiguration::new(
+            replication,
+            [node_id(1), node_id(2)].into_iter().collect(),
+            HashMap::default(),
+        );
+        let planned = [node_id(2), node_id(3)].into_iter().collect();
+        let candidates = [node_id(1), node_id(2), node_id(3)];
+        let replica_loads = HashMap::default();
+
+        let warm_current = legacy_cluster_state_with_active_processor(partition_id, node_id(1));
+        assert_eq!(
+            select_replica_overlap_anchor(
+                partition_id,
+                &current,
+                &planned,
+                &candidates,
+                &warm_current,
+                &replica_loads,
+            ),
+            Some(node_id(1)),
+            "cold overlap must not displace a warm current processor"
+        );
+
+        let warm_overlap = legacy_cluster_state_with_active_processor(partition_id, node_id(2));
+        assert_eq!(
+            select_replica_overlap_anchor(
+                partition_id,
+                &current,
+                &planned,
+                &candidates,
+                &warm_overlap,
+                &replica_loads,
+            ),
+            None,
+            "an already-planned warm current processor needs no anchor"
+        );
+    }
+
+    #[test]
+    fn balanced_leader_selection_moves_leaders_off_overloaded_node() {
+        let nodes_config = active_worker_nodes(3);
+        let cluster_state = alive_cluster_state(3);
+        let legacy_cluster_state = LegacyClusterState::empty();
+        let replication = ReplicationProperty::new_unchecked(3);
+        let partition_table = partition_table(90, replication.clone());
+        let replica_set = NodeSet::from_iter([node_id(1), node_id(2), node_id(3)]);
+        let mut partitions = HashMap::default();
+
+        for partition_id in partition_table.iter_ids().copied() {
+            let mut partition = PartitionState::new(
+                PartitionConfiguration::new(
+                    replication.clone(),
+                    replica_set.clone(),
+                    HashMap::default(),
+                ),
+                None,
+                LeadershipPolicy::default(),
+            );
+            partition.target_leader = Some(node_id(1));
+            partitions.insert(partition_id, partition);
+        }
+
+        ensure_balanced_leaders(
+            &mut partitions,
+            &cluster_state,
+            &legacy_cluster_state,
+            &nodes_config,
+            &partition_table,
+        );
+
+        let mut loads = vec![0; 3];
+        for partition in partitions.values() {
+            let leader = partition.target_leader.expect("leader should be selected");
+            loads[node_index(leader)] += 1;
+        }
+
+        assert!(
+            loads[0] < 90,
+            "node 1 should not keep every leader: {loads:?}"
+        );
+        assert!(
+            load_range(&loads) <= 1,
+            "leader load should be near-ideal: {loads:?}"
+        );
     }
 }

--- a/crates/bifrost/src/providers/replicated_loglet/provider.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/provider.rs
@@ -8,11 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::cmp;
 use std::sync::Arc;
 use std::time::Duration;
 
+use ahash::HashMap;
 use async_trait::async_trait;
 use dashmap::DashMap;
+use parking_lot::Mutex;
 use tokio::task::JoinSet;
 use tracing::{debug, info, warn};
 
@@ -21,16 +24,20 @@ use restate_core::network::{
 };
 use restate_core::{Metadata, TaskCenter, TaskCenterFutureExt, TaskKind, my_node_id};
 use restate_types::config::Configuration;
+use restate_types::locality::LocationScope;
 use restate_types::logs::metadata::{
-    Chain, LogletParams, ProviderConfiguration, ProviderKind, SegmentIndex,
+    Chain, LogletParams, Logs, ProviderConfiguration, ProviderKind, ReplicatedLogletConfig,
+    SegmentIndex,
 };
 use restate_types::logs::{LogId, LogletId, RecordCache};
 use restate_types::net::replicated_loglet::{SequencerDataService, SequencerMetaService};
-use restate_types::nodes_config::{Role, StorageState};
+use restate_types::nodes_config::{NodesConfiguration, Role, StorageState};
 use restate_types::replicated_loglet::{ReplicatedLogletParams, logserver_candidate_filter};
 use restate_types::replication::{
-    NodeSet, NodeSetChecker, NodeSetSelector, NodeSetSelectorOptions, ReplicationProperty,
+    DEFAULT_LOAD_BALANCING_TOP_N, NodeSelectorError, NodeSet, NodeSetChecker, NodeSetSelector,
+    NodeSetSelectorOptions, ReplicationProperty, extend_top_n_load_balanced,
 };
+use restate_types::{PlainNodeId, Version, Versioned};
 
 use super::loglet::ReplicatedLoglet;
 use super::metric_definitions;
@@ -40,6 +47,57 @@ use crate::loglet::{Improvement, Loglet, LogletProvider, LogletProviderFactory, 
 use crate::providers::replicated_loglet::error::ReplicatedLogletError;
 use crate::providers::replicated_loglet::loglet::FindTailFlags;
 use crate::providers::replicated_loglet::tasks::PeriodicTailChecker;
+
+fn nodeset_load_range(
+    candidates: &[PlainNodeId],
+    mut load: impl FnMut(PlainNodeId) -> usize,
+) -> usize {
+    let Some(first) = candidates.first().copied() else {
+        return 0;
+    };
+
+    let mut min = load(first);
+    let mut max = min;
+    for node_id in candidates.iter().copied().skip(1) {
+        let load = load(node_id);
+        min = min.min(load);
+        max = max.max(load);
+    }
+
+    max - min
+}
+
+fn balanced_nodeset_rebalance_improvement(
+    candidates: &[PlainNodeId],
+    current_nodeset: &NodeSet,
+    proposed_nodeset: &NodeSet,
+    current_loads: &HashMap<PlainNodeId, usize>,
+    acceptable_range: usize,
+) -> Option<(usize, usize)> {
+    if current_nodeset.is_equivalent(proposed_nodeset) {
+        return None;
+    }
+
+    let current_range = nodeset_load_range(candidates, |node_id| {
+        current_loads.get(&node_id).copied().unwrap_or_default()
+    });
+    if current_range <= acceptable_range {
+        return None;
+    }
+
+    let proposed_range = nodeset_load_range(candidates, |node_id| {
+        let mut load = current_loads.get(&node_id).copied().unwrap_or_default();
+        if current_nodeset.contains(node_id) && !proposed_nodeset.contains(node_id) {
+            load = load.saturating_sub(1);
+        }
+        if proposed_nodeset.contains(node_id) && !current_nodeset.contains(node_id) {
+            load += 1;
+        }
+        load
+    });
+
+    (proposed_range < current_range).then_some((current_range, proposed_range))
+}
 
 pub struct Factory<T> {
     networking: Networking<T>,
@@ -116,6 +174,22 @@ pub(super) struct ReplicatedLogletProvider<T> {
     active_loglets: DashMap<(LogId, SegmentIndex), Arc<ReplicatedLoglet<T>>>,
     networking: Networking<T>,
     record_cache: RecordCache,
+    nodeset_load_cache: Mutex<NodesetLoadCache>,
+}
+
+#[derive(Debug)]
+struct NodesetLoadCache {
+    logs_version: Version,
+    loads: Arc<HashMap<PlainNodeId, usize>>,
+}
+
+impl Default for NodesetLoadCache {
+    fn default() -> Self {
+        Self {
+            logs_version: Version::INVALID,
+            loads: Arc::default(),
+        }
+    }
 }
 
 impl<T: TransportConnect> ReplicatedLogletProvider<T> {
@@ -124,6 +198,7 @@ impl<T: TransportConnect> ReplicatedLogletProvider<T> {
             active_loglets: Default::default(),
             networking,
             record_cache,
+            nodeset_load_cache: Mutex::default(),
         }
     }
 
@@ -203,6 +278,207 @@ impl<T: TransportConnect> ReplicatedLogletProvider<T> {
 
         Ok(loglet)
     }
+
+    fn experimental_balanced_placement_enabled() -> bool {
+        Configuration::pinned()
+            .common
+            .experimental_placement_strategy
+            .is_balanced_v2()
+    }
+
+    fn experimental_rebalances_when_healthy() -> bool {
+        Configuration::pinned()
+            .common
+            .experimental_placement_rebalance_mode
+            .rebalances_when_healthy()
+    }
+
+    fn supports_balanced_placement(replication: &ReplicationProperty) -> bool {
+        replication.copies_at_scope(LocationScope::Region).is_none()
+            && replication.copies_at_scope(LocationScope::Zone).is_none()
+    }
+
+    fn target_nodeset_size(
+        replication: &ReplicationProperty,
+        requested_size: u32,
+        candidates: usize,
+    ) -> Option<usize> {
+        let replication_factor = replication.num_copies() as usize;
+        // Keep the legacy target-size lower bound: 2r-1 for quorum overlap, and
+        // r+1 so rf=1 still gets one spare when there is capacity.
+        let target_size = cmp::max(requested_size as usize, replication_factor * 2 - 1);
+        let target_size = cmp::max(replication_factor + 1, target_size);
+        let target_size = target_size.min(candidates);
+
+        (target_size >= replication_factor).then_some(target_size)
+    }
+
+    fn writable_log_server_candidates(nodes_config: &NodesConfiguration) -> Vec<PlainNodeId> {
+        nodes_config
+            .iter()
+            .filter(|(node_id, node_config)| {
+                logserver_candidate_filter(*node_id, node_config)
+                    && matches!(
+                        node_config.log_server_config.storage_state,
+                        StorageState::ReadWrite
+                    )
+            })
+            .map(|(node_id, _)| node_id)
+            .collect()
+    }
+
+    fn compute_nodeset_loads(logs: &Logs) -> HashMap<PlainNodeId, usize> {
+        let mut loads = HashMap::<PlainNodeId, usize>::default();
+
+        for (log_id, chain) in logs.iter() {
+            let tail = chain.tail();
+            if tail.config.kind != ProviderKind::Replicated {
+                continue;
+            }
+
+            let params = match ReplicatedLogletParams::deserialize_from(
+                tail.config.params.as_bytes(),
+            ) {
+                Ok(params) => params,
+                Err(err) => {
+                    warn!(
+                        %log_id,
+                        segment_index = %tail.index(),
+                        %err,
+                        "Ignoring replicated loglet with invalid params while computing nodeset loads"
+                    );
+                    continue;
+                }
+            };
+
+            for node_id in params.nodeset.iter().copied() {
+                *loads.entry(node_id).or_default() += 1;
+            }
+        }
+
+        loads
+    }
+
+    fn current_nodeset_loads(&self) -> Arc<HashMap<PlainNodeId, usize>> {
+        let logs = Metadata::with_current(|m| m.logs_snapshot());
+        let logs_version = logs.version();
+
+        let mut cache = self.nodeset_load_cache.lock();
+        if cache.logs_version != logs_version {
+            cache.loads = Arc::new(Self::compute_nodeset_loads(&logs));
+            cache.logs_version = logs_version;
+        }
+        Arc::clone(&cache.loads)
+    }
+
+    fn select_nodeset(
+        &self,
+        log_id: LogId,
+        defaults: &ReplicatedLogletConfig,
+        nodes_config: &NodesConfiguration,
+        preferred_nodes: &NodeSet,
+        replaced_nodeset: Option<&NodeSet>,
+    ) -> Result<NodeSet, NodeSelectorError> {
+        let my_node = my_node_id().as_plain();
+
+        if Self::experimental_balanced_placement_enabled() {
+            if Self::supports_balanced_placement(&defaults.replication_property) {
+                return self.select_balanced_nodeset(
+                    log_id,
+                    defaults,
+                    nodes_config,
+                    my_node,
+                    preferred_nodes,
+                    replaced_nodeset,
+                );
+            }
+
+            warn!(
+                replication = %defaults.replication_property,
+                "Experimental balanced replicated-loglet nodeset placement only supports flat replication; falling back to legacy placement"
+            );
+        }
+
+        let opts = NodeSetSelectorOptions::new(u32::from(log_id) as u64)
+            .with_target_size(defaults.target_nodeset_size)
+            .with_preferred_nodes(preferred_nodes)
+            .with_top_priority_node(my_node);
+
+        NodeSetSelector::select(
+            nodes_config,
+            &defaults.replication_property,
+            logserver_candidate_filter,
+            |_, config| {
+                matches!(
+                    config.log_server_config.storage_state,
+                    StorageState::ReadWrite
+                )
+            },
+            opts,
+        )
+    }
+
+    fn select_balanced_nodeset(
+        &self,
+        log_id: LogId,
+        defaults: &ReplicatedLogletConfig,
+        nodes_config: &NodesConfiguration,
+        my_node: PlainNodeId,
+        preferred_nodes: &NodeSet,
+        replaced_nodeset: Option<&NodeSet>,
+    ) -> Result<NodeSet, NodeSelectorError> {
+        let candidates = Self::writable_log_server_candidates(nodes_config);
+        let Some(target_size) = Self::target_nodeset_size(
+            &defaults.replication_property,
+            defaults.target_nodeset_size.as_u32(),
+            candidates.len(),
+        ) else {
+            return Err(NodeSelectorError::InsufficientNodes {
+                nodeset_len: candidates.len(),
+                replication_factor: defaults.replication_property.num_copies(),
+            });
+        };
+
+        let rebalance = Self::experimental_rebalances_when_healthy();
+        let mut selected = if rebalance {
+            NodeSet::new()
+        } else {
+            preferred_nodes.clone()
+        };
+
+        if !rebalance {
+            selected.retain(|node_id| candidates.contains(node_id));
+            if selected.len() >= target_size {
+                return Ok(selected);
+            }
+        }
+
+        // Keep the sequencer colocated with a writable log-server when possible. In repair-only
+        // mode, do not evict a healthy preferred member solely to achieve colocation.
+        selected.insert(my_node);
+        let loads = self.current_nodeset_loads();
+        let candidates_len = candidates.len();
+        extend_top_n_load_balanced(
+            candidates,
+            u32::from(log_id) as u64,
+            target_size,
+            selected,
+            DEFAULT_LOAD_BALANCING_TOP_N,
+            |node_id| {
+                loads
+                    .get(&node_id)
+                    .copied()
+                    .unwrap_or_default()
+                    .saturating_sub(usize::from(
+                        replaced_nodeset.is_some_and(|nodeset| nodeset.contains(node_id)),
+                    ))
+            },
+        )
+        .ok_or(NodeSelectorError::InsufficientNodes {
+            nodeset_len: candidates_len,
+            replication_factor: defaults.replication_property.num_copies(),
+        })
+    }
 }
 
 #[async_trait]
@@ -265,27 +541,21 @@ impl<T: TransportConnect> LogletProvider for ReplicatedLogletProvider<T> {
             preferred_nodes.insert(my_node);
         }
 
-        let opts = NodeSetSelectorOptions::new(u32::from(log_id) as u64)
-            .with_target_size(defaults.target_nodeset_size)
-            .with_preferred_nodes(&preferred_nodes)
-            .with_top_priority_node(my_node);
-
         let nodes_config = Metadata::with_current(|m| m.nodes_config_ref());
-
-        let selection = NodeSetSelector::select(
-            &nodes_config,
-            &defaults.replication_property,
-            logserver_candidate_filter,
-            |_, config| {
-                matches!(
-                    config.log_server_config.storage_state,
-                    StorageState::ReadWrite
-                )
-            },
-            opts,
-        );
-
-        let new_nodeset = selection.map_err(OperationError::retryable)?;
+        let balanced_nodeset_rebalance = Self::experimental_balanced_placement_enabled()
+            && Self::experimental_rebalances_when_healthy()
+            && Self::supports_balanced_placement(&defaults.replication_property);
+        let balanced_nodeset_rebalance_candidates =
+            balanced_nodeset_rebalance.then(|| Self::writable_log_server_candidates(&nodes_config));
+        let new_nodeset = self
+            .select_nodeset(
+                log_id,
+                defaults,
+                &nodes_config,
+                &preferred_nodes,
+                Some(&current_params.nodeset),
+            )
+            .map_err(OperationError::retryable)?;
 
         let mut node_set_checker =
             NodeSetChecker::new(&new_nodeset, &nodes_config, &defaults.replication_property);
@@ -302,17 +572,50 @@ impl<T: TransportConnect> LogletProvider for ReplicatedLogletProvider<T> {
             return Ok(Improvement::None);
         }
         // if it's identical, just shuffled around, then no, do nothing.
-        if current_params.nodeset.is_subset(&new_nodeset)
-            && new_nodeset.len() == current_params.nodeset.len()
-        {
+        if current_params.nodeset.is_equivalent(&new_nodeset) {
             return Ok(Improvement::None);
         }
 
+        let nodeset_range_improvement = if let Some(candidates) =
+            balanced_nodeset_rebalance_candidates.as_deref()
+            && let Some(target_size) = Self::target_nodeset_size(
+                &defaults.replication_property,
+                defaults.target_nodeset_size.as_u32(),
+                candidates.len(),
+            )
+            && current_params.nodeset.len() >= target_size
+            && current_params
+                .nodeset
+                .iter()
+                .all(|node_id| candidates.contains(node_id))
+        {
+            let current_loads = self.current_nodeset_loads();
+            let Some(improvement) = balanced_nodeset_rebalance_improvement(
+                candidates,
+                &current_params.nodeset,
+                &new_nodeset,
+                &current_loads,
+                target_size,
+            ) else {
+                return Ok(Improvement::None);
+            };
+            Some(improvement)
+        } else {
+            None
+        };
+
         Ok(Improvement::Possible {
-            reason: format!(
-                "nodeset update from {} to {}",
-                current_params.nodeset, new_nodeset
-            ),
+            reason: if let Some((current_range, proposed_range)) = nodeset_range_improvement {
+                format!(
+                    "nodeset update from {} to {} reduces nodeset load range from {} to {}",
+                    current_params.nodeset, new_nodeset, current_range, proposed_range
+                )
+            } else {
+                format!(
+                    "nodeset update from {} to {}",
+                    current_params.nodeset, new_nodeset
+                )
+            },
         })
     }
 
@@ -326,9 +629,9 @@ impl<T: TransportConnect> LogletProvider for ReplicatedLogletProvider<T> {
             panic!("ProviderConfiguration::Replicated is expected");
         };
 
-        // use the last loglet if it was replicated as a source for preferred nodes to reduce data
+        // Use the last loglet if it was replicated as a source for preferred nodes to reduce data
         // scatter for this log.
-        let mut preferred_nodes = if let Some(chain) = chain
+        let replaced_nodeset = if let Some(chain) = chain
             && let Some(tail) = chain.non_special_tail()
             && tail.config.kind == ProviderKind::Replicated
         {
@@ -337,10 +640,11 @@ impl<T: TransportConnect> LogletProvider for ReplicatedLogletProvider<T> {
                 .map_err(|e| {
                     ReplicatedLogletError::LogletParamsParsingError(log_id, tail.index(), e)
                 })?;
-            params.nodeset
+            Some(params.nodeset)
         } else {
-            NodeSet::new()
+            None
         };
+        let mut preferred_nodes = replaced_nodeset.clone().unwrap_or_else(NodeSet::new);
 
         let new_segment_index = chain
             .map(|chain| chain.tail_index().next())
@@ -352,24 +656,13 @@ impl<T: TransportConnect> LogletProvider for ReplicatedLogletProvider<T> {
             preferred_nodes.insert(my_node);
         }
 
-        let opts = NodeSetSelectorOptions::new(u32::from(log_id) as u64)
-            .with_target_size(defaults.target_nodeset_size)
-            .with_preferred_nodes(&preferred_nodes)
-            .with_top_priority_node(my_node);
-
         let nodes_config = Metadata::with_current(|m| m.nodes_config_ref());
-
-        let selection = NodeSetSelector::select(
+        let selection = self.select_nodeset(
+            log_id,
+            defaults,
             &nodes_config,
-            &defaults.replication_property,
-            logserver_candidate_filter,
-            |_, config| {
-                matches!(
-                    config.log_server_config.storage_state,
-                    StorageState::ReadWrite
-                )
-            },
-            opts,
+            &preferred_nodes,
+            replaced_nodeset.as_ref(),
         );
 
         match selection {
@@ -434,3 +727,62 @@ impl<T: TransportConnect> LogletProvider for ReplicatedLogletProvider<T> {
 #[derive(Debug, thiserror::Error)]
 #[error("not enough candidate nodes to form a node set that fulfills the replication property {0}")]
 pub struct InsufficientNodesError(ReplicationProperty);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(id: u32) -> PlainNodeId {
+        PlainNodeId::new(id)
+    }
+
+    fn loads(values: impl IntoIterator<Item = (u32, usize)>) -> HashMap<PlainNodeId, usize> {
+        values
+            .into_iter()
+            .map(|(node_id, load)| (node(node_id), load))
+            .collect()
+    }
+
+    #[test]
+    fn balanced_nodeset_rebalance_requires_material_range_improvement() {
+        let candidates = [1, 2, 3, 4, 5].map(node);
+        let current_nodeset = NodeSet::from([1, 2, 3]);
+        let proposed_nodeset = NodeSet::from([1, 4, 5]);
+
+        let already_fair = loads([(1, 59), (2, 57), (3, 58), (4, 56), (5, 58)]);
+        assert_eq!(
+            None,
+            balanced_nodeset_rebalance_improvement(
+                &candidates,
+                &current_nodeset,
+                &proposed_nodeset,
+                &already_fair,
+                3,
+            )
+        );
+
+        let skewed = loads([(1, 96), (2, 96), (3, 96), (4, 0), (5, 0)]);
+        assert_eq!(
+            Some((96, 95)),
+            balanced_nodeset_rebalance_improvement(
+                &candidates,
+                &current_nodeset,
+                &proposed_nodeset,
+                &skewed,
+                3,
+            )
+        );
+
+        let worse = loads([(1, 10), (2, 10), (3, 0), (4, 0), (5, 0)]);
+        assert_eq!(
+            None,
+            balanced_nodeset_rebalance_improvement(
+                &candidates,
+                &NodeSet::from([3, 4, 5]),
+                &NodeSet::from([1, 2, 3]),
+                &worse,
+                3,
+            )
+        );
+    }
+}

--- a/crates/log-server/src/metric_definitions.rs
+++ b/crates/log-server/src/metric_definitions.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use metrics::{Unit, describe_counter, describe_histogram};
+use metrics::{Unit, describe_counter, describe_gauge, describe_histogram};
 
 pub(crate) const LOG_SERVER_WRITE_BATCH_SIZE_BYTES: &str =
     "restate.log_server.write_batch_size_bytes";
@@ -16,6 +16,8 @@ pub(crate) const LOG_SERVER_WRITE_BATCH_SIZE_BYTES: &str =
 pub(crate) const LOG_SERVER_LOGLET_STARTED: &str = "restate.log_server.loglet_started.total";
 
 pub(crate) const LOG_SERVER_LOGLET_STOPPED: &str = "restate.log_server.loglet_stopped.total";
+
+pub(crate) const LOG_SERVER_NODESET_MEMBERSHIPS: &str = "restate.log_server.nodeset_memberships";
 
 // broken by label "status"
 // - "ok"       (accepted, stored)
@@ -47,5 +49,11 @@ pub(crate) fn describe_metrics() {
         LOG_SERVER_STORE_BYTES,
         Unit::Bytes,
         "Bytes received in STOREs broken down by status"
+    );
+
+    describe_gauge!(
+        LOG_SERVER_NODESET_MEMBERSHIPS,
+        Unit::Count,
+        "Number of current replicated log tails whose nodeset contains this log-server"
     );
 }

--- a/crates/log-server/src/service.rs
+++ b/crates/log-server/src/service.rs
@@ -10,27 +10,32 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use anyhow::Context;
+use metrics::gauge;
+use tokio::time::MissedTickBehavior;
 use tracing::{debug, instrument, warn};
 
 use restate_core::network::tonic_service_filter::{StatusInRange, TonicServiceFilter};
 use restate_core::network::{MessageRouterBuilder, NetworkServerBuilder};
-use restate_core::{Metadata, MetadataWriter, TaskCenter, TaskKind};
+use restate_core::{Metadata, MetadataWriter, TaskCenter, TaskKind, cancellation_watcher};
 use restate_metadata_store::{ReadWriteError, RetryError, retry_on_retryable_error};
-use restate_types::GenerationalNodeId;
 use restate_types::config::Configuration;
 use restate_types::health::HealthStatus;
 use restate_types::live::Live;
+use restate_types::logs::metadata::{Logs, ProviderKind};
 use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
 use restate_types::nodes_config::{NodesConfiguration, StorageState};
 use restate_types::protobuf::common::LogServerStatus;
+use restate_types::replicated_loglet::ReplicatedLogletParams;
+use restate_types::{GenerationalNodeId, PlainNodeId, Version, Versioned};
 
 use crate::error::LogServerBuildError;
 use crate::grpc_svc_handler::LogServerSvcHandler;
 use crate::logstore::LogStore;
 use crate::metadata::{ActiveWorkerMap, LogStoreMarker, LogletStateMap};
-use crate::metric_definitions::describe_metrics;
+use crate::metric_definitions::{LOG_SERVER_NODESET_MEMBERSHIPS, describe_metrics};
 use crate::network::RequestPump;
 use crate::rocksdb_logstore::{RocksDbLogStore, RocksDbLogStoreBuilder};
 
@@ -41,6 +46,23 @@ pub struct LogServerService {
     state_map: LogletStateMap,
     log_store: RocksDbLogStore,
     active_worker_map: ActiveWorkerMap,
+}
+
+const NODESET_MEMBERSHIP_METRIC_INTERVAL: Duration = Duration::from_secs(10);
+
+#[derive(Debug)]
+struct NodesetMembershipCache {
+    logs_version: Version,
+    memberships: usize,
+}
+
+impl Default for NodesetMembershipCache {
+    fn default() -> Self {
+        Self {
+            logs_version: Version::INVALID,
+            memberships: 0,
+        }
+    }
 }
 
 impl LogServerService {
@@ -135,7 +157,79 @@ impl LogServerService {
             ),
         )?;
 
+        let _ = TaskCenter::spawn(
+            TaskKind::LogServerRole,
+            "log-server-nodeset-membership-metrics",
+            Self::run_nodeset_membership_metrics(metadata),
+        )?;
+
         Ok(())
+    }
+
+    async fn run_nodeset_membership_metrics(metadata: Metadata) -> anyhow::Result<()> {
+        let mut interval = tokio::time::interval(NODESET_MEMBERSHIP_METRIC_INTERVAL);
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        let mut shutdown = std::pin::pin!(cancellation_watcher());
+        let mut cache = NodesetMembershipCache::default();
+
+        loop {
+            tokio::select! {
+                _ = &mut shutdown => {
+                    gauge!(LOG_SERVER_NODESET_MEMBERSHIPS).set(0.0);
+                    break;
+                }
+                _ = interval.tick() => {
+                    Self::publish_nodeset_membership_metrics(&metadata, &mut cache);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn publish_nodeset_membership_metrics(metadata: &Metadata, cache: &mut NodesetMembershipCache) {
+        let my_node_id = metadata.my_node_id().as_plain();
+        let logs = metadata.logs_ref();
+        let logs_version = logs.version();
+
+        if cache.logs_version != logs_version {
+            cache.memberships = Self::count_nodeset_memberships(&logs, my_node_id);
+            cache.logs_version = logs_version;
+        }
+
+        gauge!(LOG_SERVER_NODESET_MEMBERSHIPS).set(cache.memberships as f64);
+    }
+
+    fn count_nodeset_memberships(logs: &Logs, my_node_id: PlainNodeId) -> usize {
+        let mut nodeset_memberships = 0;
+
+        for (log_id, chain) in logs.iter() {
+            let tail = chain.tail();
+            if tail.config.kind != ProviderKind::Replicated {
+                continue;
+            }
+
+            let params = match ReplicatedLogletParams::deserialize_from(
+                tail.config.params.as_bytes(),
+            ) {
+                Ok(params) => params,
+                Err(err) => {
+                    warn!(
+                        %log_id,
+                        segment_index = %tail.index(),
+                        %err,
+                        "Ignoring replicated loglet with invalid params while computing nodeset membership metric"
+                    );
+                    continue;
+                }
+            };
+
+            if params.nodeset.contains(my_node_id) {
+                nodeset_memberships += 1;
+            }
+        }
+
+        nodeset_memberships
     }
 
     #[instrument(skip_all)]

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -84,6 +84,47 @@ impl ListenMode {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[cfg_attr(feature = "clap", clap(rename_all = "kebab-case"))]
+pub enum ExperimentalPlacementStrategy {
+    /// Use the existing deterministic per-partition/per-log placement algorithm.
+    #[default]
+    Legacy,
+    /// Balance partition replicas, partition leaders, and replicated-loglet nodeset members.
+    ///
+    /// This experimental strategy only applies to flat node-scope replication; region/zone-scoped
+    /// replication continues using the legacy placement selectors.
+    BalancedV2,
+}
+
+impl ExperimentalPlacementStrategy {
+    pub fn is_balanced_v2(self) -> bool {
+        matches!(self, Self::BalancedV2)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[cfg_attr(feature = "clap", clap(rename_all = "kebab-case"))]
+pub enum ExperimentalPlacementRebalanceMode {
+    /// Only repair placements that are no longer viable.
+    RepairOnly,
+    /// Rebalance existing placements while all placement candidates are healthy.
+    #[default]
+    Rebalance,
+}
+
+impl ExperimentalPlacementRebalanceMode {
+    pub fn rebalances_when_healthy(self) -> bool {
+        matches!(self, Self::Rebalance)
+    }
+}
+
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, derive_builder::Builder)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -296,6 +337,25 @@ pub struct CommonOptions {
     #[serde_as(as = "crate::replication::ReplicationPropertyFromTo")]
     #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     pub default_replication: ReplicationProperty,
+
+    /// # Experimental placement strategy
+    ///
+    /// Selects the algorithm used for partition replica, partition leader, and replicated-loglet
+    /// nodeset placement.
+    ///
+    /// This must be configured consistently across all nodes. Mixed settings can make cluster
+    /// controllers propose different placements during rollout.
+    ///
+    /// Since v1.7.3
+    pub experimental_placement_strategy: ExperimentalPlacementStrategy,
+
+    /// # Experimental placement rebalance mode
+    ///
+    /// Controls whether the experimental placement strategy only repairs invalid placements or also
+    /// rebalances existing placements when placement candidates are healthy.
+    ///
+    /// Since v1.7.3
+    pub experimental_placement_rebalance_mode: ExperimentalPlacementRebalanceMode,
 
     /// # Shutdown grace timeout
     ///
@@ -875,6 +935,8 @@ impl Default for CommonOptions {
             fabric_listener_options: Default::default(),
             default_num_partitions: 24,
             default_replication: ReplicationProperty::new_unchecked(1),
+            experimental_placement_strategy: ExperimentalPlacementStrategy::default(),
+            experimental_placement_rebalance_mode: ExperimentalPlacementRebalanceMode::default(),
             disable_prometheus: false,
             #[allow(deprecated)]
             service_client: Default::default(),

--- a/crates/types/src/replication/load_balanced_selector.rs
+++ b/crates/types/src/replication/load_balanced_selector.rs
@@ -1,0 +1,171 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::cmp::Reverse;
+use std::hash::Hasher;
+
+use xxhash_rust::xxh3::Xxh3;
+
+use crate::PlainNodeId;
+use crate::replication::NodeSet;
+
+// This is the existing Restate placement salt. Changing it reshuffles every
+// partition/log placement that uses this selector.
+pub const HASH_SALT: u64 = 14712721395741015273;
+
+/// Number of nearby HRW candidates considered when making a load-aware placement choice.
+pub const DEFAULT_LOAD_BALANCING_TOP_N: usize = 3;
+
+/// Returns the deterministic HRW score for `node_id` under the shared Restate placement salt.
+pub fn hash_node_id(hashing_id: u64, node_id: PlainNodeId) -> u64 {
+    let mut hasher = Xxh3::with_seed(HASH_SALT);
+    hasher.write_u64(hashing_id);
+    hasher.write_u64(u32::from(node_id) as u64);
+    hasher.finish()
+}
+
+/// Selects a nodeset by HRW order, but chooses the least-loaded node within the top-N window.
+pub fn select_top_n_load_balanced(
+    candidates: impl IntoIterator<Item = PlainNodeId>,
+    hashing_id: u64,
+    target_size: usize,
+    required_node: Option<PlainNodeId>,
+    top_n: usize,
+    load: impl Fn(PlainNodeId) -> usize,
+) -> Option<NodeSet> {
+    let mut selected = NodeSet::with_capacity(target_size);
+    if let Some(required_node) = required_node {
+        selected.insert(required_node);
+    }
+
+    extend_top_n_load_balanced(candidates, hashing_id, target_size, selected, top_n, load)
+}
+
+/// Extends an existing nodeset with load-aware picks from the top-N HRW candidate window.
+pub fn extend_top_n_load_balanced(
+    candidates: impl IntoIterator<Item = PlainNodeId>,
+    hashing_id: u64,
+    target_size: usize,
+    mut selected: NodeSet,
+    top_n: usize,
+    load: impl Fn(PlainNodeId) -> usize,
+) -> Option<NodeSet> {
+    assert!(target_size > 0, "target_size must be greater than zero");
+
+    let mut order = candidates.into_iter().collect::<Vec<_>>();
+    order.sort_unstable_by_key(|node_id| {
+        (
+            Reverse(hash_node_id(hashing_id, *node_id)),
+            u32::from(*node_id),
+        )
+    });
+    order.dedup();
+    selected.retain(|node_id| order.contains(node_id));
+
+    if order.len() < target_size || selected.len() > target_size {
+        return None;
+    }
+
+    while selected.len() < target_size {
+        let candidate = order
+            .iter()
+            .enumerate()
+            .map(|(rank, node_id)| (rank, *node_id))
+            .filter(|(_, node_id)| !selected.contains(*node_id))
+            .take(top_n.max(1))
+            .min_by_key(|(rank, node_id)| (load(*node_id), *rank))?
+            .1;
+        selected.insert(candidate);
+    }
+
+    Some(selected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(id: u32) -> PlainNodeId {
+        PlainNodeId::new(id)
+    }
+
+    #[test]
+    fn selects_least_loaded_candidate_within_top_n_hash_ranking() {
+        let hashing_id = 17;
+        let mut candidates = [node(1), node(2), node(3), node(4)];
+        candidates.sort_by_key(|node_id| {
+            (
+                Reverse(hash_node_id(hashing_id, *node_id)),
+                u32::from(*node_id),
+            )
+        });
+
+        let highest_ranked = candidates[0];
+        let less_loaded = candidates[1];
+        let selected = select_top_n_load_balanced(candidates, hashing_id, 1, None, 2, |node_id| {
+            if node_id == highest_ranked { 1 } else { 0 }
+        })
+        .expect("selection should succeed");
+
+        assert!(selected.contains(less_loaded));
+    }
+
+    #[test]
+    fn extends_existing_selection_without_counting_filtered_nodes() {
+        let selected = NodeSet::from_iter([node(10), node(2)]);
+        let selected =
+            extend_top_n_load_balanced([node(1), node(2), node(3)], 23, 2, selected, 3, |_| 0)
+                .expect("selection should succeed");
+
+        assert!(selected.contains(node(2)));
+        assert_eq!(selected.len(), 2);
+        assert!(!selected.contains(node(10)));
+    }
+
+    #[test]
+    #[should_panic(expected = "target_size must be greater than zero")]
+    fn rejects_zero_target_size() {
+        let _ = extend_top_n_load_balanced([node(1)], 23, 0, NodeSet::new(), 1, |_| 0);
+    }
+
+    #[test]
+    fn reports_impossible_selections() {
+        let too_few_candidates =
+            extend_top_n_load_balanced([node(1)], 23, 2, NodeSet::new(), 1, |_| 0);
+        assert!(too_few_candidates.is_none());
+
+        let too_many_selected = extend_top_n_load_balanced(
+            [node(1), node(2)],
+            23,
+            1,
+            NodeSet::from_iter([node(1), node(2)]),
+            1,
+            |_| 0,
+        );
+        assert!(too_many_selected.is_none());
+    }
+
+    #[test]
+    fn preserves_hrw_determinism_when_loads_tie_or_top_n_is_zero() {
+        let hashing_id = 17;
+        let mut candidates = [node(1), node(2), node(3), node(4)];
+        candidates.sort_by_key(|node_id| {
+            (
+                Reverse(hash_node_id(hashing_id, *node_id)),
+                u32::from(*node_id),
+            )
+        });
+
+        let selected = select_top_n_load_balanced(candidates, hashing_id, 1, None, 0, |_| 0)
+            .expect("selection should succeed");
+
+        assert!(selected.contains(candidates[0]));
+    }
+}

--- a/crates/types/src/replication/mod.rs
+++ b/crates/types/src/replication/mod.rs
@@ -10,11 +10,13 @@
 
 pub mod balanced_spread_selector;
 mod checker;
+mod load_balanced_selector;
 mod nodeset;
 mod nodeset_selector;
 mod replication_property;
 
 pub use checker::*;
+pub use load_balanced_selector::*;
 pub use nodeset::*;
 pub use nodeset_selector::DomainAwareNodeSetSelector as NodeSetSelector;
 pub use nodeset_selector::{NodeSelectorError, NodeSetSelectorOptions};

--- a/release-notes/unreleased/4808-balanced-placement.md
+++ b/release-notes/unreleased/4808-balanced-placement.md
@@ -1,0 +1,46 @@
+# Release Notes for Issue #4808: Experimental balanced placement strategy
+
+## New Feature
+
+### What Changed
+Added an opt-in experimental placement strategy for small flat clusters. When
+enabled, Restate balances partition replica placement, partition processor
+leaders, and replicated-loglet nodeset membership using deterministic load-aware
+selection.
+
+Two new common configuration options control the behavior:
+
+- `experimental-placement-strategy`: `legacy` (default) or `balanced-v2`
+- `experimental-placement-rebalance-mode`: `repair-only` or `rebalance` (default)
+
+The log-server role also now emits
+`restate.log_server.nodeset_memberships`, a per-node gauge counting current
+replicated log tails whose nodeset contains the local log-server.
+
+### Why This Matters
+The existing deterministic placement can create severe leader, follower, and
+log-server nodeset skew in small clusters with tens or hundreds of partitions.
+The experimental strategy is intended to make benchmark and load-test feedback
+objective before changing the default placement behavior.
+
+### Impact on Users
+Existing deployments continue to use the legacy placement strategy unless they
+opt in. Enabling `balanced-v2` can move existing partition replicas and loglet
+nodesets, especially with `experimental-placement-rebalance-mode = "rebalance"`.
+When rebalancing a partition, the strategy retains a current replica reported as
+active whenever the unconstrained balanced placement does not already include
+one. This lets a warm partition processor seed new replicas instead of forcing
+every replacement to restore from a snapshot. If no current replica is reported
+active, the strategy retains an eligible current member as a weaker fallback.
+Loglet nodeset rebalancing only reconfigures existing loglets when the proposed
+change reduces the current cluster-wide nodeset membership range.
+
+### Migration Guidance
+This is experimental and intended for controlled benchmark/load-test trials.
+Use it only when all nodes in the cluster are configured consistently. If some
+cluster controllers run `balanced-v2` while others run `legacy`, they can compute
+different target placements and repeatedly reconfigure partitions or loglets
+toward whichever strategy wins the latest metadata update.
+
+### Related Issues
+- Issue #4808: Improve default partition/log placement balance

--- a/tools/placement-sim/Cargo.toml
+++ b/tools/placement-sim/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "placement-sim"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+restate-workspace-hack = { workspace = true }
+
+xxhash-rust = { workspace = true, features = ["xxh3"] }
+
+[lints]
+workspace = true

--- a/tools/placement-sim/README.md
+++ b/tools/placement-sim/README.md
@@ -1,0 +1,36 @@
+# Placement Simulator
+
+This is a small deterministic simulator for Restate partition and replicated-loglet placement.
+It models homogeneous all-in-one clusters with:
+
+- partition replication factor 2
+- replicated-loglet nodeset size 3
+- one partition log per partition
+- the log sequencer colocated with the partition leader
+
+It compares current per-id HRW placement against load-aware top-N candidate placement for:
+
+- partition replicas
+- partition leaders
+- replicated-loglet nodeset members
+
+The movement report separately counts partition transitions whose old and new replica sets are
+fully disjoint. The recommended combined strategy retains one alive current replica when needed,
+matching the production safeguard for keeping a warm partition processor available during
+rebalancing.
+
+Run:
+
+```shell
+cargo run -p placement-sim
+```
+
+CSV for spreadsheet analysis:
+
+```shell
+cargo run -p placement-sim -- --csv 2> placement.csv
+```
+
+This is a model for comparing placement policies. The production selector lives in
+`crates/types/src/replication/load_balanced_selector.rs`; keep the simulator's hashing and
+top-N behavior aligned with that implementation when changing either side.

--- a/tools/placement-sim/src/main.rs
+++ b/tools/placement-sim/src/main.rs
@@ -1,0 +1,924 @@
+use std::collections::HashSet;
+use std::hash::Hasher;
+
+use xxhash_rust::xxh3::Xxh3;
+
+// Keep in sync with restate_types::replication::HASH_SALT. Changing this salt reshuffles every
+// simulated placement.
+const HASH_SALT: u64 = 14_712_721_395_741_015_273;
+const PARTITION_RF: usize = 2;
+const LOG_NODESET_SIZE: usize = 3;
+
+type Node = usize;
+
+#[derive(Clone, Debug)]
+struct Placement {
+    replicas: Vec<Node>,
+    leader: Node,
+    nodeset: Vec<Node>,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum BalancedPolicy {
+    CurrentHrw,
+    TopM { m: usize },
+    All,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum LeaderPolicy {
+    CurrentTie,
+    Balanced,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum StabilityPolicy {
+    Stateless,
+    RepairOnly,
+    RepairDownRestoreWhenAllAlive,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Algorithm {
+    name: &'static str,
+    replica_policy: BalancedPolicy,
+    leader_policy: LeaderPolicy,
+    nodeset_policy: BalancedPolicy,
+    stability_policy: StabilityPolicy,
+    retain_replica_overlap: bool,
+}
+
+#[derive(Clone, Debug)]
+struct Fairness {
+    counts: Vec<usize>,
+    range: usize,
+    rmse: f64,
+}
+
+#[derive(Clone, Debug, Default)]
+struct Movement {
+    changed_partitions: usize,
+    replica_replacements: usize,
+    disjoint_replica_sets: usize,
+    leader_changes: usize,
+    changed_nodesets: usize,
+    nodeset_replacements: usize,
+}
+
+#[derive(Clone, Debug)]
+struct RunResult {
+    nodes: usize,
+    partitions: usize,
+    algorithm: &'static str,
+    initial_replica: Fairness,
+    initial_leader: Fairness,
+    initial_nodeset: Fairness,
+    final_replica: Fairness,
+    final_leader: Fairness,
+    final_nodeset: Fairness,
+    worst_down_replica_range: usize,
+    worst_down_leader_range: usize,
+    worst_down_nodeset_range: usize,
+    rolling: Movement,
+}
+
+fn hash_node(salt: u64, id: usize, node: Node) -> u64 {
+    let mut hasher = Xxh3::with_seed(salt);
+    hasher.write_u64(id as u64);
+    hasher.write_u64(node as u64);
+    hasher.finish()
+}
+
+fn hrw_order(alive: &[Node], id: usize, salt: u64) -> Vec<Node> {
+    let mut nodes = alive.to_vec();
+    nodes.sort_by(|a, b| {
+        hash_node(salt, id, *b)
+            .cmp(&hash_node(salt, id, *a))
+            .then_with(|| a.cmp(b))
+    });
+    nodes
+}
+
+fn natural_leader(replicas: &[Node], partition_id: usize, salt: u64) -> Node {
+    replicas
+        .iter()
+        .copied()
+        .min_by_key(|node| hash_node(salt, partition_id, *node))
+        .expect("replica set is non-empty")
+}
+
+fn select_balanced_member(
+    order: &[Node],
+    selected: &[Node],
+    counts: &[usize],
+    policy: BalancedPolicy,
+) -> Node {
+    let limit = match policy {
+        BalancedPolicy::CurrentHrw => 1,
+        BalancedPolicy::TopM { m } => m,
+        BalancedPolicy::All => usize::MAX,
+    };
+    let mut pool = order
+        .iter()
+        .copied()
+        .filter(|node| !selected.contains(node))
+        .take(limit)
+        .collect::<Vec<_>>();
+
+    if pool.is_empty() {
+        pool = order
+            .iter()
+            .copied()
+            .filter(|node| !selected.contains(node))
+            .collect();
+    }
+
+    pool.into_iter()
+        .min_by_key(|node| {
+            let rank = order
+                .iter()
+                .position(|candidate| candidate == node)
+                .expect("candidate is in order");
+            (counts[*node], rank)
+        })
+        .expect("enough live nodes")
+}
+
+fn select_stateless_replicas(
+    policy: BalancedPolicy,
+    node_count: usize,
+    partition_count: usize,
+    alive: &[Node],
+    previous: Option<&[Placement]>,
+    retain_overlap: bool,
+    salt: u64,
+) -> Vec<Vec<Node>> {
+    let mut replica_counts = vec![0; node_count];
+    let mut replicas = Vec::with_capacity(partition_count);
+
+    for pid in 0..partition_count {
+        let order = hrw_order(alive, pid, salt);
+        let mut selected = Vec::with_capacity(PARTITION_RF);
+        while selected.len() < PARTITION_RF {
+            let node = select_balanced_member(&order, &selected, &replica_counts, policy);
+            selected.push(node);
+        }
+
+        if retain_overlap
+            && let Some(previous) = previous
+            && !previous[pid]
+                .replicas
+                .iter()
+                .any(|node| selected.contains(node))
+            && let Some(anchor) = previous[pid]
+                .replicas
+                .iter()
+                .copied()
+                .filter(|node| alive.contains(node))
+                .min_by_key(|node| {
+                    (
+                        replica_counts[*node],
+                        std::cmp::Reverse(hash_node(salt, pid, *node)),
+                        *node,
+                    )
+                })
+        {
+            selected.clear();
+            selected.push(anchor);
+            while selected.len() < PARTITION_RF {
+                selected.push(select_balanced_member(
+                    &order,
+                    &selected,
+                    &replica_counts,
+                    policy,
+                ));
+            }
+        }
+
+        for node in &selected {
+            replica_counts[*node] += 1;
+        }
+        replicas.push(selected);
+    }
+
+    replicas
+}
+
+fn repair_replicas(
+    policy: BalancedPolicy,
+    node_count: usize,
+    partition_count: usize,
+    alive: &[Node],
+    previous: &[Placement],
+    salt: u64,
+) -> Vec<Vec<Node>> {
+    let alive_set = alive.iter().copied().collect::<HashSet<_>>();
+    let mut replica_counts = vec![0; node_count];
+    let mut replicas = vec![Vec::new(); partition_count];
+    let mut needs_repair = Vec::new();
+
+    for pid in 0..partition_count {
+        replicas[pid] = previous[pid]
+            .replicas
+            .iter()
+            .copied()
+            .filter(|node| alive_set.contains(node))
+            .collect();
+        if replicas[pid].len() < PARTITION_RF {
+            needs_repair.push(pid);
+        }
+        for node in &replicas[pid] {
+            replica_counts[*node] += 1;
+        }
+    }
+
+    for pid in needs_repair {
+        let order = hrw_order(alive, pid, salt);
+        while replicas[pid].len() < PARTITION_RF {
+            let node = select_balanced_member(&order, &replicas[pid], &replica_counts, policy);
+            replicas[pid].push(node);
+            replica_counts[node] += 1;
+        }
+    }
+
+    replicas
+}
+
+fn assign_leaders(
+    policy: LeaderPolicy,
+    replicas: Vec<Vec<Node>>,
+    node_count: usize,
+    alive: &[Node],
+    previous: Option<&[Placement]>,
+    salt: u64,
+) -> Vec<Node> {
+    let alive_set = alive.iter().copied().collect::<HashSet<_>>();
+    let mut leaders = vec![0; replicas.len()];
+    let mut leader_counts = vec![0; node_count];
+    let mut needs_leader = Vec::new();
+
+    for pid in 0..replicas.len() {
+        if let Some(previous) = previous {
+            let old = previous[pid].leader;
+            if replicas[pid].contains(&old) && alive_set.contains(&old) {
+                leaders[pid] = old;
+                leader_counts[old] += 1;
+                continue;
+            }
+        }
+        needs_leader.push(pid);
+    }
+
+    for pid in needs_leader {
+        let natural = natural_leader(&replicas[pid], pid, salt);
+        let leader = match policy {
+            LeaderPolicy::CurrentTie => natural,
+            LeaderPolicy::Balanced => replicas[pid]
+                .iter()
+                .copied()
+                .min_by_key(|node| {
+                    (
+                        leader_counts[*node],
+                        usize::from(*node != natural),
+                        std::cmp::Reverse(hash_node(salt, pid, *node)),
+                    )
+                })
+                .expect("replica set is non-empty"),
+        };
+        leaders[pid] = leader;
+        leader_counts[leader] += 1;
+    }
+
+    leaders
+}
+
+fn select_stateless_nodesets(
+    policy: BalancedPolicy,
+    node_count: usize,
+    partition_count: usize,
+    alive: &[Node],
+    leaders: &[Node],
+    salt: u64,
+) -> Vec<Vec<Node>> {
+    let mut nodeset_counts = vec![0; node_count];
+    let mut nodesets = Vec::with_capacity(partition_count);
+    let target = LOG_NODESET_SIZE.min(alive.len());
+
+    for pid in 0..partition_count {
+        let mut selected = Vec::with_capacity(target);
+        if alive.contains(&leaders[pid]) {
+            selected.push(leaders[pid]);
+            nodeset_counts[leaders[pid]] += 1;
+        }
+
+        let order = hrw_order(alive, pid, salt);
+        while selected.len() < target {
+            let node = select_balanced_member(&order, &selected, &nodeset_counts, policy);
+            selected.push(node);
+            nodeset_counts[node] += 1;
+        }
+        nodesets.push(selected);
+    }
+
+    nodesets
+}
+
+fn repair_nodesets(
+    policy: BalancedPolicy,
+    node_count: usize,
+    partition_count: usize,
+    alive: &[Node],
+    leaders: &[Node],
+    previous: &[Placement],
+    salt: u64,
+) -> Vec<Vec<Node>> {
+    let alive_set = alive.iter().copied().collect::<HashSet<_>>();
+    let target = LOG_NODESET_SIZE.min(alive.len());
+    let mut nodeset_counts = vec![0; node_count];
+    let mut nodesets = vec![Vec::new(); partition_count];
+    let mut needs_repair = Vec::new();
+
+    for pid in 0..partition_count {
+        nodesets[pid] = previous[pid]
+            .nodeset
+            .iter()
+            .copied()
+            .filter(|node| alive_set.contains(node))
+            .collect();
+        if alive_set.contains(&leaders[pid]) && !nodesets[pid].contains(&leaders[pid]) {
+            if nodesets[pid].len() == target {
+                nodesets[pid].pop();
+            }
+            nodesets[pid].insert(0, leaders[pid]);
+        }
+        if nodesets[pid].len() < target {
+            needs_repair.push(pid);
+        }
+        for node in &nodesets[pid] {
+            nodeset_counts[*node] += 1;
+        }
+    }
+
+    for pid in needs_repair {
+        let order = hrw_order(alive, pid, salt);
+        while nodesets[pid].len() < target {
+            let node = select_balanced_member(&order, &nodesets[pid], &nodeset_counts, policy);
+            nodesets[pid].push(node);
+            nodeset_counts[node] += 1;
+        }
+    }
+
+    nodesets
+}
+
+fn select(
+    algorithm: Algorithm,
+    node_count: usize,
+    partition_count: usize,
+    alive: &[Node],
+    previous: Option<&[Placement]>,
+    salt: u64,
+) -> Vec<Placement> {
+    let restore = matches!(
+        algorithm.stability_policy,
+        StabilityPolicy::RepairDownRestoreWhenAllAlive
+    ) && alive.len() == node_count;
+
+    let stateless = matches!(algorithm.stability_policy, StabilityPolicy::Stateless);
+    let repair_previous = previous.filter(|_| !restore && !stateless);
+
+    let replicas = if let Some(previous) = repair_previous {
+        repair_replicas(
+            algorithm.replica_policy,
+            node_count,
+            partition_count,
+            alive,
+            previous,
+            salt,
+        )
+    } else {
+        select_stateless_replicas(
+            algorithm.replica_policy,
+            node_count,
+            partition_count,
+            alive,
+            previous,
+            algorithm.retain_replica_overlap,
+            salt,
+        )
+    };
+
+    let leaders = assign_leaders(
+        algorithm.leader_policy,
+        replicas.clone(),
+        node_count,
+        alive,
+        repair_previous,
+        salt,
+    );
+
+    let nodesets = if let Some(previous) = repair_previous {
+        repair_nodesets(
+            algorithm.nodeset_policy,
+            node_count,
+            partition_count,
+            alive,
+            &leaders,
+            previous,
+            salt,
+        )
+    } else {
+        select_stateless_nodesets(
+            algorithm.nodeset_policy,
+            node_count,
+            partition_count,
+            alive,
+            &leaders,
+            salt,
+        )
+    };
+
+    replicas
+        .into_iter()
+        .zip(leaders)
+        .zip(nodesets)
+        .map(|((replicas, leader), nodeset)| Placement {
+            replicas,
+            leader,
+            nodeset,
+        })
+        .collect()
+}
+
+fn fairness_from_counts(counts: Vec<usize>) -> Fairness {
+    let ideal = counts.iter().sum::<usize>() as f64 / counts.len() as f64;
+    let min = *counts.iter().min().unwrap_or(&0);
+    let max = *counts.iter().max().unwrap_or(&0);
+    let rmse = (counts
+        .iter()
+        .map(|count| {
+            let diff = *count as f64 - ideal;
+            diff * diff
+        })
+        .sum::<f64>()
+        / counts.len() as f64)
+        .sqrt();
+
+    Fairness {
+        counts,
+        range: max - min,
+        rmse,
+    }
+}
+
+fn fairness(placements: &[Placement], node_count: usize) -> (Fairness, Fairness, Fairness) {
+    let mut replicas = vec![0; node_count];
+    let mut leaders = vec![0; node_count];
+    let mut nodesets = vec![0; node_count];
+    for placement in placements {
+        for node in &placement.replicas {
+            replicas[*node] += 1;
+        }
+        leaders[placement.leader] += 1;
+        for node in &placement.nodeset {
+            nodesets[*node] += 1;
+        }
+    }
+    (
+        fairness_from_counts(replicas),
+        fairness_from_counts(leaders),
+        fairness_from_counts(nodesets),
+    )
+}
+
+fn set_of(nodes: &[Node]) -> HashSet<Node> {
+    nodes.iter().copied().collect()
+}
+
+fn movement(previous: &[Placement], next: &[Placement]) -> Movement {
+    let mut movement = Movement::default();
+    for (old, new) in previous.iter().zip(next) {
+        let old_replicas = set_of(&old.replicas);
+        let new_replicas = set_of(&new.replicas);
+        if old_replicas != new_replicas {
+            movement.changed_partitions += 1;
+            movement.replica_replacements += old_replicas.difference(&new_replicas).count();
+            movement.disjoint_replica_sets += usize::from(old_replicas.is_disjoint(&new_replicas));
+        }
+
+        if old.leader != new.leader {
+            movement.leader_changes += 1;
+        }
+
+        let old_nodeset = set_of(&old.nodeset);
+        let new_nodeset = set_of(&new.nodeset);
+        if old_nodeset != new_nodeset {
+            movement.changed_nodesets += 1;
+            movement.nodeset_replacements += old_nodeset.difference(&new_nodeset).count();
+        }
+    }
+    movement
+}
+
+fn add_movement(total: &mut Movement, step: Movement) {
+    total.changed_partitions += step.changed_partitions;
+    total.replica_replacements += step.replica_replacements;
+    total.disjoint_replica_sets += step.disjoint_replica_sets;
+    total.leader_changes += step.leader_changes;
+    total.changed_nodesets += step.changed_nodesets;
+    total.nodeset_replacements += step.nodeset_replacements;
+}
+
+fn run_scenario(algorithm: Algorithm, nodes: usize, partitions: usize, salt: u64) -> RunResult {
+    let all_alive = (0..nodes).collect::<Vec<_>>();
+    let initial = select(algorithm, nodes, partitions, &all_alive, None, salt);
+    let (initial_replica, initial_leader, initial_nodeset) = fairness(&initial, nodes);
+
+    let mut current = initial;
+    let mut rolling = Movement::default();
+    let mut worst_down_replica_range = 0;
+    let mut worst_down_leader_range = 0;
+    let mut worst_down_nodeset_range = 0;
+
+    for down_node in (0..nodes).rev() {
+        let alive = (0..nodes)
+            .filter(|node| *node != down_node)
+            .collect::<Vec<_>>();
+        let down = select(algorithm, nodes, partitions, &alive, Some(&current), salt);
+        add_movement(&mut rolling, movement(&current, &down));
+        let (replica_fairness, leader_fairness, nodeset_fairness) = fairness(&down, nodes);
+        worst_down_replica_range = worst_down_replica_range.max(replica_fairness.range);
+        worst_down_leader_range = worst_down_leader_range.max(leader_fairness.range);
+        worst_down_nodeset_range = worst_down_nodeset_range.max(nodeset_fairness.range);
+        current = down;
+
+        let up = select(
+            algorithm,
+            nodes,
+            partitions,
+            &all_alive,
+            Some(&current),
+            salt,
+        );
+        add_movement(&mut rolling, movement(&current, &up));
+        current = up;
+    }
+
+    let (final_replica, final_leader, final_nodeset) = fairness(&current, nodes);
+    RunResult {
+        nodes,
+        partitions,
+        algorithm: algorithm.name,
+        initial_replica,
+        initial_leader,
+        initial_nodeset,
+        final_replica,
+        final_leader,
+        final_nodeset,
+        worst_down_replica_range,
+        worst_down_leader_range,
+        worst_down_nodeset_range,
+        rolling,
+    }
+}
+
+fn splitmix64(mut x: u64) -> u64 {
+    x = x.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut z = x;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+fn count_string(counts: &[usize]) -> String {
+    counts
+        .iter()
+        .map(|count| count.to_string())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn average(values: &[usize]) -> f64 {
+    values.iter().sum::<usize>() as f64 / values.len() as f64
+}
+
+fn percentile(values: &mut [usize], percentile: f64) -> usize {
+    values.sort_unstable();
+    let index = ((values.len() - 1) as f64 * percentile).round() as usize;
+    values[index]
+}
+
+fn current_algorithm() -> Algorithm {
+    Algorithm {
+        name: "current",
+        replica_policy: BalancedPolicy::CurrentHrw,
+        leader_policy: LeaderPolicy::CurrentTie,
+        nodeset_policy: BalancedPolicy::CurrentHrw,
+        stability_policy: StabilityPolicy::Stateless,
+        retain_replica_overlap: false,
+    }
+}
+
+fn algorithms() -> Vec<Algorithm> {
+    vec![
+        current_algorithm(),
+        Algorithm {
+            name: "current+balanced-leaders",
+            replica_policy: BalancedPolicy::CurrentHrw,
+            leader_policy: LeaderPolicy::Balanced,
+            nodeset_policy: BalancedPolicy::CurrentHrw,
+            stability_policy: StabilityPolicy::Stateless,
+            retain_replica_overlap: false,
+        },
+        Algorithm {
+            name: "nodeset-top3-only+repair-restore",
+            replica_policy: BalancedPolicy::CurrentHrw,
+            leader_policy: LeaderPolicy::CurrentTie,
+            nodeset_policy: BalancedPolicy::TopM { m: 3 },
+            stability_policy: StabilityPolicy::RepairDownRestoreWhenAllAlive,
+            retain_replica_overlap: false,
+        },
+        Algorithm {
+            name: "partition-top3-only+repair-restore",
+            replica_policy: BalancedPolicy::TopM { m: 3 },
+            leader_policy: LeaderPolicy::Balanced,
+            nodeset_policy: BalancedPolicy::CurrentHrw,
+            stability_policy: StabilityPolicy::RepairDownRestoreWhenAllAlive,
+            retain_replica_overlap: false,
+        },
+        Algorithm {
+            name: "combined-top3+repair-only",
+            replica_policy: BalancedPolicy::TopM { m: 3 },
+            leader_policy: LeaderPolicy::Balanced,
+            nodeset_policy: BalancedPolicy::TopM { m: 3 },
+            stability_policy: StabilityPolicy::RepairOnly,
+            retain_replica_overlap: true,
+        },
+        Algorithm {
+            name: "combined-top3+repair-restore+overlap",
+            replica_policy: BalancedPolicy::TopM { m: 3 },
+            leader_policy: LeaderPolicy::Balanced,
+            nodeset_policy: BalancedPolicy::TopM { m: 3 },
+            stability_policy: StabilityPolicy::RepairDownRestoreWhenAllAlive,
+            retain_replica_overlap: true,
+        },
+        Algorithm {
+            name: "combined-all+repair-restore",
+            replica_policy: BalancedPolicy::All,
+            leader_policy: LeaderPolicy::Balanced,
+            nodeset_policy: BalancedPolicy::All,
+            stability_policy: StabilityPolicy::RepairDownRestoreWhenAllAlive,
+            retain_replica_overlap: false,
+        },
+    ]
+}
+
+fn print_baseline() {
+    let current = current_algorithm();
+    println!("## Current algorithm, exact Restate salt");
+    println!(
+        "_Model: flat all-in-one nodes, partition RF=2, log nodeset size=3, sequencer=leader._"
+    );
+    println!(
+        "| nodes | partitions | partition replicas | replica range | leaders | leader range | log nodesets | nodeset range |"
+    );
+    println!("|---:|---:|---|---:|---|---:|---|---:|");
+    for nodes in [3, 5] {
+        for partitions in [24, 48, 96, 128] {
+            let result = run_scenario(current, nodes, partitions, HASH_SALT);
+            println!(
+                "| {} | {} | {} | {} | {} | {} | {} | {} |",
+                nodes,
+                partitions,
+                count_string(&result.initial_replica.counts),
+                result.initial_replica.range,
+                count_string(&result.initial_leader.counts),
+                result.initial_leader.range,
+                count_string(&result.initial_nodeset.counts),
+                result.initial_nodeset.range,
+            );
+        }
+    }
+    println!();
+}
+
+fn print_exact_comparison(algorithms: &[Algorithm]) {
+    println!("## Exact-salt aggregate across 8 scenarios");
+    println!(
+        "| algorithm | avg leader range | max leader range | avg replica range | max replica range | avg nodeset range | max nodeset range | one-time replica moves | one-time disjoint sets | one-time leader moves | one-time nodeset moves | rolling replica moves | rolling disjoint sets | rolling leader moves | rolling nodeset moves |"
+    );
+    println!("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|");
+
+    for algorithm in algorithms {
+        let mut results = Vec::new();
+        let mut one_time = Movement::default();
+        for nodes in [3, 5] {
+            for partitions in [24, 48, 96, 128] {
+                let current = select(
+                    current_algorithm(),
+                    nodes,
+                    partitions,
+                    &(0..nodes).collect::<Vec<_>>(),
+                    None,
+                    HASH_SALT,
+                );
+                let next = select(
+                    *algorithm,
+                    nodes,
+                    partitions,
+                    &(0..nodes).collect::<Vec<_>>(),
+                    Some(&current),
+                    HASH_SALT,
+                );
+                add_movement(&mut one_time, movement(&current, &next));
+                results.push(run_scenario(*algorithm, nodes, partitions, HASH_SALT));
+            }
+        }
+
+        let avg_leader_range = results
+            .iter()
+            .map(|r| r.initial_leader.range)
+            .sum::<usize>() as f64
+            / results.len() as f64;
+        let avg_replica_range = results
+            .iter()
+            .map(|r| r.initial_replica.range)
+            .sum::<usize>() as f64
+            / results.len() as f64;
+        let avg_nodeset_range = results
+            .iter()
+            .map(|r| r.initial_nodeset.range)
+            .sum::<usize>() as f64
+            / results.len() as f64;
+        let max_leader_range = results
+            .iter()
+            .map(|r| r.initial_leader.range)
+            .max()
+            .unwrap();
+        let max_replica_range = results
+            .iter()
+            .map(|r| r.initial_replica.range)
+            .max()
+            .unwrap();
+        let max_nodeset_range = results
+            .iter()
+            .map(|r| r.initial_nodeset.range)
+            .max()
+            .unwrap();
+        let rolling_replica = results
+            .iter()
+            .map(|r| r.rolling.replica_replacements)
+            .sum::<usize>();
+        let rolling_leader = results
+            .iter()
+            .map(|r| r.rolling.leader_changes)
+            .sum::<usize>();
+        let rolling_disjoint = results
+            .iter()
+            .map(|r| r.rolling.disjoint_replica_sets)
+            .sum::<usize>();
+        let rolling_nodeset = results
+            .iter()
+            .map(|r| r.rolling.nodeset_replacements)
+            .sum::<usize>();
+
+        println!(
+            "| {} | {:.2} | {} | {:.2} | {} | {:.2} | {} | {} | {} | {} | {} | {} | {} | {} | {} |",
+            algorithm.name,
+            avg_leader_range,
+            max_leader_range,
+            avg_replica_range,
+            max_replica_range,
+            avg_nodeset_range,
+            max_nodeset_range,
+            one_time.replica_replacements,
+            one_time.disjoint_replica_sets,
+            one_time.leader_changes,
+            one_time.nodeset_replacements,
+            rolling_replica,
+            rolling_disjoint,
+            rolling_leader,
+            rolling_nodeset,
+        );
+    }
+    println!();
+}
+
+fn print_salt_sweep(algorithms: &[Algorithm]) {
+    println!("## Salt sweep aggregate");
+    println!(
+        "_256 deterministic salt trials per scenario; reports averages across all 2048 runs._"
+    );
+    println!(
+        "| algorithm | avg leader range | p95 leader range | avg replica range | p95 replica range | avg nodeset range | p95 nodeset range | avg rolling replica moves | avg rolling disjoint sets | avg rolling leader moves | avg rolling nodeset moves |"
+    );
+    println!("|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|");
+
+    for algorithm in algorithms {
+        let mut leader_ranges = Vec::new();
+        let mut replica_ranges = Vec::new();
+        let mut nodeset_ranges = Vec::new();
+        let mut rolling_replicas = Vec::new();
+        let mut rolling_disjoint = Vec::new();
+        let mut rolling_leaders = Vec::new();
+        let mut rolling_nodesets = Vec::new();
+
+        for trial in 0..256 {
+            let salt = splitmix64(HASH_SALT ^ trial);
+            for nodes in [3, 5] {
+                for partitions in [24, 48, 96, 128] {
+                    let result = run_scenario(*algorithm, nodes, partitions, salt);
+                    leader_ranges.push(result.initial_leader.range);
+                    replica_ranges.push(result.initial_replica.range);
+                    nodeset_ranges.push(result.initial_nodeset.range);
+                    rolling_replicas.push(result.rolling.replica_replacements);
+                    rolling_disjoint.push(result.rolling.disjoint_replica_sets);
+                    rolling_leaders.push(result.rolling.leader_changes);
+                    rolling_nodesets.push(result.rolling.nodeset_replacements);
+                }
+            }
+        }
+
+        let avg_leader = average(&leader_ranges);
+        let avg_replica = average(&replica_ranges);
+        let avg_nodeset = average(&nodeset_ranges);
+        let avg_roll_replica = average(&rolling_replicas);
+        let avg_roll_disjoint = average(&rolling_disjoint);
+        let avg_roll_leader = average(&rolling_leaders);
+        let avg_roll_nodeset = average(&rolling_nodesets);
+        let p95_leader = percentile(&mut leader_ranges, 0.95);
+        let p95_replica = percentile(&mut replica_ranges, 0.95);
+        let p95_nodeset = percentile(&mut nodeset_ranges, 0.95);
+
+        println!(
+            "| {} | {:.2} | {} | {:.2} | {} | {:.2} | {} | {:.2} | {:.2} | {:.2} | {:.2} |",
+            algorithm.name,
+            avg_leader,
+            p95_leader,
+            avg_replica,
+            p95_replica,
+            avg_nodeset,
+            p95_nodeset,
+            avg_roll_replica,
+            avg_roll_disjoint,
+            avg_roll_leader,
+            avg_roll_nodeset,
+        );
+    }
+    println!();
+}
+
+fn print_csv(algorithms: &[Algorithm]) {
+    eprintln!(
+        "algorithm,nodes,partitions,initial_replica_counts,initial_replica_range,initial_replica_rmse,initial_leader_counts,initial_leader_range,initial_leader_rmse,initial_nodeset_counts,initial_nodeset_range,initial_nodeset_rmse,final_replica_counts,final_replica_range,final_leader_counts,final_leader_range,final_nodeset_counts,final_nodeset_range,worst_down_replica_range,worst_down_leader_range,worst_down_nodeset_range,rolling_changed_partitions,rolling_replica_replacements,rolling_disjoint_replica_sets,rolling_leader_changes,rolling_changed_nodesets,rolling_nodeset_replacements"
+    );
+    for algorithm in algorithms {
+        for nodes in [3, 5] {
+            for partitions in [24, 48, 96, 128] {
+                let result = run_scenario(*algorithm, nodes, partitions, HASH_SALT);
+                eprintln!(
+                    "{},{},{},{},{},{:.4},{},{},{:.4},{},{},{:.4},{},{},{},{},{},{},{},{},{},{},{},{},{},{},{}",
+                    result.algorithm,
+                    result.nodes,
+                    result.partitions,
+                    count_string(&result.initial_replica.counts),
+                    result.initial_replica.range,
+                    result.initial_replica.rmse,
+                    count_string(&result.initial_leader.counts),
+                    result.initial_leader.range,
+                    result.initial_leader.rmse,
+                    count_string(&result.initial_nodeset.counts),
+                    result.initial_nodeset.range,
+                    result.initial_nodeset.rmse,
+                    count_string(&result.final_replica.counts),
+                    result.final_replica.range,
+                    count_string(&result.final_leader.counts),
+                    result.final_leader.range,
+                    count_string(&result.final_nodeset.counts),
+                    result.final_nodeset.range,
+                    result.worst_down_replica_range,
+                    result.worst_down_leader_range,
+                    result.worst_down_nodeset_range,
+                    result.rolling.changed_partitions,
+                    result.rolling.replica_replacements,
+                    result.rolling.disjoint_replica_sets,
+                    result.rolling.leader_changes,
+                    result.rolling.changed_nodesets,
+                    result.rolling.nodeset_replacements,
+                );
+            }
+        }
+    }
+}
+
+fn main() {
+    let algorithms = algorithms();
+
+    print_baseline();
+    print_exact_comparison(&algorithms);
+    print_salt_sweep(&algorithms);
+
+    if std::env::args().any(|arg| arg == "--csv") {
+        print_csv(&algorithms);
+    }
+}


### PR DESCRIPTION
Closes #4808

## Summary
- add opt-in `experimental-placement-strategy = "balanced-v2"` and `experimental-placement-rebalance-mode` config
- balance partition replicas, partition leaders, and replicated-loglet nodeset members with deterministic top-3/load-aware selection for flat placements
- retain one alive current partition replica whenever the unconstrained balanced plan would replace the entire replica set, preferring an already-active processor
- add `restate.log_server.nodeset_memberships` gauge and keep the placement simulator under `tools/placement-sim`

## Safety and stability
- legacy placement remains the default
- region/zone-scoped replication consistently falls back to the legacy replica and leader selectors
- repair-only mode preserves viable existing members
- rebalancing keeps the unconstrained balanced result when it already intersects the current replica set; it only pins one current member for an otherwise-disjoint transition
- log nodesets only rebalance when the proposed move strictly reduces the cluster-wide membership range

## Simulator signal
For the exact Restate salt across 3/5 node and 24/48/96/128 partition scenarios, combined top-3 reduced average initial ranges to leader=1.25, replica=0.75, nodeset=0.50 versus current leader=12.12, replica=15.25, nodeset=8.62. In the 256-salt sweep, combined top-3 averaged leader=0.93, replica=0.69, nodeset=0.52 versus current leader=8.02, replica=9.32, nodeset=5.32.

The overlap safeguard reduced fully disjoint one-time partition transitions from 16 to 0 across the eight exact-salt scenarios without changing the combined strategy's fairness ranges.

## Validation
- `cargo check`
- `cargo nextest run --all-features` (1,404 passed, 10 skipped)
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --all-targets --workspace -- -D warnings`
- `cargo deny --all-features check`
- `cargo run -p placement-sim`
