### PR TITLE
[Restate UI] Update to v0.1.64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8830,8 +8830,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.63"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.63#3c88d418452801434d4e1ace6bd595fe92f1277e"
+version = "0.1.64"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.64#9218de1c1b8d50093086fd39ffc5ab7b89520e06"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -39,7 +39,7 @@ restate-util-time = { workspace = true }
 restate-types = { workspace = true }
 restate-util-string = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.63", tag = "v0.1.63" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.64", tag = "v0.1.64" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.64
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.64/ui-v0.1.64.zip