### PR TITLE
Fix orphan jc-index cleanup poisoning the partition store after a snapshot restore (#4838)

### DIFF
--- a/crates/partition-store/src/journal_table_v2/mod.rs
+++ b/crates/partition-store/src/journal_table_v2/mod.rs
@@ -339,8 +339,8 @@ fn delete_journal<S: StorageAccess>(
 /// Only the keys for a single invocation are held in memory at any time to avoid unbounded
 /// memory usage on large stores.
 ///
-/// The `is_cancelled` predicate is checked when moving to a new invocation. If it returns
-/// `true`, the scan stops early and the returned `cancelled` flag is set to `true`.
+/// The `is_cancelled` predicate is checked on every scanned entry. If it returns `true`, the
+/// scan stops early and the returned `cancelled` flag is set to `true`.
 pub fn cleanup_orphaned_completion_id_index_entries(
     storage: &mut PartitionStore,
     is_cancelled: impl Fn() -> bool,
@@ -361,6 +361,15 @@ pub fn cleanup_orphaned_completion_id_index_entries(
     let mut current_invocation: Option<(PartitionKey, InvocationUuid, bool)> = None;
 
     for (mut key_bytes, _) in iter {
+        // Check cancellation on every entry so the task stops promptly when the owning
+        // partition processor shuts down. This bounds the window in which the cleanup may
+        // outlive the processor and write to a column family that a concurrent snapshot
+        // restore has dropped. See https://github.com/restatedev/restate/issues/4838.
+        if is_cancelled() {
+            cancelled = true;
+            break;
+        }
+
         let jc_key = JournalCompletionIdToCommandIndexKey::deserialize_from(&mut key_bytes)?;
 
         let is_orphan = match &current_invocation {
@@ -371,11 +380,6 @@ pub fn cleanup_orphaned_completion_id_index_entries(
                 *orphan
             }
             _ => {
-                // Check cancellation at invocation boundaries.
-                if is_cancelled() {
-                    cancelled = true;
-                    break;
-                }
                 // New invocation -- check if its journal still exists.
                 let orphan =
                     !has_journal_entries(storage, jc_key.partition_key, jc_key.invocation_uuid)?;
@@ -388,7 +392,7 @@ pub fn cleanup_orphaned_completion_id_index_entries(
         };
 
         if is_orphan {
-            storage.delete_key(&jc_key)?;
+            storage.delete_key_tolerating_missing_cf(&jc_key)?;
             deleted_entries += 1;
         }
     }

--- a/crates/partition-store/src/partition_db.rs
+++ b/crates/partition-store/src/partition_db.rs
@@ -390,9 +390,11 @@ impl PartitionCell {
             .import_cf(self.meta.cf_name().into(), import_metadata)
             .await?;
 
+        // Eagerly remove the staging directory on the success path. Downloaded snapshots also
+        // carry a TempDir guard that would clean it up on drop, but locally-produced snapshots
+        // (staging_guard == None) rely on this removal. Best-effort: since the SST files were
+        // moved into RocksDB on import, at worst the metadata file remains.
         if let Err(err) = tokio::fs::remove_dir_all(&snapshot.base_dir).await {
-            // This is not critical; since we move the SST files into RocksDB on import,
-            // at worst only the snapshot metadata file will remain in the staging dir
             warn!(
                 %err,
                 "Failed to remove local snapshot directory, continuing with startup",

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -644,6 +644,9 @@ impl PartitionStore {
             log_id: self.db.partition().log_id(),
             min_applied_lsn: applied_lsn,
             key_range: self.db.partition().key_range,
+            // Exported (not downloaded) snapshots write into a caller-managed directory that the
+            // upload path cleans up; no staging guard to own here.
+            staging_guard: None,
         })
     }
 
@@ -660,6 +663,34 @@ impl PartitionStore {
     /// Marks the one-time `jc` orphan cleanup as complete so it won't run again.
     pub fn mark_jc_orphan_cleanup_done(&mut self) -> Result<()> {
         put_jc_orphan_cleanup_done(self, self.partition_id())
+    }
+
+    /// Deletes a key, tolerating a column family that has been dropped concurrently.
+    ///
+    /// With `ignore_missing_column_families`, a write whose CF no longer exists becomes a
+    /// no-op instead of a fatal RocksDB background error that would take the entire (shared)
+    /// database read-only and fail all other partitions. This is only safe for best-effort
+    /// maintenance writes; the one-time orphan cleanup uses it because it runs on a clone of
+    /// the store whose CF a concurrent snapshot restore may drop.
+    /// See https://github.com/restatedev/restate/issues/4838.
+    pub(crate) fn delete_key_tolerating_missing_cf<K: EncodeTableKey>(
+        &mut self,
+        key: &K,
+    ) -> Result<()> {
+        let buffer = self.cleared_key_buffer_mut(key.serialized_length());
+        key.serialize_to(buffer);
+        let buffer = buffer.split();
+
+        let mut write_opts = rocksdb::WriteOptions::default();
+        write_opts.set_ignore_missing_column_families(true);
+
+        let table = self.table_handle(K::TABLE);
+        self.db
+            .rocksdb()
+            .inner()
+            .as_raw_db()
+            .delete_cf_opt(table, buffer, &write_opts)
+            .map_err(|error| StorageError::Generic(error.into()))
     }
 
     pub async fn verify_and_run_migrations(&mut self) -> Result<()> {

--- a/crates/partition-store/src/partition_store_manager.rs
+++ b/crates/partition-store/src/partition_store_manager.rs
@@ -148,7 +148,70 @@ impl PartitionStoreManager {
             use_multi_db_layout,
         });
 
+        // Remove snapshot staging directories left over from a previous run before any
+        // partition opens. These are download scratch dirs that are normally cleaned up on
+        // import/drop, but a hard crash mid-restore can leave them behind, and historically a
+        // restore crash-loop leaked one per retry until the disk filled. Safe here because no
+        // download can be in flight yet. See https://github.com/restatedev/restate/issues/4838.
+        Self::remove_stale_snapshot_staging().await;
+
         Ok(psm)
+    }
+
+    async fn remove_stale_snapshot_staging() {
+        let staging_dir = Configuration::pinned()
+            .worker
+            .storage
+            .snapshots_staging_dir();
+
+        let mut entries = match tokio::fs::read_dir(&staging_dir).await {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return,
+            Err(err) => {
+                warn!(
+                    %err,
+                    staging_dir = %staging_dir.display(),
+                    "Failed to scan snapshot staging directory for stale entries"
+                );
+                return;
+            }
+        };
+
+        let mut removed = 0usize;
+        loop {
+            match entries.next_entry().await {
+                Ok(Some(entry)) => {
+                    let path = entry.path();
+                    let result = match entry.file_type().await {
+                        Ok(file_type) if file_type.is_dir() => {
+                            tokio::fs::remove_dir_all(&path).await
+                        }
+                        _ => tokio::fs::remove_file(&path).await,
+                    };
+                    match result {
+                        Ok(()) => removed += 1,
+                        Err(err) => warn!(
+                            %err,
+                            path = %path.display(),
+                            "Failed to remove stale snapshot staging entry"
+                        ),
+                    }
+                }
+                Ok(None) => break,
+                Err(err) => {
+                    warn!(%err, "Failed to enumerate snapshot staging directory");
+                    break;
+                }
+            }
+        }
+
+        if removed > 0 {
+            info!(
+                removed,
+                staging_dir = %staging_dir.display(),
+                "Removed stale snapshot staging entries left from a previous run"
+            );
+        }
     }
 
     async fn open_rocksdb(&self, partition: &Partition) -> Result<Arc<RocksDb>, RocksError> {

--- a/crates/partition-store/src/snapshots/metadata.rs
+++ b/crates/partition-store/src/snapshots/metadata.rs
@@ -14,6 +14,7 @@ use rocksdb::LiveFile;
 use serde::{Deserialize, Serialize};
 use serde_with::hex::Hex;
 use serde_with::{DeserializeAs, SerializeAs, serde_as};
+use tempfile::TempDir;
 
 use restate_types::identifiers::{PartitionId, SnapshotId};
 use restate_types::logs::{LogId, Lsn};
@@ -159,6 +160,15 @@ pub struct LocalPartitionSnapshot {
     pub db_comparator_name: String,
     pub files: Vec<LiveFile>,
     pub key_range: KeyRange,
+    /// Owns the temporary staging directory for downloaded snapshots and removes it on drop.
+    /// This guarantees the staging directory is cleaned up on every error/abort path, not just
+    /// after a successful import -- otherwise a restore that keeps failing (e.g. while the DB is
+    /// already in an error state) leaks a copy of the snapshot per retry and can fill the disk.
+    /// `None` for locally-produced snapshots that are not downloaded into a temp dir.
+    /// See https://github.com/restatedev/restate/issues/4838.
+    // Held only for its `Drop` side effect (removing the staging directory); never read.
+    #[allow(dead_code)]
+    pub(crate) staging_guard: Option<TempDir>,
 }
 /// RocksDB SST file that is part of a snapshot. Serialization wrapper around [LiveFile].
 #[serde_as]

--- a/crates/partition-store/src/snapshots/repository.rs
+++ b/crates/partition-store/src/snapshots/repository.rs
@@ -850,12 +850,15 @@ impl SnapshotRepository {
             "Downloaded partition snapshot",
         );
         Ok(Some(LocalPartitionSnapshot {
-            base_dir: snapshot_dir.keep(),
+            base_dir: snapshot_dir.path().to_path_buf(),
             log_id: snapshot_metadata.log_id,
             min_applied_lsn: snapshot_metadata.min_applied_lsn,
             db_comparator_name: snapshot_metadata.db_comparator_name,
             files: snapshot_metadata.files,
             key_range: snapshot_metadata.key_range,
+            // Hold on to the TempDir so the staging directory is removed on drop unless a
+            // successful import has already consumed it. See issue #4838.
+            staging_guard: Some(snapshot_dir),
         }))
     }
 
@@ -1278,11 +1281,12 @@ mod tests {
         let latest = repository.get_latest(PartitionId::MIN).await?.unwrap();
         assert_eq!(latest.min_applied_lsn, snapshot2.min_applied_lsn);
         let local_path = latest.base_dir.as_path().to_string_lossy().to_string();
+        // The staging directory exists while the downloaded snapshot is held...
+        assert!(tokio::fs::try_exists(&local_path).await?);
         drop(latest);
-
-        let local_dir_exists = tokio::fs::try_exists(&local_path).await?;
-        assert!(local_dir_exists);
-        tokio::fs::remove_dir_all(&local_path).await?;
+        // ...and is removed when it is dropped without being imported, so a failing restore
+        // cannot leak a copy of the snapshot per retry. See issue #4838.
+        assert!(!tokio::fs::try_exists(&local_path).await?);
 
         Ok(())
     }

--- a/crates/partition-store/src/tests/jc_orphan_cleanup_test.rs
+++ b/crates/partition-store/src/tests/jc_orphan_cleanup_test.rs
@@ -1,0 +1,87 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use restate_core::TestCoreEnv;
+use restate_rocksdb::RocksDbManager;
+use restate_storage_api::Transaction;
+use restate_storage_api::fsm_table::{ReadFsmTable, WriteFsmTable};
+use restate_types::identifiers::{InvocationUuid, PartitionId, PartitionKey};
+use restate_types::partitions::Partition;
+use restate_types::sharding::KeyRange;
+
+use crate::PartitionStoreManager;
+use crate::journal_table_v2::JournalCompletionIdToCommandIndexKey;
+
+/// Regression test for https://github.com/restatedev/restate/issues/4838.
+///
+/// The one-time orphan cleanup runs on a clone of the partition store and could outlive a
+/// concurrent snapshot restore that drops and re-imports the partition's column family. Its
+/// delete then targeted a dropped CF, and -- because all partitions share a single RocksDB --
+/// the resulting fatal background error took the whole database read-only and crash-looped every
+/// partition. This verifies that a best-effort delete to a dropped CF is silently ignored and
+/// leaves the shared database fully writable.
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tolerant_delete_to_dropped_cf_does_not_poison_shared_db() {
+    let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+    RocksDbManager::init();
+
+    // Single shared RocksDB instance for all partitions (use_multi_db_layout = false), as in a
+    // default production deployment -- this is what makes a poisoning write catastrophic.
+    let manager = PartitionStoreManager::create(false)
+        .await
+        .expect("manager creation succeeds");
+
+    let partition_a = Partition::new(PartitionId::MIN, KeyRange::new(0, PartitionKey::MAX / 2));
+    let partition_b = Partition::new(
+        PartitionId::from(42),
+        KeyRange::new(PartitionKey::MAX / 2 + 1, PartitionKey::MAX - 1),
+    );
+
+    let store_a = manager.open(&partition_a, None).await.expect("open a");
+    let mut store_b = manager.open(&partition_b, None).await.expect("open b");
+
+    // A stale clone of A, mirroring the cleanup task that kept a CF handle past a restore.
+    let mut stale_a = store_a.clone();
+
+    // Drop partition A's column family out from under the stale handle, as a snapshot restore
+    // (drop_cf + import_cf) would.
+    manager
+        .drop_partition(PartitionId::MIN)
+        .await
+        .expect("drop a's column family");
+
+    // The best-effort delete through the stale handle must neither fail nor poison the shared DB.
+    let orphan_key = JournalCompletionIdToCommandIndexKey {
+        partition_key: 1,
+        invocation_uuid: InvocationUuid::from_u128(1),
+        completion_id: 1,
+    };
+    stale_a
+        .delete_key_tolerating_missing_cf(&orphan_key)
+        .expect("delete to a dropped CF must be ignored, not error");
+
+    // Partition B shares the same RocksDB; it must remain writable, proving the database was not
+    // put into read-only mode by the write above.
+    {
+        let mut txn = store_b.transaction();
+        txn.put_inbox_seq_number(42).expect("stage write to b");
+        txn.commit()
+            .await
+            .expect("commit to b must succeed -- shared DB must not be poisoned");
+    }
+
+    let seq_number = store_b
+        .get_inbox_seq_number()
+        .await
+        .expect("read back from b");
+    assert_eq!(seq_number, 42);
+
+    RocksDbManager::get().shutdown().await;
+}

--- a/crates/partition-store/src/tests/mod.rs
+++ b/crates/partition-store/src/tests/mod.rs
@@ -32,6 +32,7 @@ mod barrier_test;
 mod durable_lsn_tracking_test;
 mod inbox_table_test;
 mod invocation_status_table_test;
+mod jc_orphan_cleanup_test;
 mod journal_events_table_test;
 mod journal_table_test;
 mod journal_table_v2_test;

--- a/crates/partition-store/src/tests/snapshots_test/mod.rs
+++ b/crates/partition-store/src/tests/snapshots_test/mod.rs
@@ -69,6 +69,7 @@ pub(crate) async fn run_tests(
         db_comparator_name: snapshot_meta.db_comparator_name.clone(),
         files: snapshot_meta.files.clone(),
         key_range,
+        staging_guard: None,
     };
 
     let mut new_partition_store = manager

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -156,76 +156,80 @@ where
 
                     let mut partition_store = partition_store?;
 
-                    // One-time background cleanup of orphaned jc index entries left behind
-                    // by a bug in delete_journal that used the wrong scan prefix.
-                    // Runs on a blocking thread so it doesn't starve the tokio runtime.
-                    // The child task is bound to the partition processor's lifecycle and
-                    // will be cancelled if the processor shuts down (e.g. due to trim gap).
+                    // One-time cleanup of orphaned jc index entries left behind by a bug in
+                    // delete_journal that used the wrong scan prefix. Runs on a blocking thread
+                    // so it doesn't starve the tokio runtime, but is awaited here -- *before*
+                    // the processor starts -- so it can never outlive the partition attempt.
+                    // This upholds the invariant that once the processor task terminates there
+                    // are no further writes to this partition's store, which prevents writing to
+                    // a column family that a concurrent snapshot restore has dropped.
+                    // See https://github.com/restatedev/restate/issues/4838.
                     if partition_store.needs_jc_orphan_cleanup()? {
                         let mut cleanup_store = partition_store.clone();
                         let cleanup_partition_id = partition_store.partition_id();
                         let cancel = cancellation_token();
-                        TaskCenter::spawn_child(
-                            TaskKind::Background,
-                            "jc-orphan-cleanup",
-                            async move {
-                                let result = tokio::task::spawn_blocking(move || {
-                                    let start = Instant::now();
-                                    let result = restate_partition_store::cleanup_orphaned_completion_id_index_entries(
-                                        &mut cleanup_store,
-                                        || cancel.is_cancelled(),
-                                    );
-                                    (result, cleanup_store, start.elapsed())
-                                }).await.expect("cleanup blocking task must not panic");
+                        let cleanup_result = tokio::task::spawn_blocking(move || {
+                            let start = Instant::now();
+                            let result = restate_partition_store::cleanup_orphaned_completion_id_index_entries(
+                                &mut cleanup_store,
+                                || cancel.is_cancelled(),
+                            );
+                            (result, cleanup_store, start.elapsed())
+                        })
+                        .await;
 
-                                let (result, mut cleanup_store, elapsed) = result;
-                                match result {
-                                    Ok(outcome) => {
-                                        if outcome.cancelled {
-                                            info!(
-                                                partition_id = %cleanup_partition_id,
-                                                deleted_entries = outcome.deleted_entries,
-                                                affected_invocations = outcome.affected_invocations,
-                                                ?elapsed,
-                                                "Orphaned jc index cleanup cancelled, \
-                                                 will retry on next startup"
-                                            );
-                                        } else if outcome.deleted_entries > 0 {
-                                            info!(
-                                                partition_id = %cleanup_partition_id,
-                                                deleted_entries = outcome.deleted_entries,
-                                                affected_invocations = outcome.affected_invocations,
-                                                ?elapsed,
-                                                "Cleaned up orphaned journal completion-id index entries"
-                                            );
-                                        } else {
-                                            debug!(
-                                                partition_id = %cleanup_partition_id,
-                                                ?elapsed,
-                                                "No orphaned journal completion-id index entries found"
-                                            );
-                                        }
-                                        if !outcome.cancelled && let Err(err) = cleanup_store.mark_jc_orphan_cleanup_done()
-                                            {
-                                                warn!(
-                                                    partition_id = %cleanup_partition_id,
-                                                    "Failed to mark jc orphan cleanup as done, \
-                                                     will retry on next startup: {err}"
-                                                );
-                                            }
-                                    }
-                                    Err(err) => {
-                                        warn!(
-                                            partition_id = %cleanup_partition_id,
-                                            ?elapsed,
-                                            "Failed to clean up orphaned journal completion-id \
-                                             index entries, will retry on next startup: {err}"
-                                        );
-                                    }
+                        match cleanup_result {
+                            // The cleanup is best-effort: neither a panic nor an error must take
+                            // down the partition processor. Both retry on the next startup.
+                            Err(join_err) => {
+                                warn!(
+                                    partition_id = %cleanup_partition_id,
+                                    "Orphaned jc index cleanup task panicked, \
+                                     will retry on next startup: {join_err}"
+                                );
+                            }
+                            Ok((Ok(outcome), _, elapsed)) if outcome.cancelled => {
+                                info!(
+                                    partition_id = %cleanup_partition_id,
+                                    deleted_entries = outcome.deleted_entries,
+                                    affected_invocations = outcome.affected_invocations,
+                                    ?elapsed,
+                                    "Orphaned jc index cleanup cancelled, will retry on next startup"
+                                );
+                            }
+                            Ok((Ok(outcome), mut cleanup_store, elapsed)) => {
+                                if outcome.deleted_entries > 0 {
+                                    info!(
+                                        partition_id = %cleanup_partition_id,
+                                        deleted_entries = outcome.deleted_entries,
+                                        affected_invocations = outcome.affected_invocations,
+                                        ?elapsed,
+                                        "Cleaned up orphaned journal completion-id index entries"
+                                    );
+                                } else {
+                                    debug!(
+                                        partition_id = %cleanup_partition_id,
+                                        ?elapsed,
+                                        "No orphaned journal completion-id index entries found"
+                                    );
                                 }
-                                Ok(())
-                            },
-                        )?;
+                                if let Err(err) = cleanup_store.mark_jc_orphan_cleanup_done() {
+                                    warn!(
+                                        partition_id = %cleanup_partition_id,
+                                        "Failed to mark jc orphan cleanup as done, \
+                                         will retry on next startup: {err}"
+                                    );
+                                }
+                            }
+                            Ok((Err(err), _, elapsed)) => {
+                                warn!(
+                                    partition_id = %cleanup_partition_id,
+                                    ?elapsed,
+                                    "Failed to clean up orphaned journal completion-id \
+                                     index entries, will retry on next startup: {err}"
+                                );
+                            }
+                        }
                     }
 
                     let pp = pp_builder

--- a/release-notes/unreleased/4838-fix-jc-cleanup-cf-poisoning.md
+++ b/release-notes/unreleased/4838-fix-jc-cleanup-cf-poisoning.md
@@ -1,0 +1,47 @@
+# Release Notes for Issue #4838: Fix orphan-cleanup poisoning the partition store after a snapshot restore
+
+## Bug Fix
+
+### What Changed
+
+Fixed a crash loop that could take down a node after upgrading to the version that
+introduced the one-time orphaned journal completion-id (`jc`) index cleanup (#4519).
+
+The cleanup ran as a detached background task on a clone of the partition store. If the
+partition processor restarted and restored from a snapshot (which drops and re-imports the
+partition's column family) while that cleanup was still running, the cleanup would issue a
+delete against the dropped column family. Because all partitions share a single RocksDB
+instance, the resulting fatal background error put the entire database into read-only mode
+and crash-looped every partition on the node. Each restart then re-downloaded the snapshot
+into a fresh staging directory without removing the previous one, eventually filling the
+data volume.
+
+Three changes address this:
+
+1. **Lifecycle.** The cleanup is now awaited before the partition processor starts, so it
+   can no longer outlive the partition attempt or run concurrently with a snapshot restore.
+   It still runs on a blocking thread (it does not stall the async runtime) and is checked
+   for cancellation on every entry so shutdown remains prompt.
+2. **Defense in depth.** The cleanup's deletes now tolerate a missing column family, so a
+   stray write to a dropped CF is ignored instead of poisoning the shared database.
+3. **Staging cleanup.** Downloaded snapshot staging directories are now removed on every
+   error/abort path (not only after a successful import), and any directories left behind by
+   a previous run are swept on startup, so a failing restore can no longer leak a copy of
+   the snapshot per retry.
+
+### Impact on Users
+
+- **Existing deployments**: No action required. The one-time `jc` cleanup still runs
+  automatically on the first startup after upgrade and is still tracked per partition store
+  so it only runs once; it is now performed before the partition starts serving, which may
+  add a short, one-time startup delay on stores that have orphaned entries to remove.
+- **New deployments**: No impact.
+
+### Migration Guidance
+
+No action required.
+
+### Related Issues
+
+- Issue #4838
+- Issue #4519


### PR DESCRIPTION
## Summary

Fixes #4838 — a crash loop that took a node down after the upgrade that introduced the one-time orphaned journal completion-id (`jc`) index cleanup (#4519).

### Root cause (confirmed against the incident logs)

The cleanup ran as a **detached** background task (`TaskCenter::spawn_child` + `spawn_blocking`) on a **clone** of the partition store, holding that partition's RocksDB column-family handle. When a lagging, just-upgraded follower hit a trim gap, the partition processor restarted and restored from a snapshot, which **drops and re-imports the column family**. The still-running cleanup then issued a `delete` against the dropped CF. Because all partitions share a **single** RocksDB instance, the failed memtable insert raised a fatal `KMemTable` background error that put the **entire** database into read-only mode and crash-looped every partition. Each retry re-downloaded the snapshot into a fresh staging dir without removing the previous one, filling the data volume.

Timeline confirmed on the affected node: snapshot drop (`…dropping local partition store state`) → shared-DB background error (`db=db reason=KMemTable Invalid column family specified in write batch`) → cleanup failure → re-import. All three nodes had orphans and ran the cleanup; only the one that took a fast-forward restore *concurrent with* the cleanup was poisoned.

## What changed

1. **Lifecycle (the fix).** The cleanup is now **awaited before the partition processor starts**, instead of detached. It still runs on `spawn_blocking` (doesn't stall the async runtime) and now checks cancellation **on every scanned entry** so shutdown stays prompt. This upholds the invariant: *once the processor task terminates, there are no further writes to that partition's store* — so a concurrent snapshot restore can no longer drop the CF underneath a live cleanup. A panic in the cleanup is also handled gracefully (logged, retried next startup) rather than aborting the attempt.

2. **Defense in depth.** The cleanup's deletes go through a new `PartitionStore::delete_key_tolerating_missing_cf`, which sets `WriteOptions::ignore_missing_column_families(true)`. A stray write to a since-dropped CF becomes a no-op instead of poisoning the shared database. (Note: this is *per-write* and does not weaken paranoid checks for normal writes — and WAL state is irrelevant here since the failure is a `kMemTable` insert error.)

3. **Snapshot staging leak.** `LocalPartitionSnapshot` now owns a `TempDir` staging guard (RAII), so a downloaded snapshot's staging directory is removed on **every** error/abort path, not only after a successful import. A startup sweep in `PartitionStoreManager::create` also removes any staging dirs left behind by a previous run. Together these stop a failing restore from leaking a snapshot copy per retry.

## Tests

- New `tolerant_delete_to_dropped_cf_does_not_poison_shared_db`: opens two partitions on one shared RocksDB, drops partition A's CF, issues a tolerant delete through the stale handle, and asserts partition B remains writable (DB not poisoned). Verified it **fails** without the `ignore_missing_column_families` flag.
- Updated the repository download test to assert the staging dir exists while the snapshot is held and is **removed on drop** (a leak regression test).
- `cargo fmt`, `cargo clippy --all-features --all-targets -D warnings`, and the full `restate-partition-store` suite pass; `restate-worker` tests compile.

## Reviews

Reviewed by OpenAI Codex and an internal code-review agent — no blockers or majors; their nits (a stale doc comment, a now-redundant explicit `remove_dir_all`, and the cleanup-panic handling) are addressed.

## Follow-ups (not in this PR)

- Disk-full recoverability: a partition store that hit `No space left on device` should fail cleanly and recover on restart without a manual wipe.

## Release note

`release-notes/unreleased/4838-fix-jc-cleanup-cf-poisoning.md`.
