### PR TITLE
[Restate UI] Update to v0.1.66

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8830,8 +8830,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.65"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.65#5a0cea1b4d867af0808b032e0b111fe5eedecf4d"
+version = "0.1.66"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.66#1b55facd029fdbac87521ce9ee4d7c6dab3e5a33"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -39,7 +39,7 @@ restate-util-time = { workspace = true }
 restate-types = { workspace = true }
 restate-util-string = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.65", tag = "v0.1.65" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.66", tag = "v0.1.66" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v0.1.66
published at https://github.com/restatedev/restate-web-ui/releases/download/v0.1.66/ui-v0.1.66.zip