### PR TITLE
Make ingress HTTP/2 stream limit configurable

### DIFF
--- a/crates/ingress-http/src/server.rs
+++ b/crates/ingress-http/src/server.rs
@@ -10,6 +10,7 @@
 
 use std::convert::Infallible;
 use std::future::Future;
+use std::num::NonZeroU32;
 use std::time::Duration;
 
 use codederror::CodedError;
@@ -53,6 +54,7 @@ pub struct HyperServerIngress<Schemas, Dispatcher> {
     listeners: Listeners<HttpIngressPort>,
     concurrency_limit: usize,
     request_size_limit: usize,
+    http2_max_concurrent_streams: Option<NonZeroU32>,
 
     // Parameters to build the layers
     schemas: Live<Schemas>,
@@ -78,6 +80,7 @@ where
             listeners,
             ingress_options.concurrent_api_requests_limit(),
             ingress_options.request_size_limit().get(),
+            ingress_options.http2_max_concurrent_streams(),
             schemas,
             dispatcher,
             health,
@@ -94,6 +97,7 @@ where
         listeners: Listeners<HttpIngressPort>,
         concurrency_limit: usize,
         request_size_limit: usize,
+        http2_max_concurrent_streams: Option<NonZeroU32>,
         schemas: Live<Schemas>,
         dispatcher: Dispatcher,
         health: HealthStatus<IngressStatus>,
@@ -104,6 +108,7 @@ where
             listeners,
             concurrency_limit,
             request_size_limit,
+            http2_max_concurrent_streams,
             schemas,
             dispatcher,
             health,
@@ -121,6 +126,7 @@ where
             mut listeners,
             concurrency_limit,
             request_size_limit,
+            http2_max_concurrent_streams,
             schemas,
             dispatcher,
             health,
@@ -210,14 +216,16 @@ where
                             Self::handle_connection(
                                 tcp_stream,
                                 peer_addr,
-                                service.clone()
+                                service.clone(),
+                                http2_max_concurrent_streams,
                             )?;
                         }
                         Either::Right(unix_stream) => {
                             Self::handle_connection(
                                 unix_stream,
                                 peer_addr,
-                                service.clone()
+                                service.clone(),
+                                http2_max_concurrent_streams,
                             )?;
                         }
 
@@ -234,6 +242,7 @@ where
         stream: S,
         remote_peer: SocketAddress,
         handler: T,
+        http2_max_concurrent_streams: Option<NonZeroU32>,
     ) -> anyhow::Result<()>
     where
         S: AsyncWrite + AsyncRead + Unpin + Send + 'static,
@@ -262,7 +271,12 @@ where
         // Spawn a tokio task to serve the connection
         TaskCenter::spawn(TaskKind::Ingress, "ingress", async move {
             let shutdown = cancellation_watcher();
-            let auto_connection = auto::Builder::new(TaskCenterExecutor);
+            let mut auto_connection = auto::Builder::new(TaskCenterExecutor);
+            if let Some(max_concurrent_streams) = http2_max_concurrent_streams {
+                auto_connection
+                    .http2()
+                    .max_concurrent_streams(max_concurrent_streams.get());
+            }
             let serve_connection_fut = auto_connection.serve_connection(io, handler);
 
             tokio::select! {
@@ -417,6 +431,7 @@ mod tests {
             listeners,
             Semaphore::MAX_PERMITS,
             10 * 1024 * 1024, // 10MB
+            None,
             Live::from_value(mock_schemas()),
             Arc::new(mock_request_dispatcher),
             health.ingress_status(),

--- a/crates/types/src/config/ingress.rs
+++ b/crates/types/src/config/ingress.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::num::NonZeroUsize;
+use std::num::{NonZeroU32, NonZeroUsize};
 
 use restate_memory::NonZeroByteCount;
 use serde::{Deserialize, Serialize};
@@ -36,6 +36,18 @@ pub struct IngressOptions {
     /// Local concurrency limit to use to limit the amount of concurrent requests. If exceeded,
     /// the ingress will reply immediately with an appropriate status code. Default is unlimited.
     concurrent_api_requests_limit: Option<NonZeroUsize>,
+
+    /// # HTTP/2 max concurrent streams
+    ///
+    /// Caps the number of concurrent HTTP/2 streams accepted per inbound ingress connection.
+    /// If unset, Restate does not configure this limit and leaves it at hyper's runtime default.
+    /// With the current hyper version, that default is 200 streams.
+    /// Service-mesh clients such as Linkerd honor the advertised value as a hard per-connection
+    /// concurrency limit, so high-concurrency or long-poll deployments may need to raise it.
+    ///
+    /// Since v1.7.0
+    #[serde(skip_serializing_if = "Option::is_none")]
+    http2_max_concurrent_streams: Option<NonZeroU32>,
 
     /// # Kafka clusters
     ///
@@ -113,6 +125,10 @@ impl IngressOptions {
                 .unwrap_or(Semaphore::MAX_PERMITS - 1),
             Semaphore::MAX_PERMITS - 1,
         )
+    }
+
+    pub fn http2_max_concurrent_streams(&self) -> Option<NonZeroU32> {
+        self.http2_max_concurrent_streams
     }
 
     /// set derived values if they are not configured to reduce verbose configurations

--- a/release-notes/unreleased/ingress-http2-max-concurrent-streams.md
+++ b/release-notes/unreleased/ingress-http2-max-concurrent-streams.md
@@ -1,0 +1,19 @@
+# Release Notes: Configurable ingress HTTP/2 max concurrent streams
+
+## New Feature
+
+### What Changed
+Added `ingress.http2-max-concurrent-streams`, an optional configuration setting
+for the max concurrent HTTP/2 streams advertised per inbound ingress connection.
+
+### Why This Matters
+The default remains unchanged and is left to hyper. Operators running
+high-concurrency or long-poll workloads behind HTTP/2-aware clients such as
+Linkerd can now raise the per-connection stream limit instead of being silently
+bounded by the server's advertised default.
+
+### Impact on Users
+No action is required for existing deployments. Set
+`RESTATE_INGRESS__HTTP2_MAX_CONCURRENT_STREAMS` or the corresponding config file
+key only when the ingress needs to accept more concurrent streams per HTTP/2
+connection.


### PR DESCRIPTION
Summary: Adds optional ingress.http2-max-concurrent-streams config and wires it to the inbound ingress HTTP/2 server builder. Testing: cargo check; cargo nextest run --all-features; cargo fmt --all -- --check; env -u RUSTC_WRAPPER cargo clippy --all-features --all-targets --workspace -- -D warnings.