### PR TITLE
Add fail-fast timeout and diagnostics to cargo hakari disable

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -98,9 +98,32 @@ jobs:
         with:
           tool: cargo-hakari
 
+      # This step has hung intermittently in CI for 28-70 min with no cargo output,
+      # so the stalled phase is unknown. The timeout caps how long a future stall
+      # can hold the runner; the verbose env and pre-kill snapshot exist so the
+      # next hang leaves enough trace to target a real fix.
       - name: Disable hakari
         if: ${{ hashFiles('.config/hakari.toml') != '' }}
-        run: cargo hakari disable
+        timeout-minutes: 5
+        env:
+          CARGO_TERM_VERBOSE: "true"
+          CARGO_HTTP_DEBUG: "true"
+          CARGO_LOG: "cargo::core::package=info,cargo::ops::registry=info,cargo::sources::registry=info,cargo::sources::git=info,cargo::util::network=info"
+        run: |
+          (
+            sleep 270
+            echo "::group::diagnostic snapshot at 4m30s (cargo still running)"
+            echo "--- process tree (pid/ppid/elapsed/state/wait-channel/cmd) ---"
+            ps -eo pid,ppid,etime,stat,wchan:25,args 2>/dev/null \
+              | awk 'NR==1 || /cargo|hakari|[g]it/'
+            echo "--- open TCP sockets for cargo/git ---"
+            (ss -tnp 2>/dev/null || netstat -tnp 2>/dev/null) \
+              | awk 'NR<=2 || /cargo|hakari|[g]it/'
+            echo "::endgroup::"
+          ) &
+          watchdog=$!
+          trap 'kill "$watchdog" 2>/dev/null; wait "$watchdog" 2>/dev/null || true' EXIT
+          cargo hakari disable
 
       # this is needed to be able to load and push a multiplatform image in one step
       - name: Set up Docker containerd snapshotter


### PR DESCRIPTION
This PR just adds a hard timeout and hopefully some diagnostic info for when cargo hakari disable step fails. Feel free to close it if not interesting.

## What this is (and isn't)

This PR is **not** a fix. `cargo hakari disable` in the docker image build has hung intermittently for 28-70 minutes (e.g. run 26514779485 attempt 1 sat on it for 28m45s before being cancelled). After pulling the cancelled step's log, the picture got more interesting:

```
13:40:45.575  ##[endgroup]   (after "Run cargo hakari disable" group header)
                              ... 28 minutes 45 seconds of complete silence ...
14:09:30.388  ##[error]The operation was canceled.
14:09:30.562  Terminate orphan process: pid (1994) (cargo-hakari)
14:09:30.572  Terminate orphan process: pid (2003) (cargo)
```

cargo printed *nothing* for the entire 28 min. cargo's first default headers are "Updating crates.io index" and "Updating git repository `<url>`"; we see neither. So the hang is **before** the index download and before any git fetch starts. Possible silent-phase culprits: package-cache flock, libcurl/TLS init, DNS, TCP connection setup, or some pre-fetch resolver init. We do not yet have evidence to discriminate. Any "fix" right now would be guessing.

The original version of this PR added a bounded retry loop on the theory that the stall was in a git fetch. The evidence above doesn't support that theory, so the bound and retry have been dropped. The bound was speculation dressed up as a fix.

## What this PR actually does

Two narrow changes, both about making the next hang useful rather than pretending to fix it:

1. **`timeout-minutes: 5`** so the next stall fails the step in 5 min instead of taking down the 70-min job slot until a human notices. Healthy cold-cache runs finish in ~2 min and the worst non-stall observed in the sample was ~3 min, so 5 min keeps a comfortable margin.

2. **Verbose cargo env + a pre-kill watchdog snapshot** so the next stall actually leaves a paper trail:
   - `CARGO_TERM_VERBOSE`, `CARGO_HTTP_DEBUG`, and a targeted `CARGO_LOG` cover Rust-level resolver/source ops and the underlying HTTP/TLS transport. Adds ~1k log lines on a healthy 2-min run; acceptable trade.
   - At 4m30s a background watchdog dumps the live process tree (with wait-channel) and open TCP sockets, so even a stall that occurs before cargo logs anything still tells us which syscall it was wedged in and which connections it was holding.

Once a future hang reveals the actual stall point, the targeted fix follows.

## Notes

- The same unbounded `cargo hakari disable` exists in `.github/workflows/steps/release-build-setup.yml` (also cold-cache, release-critical). Left for a follow-up once we know the cause.
- No release note: internal CI infrastructure only, no user-facing behaviour change.