### PR TITLE
Make default/max idempotency and workflow retention configurable

### DIFF
--- a/crates/types/src/config/invocation.rs
+++ b/crates/types/src/config/invocation.rs
@@ -35,7 +35,7 @@ pub struct InvocationOptions {
     /// # Maximum journal retention duration
     ///
     /// Maximum journal retention duration that can be configured.
-    /// When discovering a service deployment, or when modifying the journal retention using the Admin API, the given value will be clamped.
+    /// Applied when ingesting the invocation: values higher than this limit are clamped down to it.
     ///
     /// Unset means no limit.
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -55,7 +55,7 @@ pub struct InvocationOptions {
     /// # Maximum idempotency retention duration
     ///
     /// Maximum idempotency retention duration that can be configured.
-    /// When discovering a service deployment, or when modifying the idempotency retention using the Admin API, the given value will be clamped.
+    /// Applied when ingesting the invocation: values higher than this limit are clamped down to it.
     ///
     /// Unset means no limit.
     ///
@@ -77,7 +77,7 @@ pub struct InvocationOptions {
     /// # Maximum workflow completion retention duration
     ///
     /// Maximum workflow completion retention duration that can be configured.
-    /// When discovering a service deployment, or when modifying the workflow completion retention using the Admin API, the given value will be clamped.
+    /// Applied when ingesting the invocation: values higher than this limit are clamped down to it.
     ///
     /// Unset means no limit.
     ///

--- a/crates/types/src/config/invocation.rs
+++ b/crates/types/src/config/invocation.rs
@@ -41,6 +41,50 @@ pub struct InvocationOptions {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub max_journal_retention: Option<FriendlyDuration>,
 
+    /// # Default idempotency retention
+    ///
+    /// Default idempotency retention for all invocations carrying an idempotency key.
+    ///
+    /// This default is used when neither the service nor the handler configures an idempotency retention,
+    /// and can be overridden per service/handler using the respective SDK APIs.
+    ///
+    /// Since v1.7.0
+    #[serde(skip_serializing_if = "FriendlyDuration::is_zero", default)]
+    pub default_idempotency_retention: FriendlyDuration,
+
+    /// # Maximum idempotency retention duration
+    ///
+    /// Maximum idempotency retention duration that can be configured.
+    /// When discovering a service deployment, or when modifying the idempotency retention using the Admin API, the given value will be clamped.
+    ///
+    /// Unset means no limit.
+    ///
+    /// Since v1.7.0
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub max_idempotency_retention: Option<FriendlyDuration>,
+
+    /// # Default workflow completion retention
+    ///
+    /// Default workflow completion retention for all workflow invocations.
+    ///
+    /// This default is used when neither the workflow service nor the handler configures a workflow completion retention,
+    /// and can be overridden per service/handler using the respective SDK APIs.
+    ///
+    /// Since v1.7.0
+    #[serde(skip_serializing_if = "FriendlyDuration::is_zero", default)]
+    pub default_workflow_completion_retention: FriendlyDuration,
+
+    /// # Maximum workflow completion retention duration
+    ///
+    /// Maximum workflow completion retention duration that can be configured.
+    /// When discovering a service deployment, or when modifying the workflow completion retention using the Admin API, the given value will be clamped.
+    ///
+    /// Unset means no limit.
+    ///
+    /// Since v1.7.0
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub max_workflow_completion_retention: Option<FriendlyDuration>,
+
     /// # Default retry policy
     ///
     /// The default retry policy to use for invocations.
@@ -85,6 +129,10 @@ impl Default for InvocationOptions {
         Self {
             default_journal_retention: FriendlyDuration::from_secs(60 * 60 * 24),
             max_journal_retention: None,
+            default_idempotency_retention: FriendlyDuration::from_secs(60 * 60 * 24),
+            max_idempotency_retention: None,
+            default_workflow_completion_retention: FriendlyDuration::from_secs(60 * 60 * 24),
+            max_workflow_completion_retention: None,
             default_retry_policy: InvocationRetryPolicyOptions::default(),
             max_retry_policy_max_attempts: None,
             invocation_yield_threshold: None,

--- a/crates/types/src/schema/metadata/mod.rs
+++ b/crates/types/src/schema/metadata/mod.rs
@@ -42,9 +42,8 @@ use crate::retries::{RetryIter, RetryPolicy};
 use crate::schema::deployment::{DeploymentResolver, DeploymentType, ProtocolType};
 use crate::schema::info::SchemaInfo;
 use crate::schema::invocation_target::{
-    DEFAULT_IDEMPOTENCY_RETENTION, DEFAULT_WORKFLOW_COMPLETION_RETENTION, DeploymentStatus,
-    InputRules, InvocationAttemptOptions, InvocationTargetMetadata, InvocationTargetResolver,
-    OnMaxAttempts, OutputRules,
+    DeploymentStatus, InputRules, InvocationAttemptOptions, InvocationTargetMetadata,
+    InvocationTargetResolver, OnMaxAttempts, OutputRules,
 };
 use crate::schema::kafka::{
     DUPLICATED_KAFKA_CLUSTER_INFO_MESSAGE, KafkaCluster, KafkaClusterResolver,
@@ -413,6 +412,48 @@ impl ServiceRevision {
             ))
         }
 
+        let (idempotency_retention, got_idempotency_retention_clamped) = configuration
+            .clamp_idempotency_retention(self.idempotency_retention.or_else(|| {
+                configuration
+                    .invocation
+                    .default_idempotency_retention
+                    .to_non_zero_std()
+            }));
+        if got_idempotency_retention_clamped {
+            info.push(SchemaInfo::new_with_code(
+                &restate_errors::RT0022,
+                "The configured idempotency_retention is clamped to the maximum server limit."
+                    .to_string(),
+            ))
+        }
+
+        let workflow_completion_retention = if self.ty == ServiceType::Workflow {
+            let requested = self
+                .handlers
+                .iter()
+                .find(|(_, h)| h.workflow_completion_retention.is_some())
+                .and_then(|(_, h)| h.workflow_completion_retention)
+                .or(self.workflow_completion_retention)
+                .or_else(|| {
+                    configuration
+                        .invocation
+                        .default_workflow_completion_retention
+                        .to_non_zero_std()
+                });
+            let (clamped, got_clamped) =
+                configuration.clamp_workflow_completion_retention(requested);
+            if got_clamped {
+                info.push(SchemaInfo::new_with_code(
+                    &restate_errors::RT0022,
+                    "The configured workflow_completion_retention is clamped to the maximum server limit."
+                        .to_string(),
+                ))
+            }
+            Some(clamped.unwrap_or(Duration::ZERO))
+        } else {
+            None
+        };
+
         service::ServiceMetadata {
             name: self.name.clone(),
             handlers: self
@@ -435,21 +476,8 @@ impl ServiceRevision {
             deployment_id,
             revision: self.revision,
             public: self.public,
-            idempotency_retention: self
-                .idempotency_retention
-                .unwrap_or(DEFAULT_IDEMPOTENCY_RETENTION),
-            workflow_completion_retention: if self.ty == ServiceType::Workflow {
-                Some(
-                    self.handlers
-                        .iter()
-                        .find(|(_, h)| h.workflow_completion_retention.is_some())
-                        .and_then(|(_, h)| h.workflow_completion_retention)
-                        .or(self.workflow_completion_retention)
-                        .unwrap_or(DEFAULT_WORKFLOW_COMPLETION_RETENTION),
-                )
-            } else {
-                None
-            },
+            idempotency_retention: idempotency_retention.unwrap_or(Duration::ZERO),
+            workflow_completion_retention,
             journal_retention,
             inactivity_timeout: if served_using_protocol_type == Some(ProtocolType::RequestResponse)
             {
@@ -580,6 +608,16 @@ impl Handler {
             ))
         }
 
+        let (idempotency_retention, got_idempotency_retention_clamped) =
+            configuration.clamp_idempotency_retention(self.idempotency_retention);
+        if got_idempotency_retention_clamped {
+            info.push(SchemaInfo::new_with_code(
+                &restate_errors::RT0022,
+                "The configured idempotency_retention is clamped to the maximum server limit."
+                    .to_string(),
+            ))
+        }
+
         service::HandlerMetadata {
             name: self.name.clone(),
             ty: self.target_ty.into(),
@@ -590,7 +628,7 @@ impl Handler {
             output_description: self.output_rules.to_string(),
             input_json_schema: self.input_rules.json_schema(),
             output_json_schema: self.output_rules.json_schema(),
-            idempotency_retention: self.idempotency_retention,
+            idempotency_retention,
             journal_retention,
             inactivity_timeout: if served_using_protocol_type == Some(ProtocolType::RequestResponse)
             {
@@ -708,15 +746,35 @@ impl InvocationTargetResolver for Schema {
 
         let completion_retention =
             if handler.target_ty == InvocationTargetType::Workflow(WorkflowHandlerType::Workflow) {
-                handler
-                    .workflow_completion_retention
-                    .or(service_revision.workflow_completion_retention)
-                    .unwrap_or(DEFAULT_WORKFLOW_COMPLETION_RETENTION)
+                configuration
+                    .clamp_workflow_completion_retention(
+                        handler
+                            .workflow_completion_retention
+                            .or(service_revision.workflow_completion_retention)
+                            .or_else(|| {
+                                configuration
+                                    .invocation
+                                    .default_workflow_completion_retention
+                                    .to_non_zero_std()
+                            }),
+                    )
+                    .0
+                    .unwrap_or(Duration::ZERO)
             } else {
-                handler
-                    .idempotency_retention
-                    .or(service_revision.idempotency_retention)
-                    .unwrap_or(DEFAULT_IDEMPOTENCY_RETENTION)
+                configuration
+                    .clamp_idempotency_retention(
+                        handler
+                            .idempotency_retention
+                            .or(service_revision.idempotency_retention)
+                            .or_else(|| {
+                                configuration
+                                    .invocation
+                                    .default_idempotency_retention
+                                    .to_non_zero_std()
+                            }),
+                    )
+                    .0
+                    .unwrap_or(Duration::ZERO)
             };
         let journal_retention = configuration
             .clamp_journal_retention(
@@ -1095,6 +1153,30 @@ impl Configuration {
         clamp_max(
             requested,
             self.invocation.max_journal_retention.map(Duration::from),
+        )
+    }
+
+    fn clamp_idempotency_retention(
+        &self,
+        requested: Option<Duration>,
+    ) -> (Option<Duration>, /* got clamped */ bool) {
+        clamp_max(
+            requested,
+            self.invocation
+                .max_idempotency_retention
+                .map(Duration::from),
+        )
+    }
+
+    fn clamp_workflow_completion_retention(
+        &self,
+        requested: Option<Duration>,
+    ) -> (Option<Duration>, /* got clamped */ bool) {
+        clamp_max(
+            requested,
+            self.invocation
+                .max_workflow_completion_retention
+                .map(Duration::from),
         )
     }
 

--- a/crates/types/src/schema/metadata/updater/mod.rs
+++ b/crates/types/src/schema/metadata/updater/mod.rs
@@ -24,8 +24,8 @@ use crate::invocation::{
 use crate::schema::Redaction;
 use crate::schema::deployment::DeploymentType;
 use crate::schema::invocation_target::{
-    BadInputContentType, DEFAULT_IDEMPOTENCY_RETENTION, DEFAULT_WORKFLOW_COMPLETION_RETENTION,
-    InputRules, InputValidationRule, OnMaxAttempts, OutputContentTypeRule, OutputRules,
+    BadInputContentType, InputRules, InputValidationRule, OnMaxAttempts, OutputContentTypeRule,
+    OutputRules,
 };
 use crate::schema::kafka::{KafkaClusterName, KafkaClusterResolver};
 use crate::schema::registry::{DeploymentConnectionParameters, DiscoveryResponse};
@@ -555,8 +555,7 @@ impl SchemaUpdater {
             if service_level_settings_behavior.preserve() {
                 previous_service_revision.and_then(|old_svc| old_svc.idempotency_retention)
             } else {
-                // TODO(slinydeveloper) Remove this in Restate 1.6, no need for this defaulting anymore!
-                Some(DEFAULT_IDEMPOTENCY_RETENTION)
+                None
             }
         });
         let journal_retention = resolve_optional_config_option!(
@@ -569,9 +568,6 @@ impl SchemaUpdater {
             && previous_service_revision.map(|old_svc| old_svc.ty == ServiceType::Workflow).unwrap_or(false)
         {
             previous_service_revision.and_then(|old_svc| old_svc.workflow_completion_retention)
-        } else if service_type == ServiceType::Workflow {
-            // TODO(slinydeveloper) Remove this in Restate 1.6, no need for this defaulting anymore!
-            Some(DEFAULT_WORKFLOW_COMPLETION_RETENTION)
         } else {
             None
         };

--- a/crates/types/src/schema/metadata/updater/tests.rs
+++ b/crates/types/src/schema/metadata/updater/tests.rs
@@ -2011,6 +2011,88 @@ mod endpoint_manifest_options_propagation {
     }
 
     #[test]
+    fn idempotency_retention_default_and_max() {
+        // Custom default kicks in when neither service nor handler sets it; max clamps an SDK-set value.
+        let mut config = Configuration::default();
+        config.invocation.default_idempotency_retention = FriendlyDuration::from_secs(120);
+        config.invocation.max_idempotency_retention = Some(FriendlyDuration::from_secs(60));
+        crate::config::set_current_config(config);
+
+        // No idempotency_retention in the manifest -> config default applies, then clamps to max (60s).
+        let target = init_discover_and_resolve_target(
+            greeter_service(),
+            GREETER_SERVICE_NAME,
+            GREET_HANDLER_NAME,
+        );
+        assert_that!(
+            target.compute_retention(true), // has_idempotency_key = true to exercise completion_retention
+            eq(InvocationRetention {
+                completion_retention: Duration::from_secs(60),
+                journal_retention: Duration::from_secs(60),
+            })
+        );
+
+        // SDK requests 5 minutes -> still clamped to max (60s).
+        let target = init_discover_and_resolve_target(
+            endpoint_manifest::Service {
+                idempotency_retention: Some(5 * 60 * 1000),
+                ..greeter_service()
+            },
+            GREETER_SERVICE_NAME,
+            GREET_HANDLER_NAME,
+        );
+        assert_that!(
+            target.compute_retention(true),
+            eq(InvocationRetention {
+                completion_retention: Duration::from_secs(60),
+                journal_retention: Duration::from_secs(60),
+            })
+        );
+    }
+
+    #[test]
+    fn workflow_completion_retention_default_and_max() {
+        let mut config = Configuration::default();
+        config.invocation.default_workflow_completion_retention = FriendlyDuration::from_secs(120);
+        config.invocation.max_workflow_completion_retention = Some(FriendlyDuration::from_secs(60));
+        crate::config::set_current_config(config);
+
+        // No workflow_completion_retention in the manifest -> config default applies, then clamps to max (60s).
+        let target = init_discover_and_resolve_target(
+            greeter_workflow(),
+            GREETER_SERVICE_NAME,
+            GREET_HANDLER_NAME,
+        );
+        assert_that!(
+            target.compute_retention(false),
+            eq(InvocationRetention {
+                completion_retention: Duration::from_secs(60),
+                journal_retention: Duration::from_secs(60),
+            })
+        );
+
+        // SDK requests 5 minutes -> still clamped to max (60s).
+        let target = init_discover_and_resolve_target(
+            endpoint_manifest::Service {
+                handlers: vec![endpoint_manifest::Handler {
+                    workflow_completion_retention: Some(5 * 60 * 1000),
+                    ..greeter_workflow_greet_handler()
+                }],
+                ..greeter_workflow()
+            },
+            GREETER_SERVICE_NAME,
+            GREET_HANDLER_NAME,
+        );
+        assert_that!(
+            target.compute_retention(false),
+            eq(InvocationRetention {
+                completion_retention: Duration::from_secs(60),
+                journal_retention: Duration::from_secs(60),
+            })
+        );
+    }
+
+    #[test]
     fn max_journal_retention_zero_wins_over_default_and_set_values() {
         // Create a service with default journal_retention
         let mut config = Configuration::default();

--- a/crates/types/src/schema/metadata/updater/tests.rs
+++ b/crates/types/src/schema/metadata/updater/tests.rs
@@ -15,7 +15,9 @@ use crate::Versioned;
 use crate::schema::deployment::DeploymentResolver;
 use crate::schema::deployment::ProtocolType;
 use crate::schema::info::SchemaInfo;
-use crate::schema::invocation_target::InvocationTargetResolver;
+use crate::schema::invocation_target::{
+    DEFAULT_IDEMPOTENCY_RETENTION, DEFAULT_WORKFLOW_COMPLETION_RETENTION, InvocationTargetResolver,
+};
 use crate::schema::service::ServiceMetadataResolver;
 use crate::service_protocol::{
     MAX_INFLIGHT_SERVICE_PROTOCOL_VERSION, MIN_INFLIGHT_SERVICE_PROTOCOL_VERSION,

--- a/release-notes/unreleased/configurable-default-and-max-idempotency-and-workflow-retention.md
+++ b/release-notes/unreleased/configurable-default-and-max-idempotency-and-workflow-retention.md
@@ -1,0 +1,49 @@
+# Release Notes: Configurable default and max for idempotency and workflow completion retention
+
+## New Feature
+
+### What Changed
+
+`InvocationOptions` now exposes four new server-wide retention knobs alongside the existing
+`default-journal-retention` / `max-journal-retention` pair:
+
+- `default-idempotency-retention`
+- `max-idempotency-retention`
+- `default-workflow-completion-retention`
+- `max-workflow-completion-retention`
+
+The `default-*` options provide the fallback retention used when neither the service nor the
+handler configures its own value via the SDK or the Admin API. The `max-*` options act as a
+ceiling: when discovering a service deployment, or when serving service/handler metadata, any
+configured retention higher than the configured max is clamped down to that max (and a
+`SchemaInfo` message is attached, same as journal retention today).
+
+Hardcoded 24-hour defaults that were previously baked into discovery (`DEFAULT_IDEMPOTENCY_RETENTION`,
+`DEFAULT_WORKFLOW_COMPLETION_RETENTION`) are now expressed through the new config options.
+
+### Why This Matters
+
+Operators can now centrally control idempotency and workflow completion retention from
+`restate.toml` — both the default applied to services that don't set a value, and a hard
+ceiling that protects against misconfigured services or accidental retention explosions.
+Previously, only journal retention had this treatment; idempotency and workflow retention
+were stuck at a fixed 24-hour default with no max.
+
+### Impact on Users
+
+- **Defaults unchanged**: the new `default-*` options default to `24h`, matching the prior
+  hardcoded behavior. Existing deployments will not see any retention difference on upgrade.
+- **Storage semantics unchanged**: just like journal retention, the values you (or your SDK)
+  configure are stored verbatim; clamping happens at read time. The `modify_service` Admin
+  API path is unaffected.
+- **New opt-in capability**: setting the `max-*` options will start clamping configured
+  retentions when they exceed your limit.
+
+### Configuration Example
+
+```toml
+default-idempotency-retention = "1h"
+max-idempotency-retention = "7d"
+default-workflow-completion-retention = "30d"
+max-workflow-completion-retention = "90d"
+```


### PR DESCRIPTION
## Summary
- Add four new `InvocationOptions` knobs — `default-idempotency-retention`, `max-idempotency-retention`, `default-workflow-completion-retention`, `max-workflow-completion-retention` — mirroring the existing `default-journal-retention` / `max-journal-retention` pair.
- Wire them through `restate-types`' schema module exactly like `journal_retention`: stored values stay raw, the configured default is applied at runtime when nothing is set on the service/handler, and the configured max clamps at read time (with a `SchemaInfo` warning attached). The `modify_service` Admin API path is untouched.
- Drop the hardcoded `Some(DEFAULT_IDEMPOTENCY_RETENTION)` / `Some(DEFAULT_WORKFLOW_COMPLETION_RETENTION)` discovery fallback so the new config defaults actually take effect (resolves the pre-existing TODO).

## Test plan
- [x] `CC=clang cargo check -p restate-types --all-features`
- [x] `CC=clang cargo check --workspace --all-features`
- [x] `CC=clang cargo nextest run -p restate-types --all-features` (357 passed)
- [x] `CC=clang cargo fmt --all -- --check`
- [x] `CC=clang cargo clippy -p restate-types --all-features --all-targets -- -D warnings`
- [ ] Manual: start a server with `invocation.max-idempotency-retention = "1h"`, discover a service requesting 24h, and confirm `ServiceMetadata` reports 1h plus the clamp `SchemaInfo` while the stored `ServiceRevision` keeps 24h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)