### PR TITLE
Fix build: update remaining SchemaInfo references to Info

### DIFF
--- a/crates/types/src/schema/metadata/mod.rs
+++ b/crates/types/src/schema/metadata/mod.rs
@@ -395,7 +395,7 @@ impl ServiceRevision {
                     .to_non_zero_std()
             }));
         if got_idempotency_retention_clamped {
-            info.push(SchemaInfo::new_with_code(
+            info.push(Info::new_with_code(
                 &restate_errors::RT0022,
                 "The configured idempotency_retention is clamped to the maximum server limit."
                     .to_string(),
@@ -418,7 +418,7 @@ impl ServiceRevision {
             let (clamped, got_clamped) =
                 configuration.clamp_workflow_completion_retention(requested);
             if got_clamped {
-                info.push(SchemaInfo::new_with_code(
+                info.push(Info::new_with_code(
                     &restate_errors::RT0022,
                     "The configured workflow_completion_retention is clamped to the maximum server limit."
                         .to_string(),
@@ -586,7 +586,7 @@ impl Handler {
         let (idempotency_retention, got_idempotency_retention_clamped) =
             configuration.clamp_idempotency_retention(self.idempotency_retention);
         if got_idempotency_retention_clamped {
-            info.push(SchemaInfo::new_with_code(
+            info.push(Info::new_with_code(
                 &restate_errors::RT0022,
                 "The configured idempotency_retention is clamped to the maximum server limit."
                     .to_string(),


### PR DESCRIPTION
The `SchemaInfo` type in `crates/types/src/schema/info.rs` was renamed to `Info` on `cloudrun`, and the import in `schema/metadata/mod.rs` was updated to `use crate::schema::info::Info;`. However three call sites in that file still referenced the old `SchemaInfo` name, causing `error[E0433]: failed to resolve: use of undeclared type SchemaInfo` and breaking the release build (e.g. the docker image build job).

This updates those three remaining call sites (the retention-clamping warnings) to use `Info::new_with_code(...)`, matching the other call sites in the same file.

Verified with `cargo check -p restate-types` (clean) and `cargo fmt -p restate-types -- --check` (no diffs).