### PR TITLE
[VQueues] Set pinned deployment to entry status

### DIFF
--- a/crates/storage-api/src/vqueue_table/entry.rs
+++ b/crates/storage-api/src/vqueue_table/entry.rs
@@ -13,6 +13,7 @@ use std::num::NonZeroU16;
 use restate_clock::RoughTimestamp;
 use restate_memory::NonZeroByteCount;
 use restate_types::vqueues::{EntryId, EntryKind, Seq};
+use restate_util_string::ReString;
 
 use super::Status;
 use super::stats::EntryStatistics;
@@ -187,8 +188,6 @@ impl EntryValue {
 
 #[derive(Debug, Clone, Eq, Default, PartialEq, bilrost::Message)]
 pub struct EntryMetadataRef<'a> {
-    // todo: maybe add "deployment_id?" or other metadata needed to identify the deployment
-    // or maybe service revision.
     #[bilrost(tag(1))]
     deployment: Option<&'a str>,
     // If set, this is the amount of memory the invocation seems to require to
@@ -213,12 +212,10 @@ impl<'a> From<&'a EntryMetadata> for EntryMetadataRef<'a> {
     }
 }
 
-#[derive(Debug, Clone, Eq, Default, PartialEq, bilrost::Message)]
+#[derive(Debug, Clone, Default, bilrost::Message)]
 pub struct EntryMetadata {
-    // todo: This is temporary placeholder, type and name _will_ change.
     #[bilrost(tag(1))]
-    pub deployment: Option<String>,
-
+    pub deployment: Option<ReString>,
     // If set, this is the amount of memory the invocation seems to require to
     // run on the invoker side.
     #[bilrost(tag(2), encoding(fixed))]

--- a/crates/storage-query-datafusion/src/vqueues/tests.rs
+++ b/crates/storage-query-datafusion/src/vqueues/tests.rs
@@ -25,6 +25,7 @@ use restate_storage_api::vqueue_table::{
 use restate_types::clock::UniqueTimestamp;
 use restate_types::time::MillisSinceEpoch;
 use restate_types::vqueues::VQueueId;
+use restate_util_string::ToReString;
 
 #[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_vqueue_entry_value_fields() {
@@ -59,7 +60,7 @@ async fn get_vqueue_entry_value_fields() {
     let value = EntryValue {
         status: Status::BackingOff,
         metadata: EntryMetadata {
-            deployment: Some("dp_123".to_string()),
+            deployment: Some("dp_123".to_restring()),
             ..Default::default()
         },
         stats,

--- a/crates/vqueues/src/lib.rs
+++ b/crates/vqueues/src/lib.rs
@@ -124,36 +124,6 @@ where
         self.cache.get(self.handle).unwrap().meta()
     }
 
-    /// The entry has completed execution and it needs to be removed from the vqueue.
-    ///
-    /// Does nothing if the entry was not found in the previous stage.
-    ///
-    /// Returns true if the entry was found and was ended correctly, false otherwise.
-    pub async fn end_by_id(
-        storage: &'a mut S,
-        cache: &'a mut VQueuesMetaCache,
-        action_collector: Option<&'a mut Vec<A>>,
-        at: UniqueTimestamp,
-        partition_key: PartitionKey,
-        id: &EntryId,
-        status: Status,
-    ) -> Result<bool, StorageError> {
-        // find the entry
-        let header = storage.get_vqueue_entry_status(partition_key, id).await?;
-
-        let Some(entry_state) = header else {
-            return Ok(false);
-        };
-
-        let inbox = Self::get(entry_state.vqueue_id(), storage, cache, action_collector).await?;
-        let Some(mut inbox) = inbox else {
-            return Ok(false);
-        };
-
-        inbox.end(at, &entry_state, status);
-        Ok(true)
-    }
-
     /// Get access to the vqueue if it exists, otherwise this returns None.
     pub async fn get(
         qid: &VQueueId,
@@ -1062,6 +1032,27 @@ where
             event.push(EventDetails::QueueResumed);
             collector.push(A::from(event));
         }
+    }
+
+    pub fn update_entry_metadata(
+        &mut self,
+        header: &impl EntryStatusHeader,
+        metadata: &EntryMetadata,
+    ) {
+        debug!(
+            "update_entry_metadata: {} {metadata:?}, stage: {}",
+            header.display_entry_id(),
+            header.stage(),
+        );
+
+        self.storage.put_vqueue_entry_status(
+            header.vqueue_id(),
+            header.stage(),
+            header.entry_key(),
+            metadata,
+            header.stats().clone(),
+            header.status(),
+        );
     }
 
     #[inline]

--- a/crates/worker/src/partition/state_machine/lifecycle/pinned_deployment.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/pinned_deployment.rs
@@ -8,10 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::VerifyOrMigrateJournalTableToV2Command;
+use tracing::trace;
 
-use crate::debug_if_leader;
-use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
 use restate_storage_api::fsm_table::WriteFsmTable;
 use restate_storage_api::inbox_table::WriteInboxTable;
 use restate_storage_api::invocation_status_table::{
@@ -24,12 +22,19 @@ use restate_storage_api::promise_table::{ReadPromiseTable, WritePromiseTable};
 use restate_storage_api::service_status_table::WriteVirtualObjectStatusTable;
 use restate_storage_api::state_table::{ReadStateTable, WriteStateTable};
 use restate_storage_api::timer_table::WriteTimerTable;
-use restate_storage_api::vqueue_table::{ReadVQueueTable, WriteVQueueTable};
+use restate_storage_api::vqueue_table::{EntryStatusHeader, ReadVQueueTable, WriteVQueueTable};
 use restate_storage_api::{journal_table as journal_table_v1, journal_table_v2};
 use restate_types::deployment::PinnedDeployment;
 use restate_types::identifiers::InvocationId;
 use restate_types::service_protocol::ServiceProtocolVersion;
-use tracing::trace;
+use restate_types::sharding::WithPartitionKey;
+use restate_types::vqueues::EntryId;
+use restate_util_string::ToReString;
+use restate_vqueues::VQueue;
+
+use super::VerifyOrMigrateJournalTableToV2Command;
+use crate::debug_if_leader;
+use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
 
 pub struct OnPinnedDeploymentCommand {
     pub invocation_id: InvocationId,
@@ -86,12 +91,35 @@ where
             restate.deployment.service_protocol_version = %self.pinned_deployment.service_protocol_version.as_repr(),
             "Store chosen deployment to storage"
         );
+
+        if let Some(ref vqueue_id) = in_flight_invocation_metadata.vqueue_id {
+            let entry_id = EntryId::from(&self.invocation_id);
+            let Some(header) = ctx
+                .storage
+                .get_vqueue_entry_status(self.invocation_id.partition_key(), &entry_id)
+                .await?
+            else {
+                panic!(
+                    "Trying to update an invocation {}, in vqueue {vqueue_id} which does not have a vqueue entry!",
+                    self.invocation_id
+                );
+            };
+            let mut metadata = header.metadata().clone();
+            metadata.deployment = Some(self.pinned_deployment.deployment_id.to_restring());
+
+            VQueue::get(
+                vqueue_id,
+                ctx.storage,
+                ctx.vqueues_cache,
+                ctx.is_leader.then_some(ctx.action_collector),
+            )
+            .await?
+            .expect("pinning in a non-existent vqueue")
+            .update_entry_metadata(&header, &metadata);
+        }
+
         in_flight_invocation_metadata
             .set_pinned_deployment(self.pinned_deployment, ctx.record_created_at);
-
-        // todo: set the pinned deployment in the vqueue entry metadata so that the scheduler can know
-        // about it.
-
         // We recreate the InvocationStatus in Invoked state as the invoker can notify the
         // chosen deployment_id only when the invocation is in-flight.
         ctx.storage

--- a/crates/worker/src/partition/state_machine/lifecycle/yield_invocation.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/yield_invocation.rs
@@ -53,8 +53,8 @@ where
         else {
             // It could be that the invocation was killed and purged before the invoker yielded it.
             info!(
-                "Not yielding {} because it has no vqueue state",
-                self.invocation_id,
+                "Not yielding {} because it has no vqueue state, yield_reason: {}",
+                self.invocation_id, self.yield_reason
             );
             return Ok(());
         };


### PR DESCRIPTION

When a deployment is pinned we update the EntryMetadata in the entry header. Note that this doesn't change the copy of EntryMetadata that lives in the VQueue inbox.
The inbox will pick up the entry metadata change in the next stage transition. This means that when querying `sys_vqueues` we will not always observe the latest `EntryMetadata`.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4825).
* #4828
* #4827
* #4826
* __->__ #4825