### PR TITLE
Make default and max idempotency/workflow retention configurable

### DIFF
--- a/crates/types/src/config/invocation.rs
+++ b/crates/types/src/config/invocation.rs
@@ -39,6 +39,50 @@ pub struct InvocationOptions {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub max_journal_retention: Option<FriendlyDuration>,
 
+    /// # Default idempotency retention
+    ///
+    /// Default idempotency retention for all invocations carrying an idempotency key.
+    ///
+    /// This default is used when neither the service nor the handler configures an idempotency retention,
+    /// and can be overridden per service/handler using the respective SDK APIs.
+    ///
+    /// Since v1.7.0
+    #[serde(skip_serializing_if = "FriendlyDuration::is_zero", default)]
+    pub default_idempotency_retention: FriendlyDuration,
+
+    /// # Maximum idempotency retention duration
+    ///
+    /// Maximum idempotency retention duration that can be configured.
+    /// When discovering a service deployment, or when modifying the idempotency retention using the Admin API, the given value will be clamped.
+    ///
+    /// Unset means no limit.
+    ///
+    /// Since v1.7.0
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub max_idempotency_retention: Option<FriendlyDuration>,
+
+    /// # Default workflow completion retention
+    ///
+    /// Default workflow completion retention for all workflow invocations.
+    ///
+    /// This default is used when neither the workflow service nor the handler configures a workflow completion retention,
+    /// and can be overridden per service/handler using the respective SDK APIs.
+    ///
+    /// Since v1.7.0
+    #[serde(skip_serializing_if = "FriendlyDuration::is_zero", default)]
+    pub default_workflow_completion_retention: FriendlyDuration,
+
+    /// # Maximum workflow completion retention duration
+    ///
+    /// Maximum workflow completion retention duration that can be configured.
+    /// When discovering a service deployment, or when modifying the workflow completion retention using the Admin API, the given value will be clamped.
+    ///
+    /// Unset means no limit.
+    ///
+    /// Since v1.7.0
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub max_workflow_completion_retention: Option<FriendlyDuration>,
+
     /// # Default retry policy
     ///
     /// The default retry policy to use for invocations.
@@ -63,6 +107,10 @@ impl Default for InvocationOptions {
         Self {
             default_journal_retention: FriendlyDuration::from_secs(60 * 60 * 24),
             max_journal_retention: None,
+            default_idempotency_retention: FriendlyDuration::from_secs(60 * 60 * 24),
+            max_idempotency_retention: None,
+            default_workflow_completion_retention: FriendlyDuration::from_secs(60 * 60 * 24),
+            max_workflow_completion_retention: None,
             default_retry_policy: InvocationRetryPolicyOptions::default(),
             max_retry_policy_max_attempts: None,
         }

--- a/crates/types/src/schema/metadata/mod.rs
+++ b/crates/types/src/schema/metadata/mod.rs
@@ -41,9 +41,8 @@ use crate::retries::{RetryIter, RetryPolicy};
 use crate::schema::deployment::{DeploymentResolver, DeploymentType, ProtocolType};
 use crate::schema::info::Info;
 use crate::schema::invocation_target::{
-    DEFAULT_IDEMPOTENCY_RETENTION, DEFAULT_WORKFLOW_COMPLETION_RETENTION, DeploymentStatus,
-    InputRules, InvocationAttemptOptions, InvocationTargetMetadata, InvocationTargetResolver,
-    OnMaxAttempts, OutputRules,
+    DeploymentStatus, InputRules, InvocationAttemptOptions, InvocationTargetMetadata,
+    InvocationTargetResolver, OnMaxAttempts, OutputRules,
 };
 use crate::schema::metadata::openapi::ServiceOpenAPI;
 use crate::schema::service::{
@@ -388,6 +387,48 @@ impl ServiceRevision {
             ))
         }
 
+        let (idempotency_retention, got_idempotency_retention_clamped) = configuration
+            .clamp_idempotency_retention(self.idempotency_retention.or_else(|| {
+                configuration
+                    .invocation
+                    .default_idempotency_retention
+                    .to_non_zero_std()
+            }));
+        if got_idempotency_retention_clamped {
+            info.push(SchemaInfo::new_with_code(
+                &restate_errors::RT0022,
+                "The configured idempotency_retention is clamped to the maximum server limit."
+                    .to_string(),
+            ))
+        }
+
+        let workflow_completion_retention = if self.ty == ServiceType::Workflow {
+            let requested = self
+                .handlers
+                .iter()
+                .find(|(_, h)| h.workflow_completion_retention.is_some())
+                .and_then(|(_, h)| h.workflow_completion_retention)
+                .or(self.workflow_completion_retention)
+                .or_else(|| {
+                    configuration
+                        .invocation
+                        .default_workflow_completion_retention
+                        .to_non_zero_std()
+                });
+            let (clamped, got_clamped) =
+                configuration.clamp_workflow_completion_retention(requested);
+            if got_clamped {
+                info.push(SchemaInfo::new_with_code(
+                    &restate_errors::RT0022,
+                    "The configured workflow_completion_retention is clamped to the maximum server limit."
+                        .to_string(),
+                ))
+            }
+            Some(clamped.unwrap_or(Duration::ZERO))
+        } else {
+            None
+        };
+
         service::ServiceMetadata {
             name: self.name.clone(),
             handlers: self
@@ -410,21 +451,8 @@ impl ServiceRevision {
             deployment_id,
             revision: self.revision,
             public: self.public,
-            idempotency_retention: self
-                .idempotency_retention
-                .unwrap_or(DEFAULT_IDEMPOTENCY_RETENTION),
-            workflow_completion_retention: if self.ty == ServiceType::Workflow {
-                Some(
-                    self.handlers
-                        .iter()
-                        .find(|(_, h)| h.workflow_completion_retention.is_some())
-                        .and_then(|(_, h)| h.workflow_completion_retention)
-                        .or(self.workflow_completion_retention)
-                        .unwrap_or(DEFAULT_WORKFLOW_COMPLETION_RETENTION),
-                )
-            } else {
-                None
-            },
+            idempotency_retention: idempotency_retention.unwrap_or(Duration::ZERO),
+            workflow_completion_retention,
             journal_retention,
             inactivity_timeout: if served_using_protocol_type == Some(ProtocolType::RequestResponse)
             {
@@ -555,6 +583,16 @@ impl Handler {
             ))
         }
 
+        let (idempotency_retention, got_idempotency_retention_clamped) =
+            configuration.clamp_idempotency_retention(self.idempotency_retention);
+        if got_idempotency_retention_clamped {
+            info.push(SchemaInfo::new_with_code(
+                &restate_errors::RT0022,
+                "The configured idempotency_retention is clamped to the maximum server limit."
+                    .to_string(),
+            ))
+        }
+
         service::HandlerMetadata {
             name: self.name.clone(),
             ty: self.target_ty.into(),
@@ -565,7 +603,7 @@ impl Handler {
             output_description: self.output_rules.to_string(),
             input_json_schema: self.input_rules.json_schema(),
             output_json_schema: self.output_rules.json_schema(),
-            idempotency_retention: self.idempotency_retention,
+            idempotency_retention,
             journal_retention,
             inactivity_timeout: if served_using_protocol_type == Some(ProtocolType::RequestResponse)
             {
@@ -683,15 +721,35 @@ impl InvocationTargetResolver for Schema {
 
         let completion_retention =
             if handler.target_ty == InvocationTargetType::Workflow(WorkflowHandlerType::Workflow) {
-                handler
-                    .workflow_completion_retention
-                    .or(service_revision.workflow_completion_retention)
-                    .unwrap_or(DEFAULT_WORKFLOW_COMPLETION_RETENTION)
+                configuration
+                    .clamp_workflow_completion_retention(
+                        handler
+                            .workflow_completion_retention
+                            .or(service_revision.workflow_completion_retention)
+                            .or_else(|| {
+                                configuration
+                                    .invocation
+                                    .default_workflow_completion_retention
+                                    .to_non_zero_std()
+                            }),
+                    )
+                    .0
+                    .unwrap_or(Duration::ZERO)
             } else {
-                handler
-                    .idempotency_retention
-                    .or(service_revision.idempotency_retention)
-                    .unwrap_or(DEFAULT_IDEMPOTENCY_RETENTION)
+                configuration
+                    .clamp_idempotency_retention(
+                        handler
+                            .idempotency_retention
+                            .or(service_revision.idempotency_retention)
+                            .or_else(|| {
+                                configuration
+                                    .invocation
+                                    .default_idempotency_retention
+                                    .to_non_zero_std()
+                            }),
+                    )
+                    .0
+                    .unwrap_or(Duration::ZERO)
             };
         let journal_retention = configuration
             .clamp_journal_retention(
@@ -888,6 +946,30 @@ impl Configuration {
         clamp_max(
             requested,
             self.invocation.max_journal_retention.map(Duration::from),
+        )
+    }
+
+    fn clamp_idempotency_retention(
+        &self,
+        requested: Option<Duration>,
+    ) -> (Option<Duration>, /* got clamped */ bool) {
+        clamp_max(
+            requested,
+            self.invocation
+                .max_idempotency_retention
+                .map(Duration::from),
+        )
+    }
+
+    fn clamp_workflow_completion_retention(
+        &self,
+        requested: Option<Duration>,
+    ) -> (Option<Duration>, /* got clamped */ bool) {
+        clamp_max(
+            requested,
+            self.invocation
+                .max_workflow_completion_retention
+                .map(Duration::from),
         )
     }
 

--- a/crates/types/src/schema/metadata/updater/mod.rs
+++ b/crates/types/src/schema/metadata/updater/mod.rs
@@ -20,8 +20,8 @@ use crate::invocation::{
 };
 use crate::schema::deployment::DeploymentType;
 use crate::schema::invocation_target::{
-    BadInputContentType, DEFAULT_IDEMPOTENCY_RETENTION, DEFAULT_WORKFLOW_COMPLETION_RETENTION,
-    InputRules, InputValidationRule, OnMaxAttempts, OutputContentTypeRule, OutputRules,
+    BadInputContentType, InputRules, InputValidationRule, OnMaxAttempts, OutputContentTypeRule,
+    OutputRules,
 };
 use crate::schema::registry::{DeploymentConnectionParameters, DiscoveryResponse};
 use crate::schema::subscriptions::{EventInvocationTargetTemplate, Sink, Source, Subscription};
@@ -554,8 +554,7 @@ impl SchemaUpdater {
             if service_level_settings_behavior.preserve() {
                 previous_service_revision.and_then(|old_svc| old_svc.idempotency_retention)
             } else {
-                // TODO(slinydeveloper) Remove this in Restate 1.6, no need for this defaulting anymore!
-                Some(DEFAULT_IDEMPOTENCY_RETENTION)
+                None
             },
         );
         let journal_retention = resolve_optional_config_option!(
@@ -568,9 +567,6 @@ impl SchemaUpdater {
             && previous_service_revision.map(|old_svc| old_svc.ty == ServiceType::Workflow).unwrap_or(false)
         {
             previous_service_revision.and_then(|old_svc| old_svc.workflow_completion_retention)
-        } else if service_type == ServiceType::Workflow {
-            // TODO(slinydeveloper) Remove this in Restate 1.6, no need for this defaulting anymore!
-            Some(DEFAULT_WORKFLOW_COMPLETION_RETENTION)
         } else {
             None
         };

--- a/crates/types/src/schema/metadata/updater/tests.rs
+++ b/crates/types/src/schema/metadata/updater/tests.rs
@@ -15,7 +15,9 @@ use crate::Versioned;
 use crate::schema::deployment::DeploymentResolver;
 use crate::schema::deployment::ProtocolType;
 use crate::schema::info::Info;
-use crate::schema::invocation_target::InvocationTargetResolver;
+use crate::schema::invocation_target::{
+    DEFAULT_IDEMPOTENCY_RETENTION, DEFAULT_WORKFLOW_COMPLETION_RETENTION, InvocationTargetResolver,
+};
 use crate::schema::service::ServiceMetadataResolver;
 use crate::service_protocol::{
     MAX_INFLIGHT_SERVICE_PROTOCOL_VERSION, MIN_INFLIGHT_SERVICE_PROTOCOL_VERSION,

--- a/release-notes/unreleased/configurable-default-and-max-idempotency-and-workflow-retention.md
+++ b/release-notes/unreleased/configurable-default-and-max-idempotency-and-workflow-retention.md
@@ -1,0 +1,49 @@
+# Release Notes: Configurable default and max for idempotency and workflow completion retention
+
+## New Feature
+
+### What Changed
+
+`InvocationOptions` now exposes four new server-wide retention knobs alongside the existing
+`default-journal-retention` / `max-journal-retention` pair:
+
+- `default-idempotency-retention`
+- `max-idempotency-retention`
+- `default-workflow-completion-retention`
+- `max-workflow-completion-retention`
+
+The `default-*` options provide the fallback retention used when neither the service nor the
+handler configures its own value via the SDK or the Admin API. The `max-*` options act as a
+ceiling: when discovering a service deployment, or when serving service/handler metadata, any
+configured retention higher than the configured max is clamped down to that max (and a
+`SchemaInfo` message is attached, same as journal retention today).
+
+Hardcoded 24-hour defaults that were previously baked into discovery (`DEFAULT_IDEMPOTENCY_RETENTION`,
+`DEFAULT_WORKFLOW_COMPLETION_RETENTION`) are now expressed through the new config options.
+
+### Why This Matters
+
+Operators can now centrally control idempotency and workflow completion retention from
+`restate.toml` — both the default applied to services that don't set a value, and a hard
+ceiling that protects against misconfigured services or accidental retention explosions.
+Previously, only journal retention had this treatment; idempotency and workflow retention
+were stuck at a fixed 24-hour default with no max.
+
+### Impact on Users
+
+- **Defaults unchanged**: the new `default-*` options default to `24h`, matching the prior
+  hardcoded behavior. Existing deployments will not see any retention difference on upgrade.
+- **Storage semantics unchanged**: just like journal retention, the values you (or your SDK)
+  configure are stored verbatim; clamping happens at read time. The `modify_service` Admin
+  API path is unaffected.
+- **New opt-in capability**: setting the `max-*` options will start clamping configured
+  retentions when they exceed your limit.
+
+### Configuration Example
+
+```toml
+default-idempotency-retention = "1h"
+max-idempotency-retention = "7d"
+default-workflow-completion-retention = "30d"
+max-workflow-completion-retention = "90d"
+```


### PR DESCRIPTION
Add four new InvocationOptions — default_idempotency_retention, max_idempotency_retention, default_workflow_completion_retention, max_workflow_completion_retention — wired through restate-types' schema module exactly like the existing journal_retention options: stored values stay raw, defaults are filled in at runtime, and configured maxima clamp at read time. Drops the hardcoded discovery-time DEFAULT_* fallbacks so the new config defaults actually take effect.