### PR TITLE
connection-pool: Only start pinging after keep-alive interval

### DIFF
--- a/crates/service-client/src/pool/conn.rs
+++ b/crates/service-client/src/pool/conn.rs
@@ -507,7 +507,8 @@ where
             Some(interval) => interval,
         };
 
-        let mut interval = tokio::time::interval(interval);
+        let mut interval =
+            tokio::time::interval_at(tokio::time::Instant::now() + interval, interval);
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
         loop {


### PR DESCRIPTION
connection-pool: Only start pinging after keep-alive interval

Summary:
This avoid sending pings immediately after handshake
and only start after <interval> seconds. This gives
time for the server SETTINGS frame to arrive specially
when deployment is under heavy load
