### PR TITLE
provision: send disabled features instead of enabled set

### DIFF
--- a/crates/core/protobuf/node_ctl_svc.proto
+++ b/crates/core/protobuf/node_ctl_svc.proto
@@ -57,14 +57,20 @@ message ProvisionClusterRequest {
   // if unset then the configured cluster default target nodeset size will be
   // used
   optional uint32 target_nodeset_size = 6;
-  // A set of cluster wide enabled 
-  // features.
-  repeated ClusterFeature features = 7;
+  // A set of cluster-wide features to opt out of. At provision time the server
+  // enables all default features except those listed here. Leaving this empty
+  // (or sending it from an older client that doesn't know about a feature) will
+  // result in all current default features being enabled.
+  repeated ClusterFeature disabled_features = 7;
 }
 
 message ProvisionClusterResponse {
   bool dry_run = 1;
   restate.cluster.ClusterConfiguration cluster_configuration = 2;
+  // The features that will be enabled on this cluster (defaults minus
+  // disabled_features from the request). Populated by the server so older
+  // clients can render an authoritative preview.
+  repeated ClusterFeature enabled_features = 3;
 }
 
 message IdentResponse {

--- a/crates/core/src/protobuf.rs
+++ b/crates/core/src/protobuf.rs
@@ -49,19 +49,34 @@ pub mod node_ctl_svc {
         tonic::include_file_descriptor_set!("node_ctl_svc_descriptor");
 
     impl ProvisionClusterResponse {
-        pub fn dry_run(cluster_configuration: ClusterConfiguration) -> Self {
+        pub fn dry_run(
+            cluster_configuration: ClusterConfiguration,
+            enabled_features: EnumSet<nodes_config::ClusterFeature>,
+        ) -> Self {
             ProvisionClusterResponse {
                 dry_run: true,
                 cluster_configuration: Some(cluster_configuration),
+                enabled_features: features_to_proto(enabled_features),
             }
         }
 
-        pub fn provisioned(cluster_configuration: ClusterConfiguration) -> Self {
+        pub fn provisioned(
+            cluster_configuration: ClusterConfiguration,
+            enabled_features: EnumSet<nodes_config::ClusterFeature>,
+        ) -> Self {
             ProvisionClusterResponse {
                 dry_run: false,
                 cluster_configuration: Some(cluster_configuration),
+                enabled_features: features_to_proto(enabled_features),
             }
         }
+    }
+
+    fn features_to_proto(features: EnumSet<nodes_config::ClusterFeature>) -> Vec<i32> {
+        features
+            .iter()
+            .map(|f| ClusterFeature::from(f) as i32)
+            .collect()
     }
 
     /// Creates a new NodeCtlSvcClient with appropriate configuration
@@ -97,9 +112,10 @@ pub mod node_ctl_svc {
         }
     }
 
-    /// Converts the wire representation of cluster features (a slice of i32) into an
-    /// [`EnumSet`] of [`nodes_config::ClusterFeature`]. Returns an error if any entry is
-    /// out of range or maps to the `Unknown` sentinel.
+    /// Converts the wire representation of a cluster feature list (a slice of i32) into
+    /// an [`EnumSet`] of [`nodes_config::ClusterFeature`]. Semantics-neutral — the caller
+    /// decides whether the list represents enabled or disabled features. Returns an error
+    /// if any entry is out of range or maps to the `Unknown` sentinel.
     pub fn cluster_features_from_proto(
         features: &[i32],
     ) -> anyhow::Result<EnumSet<nodes_config::ClusterFeature>> {

--- a/crates/local-cluster-runner/src/node/mod.rs
+++ b/crates/local-cluster-runner/src/node/mod.rs
@@ -855,7 +855,7 @@ impl StartedNode {
         num_partitions: Option<NonZeroU16>,
         partition_replication: ReplicationProperty,
         provider_configuration: Option<ProviderConfiguration>,
-        features: EnumSet<ClusterFeature>,
+        disabled_features: EnumSet<ClusterFeature>,
     ) -> anyhow::Result<bool> {
         let channel = create_tonic_channel(
             self.advertised_address().clone(),
@@ -879,7 +879,7 @@ impl StartedNode {
                     .target_nodeset_size()
                     .map(|nodeset_size| nodeset_size.as_u32())
             }),
-            features: features
+            disabled_features: disabled_features
                 .iter()
                 .map(|f| restate_core::protobuf::node_ctl_svc::ClusterFeature::from(f) as i32)
                 .collect(),

--- a/crates/node/src/network_server/grpc_svc_handler.rs
+++ b/crates/node/src/network_server/grpc_svc_handler.rs
@@ -42,7 +42,7 @@ use restate_types::config::{Configuration, NetworkingOptions};
 use restate_types::errors::{ConversionError, MaybeRetryableError};
 use restate_types::logs::metadata::{NodeSetSize, ProviderConfiguration};
 use restate_types::metadata::VersionedValue;
-use restate_types::nodes_config::Role;
+use restate_types::nodes_config::{ClusterFeature, Role};
 use restate_types::protobuf::cluster::ClusterConfiguration as ProtoClusterConfiguration;
 use restate_types::protobuf::common::DatabaseKind;
 use restate_types::replication::ReplicationProperty;
@@ -171,14 +171,16 @@ impl NodeCtlSvc for NodeCtlSvcHandler {
         let config = Configuration::pinned();
 
         let dry_run = request.dry_run;
-        let features = cluster_features_from_proto(&request.features)
+        let disabled = cluster_features_from_proto(&request.disabled_features)
             .map_err(|err| Status::invalid_argument(err.to_string()))?;
+        let features = ClusterFeature::default_features() - disabled;
         let cluster_configuration = Self::resolve_cluster_configuration(&config, request)
             .map_err(|err| Status::invalid_argument(err.to_string()))?;
 
         if dry_run {
             return Ok(Response::new(ProvisionClusterResponse::dry_run(
                 ProtoClusterConfiguration::from(cluster_configuration),
+                features,
             )));
         }
 
@@ -199,6 +201,7 @@ impl NodeCtlSvc for NodeCtlSvcHandler {
 
         Ok(Response::new(ProvisionClusterResponse::provisioned(
             ProtoClusterConfiguration::from(cluster_configuration),
+            features,
         )))
     }
 

--- a/release-notes/unreleased/restatectl-provision-features.md
+++ b/release-notes/unreleased/restatectl-provision-features.md
@@ -20,7 +20,10 @@ restatectl provision --disable-feature controlled-idempotent-sharding,other-feat
 ```
 
 The dry-run preview lists the features that will be enabled, as well as any
-features explicitly disabled via the flag.
+features explicitly disabled via the flag. The enabled-feature list is computed
+on the server and echoed back in the response, so older `restatectl` builds
+will continue to provision new default features added in future server
+releases — the operator only needs to express what they want *off*.
 
 ### Impact on Users
 

--- a/tools/restatectl/src/commands/provision.rs
+++ b/tools/restatectl/src/commands/provision.rs
@@ -102,12 +102,8 @@ async fn provision_cluster(
         .or_else(|| provision_opts.replication.clone())
         .map(Into::into);
 
-    let enabled_features: Vec<ClusterFeature> = ClusterFeature::default_features()
-        .iter()
-        .filter(|f| !provision_opts.disable_features.contains(f))
-        .collect();
-
-    let features: Vec<i32> = enabled_features
+    let disabled_features: Vec<i32> = provision_opts
+        .disable_features
         .iter()
         .copied()
         .map(|f| ProtoClusterFeature::from(f) as i32)
@@ -122,7 +118,7 @@ async fn provision_cluster(
             .map(|provider| provider.to_string()),
         log_replication,
         target_nodeset_size: provision_opts.log_default_nodeset_size.map(Into::into),
-        features: features.clone(),
+        disabled_features: disabled_features.clone(),
     };
 
     let response = match client.provision_cluster(request).await {
@@ -137,6 +133,7 @@ async fn provision_cluster(
     };
 
     debug_assert!(response.dry_run, "Provision with dry run");
+    let enabled_features = response.enabled_features.clone();
     let cluster_configuration_to_provision = response
         .cluster_configuration
         .expect("Provision response should carry a cluster configuration");
@@ -148,8 +145,16 @@ async fn provision_cluster(
 
     if !enabled_features.is_empty() {
         c_println!("Features to enable:");
-        for f in &enabled_features {
-            c_println!("  - {f}");
+        for raw in &enabled_features {
+            match ProtoClusterFeature::try_from(*raw) {
+                Ok(ProtoClusterFeature::Unknown) | Err(_) => {
+                    c_println!("  - Unknown feature ({raw})")
+                }
+                Ok(proto_feature) => {
+                    let feature = ClusterFeature::from(proto_feature);
+                    c_println!("  - {feature}");
+                }
+            }
         }
     }
 
@@ -201,7 +206,7 @@ async fn provision_cluster(
         log_provider,
         log_replication,
         target_nodeset_size,
-        features,
+        disabled_features,
     };
 
     match client.provision_cluster(request).await {


### PR DESCRIPTION
provision: send disabled features instead of enabled set

Flip ProvisionClusterRequest.features to disabled_features. The server
now computes default_features() - disabled instead of trusting the
client's enabled list, and echoes the resolved set back in
ProvisionClusterResponse.enabled_features.

This makes provisioning forward-compatible: an older restatectl that
doesn't know about a new default feature will send an empty disabled
list and still get all defaults turned on by the newer server.

The CLI decodes the echoed enabled_features inline so unknown feature
ids from a newer server are rendered as "Unknown feature (<id>)" rather
than failing the dry-run.

Existing integration tests passing EnumSet::empty() now provision with
default features on (previously: all off) — that's the correct path for
a normally-configured cluster.

This feature is unreleased; the wire/semantic change of field 7 is
intentional.
