### PR TITLE
Raise ingress HTTP/2 stream limit

### DIFF
--- a/crates/ingress-http/src/server.rs
+++ b/crates/ingress-http/src/server.rs
@@ -262,7 +262,10 @@ where
         // Spawn a tokio task to serve the connection
         TaskCenter::spawn(TaskKind::Ingress, "ingress", async move {
             let shutdown = cancellation_watcher();
-            let auto_connection = auto::Builder::new(TaskCenterExecutor);
+            let mut auto_connection = auto::Builder::new(TaskCenterExecutor);
+            auto_connection
+                .http2()
+                .max_concurrent_streams(Some(u32::MAX));
             let serve_connection_fut = auto_connection.serve_connection(io, handler);
 
             tokio::select! {


### PR DESCRIPTION
## Summary
- Raise the HTTP/2 max concurrent streams advertised by ingress-http server connections to u32::MAX.
- Align worker ingress with the cloud ingress and tunnel server behavior so pooled BYOC ingress connections do not hit Hyper's default 200-stream cap.

## Testing
- cargo fmt --check
- cargo check -p restate-ingress-http