### PR TITLE
config: deprecate root-level service-client options in favor of worker.invoker.service-client

### DIFF
--- a/crates/node/src/roles/admin.rs
+++ b/crates/node/src/roles/admin.rs
@@ -101,15 +101,19 @@ impl<T: TransportConnect> AdminRole<T> {
 
         // Total duration roughly 1s
         let retry_policy = RetryPolicy::exponential(Duration::from_millis(100), 2.0, Some(4), None);
-        let service_client =
-            ServiceClient::from_options(&config.common.service_client, AssumeRoleCacheMode::None)?;
+        let service_client = ServiceClient::from_options(
+            &config.worker.invoker.service_client,
+            AssumeRoleCacheMode::None,
+        )?;
         let serdes_client = SerdesClient::new(service_client.clone());
         let service_discovery = ServiceDiscovery::new(retry_policy, service_client);
 
         let telemetry_http_client = if config.common.disable_telemetry {
             None
         } else {
-            Some(HttpClient::from_options(&config.common.service_client.http))
+            Some(HttpClient::from_options(
+                &config.worker.invoker.service_client.http,
+            ))
         };
 
         let query_context = if let Some(query_context) = local_query_context {

--- a/crates/service-client/src/http.rs
+++ b/crates/service-client/src/http.rs
@@ -83,7 +83,10 @@ impl HttpClient {
             hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::default());
         builder.timer(hyper_util::rt::TokioTimer::default());
 
-        let keep_alive_interval: Duration = options.http_keep_alive_options.interval.into();
+        let keep_alive_interval: Duration = options
+            .http_keep_alive_options
+            .http2_keep_alive_interval
+            .into();
         let keep_alive_interval = if keep_alive_interval == Duration::ZERO {
             None
         } else {
@@ -92,10 +95,17 @@ impl HttpClient {
 
         builder
             .http2_initial_max_send_streams(
-                options.initial_max_send_streams.map(|v| v.get() as usize),
+                options
+                    .http2_initial_max_send_streams
+                    .map(|v| v.get() as usize),
             )
             .http2_adaptive_window(true)
-            .http2_keep_alive_timeout(options.http_keep_alive_options.timeout.into())
+            .http2_keep_alive_timeout(
+                options
+                    .http_keep_alive_options
+                    .http2_keep_alive_timeout
+                    .into(),
+            )
             .http2_keep_alive_interval(keep_alive_interval);
 
         let mut http_connector = HttpConnector::new();
@@ -132,19 +142,24 @@ impl HttpClient {
 
             let builder = pool::PoolBuilder::default()
                 .keep_alive_interval(keep_alive_interval)
-                .keep_alive_timeout(options.http_keep_alive_options.timeout.into())
-                .keep_alive_interval_jitter(options.http_keep_alive_options.jitter)
-                .streams_per_connection_limit(options.streams_per_connection_limit)
+                .keep_alive_timeout(
+                    options
+                        .http_keep_alive_options
+                        .http2_keep_alive_timeout
+                        .into(),
+                )
+                .keep_alive_interval_jitter(options.http_keep_alive_options.http2_keep_alive_jitter)
+                .streams_per_connection_limit(options.http2_streams_per_connection_limit)
                 .initial_stream_window_size(options.initial_stream_window_size())
                 .initial_connection_window_size(options.initial_connection_window_size())
                 .max_frame_size(options.max_frame_size())
-                .idle_connection_timeout(if options.idle_connection_timeout.is_zero() {
+                .idle_connection_timeout(if options.http2_idle_connection_timeout.is_zero() {
                     None
                 } else {
-                    Some(options.idle_connection_timeout.into())
+                    Some(options.http2_idle_connection_timeout.into())
                 });
 
-            let builder = match options.initial_max_send_streams {
+            let builder = match options.http2_initial_max_send_streams {
                 Some(value) => builder.initial_max_send_streams(value),
                 None => builder,
             };

--- a/crates/types/src/config/aws.rs
+++ b/crates/types/src/config/aws.rs
@@ -8,9 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use restate_util_bytecount::ByteCount;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
+
+use restate_util_bytecount::ByteCount;
 
 /// # AWS options
 #[serde_as]
@@ -42,6 +43,42 @@ pub struct AwsLambdaOptions {
     pub request_compression_threshold: Option<ByteCount>,
 }
 
+impl AwsLambdaOptions {
+    pub(crate) fn apply_deprecated(
+        &mut self,
+        new_base: &str,
+        deprecated: DeprecatedAwsLambdaOptions,
+    ) {
+        let DeprecatedAwsLambdaOptions {
+            aws_profile,
+            aws_assume_role_external_id,
+            request_compression_threshold,
+        } = deprecated;
+
+        super::apply_deprecated_field_optional(
+            &mut self.aws_profile,
+            aws_profile,
+            new_base,
+            "aws-profile",
+            None,
+        );
+        super::apply_deprecated_field_optional(
+            &mut self.aws_assume_role_external_id,
+            aws_assume_role_external_id,
+            new_base,
+            "aws-assume-role-external-id",
+            None,
+        );
+        super::apply_deprecated_field_optional(
+            &mut self.request_compression_threshold,
+            request_compression_threshold,
+            new_base,
+            "request-compression-threshold",
+            None,
+        );
+    }
+}
+
 impl Default for AwsLambdaOptions {
     fn default() -> Self {
         Self {
@@ -50,4 +87,15 @@ impl Default for AwsLambdaOptions {
             request_compression_threshold: Some((4usize * 1024 * 1024).into()),
         }
     }
+}
+
+/// Shadow of [`AwsLambdaOptions`] for the deprecated `service-client` root location. Every field
+/// is `Option<T>` so `None` means "user didn't set it" and `Some(_)` means "user set this value".
+// todo: Remove in Restate v1.8
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub(crate) struct DeprecatedAwsLambdaOptions {
+    pub aws_profile: Option<String>,
+    pub aws_assume_role_external_id: Option<String>,
+    pub request_compression_threshold: Option<ByteCount>,
 }

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -24,12 +24,12 @@ use restate_util_bytecount::NonZeroByteCount;
 use restate_util_time::{FriendlyDuration, NonZeroFriendlyDuration};
 
 use super::{
-    AwsLambdaOptions, CPU_COUNT, DEFAULT_MESSAGE_SIZE_LIMIT, GossipOptions, HttpOptions,
-    InvalidConfigurationError, ObjectStoreOptions, PerfStatsLevel, RocksDbOptions,
+    CPU_COUNT, DEFAULT_MESSAGE_SIZE_LIMIT, GossipOptions, InvalidConfigurationError,
+    ObjectStoreOptions, PerfStatsLevel, RocksDbOptions,
 };
 use crate::PlainNodeId;
-use crate::config::NetworkingOptions;
 use crate::config::dynamodb_store::DynamoDbOptions;
+use crate::config::{DeprecatedServiceClientOptions, NetworkingOptions};
 use crate::locality::NodeLocation;
 use crate::net::address::{AdvertisedAddress, ListenerPort};
 use crate::net::address::{BindAddress, FabricPort, TokioConsolePort};
@@ -45,8 +45,6 @@ const MIN_MEMTABLE_TOTAL_BUDGET: NonZeroByteCount =
     NonZeroByteCount::new(NonZeroUsize::new(32 * 1024 * 1024).unwrap());
 
 const DEFAULT_STORAGE_DIRECTORY: &str = "restate-data";
-const X_RESTATE_CLUSTER_NAME: http::HeaderName =
-    http::HeaderName::from_static("x-restate-cluster-name");
 
 static HOSTNAME: LazyLock<String> = LazyLock::new(|| {
     hostname::get()
@@ -344,8 +342,11 @@ pub struct CommonOptions {
     )]
     tokio_console_listener_options: ListenerOptions<TokioConsolePort>,
 
-    #[serde(flatten)]
-    pub service_client: ServiceClientOptions,
+    // todo: remove in Restate v1.8
+    #[serde(flatten, skip_serializing)]
+    #[cfg_attr(feature = "schemars", schemars(skip))]
+    #[deprecated(since = "1.7.0", note = "Moved to `worker.invoker.service-client`")]
+    pub(crate) service_client: DeprecatedServiceClientOptions,
 
     /// Disable prometheus metric recording and reporting. Default is `false`.
     pub disable_prometheus: bool,
@@ -789,23 +790,6 @@ impl CommonOptions {
 
         self.metadata_client.merge(network_options);
 
-        if self.service_client.additional_request_headers.is_none() {
-            let cluster_name_visible_ascii = self
-                .cluster_name()
-                .chars()
-                .filter(|c| *c >= ' ' && *c <= '~')
-                .collect::<String>();
-
-            self.service_client.additional_request_headers = Some(
-                std::collections::HashMap::from_iter([(
-                    X_RESTATE_CLUSTER_NAME,
-                    http::HeaderValue::from_str(&cluster_name_visible_ascii)
-                        .expect("a visible ascii string must be a valid header value"),
-                )])
-                .into(),
-            )
-        }
-
         Ok(())
     }
 
@@ -839,6 +823,7 @@ impl Default for CommonOptions {
             default_num_partitions: 24,
             default_replication: ReplicationProperty::new_unchecked(1),
             disable_prometheus: false,
+            #[allow(deprecated)]
             service_client: Default::default(),
             shutdown_timeout: NonZeroFriendlyDuration::from_secs_unchecked(60),
             tracing: TracingOptions::default(),
@@ -875,42 +860,6 @@ impl Default for CommonOptions {
             disable_controlled_idempotent_sharding: false,
         }
     }
-}
-
-/// # Service Client options
-#[serde_as]
-#[derive(Debug, Clone, Serialize, Deserialize, derive_builder::Builder)]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[cfg_attr(
-    feature = "schemars",
-    schemars(rename = "ServiceClientOptions", default)
-)]
-#[builder(default)]
-#[derive(Default)]
-#[serde(rename_all = "kebab-case")]
-pub struct ServiceClientOptions {
-    #[serde(flatten)]
-    pub http: HttpOptions,
-    #[serde(flatten)]
-    pub lambda: AwsLambdaOptions,
-
-    /// # Request identity private key PEM file
-    ///
-    /// A path to a file, such as "/var/secrets/key.pem", which contains exactly one ed25519 private
-    /// key in PEM format. Such a file can be generated with `openssl genpkey -algorithm ed25519`.
-    /// If provided, this key will be used to attach JWTs to requests from this client which
-    /// SDKs may optionally verify, proving that the caller is a particular Restate instance.
-    ///
-    /// This file is currently only read on client creation, but this may change in future.
-    /// Parsed public keys will be logged at INFO level in the same format that SDKs expect.
-    pub request_identity_private_key_pem_file: Option<PathBuf>,
-
-    /// # Additional request headers
-    ///
-    /// Headers that should be applied to all outgoing requests (HTTP and Lambda).
-    /// Defaults to `x-restate-cluster-name: <cluster name>`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub additional_request_headers: Option<SerdeableHeaderHashMap>,
 }
 
 /// # Log format

--- a/crates/types/src/config/http.rs
+++ b/crates/types/src/config/http.rs
@@ -26,6 +26,7 @@ pub struct HttpOptions {
     /// # HTTP/2 Keep-alive
     ///
     /// Configuration for the HTTP/2 keep-alive mechanism, using PING frames.
+    #[serde(flatten)]
     pub http_keep_alive_options: Http2KeepAliveOptions,
     /// # Proxy URI
     ///
@@ -50,7 +51,7 @@ pub struct HttpOptions {
     /// it a failed attempt.
     pub connect_timeout: NonZeroFriendlyDuration,
 
-    /// # Initial Max Send Streams
+    /// # HTTP/2 Initial Max Send Streams
     ///
     /// Sets the initial maximum of locally initiated (send) streams.
     ///
@@ -63,7 +64,7 @@ pub struct HttpOptions {
     ///
     /// **NOTE**: Setting this value to None (default) users the default
     /// recommended value from HTTP2 specs
-    pub initial_max_send_streams: Option<NonZeroU32>,
+    pub http2_initial_max_send_streams: Option<NonZeroU32>,
 
     /// Upper bound on the per-connection max-send-streams.
     ///
@@ -76,9 +77,9 @@ pub struct HttpOptions {
     /// Since v1.7.0
     ///
     /// Default: 128
-    pub streams_per_connection_limit: NonZeroUsize,
+    pub http2_streams_per_connection_limit: NonZeroUsize,
 
-    /// # Idle Connection Timeout
+    /// # HTTP/2 Idle Connection Timeout
     ///
     /// How long a connection can be idle before it is evicted
     /// and closed. Set to `0` to disable eviction.
@@ -86,7 +87,7 @@ pub struct HttpOptions {
     /// Since: v1.7.0
     ///
     /// Default: 5 minutes
-    pub idle_connection_timeout: FriendlyDuration,
+    pub http2_idle_connection_timeout: FriendlyDuration,
 
     /// # HTTP/2 initial stream window size
     ///
@@ -126,9 +127,9 @@ impl Default for HttpOptions {
             http_proxy: None,
             no_proxy: None,
             connect_timeout: NonZeroFriendlyDuration::from_secs_unchecked(10),
-            initial_max_send_streams: None,
-            streams_per_connection_limit: NonZeroUsize::new(128).unwrap(),
-            idle_connection_timeout: FriendlyDuration::from_secs(300),
+            http2_initial_max_send_streams: None,
+            http2_streams_per_connection_limit: NonZeroUsize::new(128).unwrap(),
+            http2_idle_connection_timeout: FriendlyDuration::from_secs(300),
             http2_initial_stream_window_size: NonZeroByteCount::new(
                 NonZeroUsize::new(2 * 1024 * 1024).unwrap(),
             ),
@@ -158,7 +159,96 @@ impl HttpOptions {
             .unwrap_or(u32::MAX)
             .clamp(16_384, 16_777_215)
     }
+
+    pub(crate) fn apply_deprecated(&mut self, new_base: &str, deprecated: DeprecatedHttpOptions) {
+        let DeprecatedHttpOptions {
+            http_keep_alive_options,
+            http_proxy,
+            no_proxy,
+            connect_timeout,
+            initial_max_send_streams,
+        } = deprecated;
+
+        super::apply_deprecated_field(
+            &mut self.http_keep_alive_options.http2_keep_alive_interval,
+            http_keep_alive_options.interval,
+            new_base,
+            "http-keep-alive-options.interval",
+            Some("http2-keep-alive-interval"),
+        );
+
+        super::apply_deprecated_field(
+            &mut self.http_keep_alive_options.http2_keep_alive_timeout,
+            http_keep_alive_options.timeout,
+            new_base,
+            "http-keep-alive-options.timeout",
+            Some("http2-keep-alive-timeout"),
+        );
+
+        super::apply_deprecated_field(
+            &mut self.http_keep_alive_options.http2_keep_alive_jitter,
+            http_keep_alive_options.jitter,
+            new_base,
+            "http-keep-alive-options.jitter",
+            Some("http2-keep-alive-jitter"),
+        );
+
+        super::apply_deprecated_field_optional(
+            &mut self.http_proxy,
+            http_proxy,
+            new_base,
+            "http-proxy",
+            None,
+        );
+
+        super::apply_deprecated_field_optional(
+            &mut self.no_proxy,
+            no_proxy,
+            new_base,
+            "no-proxy",
+            None,
+        );
+
+        super::apply_deprecated_field(
+            &mut self.connect_timeout,
+            connect_timeout,
+            new_base,
+            "connect-timeout",
+            None,
+        );
+        super::apply_deprecated_field_optional(
+            &mut self.http2_initial_max_send_streams,
+            initial_max_send_streams,
+            new_base,
+            "initial-max-send-streams",
+            Some("http2-initial-max-send-streams"),
+        );
+    }
 }
+
+/// Shadow of [`HttpOptions`] for the deprecated `service-client` root location. Every leaf field
+/// is `Option<T>` so `None` means "user didn't set it" and `Some(_)` means "user set this value".
+// todo: Remove in Restate v1.8
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub(crate) struct DeprecatedHttpOptions {
+    pub http_keep_alive_options: DeprecatedHttp2KeepAliveOptions,
+    pub http_proxy: Option<String>,
+    pub no_proxy: Option<NoProxy>,
+    pub connect_timeout: Option<NonZeroFriendlyDuration>,
+    pub initial_max_send_streams: Option<NonZeroU32>,
+}
+
+/// Shadow of [`Http2KeepAliveOptions`] for the deprecated `service-client` root location.
+// todo: Remove in Restate v1.8
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub(crate) struct DeprecatedHttp2KeepAliveOptions {
+    pub interval: Option<FriendlyDuration>,
+    pub timeout: Option<NonZeroFriendlyDuration>,
+    pub jitter: Option<f32>,
+}
+
 /// NO_PROXY can be provided as either a comma-separated string `example.com,::1,localhost`, or a list of strings `["example.com", "::1", "localhost"]`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -188,33 +278,33 @@ pub struct Http2KeepAliveOptions {
     /// `0` disables keep-alive pings entirely. Defaults to `40s`.
     ///
     /// You should set this timeout with a value lower than the `abort_timeout`.
-    pub interval: FriendlyDuration,
+    pub http2_keep_alive_interval: FriendlyDuration,
 
-    /// # Timeout
+    /// # HTTP/2 Keep-Alive Timeout
     ///
     /// Sets a timeout for receiving an acknowledgement of the keep-alive ping.
     ///
     /// If the ping is not acknowledged within the timeout, the connection will
     /// be closed.
     ///
-    /// Only meaningful when `interval` is not zero. Defaults to 20 s.
-    pub timeout: NonZeroFriendlyDuration,
+    /// Only meaningful when `http2-keep-alive-interval` is not zero. Defaults to 20 s.
+    pub http2_keep_alive_timeout: NonZeroFriendlyDuration,
 
-    /// # Jitter
+    /// # HTTP/2 Keep-Alive Jitter
     ///
-    /// Fractional jitter added to `interval`, expressed as a fraction
+    /// Fractional jitter added to `http2-keep-alive-interval`, expressed as a fraction
     /// of the interval (e.g. 0.1 = up to +10%, 1.0 = up to +100%).
     ///
-    /// Default 0.2 (20% of interval)
-    pub jitter: f32,
+    /// Default 0.2 (20% of http2-keep-alive-interval)
+    pub http2_keep_alive_jitter: f32,
 }
 
 impl Default for Http2KeepAliveOptions {
     fn default() -> Self {
         Self {
-            interval: FriendlyDuration::from_secs(40),
-            timeout: NonZeroFriendlyDuration::from_secs_unchecked(20),
-            jitter: 0.2,
+            http2_keep_alive_interval: FriendlyDuration::from_secs(40),
+            http2_keep_alive_timeout: NonZeroFriendlyDuration::from_secs_unchecked(20),
+            http2_keep_alive_jitter: 0.2,
         }
     }
 }

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -287,7 +287,9 @@ impl Configuration {
             .common
             .set_derived_values(&config.networking)
             .unwrap();
-        config.worker.set_derived_values(&config.networking);
+        config
+            .worker
+            .set_derived_values(&config.common, &config.networking);
         config.bifrost.set_derived_values(&config.networking);
         config.admin.set_derived_values(&config.common);
         config
@@ -303,7 +305,9 @@ impl Configuration {
             .common
             .set_derived_values(&config.networking)
             .unwrap();
-        config.worker.set_derived_values(&config.networking);
+        config
+            .worker
+            .set_derived_values(&config.common, &config.networking);
         config.bifrost.set_derived_values(&config.networking);
         config.admin.set_derived_values(&config.common);
         config
@@ -449,6 +453,43 @@ pub enum InvalidConfigurationError {
     DeriveBindAddress(String),
     #[error("node-name is required: {0}")]
     RequiredNodeName(String),
+}
+
+/// Migrates a single field from a deprecated config location to its new one.
+///
+/// `deprecated` is `Some` iff the user set the field at the old location (the all-Option shadow
+/// type the deprecated location deserializes into makes this unambiguous). When set, the value
+/// is moved into `new` and a deprecation warning is printed — even if the new location also has
+/// a value, the deprecated one wins so the user's prior effective behavior is preserved during
+/// the migration window.
+fn apply_deprecated_field<T>(
+    new: &mut T,
+    deprecated: Option<T>,
+    new_base: &str,
+    field: &'static str,
+    new_field: Option<&'static str>,
+) {
+    if let Some(value) = deprecated {
+        let new_field = new_field.unwrap_or(field);
+        print_warning_deprecated_config_option(field, Some(&format!("{new_base}.{new_field}")));
+        *new = value;
+    }
+}
+
+/// Same as [`apply_deprecated_field`], but for canonical fields that are themselves `Option<T>`.
+/// The shadow side carries `Option<T>` (single layer) using `Some` as the "user set this" flag.
+fn apply_deprecated_field_optional<T>(
+    new: &mut Option<T>,
+    deprecated: Option<T>,
+    new_base: &str,
+    field: &str,
+    new_field: Option<&'static str>,
+) {
+    if deprecated.is_some() {
+        let new_field = new_field.unwrap_or(field);
+        print_warning_deprecated_config_option(field, Some(&format!("{new_base}.{new_field}")));
+        *new = deprecated;
+    }
 }
 
 #[allow(dead_code)]

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -12,6 +12,7 @@ use std::num::{NonZero, NonZeroU8, NonZeroU32, NonZeroU64, NonZeroUsize};
 use std::path::PathBuf;
 use std::time::Duration;
 
+use restate_serde_util::SerdeableHeaderHashMap;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use tracing::warn;
@@ -23,7 +24,10 @@ use super::{
     BackgroundWorkBudget, CommonOptions, DEFAULT_MESSAGE_SIZE_LIMIT, NetworkingOptions,
     ObjectStoreOptions, RocksDbOptions, RocksDbOptionsBuilder,
 };
-use crate::config::IngestionOptions;
+use crate::config::{
+    AwsLambdaOptions, DeprecatedAwsLambdaOptions, DeprecatedHttpOptions, HttpOptions,
+    IngestionOptions,
+};
 use crate::identifiers::PartitionId;
 use crate::net::connect_opts::MESSAGE_SIZE_OVERHEAD;
 use crate::rate::Rate;
@@ -32,6 +36,8 @@ use crate::retries::RetryPolicy;
 const MIN_ROCKSDB_MEMORY: NonZeroByteCount =
     NonZeroByteCount::new(NonZeroUsize::new(32 * 1024 * 1024).unwrap());
 
+const X_RESTATE_CLUSTER_NAME: http::HeaderName =
+    http::HeaderName::from_static("x-restate-cluster-name");
 /// # Worker options
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, derive_builder::Builder)]
@@ -141,8 +147,8 @@ pub struct WorkerOptions {
 
 impl WorkerOptions {
     /// set networking-derived values if they are not configured to reduce verbose configurations
-    pub fn set_derived_values(&mut self, opts: &NetworkingOptions) {
-        self.invoker.merge(opts);
+    pub fn set_derived_values(&mut self, common: &CommonOptions, opts: &NetworkingOptions) {
+        self.invoker.merge(common, opts);
     }
 
     pub fn internal_queue_length(&self) -> usize {
@@ -428,6 +434,17 @@ pub struct InvokerOptions {
     ///
     /// Since v1.6.3
     pub per_invocation_initial_memory: NonZeroByteCount,
+
+    /// # Service client options
+    ///
+    /// Configures the HTTP/Lambda client the invoker uses to call service deployments.
+    /// Covers HTTP connection tuning (keep-alive, proxy, timeouts, HTTP/2 windows),
+    /// AWS Lambda settings, the optional request-identity signing key, and any
+    /// additional outbound headers applied to every invocation request.
+    ///
+    /// Since v1.7.0
+    #[serde(flatten)]
+    pub service_client: ServiceClientOptions,
 }
 
 impl InvokerOptions {
@@ -477,7 +494,28 @@ impl InvokerOptions {
             .unwrap_or_else(|| self.message_size_limit().get())
     }
 
-    pub(crate) fn merge(&mut self, opts: &NetworkingOptions) {
+    pub(crate) fn merge(&mut self, common: &CommonOptions, opts: &NetworkingOptions) {
+        #[allow(deprecated)]
+        self.service_client
+            .apply_deprecated("worker.invoker", common.service_client.clone());
+
+        if self.service_client.additional_request_headers.is_none() {
+            let cluster_name_visible_ascii = common
+                .cluster_name()
+                .chars()
+                .filter(|c| *c >= ' ' && *c <= '~')
+                .collect::<String>();
+
+            self.service_client.additional_request_headers = Some(
+                std::collections::HashMap::from_iter([(
+                    X_RESTATE_CLUSTER_NAME,
+                    http::HeaderValue::from_str(&cluster_name_visible_ascii)
+                        .expect("a visible ascii string must be a valid header value"),
+                )])
+                .into(),
+            )
+        }
+
         self.message_size_limit = Some(
             self.message_size_limit
                 .map(|limit| limit.min(opts.message_size_limit))
@@ -540,8 +578,94 @@ impl Default for InvokerOptions {
             ),
             per_invocation_memory_limit: None,
             per_invocation_initial_memory: DEFAULT_PER_INVOCATION_INITIAL_MEMORY,
+            service_client: ServiceClientOptions::default(),
         }
     }
+}
+
+/// # Service Client options
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize, derive_builder::Builder)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "schemars",
+    schemars(rename = "ServiceClientOptions", default)
+)]
+#[builder(default)]
+#[derive(Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct ServiceClientOptions {
+    #[serde(flatten)]
+    pub http: HttpOptions,
+    #[serde(flatten)]
+    pub lambda: AwsLambdaOptions,
+
+    /// # Request identity private key PEM file
+    ///
+    /// A path to a file, such as "/var/secrets/key.pem", which contains exactly one ed25519 private
+    /// key in PEM format. Such a file can be generated with `openssl genpkey -algorithm ed25519`.
+    /// If provided, this key will be used to attach JWTs to requests from this client which
+    /// SDKs may optionally verify, proving that the caller is a particular Restate instance.
+    ///
+    /// This file is currently only read on client creation, but this may change in future.
+    /// Parsed public keys will be logged at INFO level in the same format that SDKs expect.
+    pub request_identity_private_key_pem_file: Option<PathBuf>,
+
+    /// # Additional request headers
+    ///
+    /// Headers that should be applied to all outgoing requests (HTTP and Lambda).
+    /// Defaults to `x-restate-cluster-name: <cluster name>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub additional_request_headers: Option<SerdeableHeaderHashMap>,
+}
+
+impl ServiceClientOptions {
+    // todo: Remove in Restate v1.8
+    pub(crate) fn apply_deprecated(
+        &mut self,
+        new_base: &str,
+        deprecated: DeprecatedServiceClientOptions,
+    ) {
+        let DeprecatedServiceClientOptions {
+            http,
+            lambda,
+            request_identity_private_key_pem_file,
+            additional_request_headers,
+        } = deprecated;
+
+        self.http.apply_deprecated(new_base, http);
+        self.lambda.apply_deprecated(new_base, lambda);
+
+        super::apply_deprecated_field_optional(
+            &mut self.request_identity_private_key_pem_file,
+            request_identity_private_key_pem_file,
+            new_base,
+            "request-identity-private-key-pem-file",
+            None,
+        );
+        super::apply_deprecated_field_optional(
+            &mut self.additional_request_headers,
+            additional_request_headers,
+            new_base,
+            "additional-request-headers",
+            None,
+        );
+    }
+}
+
+/// Shadow of [`ServiceClientOptions`] for the deprecated `service-client` root location. Every
+/// leaf field is `Option<T>` so `None` means "user didn't set it" and `Some(_)` means "user set
+/// this value".
+// todo: Remove in Restate v1.8
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub(crate) struct DeprecatedServiceClientOptions {
+    #[serde(flatten)]
+    pub http: DeprecatedHttpOptions,
+    #[serde(flatten)]
+    pub lambda: DeprecatedAwsLambdaOptions,
+    pub request_identity_private_key_pem_file: Option<PathBuf>,
+    pub additional_request_headers: Option<SerdeableHeaderHashMap>,
 }
 
 /// # Storage options
@@ -971,5 +1095,65 @@ mod serde_helpers {
 
     pub fn is_default_compact_on_deletions_min_sst_file_size(v: &ByteCount) -> bool {
         *v == default_compact_on_deletions_min_sst_file_size()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+
+    #[test]
+    fn apply_deprecated_precedence() {
+        let base = "worker.invoker";
+
+        // empty shadow: canonical is untouched.
+        let mut new = ServiceClientOptions::default();
+        new.lambda.aws_profile = Some("kept".to_owned());
+        new.apply_deprecated(base, DeprecatedServiceClientOptions::default());
+        assert_eq!(new.lambda.aws_profile.as_deref(), Some("kept"));
+
+        // deprecated-only: the value migrates from the old location into the new one
+        // (also exercises delegation into the flattened `lambda` child).
+        let mut new = ServiceClientOptions::default();
+        let deprecated = DeprecatedServiceClientOptions {
+            lambda: DeprecatedAwsLambdaOptions {
+                aws_profile: Some("old".to_owned()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        new.apply_deprecated(base, deprecated);
+        assert_eq!(new.lambda.aws_profile.as_deref(), Some("old"));
+
+        // both set: deprecated wins (preserves the user's prior effective behavior during the
+        // migration window; warning fires telling them to remove the deprecated key).
+        let mut new = ServiceClientOptions::default();
+        new.http.connect_timeout = NonZeroFriendlyDuration::from_secs_unchecked(7);
+        let deprecated = DeprecatedServiceClientOptions {
+            http: DeprecatedHttpOptions {
+                connect_timeout: Some(NonZeroFriendlyDuration::from_secs_unchecked(5)),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        new.apply_deprecated(base, deprecated);
+        assert_eq!(
+            new.http.connect_timeout,
+            NonZeroFriendlyDuration::from_secs_unchecked(5)
+        );
+
+        // an own field migrates through the same logic
+        let mut new = ServiceClientOptions::default();
+        let deprecated = DeprecatedServiceClientOptions {
+            request_identity_private_key_pem_file: Some("/key.pem".into()),
+            ..Default::default()
+        };
+        new.apply_deprecated(base, deprecated);
+        assert_eq!(
+            new.request_identity_private_key_pem_file.as_deref(),
+            Some(Path::new("/key.pem"))
+        );
     }
 }

--- a/crates/types/src/config_loader.rs
+++ b/crates/types/src/config_loader.rs
@@ -83,7 +83,9 @@ impl ConfigLoader {
         config
             .ingress
             .set_derived_values(&config.common, &config.networking);
-        config.worker.set_derived_values(&config.networking);
+        config
+            .worker
+            .set_derived_values(&config.common, &config.networking);
 
         if self.metadata_migration_mode {
             // In metadata migration mode we keep only Admin and MetadataServer roles that were

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -434,7 +434,7 @@ where
                 self.partition.key_range,
                 InvokerStorageReader::new(partition_store.clone()),
                 invoker_tx,
-                &config.common.service_client,
+                &config.worker.invoker.service_client,
                 &config.worker.invoker,
                 EntryEnricher::new(schema.clone()),
                 schema,

--- a/lite/src/lib.rs
+++ b/lite/src/lib.rs
@@ -205,7 +205,9 @@ impl Restate {
             .ingress
             .set_derived_values(&config.common, &config.networking);
         config.admin.set_derived_values(&config.common);
-        config.worker.set_derived_values(&config.networking);
+        config
+            .worker
+            .set_derived_values(&config.common, &config.networking);
         let config = config.apply_cascading_values();
         config.validate()?;
 

--- a/release-notes/unreleased/service-client-config-location.md
+++ b/release-notes/unreleased/service-client-config-location.md
@@ -1,0 +1,70 @@
+# Release Notes: Move `service-client` options under `worker.invoker`
+
+## Deprecation
+
+### What Changed
+
+The service-client configuration options — HTTP client tuning, AWS Lambda options, request
+identity, and additional outbound headers — have moved from the TOML root to a dedicated
+section under `worker.invoker`. The previous root-level location continues
+to work but is deprecated and will be removed in Restate v1.8.
+
+Affected keys (every key in this list previously lived at the TOML root):
+
+- HTTP client: `http-keep-alive-options.interval`, `http-keep-alive-options.timeout`,
+  `http-keep-alive-options.jitter`, `http-proxy`, `no-proxy`, `connect-timeout`,
+  `initial-max-send-streams`, `streams-per-connection-limit`, `idle-connection-timeout`,
+  `http2-initial-stream-window-size`, `http2-initial-connection-window-size`,
+  `http2-max-frame-size`
+- AWS Lambda: `aws-profile`, `aws-assume-role-external-id`, `request-compression-threshold`
+- Identity / headers: `request-identity-private-key-pem-file`, `additional-request-headers`
+
+### Why This Matters
+
+These options govern the HTTP/Lambda client Restate uses to invoke service deployments —
+the worker's invoker. Their presence at the TOML root was a side effect of how the original
+config struct was flattened, and obscured their scope (the same keys at root read like they
+could apply to other HTTP clients in the system). Grouping them under
+`worker.invoker` makes the ownership explicit and aligns them with the
+other `worker.invoker.*` settings.
+
+### Migration Guidance
+
+Move existing settings from the TOML root into the new section. For example:
+
+```toml
+# Before — at the TOML root
+http-proxy = "http://proxy.internal:3128"
+no-proxy = "localhost,127.0.0.1"
+aws-profile = "restate-prod"
+request-identity-private-key-pem-file = "/var/secrets/key.pem"
+
+[http-keep-alive-options]
+interval = "1m"
+timeout = "30s"
+```
+
+becomes:
+
+```toml
+# After — under worker.invoker
+[worker.invoker]
+http-proxy = "http://proxy.internal:3128"
+no-proxy = "localhost,127.0.0.1"
+aws-profile = "restate-prod"
+request-identity-private-key-pem-file = "/var/secrets/key.pem"
+
+[worker.invoker.http-keep-alive-options]
+interval = "1m"
+timeout = "30s"
+```
+
+### Impact on Users
+
+- **Existing configs continue to work**: any affected key at the TOML root is still read
+  on startup and emits a deprecation warning telling you to move it.
+- **When both locations set the same key**, the deprecated (root) value takes precedence
+  and a warning is emitted. Remove the deprecated key once you've moved it to avoid the
+  warning and surprises when the old location is removed.
+- **Removal target**: the root-level keys will be removed in Restate v1.8. Migrate during
+  the v1.7 window.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -259,7 +259,7 @@ fn main() {
             config_loader.start();
 
             // Initialize telemetry
-            let telemetry = telemetry::Telemetry::create(&Configuration::pinned().common);
+            let telemetry = telemetry::Telemetry::create(&Configuration::pinned());
             telemetry.start();
 
             let node = Node::create(Configuration::live(), prometheus, address_book).await;

--- a/server/src/telemetry.rs
+++ b/server/src/telemetry.rs
@@ -13,7 +13,7 @@ use std::{str::FromStr, time::Duration};
 use http::{HeaderMap, HeaderValue, Uri, uri::PathAndQuery};
 use restate_core::{TaskCenter, TaskKind, cancellation_watcher};
 use restate_service_client::HttpClient;
-use restate_types::config::CommonOptions;
+use restate_types::config::Configuration;
 use tokio::time::Instant;
 use tracing::debug;
 
@@ -35,11 +35,11 @@ pub struct TelemetryEnabled {
 }
 
 impl Telemetry {
-    pub fn create(options: &CommonOptions) -> Self {
-        if options.disable_telemetry {
+    pub fn create(config: &Configuration) -> Self {
+        if config.common.disable_telemetry {
             Self::Disabled
         } else {
-            let client = HttpClient::from_options(&options.service_client.http);
+            let client = HttpClient::from_options(&config.worker.invoker.service_client.http);
             let session_id = ulid::Ulid::new().to_string();
 
             Self::Enabled(Box::new(TelemetryEnabled {

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -226,9 +226,11 @@ async fn generate_rest_api_doc() -> anyhow::Result<()> {
 
     let socket_dir = tempfile::tempdir()?;
     let socket_path = socket_dir.path().join("admin.sock");
-    let service_client =
-        ServiceClient::from_options(&config.common.service_client, AssumeRoleCacheMode::None)
-            .unwrap();
+    let service_client = ServiceClient::from_options(
+        &config.worker.invoker.service_client,
+        AssumeRoleCacheMode::None,
+    )
+    .unwrap();
     let admin_service = AdminService::new(
         Listeners::new_unix_listener(socket_path.clone())?,
         node_env.metadata_writer.clone(),


### PR DESCRIPTION
config: deprecate root-level service-client options in favor of worker.invoker.service-client

The service-client options (HTTP client, AWS Lambda, request-identity key,
additional headers) were configurable via CommonOptions::service_client, which
is #[serde(flatten)]-chained through CommonOptions into Configuration. As a
result these keys collapse to bare, prefix-less keys at the TOML root. They now
live under worker.invoker.* location instead.

This introduces the migration mechanism that reads values set at the old
(deprecated) location and applies them to the new one, warning the user to move
each option it finds.

> Note: the deprecation message does not include flags that was added in v1.7

## Output snippet:
```
Using the deprecated config option 'http-keep-alive-options.interval' instead of 'worker.invoker.http2-keep-alive-interval'. Please update the config to use 'w
orker.invoker.http2-keep-alive-interval' instead.
Using the deprecated config option 'http-keep-alive-options.timeout' instead of 'worker.invoker.http2-keep-alive-timeout'. Please update the config to use 'wor
ker.invoker.http2-keep-alive-timeout' instead.
Using the deprecated config option 'http-keep-alive-options.jitter' instead of 'worker.invoker.http2-keep-alive-jitter'. Please update the config to use 'worke
r.invoker.http2-keep-alive-jitter' instead.
Using the deprecated config option 'initial-max-send-streams' instead of 'worker.invoker.http2-initial-max-send-streams'. Please update the config to use 'work
er.invoker.http2-initial-max-send-streams' instead.
```
