### PR TITLE
Fix panic observed when upgrading an existing cluster due to clean up of orphaned journal completion ids

### DIFF
--- a/crates/partition-store/src/partition_db.rs
+++ b/crates/partition-store/src/partition_db.rs
@@ -352,7 +352,7 @@ impl PartitionCell {
     }
 
     // low-level importing a column family from a locally downloaded a snapshot
-    #[instrument(level = "error", skip_all, fields(partition_id = %self.meta.partition_id, cf_name = %self.meta.cf_name(), path = %snapshot.base_dir.display()))]
+    #[instrument(level = "error", skip_all, fields(partition_id = %self.meta.partition_id, cf_name = %self.meta.cf_name(), path = %snapshot.base_dir.path().display()))]
     pub async fn import_cf(
         &self,
         guard: &mut tokio::sync::RwLockWriteGuard<'_, State>,
@@ -377,7 +377,7 @@ impl PartitionCell {
 
         info!(
             snapshot_applied_lsn = %snapshot.min_applied_lsn,
-            path = ?snapshot.base_dir,
+            path = ?snapshot.base_dir.path(),
             "Importing partition store snapshot"
         );
 
@@ -390,14 +390,8 @@ impl PartitionCell {
             .import_cf(self.meta.cf_name().into(), import_metadata)
             .await?;
 
-        if let Err(err) = tokio::fs::remove_dir_all(&snapshot.base_dir).await {
-            // This is not critical; since we move the SST files into RocksDB on import,
-            // at worst only the snapshot metadata file will remain in the staging dir
-            warn!(
-                %err,
-                "Failed to remove local snapshot directory, continuing with startup",
-            );
-        };
+        // Remove the remaining snapshot files in a non-blocking way.
+        snapshot.base_dir.remove().await;
 
         let db = PartitionDb::new(
             self.meta.clone(),

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -53,7 +53,7 @@ use crate::migrations::run_migrations_up_to;
 use crate::partition_db::PartitionDb;
 use crate::scan::PhysicalScan;
 use crate::scan::TableScan;
-use crate::snapshots::LocalPartitionSnapshot;
+use crate::snapshots::{LocalPartitionSnapshot, SnapshotDir};
 
 pub type DB = rocksdb::DB;
 
@@ -638,7 +638,7 @@ impl PartitionStore {
         );
 
         Ok(LocalPartitionSnapshot {
-            base_dir: snapshot_dir,
+            base_dir: SnapshotDir::new(snapshot_dir),
             files: export_files.get_files(),
             db_comparator_name: export_files.get_db_comparator_name(),
             log_id: self.db.partition().log_id(),

--- a/crates/partition-store/src/snapshots/metadata.rs
+++ b/crates/partition-store/src/snapshots/metadata.rs
@@ -8,12 +8,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use rocksdb::LiveFile;
 use serde::{Deserialize, Serialize};
 use serde_with::hex::Hex;
 use serde_with::{DeserializeAs, SerializeAs, serde_as};
+use tracing::warn;
 
 use restate_types::identifiers::{PartitionId, SnapshotId};
 use restate_types::logs::{LogId, Lsn};
@@ -150,10 +151,76 @@ impl From<PartitionSnapshotMetadataShadow> for PartitionSnapshotMetadata {
     }
 }
 
+/// Owns a snapshot's local on-disk directory and removes it when dropped.
+///
+/// This makes [`LocalPartitionSnapshot`] the sole owner of its staging directory: the files
+/// never outlive the snapshot, so a failed restore or upload cannot leak them (see
+/// <https://github.com/restatedev/restate/issues/4838>). A caller that genuinely needs the
+/// directory to outlive the snapshot must explicitly take ownership via [`SnapshotDir::into_path`].
+#[derive(Debug)]
+pub struct SnapshotDir {
+    // `None` only after `into_path` has relinquished ownership; the value is taken in both
+    // `into_path` and `Drop`, so the directory is removed at most once.
+    path: Option<PathBuf>,
+}
+
+impl SnapshotDir {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path: Some(path) }
+    }
+
+    pub fn path(&self) -> &Path {
+        self.path
+            .as_deref()
+            .expect("path is present until into_path() or drop")
+    }
+
+    /// Relinquishes ownership of the directory: returns its path and disables the drop-time
+    /// cleanup. Use when the directory must outlive the snapshot.
+    pub fn into_path(mut self) -> PathBuf {
+        self.path
+            .take()
+            .expect("path is present until into_path() or drop")
+    }
+
+    /// Asynchronously removes the directory, consuming the guard. Prefer this over the
+    /// synchronous drop-time cleanup when running on an async runtime and the directory may hold
+    /// large files (e.g. a freshly exported snapshot before upload).
+    pub async fn remove(self) {
+        let path = self.into_path();
+        if let Err(err) = tokio::fs::remove_dir_all(&path).await
+            && err.kind() != std::io::ErrorKind::NotFound
+        {
+            warn!(
+                %err,
+                path = %path.display(),
+                "Failed to remove local snapshot directory",
+            );
+        }
+    }
+}
+
+impl Drop for SnapshotDir {
+    fn drop(&mut self) {
+        if let Some(path) = self.path.take()
+            && let Err(err) = std::fs::remove_dir_all(&path)
+            && err.kind() != std::io::ErrorKind::NotFound
+        {
+            warn!(
+                %err,
+                path = %path.display(),
+                "Failed to remove local snapshot directory",
+            );
+        }
+    }
+}
+
 /// A locally-stored partition snapshot.
 #[derive(Debug)]
 pub struct LocalPartitionSnapshot {
-    pub base_dir: PathBuf,
+    /// The snapshot's local directory. Owned by the snapshot and removed on drop unless
+    /// explicitly relinquished via [`SnapshotDir::into_path`].
+    pub base_dir: SnapshotDir,
     pub log_id: LogId,
     pub min_applied_lsn: Lsn,
     pub db_comparator_name: String,

--- a/crates/partition-store/src/snapshots/repository.rs
+++ b/crates/partition-store/src/snapshots/repository.rs
@@ -38,7 +38,9 @@ use restate_types::logs::{LogId, Lsn};
 use restate_types::nodes_config::ClusterFingerprint;
 use restate_types::time::MillisSinceEpoch;
 
-use super::{LocalPartitionSnapshot, PartitionSnapshotMetadata, SnapshotFormatVersion};
+use super::{
+    LocalPartitionSnapshot, PartitionSnapshotMetadata, SnapshotDir, SnapshotFormatVersion,
+};
 
 /// Provides read and write access to the long-term partition snapshot storage destination.
 ///
@@ -322,6 +324,12 @@ impl SnapshotRepository {
         )
         .await?;
 
+        // Best-effort cleanup of leftover snapshot staging directories from a previous run
+        // (e.g. downloads interrupted by a hard crash mid-import, which the per-download RAII
+        // guard cannot clean up). Safe here because no downloads are in flight at startup.
+        // See https://github.com/restatedev/restate/issues/4838.
+        Self::sweep_staging_dir(&staging_dir).await;
+
         Ok(Some(SnapshotRepository {
             object_store,
             destination,
@@ -333,20 +341,44 @@ impl SnapshotRepository {
         }))
     }
 
+    /// Removes any entries left over in the snapshot staging directory by a previous run.
+    ///
+    /// This is best-effort: failures are logged and ignored. It must only be called at
+    /// startup, before any snapshot download can be in flight.
+    async fn sweep_staging_dir(staging_dir: &Path) {
+        // Remove the whole staging directory; `get_latest_inner` recreates it on demand before
+        // the next download. No download can be in flight at startup, so this is safe.
+        match tokio::fs::remove_dir_all(staging_dir).await {
+            Ok(()) => debug!(
+                path = %staging_dir.display(),
+                "Cleared snapshot staging directory left over from a previous run",
+            ),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(err) => warn!(
+                %err,
+                path = %staging_dir.display(),
+                "Failed to clear snapshot staging directory",
+            ),
+        }
+    }
+
     /// Write a partition snapshot to the snapshot repository
     ///
     /// Returns the latest snapshot status on successful upload. Depending on retention settings,
     /// the archived LSN may be earlier than that of the snapshot which was just uploaded.
+    /// Uploads a local snapshot to the repository. Takes ownership of the local snapshot
+    /// directory via [`SnapshotDir`] and removes it once the upload completes (success or
+    /// failure), so callers cannot leak it.
     #[instrument(
         level = "error",
         err,
         skip_all,
-        fields(local_path = %local_snapshot_path.display())
+        fields(local_path = %local_snapshot.path().display())
     )]
     pub(crate) async fn put(
         &self,
         snapshot: &PartitionSnapshotMetadata,
-        local_snapshot_path: PathBuf,
+        local_snapshot: SnapshotDir,
     ) -> anyhow::Result<PartitionSnapshotStatus> {
         use crate::metric_definitions::{
             SNAPSHOT_UPLOAD_DURATION, SNAPSHOT_UPLOAD_FAILED, SNAPSHOT_UPLOAD_SUCCESS,
@@ -356,15 +388,13 @@ impl SnapshotRepository {
 
         let start = tokio::time::Instant::now();
         let put_result = self
-            .put_snapshot_inner(snapshot, local_snapshot_path.as_path())
+            .put_snapshot_inner(snapshot, local_snapshot.path())
             .await;
 
-        // We only log the error here since (a) it's relatively unlikely for rmdir to fail, and (b)
-        // if we've uploaded the snapshot, we should get the response back to the caller. Logging at
-        // WARN level as repeated failures could compromise the cluster.
-        if let Err(err) = tokio::fs::remove_dir_all(local_snapshot_path.as_path()).await {
-            warn!(%err, "Failed to delete local snapshot files");
-        }
+        // We own the local snapshot directory; remove it asynchronously (it may hold large SST
+        // files) regardless of the upload outcome. Failure is only logged: if the snapshot was
+        // uploaded we still want to return the result to the caller.
+        local_snapshot.remove().await;
 
         metrics::histogram!(SNAPSHOT_UPLOAD_DURATION).record(start.elapsed());
 
@@ -849,8 +879,11 @@ impl SnapshotRepository {
             path = %snapshot_dir.path().display(),
             "Downloaded partition snapshot",
         );
+        // Transfer ownership of the staging directory from the `TempDir` (which auto-cleans on
+        // an early return mid-download) to the snapshot's `SnapshotDir`, which removes it on drop
+        // whether the subsequent import succeeds or fails (see #4838).
         Ok(Some(LocalPartitionSnapshot {
-            base_dir: snapshot_dir.keep(),
+            base_dir: SnapshotDir::new(snapshot_dir.keep()),
             log_id: snapshot_metadata.log_id,
             min_applied_lsn: snapshot_metadata.min_applied_lsn,
             db_comparator_name: snapshot_metadata.db_comparator_name,
@@ -1108,7 +1141,7 @@ mod tests {
     use crate::snapshots::repository::{LatestSnapshotVersion, SnapshotUploadProgress};
 
     use super::{LatestSnapshot, SnapshotReference, SnapshotRepository, UniqueSnapshotKey};
-    use super::{PartitionSnapshotMetadata, SnapshotFormatVersion};
+    use super::{PartitionSnapshotMetadata, SnapshotDir, SnapshotFormatVersion};
 
     #[restate_core::test]
     async fn overwrite_unparsable_latest() -> anyhow::Result<()> {
@@ -1152,7 +1185,12 @@ mod tests {
         latest.write_all(b"not valid json").await?;
         latest.shutdown().await?;
 
-        assert!(repository.put(&snapshot, source_dir).await.is_err());
+        assert!(
+            repository
+                .put(&snapshot, SnapshotDir::new(source_dir))
+                .await
+                .is_err()
+        );
 
         Ok(())
     }
@@ -1222,7 +1260,9 @@ mod tests {
             .await?
             .unwrap();
 
-        repository.put(&snapshot1, source_dir.clone()).await?;
+        repository
+            .put(&snapshot1, SnapshotDir::new(source_dir.clone()))
+            .await?;
 
         let partition_prefix =
             ObjectPath::from(destination_url.path()).join(snapshot1.partition_id.to_string());
@@ -1266,7 +1306,9 @@ mod tests {
         );
         snapshot2.min_applied_lsn = snapshot1.min_applied_lsn.next();
 
-        repository.put(&snapshot2, source_dir).await?;
+        repository
+            .put(&snapshot2, SnapshotDir::new(source_dir))
+            .await?;
 
         let latest = object_store
             .get(&partition_prefix.join("latest.json"))
@@ -1277,12 +1319,15 @@ mod tests {
 
         let latest = repository.get_latest(PartitionId::MIN).await?.unwrap();
         assert_eq!(latest.min_applied_lsn, snapshot2.min_applied_lsn);
-        let local_path = latest.base_dir.as_path().to_string_lossy().to_string();
-        drop(latest);
+        let local_path = latest.base_dir.path().to_string_lossy().to_string();
 
-        let local_dir_exists = tokio::fs::try_exists(&local_path).await?;
-        assert!(local_dir_exists);
-        tokio::fs::remove_dir_all(&local_path).await?;
+        // The staging directory exists while the snapshot is held...
+        assert!(tokio::fs::try_exists(&local_path).await?);
+
+        // ...and is removed by its owning SnapshotDir once the snapshot is dropped, so failed
+        // restores no longer leak downloads (#4838).
+        drop(latest);
+        assert!(!tokio::fs::try_exists(&local_path).await?);
 
         Ok(())
     }
@@ -1379,7 +1424,9 @@ mod tests {
             );
             snapshot.min_applied_lsn = Lsn::new(i * 1000);
 
-            repository.put(&snapshot, source_dir).await?;
+            repository
+                .put(&snapshot, SnapshotDir::new(source_dir))
+                .await?;
         }
 
         let latest_path = ObjectPath::from(Url::parse(&destination)?.path().to_string())
@@ -1489,7 +1536,9 @@ mod tests {
         );
         snapshot_v2.min_applied_lsn = Lsn::new(2000);
 
-        repository.put(&snapshot_v2, source_dir_2).await?;
+        repository
+            .put(&snapshot_v2, SnapshotDir::new(source_dir_2))
+            .await?;
 
         let latest_data = object_store.get(&latest_path).await?;
         let latest: LatestSnapshot = serde_json::from_slice(&latest_data.bytes().await?)?;
@@ -1534,7 +1583,9 @@ mod tests {
             );
             snapshot.min_applied_lsn = Lsn::new(i * 1000);
 
-            repository.put(&snapshot, source_dir).await?;
+            repository
+                .put(&snapshot, SnapshotDir::new(source_dir))
+                .await?;
         }
 
         let status = repository
@@ -1574,7 +1625,9 @@ mod tests {
             let (snapshot, source_dir) =
                 mock_snapshot(format!("data-{}", i).as_bytes(), Lsn::new(100 * i)).await?;
             all_snapshot_paths.push(SnapshotReference::from_metadata(&snapshot).path);
-            repository.put(&snapshot, source_dir).await?;
+            repository
+                .put(&snapshot, SnapshotDir::new(source_dir))
+                .await?;
         }
 
         let latest_path = repository.latest_snapshot_pointer_path(PartitionId::MIN);
@@ -1691,6 +1744,64 @@ mod tests {
             MillisSinceEpoch::UNIX_EPOCH + Duration::from_secs(2),
             "reports the latest retained snapshot's created-at time"
         );
+
+        Ok(())
+    }
+
+    #[restate_core::test]
+    async fn sweep_staging_dir_removes_leftovers() -> anyhow::Result<()> {
+        let staging = TempDir::new()?;
+
+        // A leftover snapshot directory with a file inside, plus a stray file.
+        let leftover_dir = staging.path().join("snap-abc123");
+        tokio::fs::create_dir_all(&leftover_dir).await?;
+        tokio::fs::write(leftover_dir.join("data.sst"), b"x").await?;
+        tokio::fs::write(staging.path().join("stray.tmp"), b"y").await?;
+
+        SnapshotRepository::sweep_staging_dir(staging.path()).await;
+
+        assert!(
+            !staging.path().exists(),
+            "staging directory should be removed by the sweep"
+        );
+
+        // A missing staging directory is a no-op (must not panic).
+        SnapshotRepository::sweep_staging_dir(&staging.path().join("does-not-exist")).await;
+
+        Ok(())
+    }
+
+    fn mock_local_snapshot(base_dir: super::SnapshotDir) -> super::LocalPartitionSnapshot {
+        super::LocalPartitionSnapshot {
+            base_dir,
+            log_id: LogId::MIN,
+            min_applied_lsn: Lsn::new(1),
+            db_comparator_name: "leveldb.BytewiseComparator".to_owned(),
+            files: vec![],
+            key_range: KeyRange::new(0, 100),
+        }
+    }
+
+    #[restate_core::test]
+    async fn snapshot_dir_cleaned_on_drop_unless_disarmed() -> anyhow::Result<()> {
+        let staging = TempDir::new()?;
+
+        // An owned SnapshotDir removes its directory when the snapshot is dropped -- this is
+        // what protects the import failure paths in #4838.
+        let dir = TempDir::with_prefix_in("snap-", staging.path())?.keep();
+        assert!(dir.exists());
+        drop(mock_local_snapshot(SnapshotDir::new(dir.clone())));
+        assert!(
+            !dir.exists(),
+            "an owned snapshot directory must be removed on drop"
+        );
+
+        // into_path() disarms the guard: the directory survives the snapshot.
+        let dir = TempDir::with_prefix_in("snap-", staging.path())?.keep();
+        let snapshot = mock_local_snapshot(SnapshotDir::new(dir.clone()));
+        let kept = snapshot.base_dir.into_path();
+        assert_eq!(kept, dir);
+        assert!(dir.exists(), "into_path() must leave the directory intact");
 
         Ok(())
     }

--- a/crates/partition-store/src/snapshots/snapshot_task.rs
+++ b/crates/partition-store/src/snapshots/snapshot_task.rs
@@ -88,6 +88,7 @@ impl SnapshotPartitionTask {
 
         let status = self
             .snapshot_repository
+            // `put` takes ownership of the snapshot directory and removes it after upload.
             .put(&metadata, snapshot.base_dir)
             .await
             .map_err(|e| SnapshotError {

--- a/crates/partition-store/src/tests/snapshots_test/mod.rs
+++ b/crates/partition-store/src/tests/snapshots_test/mod.rs
@@ -20,7 +20,9 @@ use restate_types::partitions::Partition;
 use restate_types::sharding::KeyRange;
 use restate_types::time::MillisSinceEpoch;
 
-use crate::snapshots::{LocalPartitionSnapshot, PartitionSnapshotMetadata, SnapshotFormatVersion};
+use crate::snapshots::{
+    LocalPartitionSnapshot, PartitionSnapshotMetadata, SnapshotDir, SnapshotFormatVersion,
+};
 use crate::{PartitionStore, PartitionStoreManager};
 
 pub(crate) async fn run_tests(
@@ -56,14 +58,16 @@ pub(crate) async fn run_tests(
     let metadata_json = serde_json::to_string_pretty(&snapshot_meta).unwrap();
 
     drop(partition_store);
-    drop(snapshot);
+    // Disarm the exported snapshot's directory guard so the on-disk SST files survive past this
+    // drop; we restore from them below. `snapshots_dir` (a TempDir) still owns the parent dir.
+    let _exported_dir = snapshot.base_dir.into_path();
 
     manager.drop_partition(partition_id).await.unwrap();
 
     let snapshot_meta: PartitionSnapshotMetadata = serde_json::from_str(&metadata_json).unwrap();
 
     let snapshot = LocalPartitionSnapshot {
-        base_dir: snapshots_dir.path().into(),
+        base_dir: SnapshotDir::new(snapshots_dir.path().into()),
         log_id: LogId::from(partition_id),
         min_applied_lsn: snapshot_meta.min_applied_lsn,
         db_comparator_name: snapshot_meta.db_comparator_name.clone(),

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::convert::Infallible;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
@@ -161,14 +162,16 @@ where
                     // Runs on a blocking thread so it doesn't starve the tokio runtime.
                     // The child task is bound to the partition processor's lifecycle and
                     // will be cancelled if the processor shuts down (e.g. due to trim gap).
-                    if partition_store.needs_jc_orphan_cleanup()? {
+                    let cleanup_task = if partition_store.needs_jc_orphan_cleanup()? {
                         let mut cleanup_store = partition_store.clone();
                         let cleanup_partition_id = partition_store.partition_id();
-                        let cancel = cancellation_token();
-                        TaskCenter::spawn_child(
+                        let cleanup_task = TaskCenter::spawn_unmanaged_child(
                             TaskKind::Background,
                             "jc-orphan-cleanup",
                             async move {
+                                // Observe this task's own cancellation token so the
+                                // cancel_task() below reliably stops the blocking scan.
+                                let cancel = cancellation_token();
                                 let result = tokio::task::spawn_blocking(move || {
                                     let start = Instant::now();
                                     let result = restate_partition_store::cleanup_orphaned_completion_id_index_entries(
@@ -223,26 +226,44 @@ where
                                         );
                                     }
                                 }
-                                Ok(())
+                                Ok::<_, Infallible>(())
                             },
                         )?;
+                        Some(cleanup_task)
+                    } else {
+                        None
+                    };
+
+                    let run_result = async move {
+                        let pp = pp_builder
+                            .build(
+                                bifrost,
+                                ingestion_client,
+                                partition_store,
+                                replica_set_states,
+                            )
+                            .await
+                            .map_err(ProcessorError::from)?;
+                        Box::pin(pp.run()).await
+                    }
+                    .await;
+
+                    // Cancel and join the one-time jc-orphan-cleanup task before this
+                    // runtime task returns. The partition store manager only drops or
+                    // re-imports this partition's column family on a *subsequent* open(),
+                    // which cannot run until this runtime task has fully completed (see
+                    // PartitionProcessorManager::await_runtime_task_result). Joining here
+                    // guarantees the cleanup can never write through a stale column-family
+                    // handle and poison the shared RocksDB instance (see #4838).
+                    if let Some(cleanup_task) = cleanup_task {
+                        let _ = cleanup_task.cancel_and_wait().await;
                     }
 
-                    let pp = pp_builder
-                        .build(
-                            bifrost,
-                            ingestion_client,
-                            partition_store,
-                            replica_set_states,
-                        )
-                        .await
-                        .map_err(ProcessorError::from)?;
-                    let result = Box::pin(pp.run()).await;
                     info!(
                         partition_id = %partition.partition_id,
                         "Partition processor stopped"
                     );
-                    result
+                    run_result
                 }
             },
         )?;


### PR DESCRIPTION
[Own snapshot staging directories with an RAII guard](https://github.com/restatedev/restate/commit/fd7f4bbcfb60a2e9e06c9bbf58852daf0aadd1b1) 

Introduce SnapshotDir, which owns a snapshot's local directory and removes it
on drop, with an async remove() for non-blocking cleanup and into_path() to
relinquish ownership. LocalPartitionSnapshot now holds a SnapshotDir instead of
a bare PathBuf, so a failed restore or upload can no longer leak the downloaded
directory. SnapshotRepository::put takes ownership of the directory and removes
it after upload, and new_from_config sweeps any leftover staging directory from
a previous run on startup (covering hard-crash leaks).

[Join the jc-orphan cleanup task before the processor stops](https://github.com/restatedev/restate/commit/5ff689a771709ab91f8b4eb8d1163dcbe7d098cc) 

The one-time orphaned journal completion-id index cleanup ran detached and
could keep writing through a cached column-family handle after the partition
store manager dropped or re-imported that column family (e.g. on a trim-gap
snapshot restore), poisoning the shared RocksDB instance with "Invalid column
family specified in write batch" and crash-looping the node. Spawn it as an
unmanaged child and cancel_and_wait it on every exit path before the runtime
task returns. Since PartitionProcessorManager::await_runtime_task_result only
re-opens the partition after the runtime task completes, the cleanup can no
longer race a column-family drop. Fixes https://github.com/restatedev/restate/issues/4838.