### PR TITLE
Add JWT sub claim to service protocol v4+ invoker runner

### DIFF
--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
@@ -185,6 +185,7 @@ where
             self.service_protocol_version,
             &self.invocation_task.invocation_id,
             attempt_span.span_context(),
+            self.invocation_task.invocation_target.key(),
         );
 
         // Initialize the response stream state
@@ -403,6 +404,7 @@ where
         service_protocol_version: ServiceProtocolVersion,
         invocation_id: &InvocationId,
         parent_span_context: &SpanContext,
+        service_key: Option<&ByteString>,
     ) -> (InvokerBodySender, Request<InvokerBodyType>) {
         // Use an unbounded channel: backpressure is provided by the memory budget
         // (each frame's Bytes embeds a LocalMemoryLease via from_owner) rather than
@@ -461,10 +463,12 @@ where
 
         headers.extend(deployment_metadata.additional_headers);
 
-        (
-            http_stream_tx,
-            Request::new(Parts::new(Method::Post, address, path, headers), req_body),
-        )
+        let mut request_parts = Parts::new(Method::Post, address, path, headers);
+        if let Some(service_key) = service_key {
+            request_parts = request_parts.with_request_identity_sub_field(service_key.clone());
+        }
+
+        (http_stream_tx, Request::new(request_parts, req_body))
     }
 
     // --- Loops


### PR DESCRIPTION
## What

The request-identity JWT (`x-restate-jwt-v1`) `sub` claim — the invoked virtual object / workflow key — was added in #4779, but only wired into the `<= v3` invoker protocol runner. The `v4+` runner (`service_protocol_runner_v4.rs`), which is the path used by all modern SDKs since they negotiate protocol v5, built the outbound request without threading the key into the request identity. As a result, JWTs for keyed targets on protocol v4+ carried only `aud`/`exp`/`iat`/`nbf` and no `sub`.

## Fix

Mirror the `<= v3` runner (introduced in #4779) in `service_protocol_runner_v4.rs`:
- pass `invocation_target.key()` at the `prepare_request` call site
- add a `service_key: Option<&ByteString>` parameter
- set it via `with_request_identity_sub_field(..)` when a key is present

## Verification

Manually verified against a local Node SDK (protocol v5) invoking a keyed virtual object:
- **Before:** `{"aud":"/invoke/counter/add", ...}` — no `sub`
- **After:** `{"aud":"/invoke/counter/add", ..., "sub":"x"}`

`cargo check`, `cargo clippy -p restate-invoker-impl -- -D warnings`, `cargo fmt --all --check`, and `cargo nextest run -p restate-invoker-impl -p restate-service-client` all pass (including the shared `sign_with_sub` test that already covers JWT serialization for both runners).

## Notes

The invocation itself was never affected — the target key is always delivered to the SDK in the protocol `Start` message; only the JWT request-identity claim was missing on v4+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
