### PR TITLE
connection-pool: Configurable window sizes

### DIFF
--- a/crates/service-client/benches/h2_pool_benchmark.rs
+++ b/crates/service-client/benches/h2_pool_benchmark.rs
@@ -411,7 +411,11 @@ fn bench_concurrent_requests(c: &mut Criterion) {
 fn bench_body_throughput(c: &mut Criterion) {
     let rt = Builder::new_multi_thread().enable_all().build().unwrap();
 
-    for (label, size) in [("1KB", 1024), ("64KB", 64 * 1024)] {
+    for (label, size) in [
+        ("1KB", 1024),
+        ("64KB", 64 * 1024),
+        ("10MB", 10 * 1024 * 1024),
+    ] {
         let payload = Bytes::from(vec![0xABu8; size]);
         let mut group = c.benchmark_group(format!("body-{label}"));
         group

--- a/crates/service-client/src/http.rs
+++ b/crates/service-client/src/http.rs
@@ -133,6 +133,9 @@ impl HttpClient {
             let builder = pool::PoolBuilder::default()
                 .keep_alive_interval(keep_alive_interval)
                 .streams_per_connection_limit(options.streams_per_connection_limit)
+                .initial_stream_window_size(options.initial_stream_window_size())
+                .initial_connection_window_size(options.initial_connection_window_size())
+                .max_frame_size(options.max_frame_size())
                 .keep_alive_timeout(options.http_keep_alive_options.timeout.into())
                 .idle_connection_timeout(if options.idle_connection_timeout.is_zero() {
                     None

--- a/crates/service-client/src/pool/authority.rs
+++ b/crates/service-client/src/pool/authority.rs
@@ -106,7 +106,7 @@ impl<C> AuthorityPool<C> {
 impl<C> AuthorityPool<C>
 where
     C: Service<Uri> + Clone,
-    C::Response: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static,
+    C::Response: AsyncRead + AsyncWrite + std::fmt::Debug + Unpin + Send + Sync + 'static,
     C::Future: Send + 'static,
     C::Error: Into<Error>,
 {
@@ -114,6 +114,9 @@ where
         let connection_config = ConnectionConfigBuilder::default()
             .initial_max_send_streams(config.initial_max_send_streams.get())
             .streams_per_connection_limit(config.streams_per_connection_limit.get())
+            .initial_stream_window_size(config.initial_stream_window_size)
+            .initial_connection_window_size(config.initial_connection_window_size)
+            .max_frame_size(config.max_frame_size)
             .keep_alive_interval(config.keep_alive_interval)
             .keep_alive_timeout(config.keep_alive_timeout)
             .build()
@@ -270,6 +273,8 @@ where
 
                     let mut total_available_streams = 0usize;
                     let mut total_max_concurrent_streams = 0usize;
+                    // only for logging number of valid connections
+                    let mut total_connections = 0usize;
 
                     for candidate in &inner.connections {
                         if candidate.is_closed() {
@@ -286,6 +291,7 @@ where
                             );
                         }
 
+                        total_connections += 1;
                         total_available_streams =
                             total_available_streams.saturating_add(available_streams);
                         total_max_concurrent_streams =
@@ -320,7 +326,7 @@ where
                     if scaleup {
                         debug!(
                             "Try scaling up pool (connections: {}, available streams: {}, total streams:{})",
-                            inner.connections.len(),
+                            total_connections,
                             total_available_streams,
                             total_max_concurrent_streams
                         );

--- a/crates/service-client/src/pool/config.rs
+++ b/crates/service-client/src/pool/config.rs
@@ -53,6 +53,21 @@ pub struct PoolConfig {
     #[builder(default = NonZeroUsize::new(128).unwrap())]
     pub(crate) streams_per_connection_limit: NonZeroUsize,
 
+    /// Initial flow-control window (in bytes) for received data on each H2
+    /// stream. Default: 2 MiB.
+    #[builder(default = 2 * 1024 * 1024)]
+    pub(crate) initial_stream_window_size: u32,
+
+    /// Initial connection-level flow-control window (in bytes) for received
+    /// data. Default: 5 MiB.
+    #[builder(default = 5 * 1024 * 1024)]
+    pub(crate) initial_connection_window_size: u32,
+
+    /// Largest H2 DATA frame payload (in bytes) this client will accept.
+    /// Default: 16 KiB.
+    #[builder(default = 16 * 1024)]
+    pub(crate) max_frame_size: u32,
+
     /// Maximum time to wait for an HTTP/2 PING response before declaring the
     /// connection dead and returning [`ConnectionError::KeepAliveTimeout`].
     /// Only meaningful when `keep_alive_interval` is `Some`. Defaults to 20 s.
@@ -71,6 +86,9 @@ impl Default for PoolConfig {
             connection_saturation_threshold: Some(0.7f64),
             initial_max_send_streams: NonZeroU32::new(50).unwrap(),
             streams_per_connection_limit: NonZeroUsize::new(128).unwrap(),
+            initial_stream_window_size: 2 * 1024 * 1024,
+            initial_connection_window_size: 5 * 1024 * 1024,
+            max_frame_size: 16 * 1024,
             keep_alive_interval: None,
             keep_alive_timeout: Duration::from_secs(20),
             idle_connection_timeout: Some(Duration::from_secs(300)),

--- a/crates/service-client/src/pool/conn.rs
+++ b/crates/service-client/src/pool/conn.rs
@@ -29,7 +29,7 @@ use parking_lot::Mutex;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::sync::{CancellationToken, DropGuard};
 use tower::Service;
-use tracing::debug;
+use tracing::{debug, trace};
 
 use restate_types::errors::GenericError;
 use restate_types::time::MillisSinceEpoch;
@@ -139,6 +139,9 @@ pub struct ConnectionConfig {
     initial_max_send_streams: u32,
     // upper bound applied to the peer's advertised max-concurrent-streams
     streams_per_connection_limit: usize,
+    initial_stream_window_size: u32,
+    initial_connection_window_size: u32,
+    max_frame_size: u32,
     keep_alive_timeout: Duration,
     keep_alive_interval: Option<Duration>,
 }
@@ -148,6 +151,9 @@ impl Default for ConnectionConfig {
         Self {
             initial_max_send_streams: 50,
             streams_per_connection_limit: 128,
+            initial_stream_window_size: 2 * 1024 * 1024,
+            initial_connection_window_size: 5 * 1024 * 1024,
+            max_frame_size: 16 * 1024,
             keep_alive_timeout: Duration::from_secs(20),
             keep_alive_interval: None,
         }
@@ -226,7 +232,7 @@ impl<C> Connection<C> {
 impl<C> Connection<C>
 where
     C: Service<Uri>,
-    C::Response: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static,
+    C::Response: AsyncRead + AsyncWrite + std::fmt::Debug + Unpin + Send + Sync + 'static,
     C::Future: Send + 'static,
     C::Error: Into<Error>,
 {
@@ -416,8 +422,20 @@ where
                 counter!(CONNECTION_POOL_CONNECTION_OPEN_FAILED).increment(1);
             })?;
 
+            let stream_dbg = format!("{stream:?}");
+            trace!(
+                initial_max_send_streams = shared.config.initial_max_send_streams,
+                initial_connection_window_size = shared.config.initial_connection_window_size,
+                initial_stream_window_size = shared.config.initial_stream_window_size,
+                max_frame_size = shared.config.max_frame_size,
+                "Building h2 connection"
+            );
+
             let (send_request, mut connection) = h2::client::Builder::new()
                 .initial_max_send_streams(shared.config.initial_max_send_streams as usize)
+                .initial_connection_window_size(shared.config.initial_connection_window_size)
+                .initial_window_size(shared.config.initial_stream_window_size)
+                .max_frame_size(shared.config.max_frame_size)
                 .handshake::<_, Bytes>(stream)
                 .await
                 .inspect_err(|_| {
@@ -445,11 +463,11 @@ where
                                 debug!("h2 connection shutdown");
                             },
                             Err(err) => {
-                                debug!("h2 connection shutdown with error: {err}");
+                                debug!("h2 connection ({stream_dbg}) shutdown with error: {err}");
                             }
                         },
                         Err(err) = &mut keep_alive => {
-                            debug!("h2 connection keep-alive error: {err}");
+                            debug!("h2 connection ({stream_dbg}) keep-alive error: {err}");
                         }
                         _ = cancel.cancelled() => {
                             debug!("h2 connection cancelled");
@@ -806,12 +824,15 @@ where
         if frame.is_data() {
             let mut data = frame.into_data().unwrap();
 
+            trace!("Requesting capacity to send {} bytes", data.len());
+            self.send_stream.reserve_capacity(data.len());
+
             while !data.is_empty() {
-                self.send_stream.reserve_capacity(data.len());
                 let size = poll_fn(|cx| self.send_stream.poll_capacity(cx))
                     .await
                     .ok_or(Reason::INTERNAL_ERROR)??;
 
+                trace!("Ready capacity to send {}", size);
                 let chunk = data.split_to(size.min(data.len()));
                 self.send_stream
                     .send_data(chunk, end_of_stream && data.is_empty())?;

--- a/crates/service-client/src/pool/mod.rs
+++ b/crates/service-client/src/pool/mod.rs
@@ -94,7 +94,7 @@ impl<C: Clone + Send + Sync + 'static> Pool<C> {
 impl<C> Pool<C>
 where
     C: Service<Uri> + Send + Sync + Clone + 'static,
-    C::Response: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static,
+    C::Response: AsyncRead + AsyncWrite + std::fmt::Debug + Unpin + Send + Sync + 'static,
     C::Future: Send + 'static,
     C::Error: Into<Error>,
 {

--- a/crates/service-client/src/pool/tls.rs
+++ b/crates/service-client/src/pool/tls.rs
@@ -255,6 +255,7 @@ where
 /// Provides a unified interface for both encrypted (HTTPS) and plain (HTTP)
 /// connections. Implements [`AsyncRead`] and [`AsyncWrite`] by delegating
 /// to the inner stream.
+#[derive(Debug)]
 pub enum MaybeTlsStream<S> {
     /// A TLS-encrypted stream (HTTPS).
     Tls(Box<TlsStream<S>>),

--- a/crates/types/src/config/http.rs
+++ b/crates/types/src/config/http.rs
@@ -13,6 +13,7 @@ use std::num::{NonZeroU32, NonZeroUsize};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
+use restate_memory::NonZeroByteCount;
 use restate_util_time::{FriendlyDuration, NonZeroFriendlyDuration};
 
 /// # HTTP client options
@@ -86,6 +87,36 @@ pub struct HttpOptions {
     ///
     /// Default: 5 minutes
     pub idle_connection_timeout: FriendlyDuration,
+
+    /// # HTTP/2 initial stream window size
+    ///
+    /// Initial flow-control window (in bytes) for received data on each HTTP/2
+    /// stream in the connection pool. Valid range: 65535 B .. 2 GiB.
+    ///
+    /// Since: v1.7.0
+    ///
+    /// Default: 2 MiB
+    http2_initial_stream_window_size: NonZeroByteCount,
+
+    /// # HTTP/2 initial connection window size
+    ///
+    /// Initial connection-level flow-control window (in bytes) for received
+    /// data. Should be >= the per-stream window. Valid range: 65535 B .. 2 GiB.
+    ///
+    /// Since: v1.7.0
+    ///
+    /// Default: 5 MiB
+    http2_initial_connection_window_size: NonZeroByteCount,
+
+    /// # HTTP/2 max frame size
+    ///
+    /// Largest HTTP/2 DATA frame payload (in bytes) this client will accept.
+    /// Must be within 16 KiB .. 16 MiB (h2 protocol limits).
+    ///
+    /// Since: v1.7.0
+    ///
+    /// Default: 16 KiB
+    http2_max_frame_size: NonZeroByteCount,
 }
 
 impl Default for HttpOptions {
@@ -98,10 +129,36 @@ impl Default for HttpOptions {
             initial_max_send_streams: None,
             streams_per_connection_limit: NonZeroUsize::new(128).unwrap(),
             idle_connection_timeout: FriendlyDuration::from_secs(300),
+            http2_initial_stream_window_size: NonZeroByteCount::new(
+                NonZeroUsize::new(2 * 1024 * 1024).unwrap(),
+            ),
+            http2_initial_connection_window_size: NonZeroByteCount::new(
+                NonZeroUsize::new(5 * 1024 * 1024).unwrap(),
+            ),
+            http2_max_frame_size: NonZeroByteCount::new(NonZeroUsize::new(16 * 1024).unwrap()),
         }
     }
 }
 
+impl HttpOptions {
+    pub fn initial_stream_window_size(&self) -> u32 {
+        u32::try_from(self.http2_initial_stream_window_size.as_usize())
+            .unwrap_or(u32::MAX)
+            .clamp(65_535, 2_147_483_647)
+    }
+
+    pub fn initial_connection_window_size(&self) -> u32 {
+        u32::try_from(self.http2_initial_connection_window_size.as_usize())
+            .unwrap_or(u32::MAX)
+            .clamp(65_535, 2_147_483_647)
+    }
+
+    pub fn max_frame_size(&self) -> u32 {
+        u32::try_from(self.http2_max_frame_size.as_usize())
+            .unwrap_or(u32::MAX)
+            .clamp(16_384, 16_777_215)
+    }
+}
 /// NO_PROXY can be provided as either a comma-separated string `example.com,::1,localhost`, or a list of strings `["example.com", "::1", "localhost"]`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]


### PR DESCRIPTION
connection-pool: Configurable window sizes

Summary:
- Configurable connection and stream window sizes, use sane defaults from hyper
- Configurable frame size

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4819).
* #4820
* __->__ #4819