### PR TITLE
[Restate UI] Update to v1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8830,8 +8830,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "0.1.66"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v0.1.66#1b55facd029fdbac87521ce9ee4d7c6dab3e5a33"
+version = "1.0.1"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v1.0.1#25c965da8e9f289e05f75642e0a2764ab225c055"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -39,7 +39,7 @@ restate-util-time = { workspace = true }
 restate-types = { workspace = true }
 restate-util-string = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "0.1.66", tag = "v0.1.66" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "1.0.1", tag = "v1.0.1" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v1.0.1
published at https://github.com/restatedev/restate-web-ui/releases/download/v1.0.1/ui-v1.0.1.zip