### PR TITLE
Fix ingested record loss during partition leadership transitions

### DIFF
--- a/crates/ingestion-client/src/chunks_size.rs
+++ b/crates/ingestion-client/src/chunks_size.rs
@@ -30,11 +30,16 @@ impl<F, S: Stream> ChunksSize<F, S>
 where
     F: Fn(&S::Item) -> usize,
 {
-    pub fn new(stream: S, max_size: usize, size_fn: F) -> Self {
+    /// Creates a chunker, pre-seeding the accumulation buffer with `buffered` items so they lead the
+    /// next emitted chunk. Pass an empty `Vec` to start fresh. Seeding is used to carry a previously
+    /// over-pulled item across a recreated `ChunksSize` (e.g. after a reconnect) without losing it or
+    /// reordering it.
+    pub fn with_buffered(stream: S, max_size: usize, size_fn: F, buffered: Vec<S::Item>) -> Self {
+        let size = buffered.iter().map(&size_fn).sum();
         ChunksSize {
             stream: stream.fuse(),
-            items: Vec::default(),
-            size: 0,
+            items: buffered,
+            size,
             cap: max_size,
             size_fn,
         }
@@ -111,7 +116,10 @@ mod tests {
     #[tokio::test]
     async fn splits_into_size_bound_chunks() {
         let stream = iter([2usize, 2, 3, 1]);
-        let chunks: Vec<Vec<usize>> = ChunksSize::new(stream, 5, |item| *item).collect().await;
+        let chunks: Vec<Vec<usize>> =
+            ChunksSize::with_buffered(stream, 5, |item| *item, Vec::new())
+                .collect()
+                .await;
 
         assert_eq!(chunks, vec![vec![2, 2], vec![3, 1]]);
     }
@@ -119,7 +127,10 @@ mod tests {
     #[tokio::test]
     async fn emits_item_larger_than_cap_as_its_own_chunk() {
         let stream = iter([10usize, 2]);
-        let chunks: Vec<Vec<usize>> = ChunksSize::new(stream, 5, |item| *item).collect().await;
+        let chunks: Vec<Vec<usize>> =
+            ChunksSize::with_buffered(stream, 5, |item| *item, Vec::new())
+                .collect()
+                .await;
 
         assert_eq!(chunks, vec![vec![10], vec![2]]);
     }
@@ -137,7 +148,10 @@ mod tests {
             }
         });
 
-        let chunks: Vec<Vec<usize>> = ChunksSize::new(stream, 10, |item| *item).collect().await;
+        let chunks: Vec<Vec<usize>> =
+            ChunksSize::with_buffered(stream, 10, |item| *item, Vec::new())
+                .collect()
+                .await;
 
         assert_eq!(chunks, vec![vec![1], vec![2]]);
     }

--- a/crates/ingestion-client/src/client.rs
+++ b/crates/ingestion-client/src/client.rs
@@ -468,4 +468,47 @@ mod test {
             )
         );
     }
+
+    // Regression test for record loss caused by out-of-order commits (issue #4810).
+    //
+    // The partition processor checks leadership *per* ingest RPC, so on a single connection a
+    // leadership transition can return `NotLeader` for an earlier batch (which is therefore not
+    // appended) while a later batch is appended and acked. The dedup mechanism uses a monotonic
+    // high-water-mark per producer, so once the later (higher sequence number) records are applied
+    // the earlier ones get permanently dropped as "outdated". This is only possible if the session
+    // keeps more than one batch in flight per partition. This test pins that the session does not
+    // pipeline a second batch before the head batch has been acknowledged.
+    #[test(restate_core::test(start_paused = true))]
+    async fn does_not_pipeline_unacked_batches() {
+        let (mut incoming, mut client) = init_env(1024).await;
+
+        // Ingest the head record; the session sends it as its own batch because it is the only
+        // record available at the time the batch is formed.
+        let _c0 = client.ingest(0, InputRecord::from_str("r0")).await.unwrap();
+        let head = must_next(&mut incoming).await;
+        let (head_rx, head_body) = head.split();
+        assert_that!(head_body.records, len(eq(1)));
+
+        // Ingest a second record to the same partition while the head batch is still unacked.
+        let _c1 = client.ingest(0, InputRecord::from_str("r1")).await.unwrap();
+
+        // Let the session task run to completion. Under `start_paused`, once all tasks are parked
+        // the runtime auto-advances time to fire this sleep, so afterwards the session has done all
+        // the work it could: if it were going to pipeline the second batch, it would have by now.
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        // The session must not have put a second batch on the wire before the head was acked.
+        let mut next = std::pin::pin!(must_next(&mut incoming));
+        assert!(
+            (&mut next).now_or_never().is_none(),
+            "session pipelined a second batch before the head batch was acknowledged"
+        );
+
+        // Acking the head unblocks the next batch, which now carries the second record in order.
+        head_rx.send(ResponseStatus::Ack.into());
+        let tail = next.await;
+        let (tail_rx, tail_body) = tail.split();
+        assert_that!(tail_body.records, len(eq(1)));
+        tail_rx.send(ResponseStatus::Ack.into());
+    }
 }

--- a/crates/ingestion-client/src/client.rs
+++ b/crates/ingestion-client/src/client.rs
@@ -511,4 +511,59 @@ mod test {
         assert_that!(tail_body.records, len(eq(1)));
         tail_rx.send(ResponseStatus::Ack.into());
     }
+
+    // Regression test for the cross-reconnect variant of #4810 (found reviewing PR #4880).
+    //
+    // `ChunksSize` must read one record past a full batch to detect the cap boundary, so it buffers
+    // that record internally. On a reconnect the buffered record must not become a *second* in-flight
+    // batch (which `replay()` would pipeline, recreating the out-of-order append and record loss).
+    // It is carried over into the next batch and sent only after the head is acknowledged, and it is
+    // never failed/cancelled (the Kafka ingress and shuffle have no cheap retry).
+    #[test(restate_core::test(start_paused = true))]
+    async fn reconnect_carries_over_buffered_records() {
+        // Cap fits exactly one record, so the second record overflows and is buffered by the chunker.
+        let mut buf = BytesMut::new();
+        let one_record = InputRecord::from_str("r0")
+            .into_record(&mut buf)
+            .estimate_size();
+        let (mut incoming, mut client) = init_env(one_record).await;
+
+        // Queue both records before the session forms a batch: `ingest().await` does not yield to the
+        // session task, so both are in the channel when the chunker first runs (during the sleep).
+        let c0 = client.ingest(0, InputRecord::from_str("r0")).await.unwrap();
+        let c1 = client.ingest(0, InputRecord::from_str("r1")).await.unwrap();
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        // The chunker emits B1=[r0] and buffers r1.
+        let head = must_next(&mut incoming).await;
+        let (head_rx, head_body) = head.split();
+        assert_that!(head_body.records, len(eq(1)));
+
+        // A NotLeader on the head triggers reconnect + replay. The buffered r1 must be carried over,
+        // not turned into a second in-flight batch.
+        head_rx.send(ResponseStatus::NotLeader { of: 0.into() }.into());
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        // Replay re-sends only the head (r0); r1 is buffered, not in flight.
+        let head = must_next(&mut incoming).await;
+        let (head_rx, head_body) = head.split();
+        assert_that!(head_body.records, len(eq(1)));
+
+        let mut next = std::pin::pin!(must_next(&mut incoming));
+        assert!(
+            (&mut next).now_or_never().is_none(),
+            "session put a second batch in flight after reconnect"
+        );
+
+        // Acking the head releases the carried-over r1 as the next batch.
+        head_rx.send(ResponseStatus::Ack.into());
+        let tail = next.await;
+        let (tail_rx, tail_body) = tail.split();
+        assert_that!(tail_body.records, len(eq(1)));
+        tail_rx.send(ResponseStatus::Ack.into());
+
+        // Nothing was failed/cancelled: both records eventually commit.
+        c0.await.expect("r0 commits");
+        c1.await.expect("r1 commits");
+    }
 }

--- a/crates/ingestion-client/src/session.rs
+++ b/crates/ingestion-client/src/session.rs
@@ -219,6 +219,10 @@ pub struct PartitionSession<T> {
     rx: UnboundedReceiverStream<(RecordCommitResolver, IngestRecord)>,
     tx: mpsc::UnboundedSender<(RecordCommitResolver, IngestRecord)>,
     inflight: VecDeque<IngestionBatch>,
+    // Records pulled from `rx` while detecting a batch boundary but not yet sent. Carried across
+    // reconnects and fed back into the chunker so they lead the next batch, instead of becoming a
+    // second in-flight batch (which would let `replay()` append records out of order). See #4810.
+    carry_over: Vec<(RecordCommitResolver, IngestRecord)>,
 }
 
 impl<T> PartitionSession<T> {
@@ -241,6 +245,7 @@ impl<T> PartitionSession<T> {
             inflight: Default::default(),
             rx,
             tx,
+            carry_over: Vec::new(),
         }
     }
 
@@ -366,11 +371,21 @@ where
             return SessionState::Connecting;
         }
 
-        let mut chunked = ChunksSize::new(&mut self.rx, self.opts.batch_size, |(_, item)| {
-            item.estimate_size()
-        });
+        // Seed the chunker with any records over-pulled but not sent on the previous connection so
+        // they lead the next batch (in produced order) rather than being lost or reordered.
+        let mut chunked = ChunksSize::with_buffered(
+            &mut self.rx,
+            self.opts.batch_size,
+            |(_, item)| item.estimate_size(),
+            std::mem::take(&mut self.carry_over),
+        );
 
         let state = loop {
+            debug_assert!(
+                self.inflight.len() <= 1,
+                "ingestion session must keep at most one batch in flight"
+            );
+
             // Only pull a new batch when nothing is in flight. Keeping at most one unacked batch
             // per partition guarantees that records reach the partition log in the order they were
             // produced: a trailing batch can never be appended before an earlier one that is being
@@ -435,11 +450,10 @@ where
         // state == Connecting
         assert!(matches!(state, SessionState::Connecting));
 
-        // don't lose the buffered batch
-        let remainder = chunked.into_remainder();
-        if !remainder.is_empty() {
-            self.inflight.push_back(IngestionBatch::new(remainder));
-        }
+        // Carry the chunker's buffered-but-unsent records over to the next connection instead of
+        // turning them into a second in-flight batch: `replay()` only resends `inflight`, so keeping
+        // these here preserves the at-most-one-batch-in-flight invariant while not losing them.
+        self.carry_over = chunked.into_remainder();
 
         state
     }

--- a/crates/ingestion-client/src/session.rs
+++ b/crates/ingestion-client/src/session.rs
@@ -371,6 +371,13 @@ where
         });
 
         let state = loop {
+            // Only pull a new batch when nothing is in flight. Keeping at most one unacked batch
+            // per partition guarantees that records reach the partition log in the order they were
+            // produced: a trailing batch can never be appended before an earlier one that is being
+            // retried (e.g. after a `NotLeader` response during a leadership transition). Out-of-order
+            // appends would otherwise be silently dropped by the producer dedup high-water-mark. See
+            // https://github.com/restatedev/restate/issues/4810.
+            let can_send_next = self.inflight.is_empty();
             let head: OptionFuture<_> = self
                 .inflight
                 .front_mut()
@@ -381,7 +388,7 @@ where
                 _ = connection.closed() => {
                     break SessionState::Connecting;
                 }
-                Some(batch) = chunked.next() => {
+                Some(batch) = chunked.next(), if can_send_next => {
                     let batch = IngestionBatch::new(batch);
                     let records = Arc::clone(&batch.records);
 


### PR DESCRIPTION
The partition processor checks leadership on a per-request basis, so on a single connection a leadership transition can return NotLeader for one ingest batch (which is therefore not appended) while a subsequent batch on the same connection is appended and acknowledged. Because the ingestion session pipelined multiple unacknowledged batches per partition and, on a head-batch failure, replayed all inflight batches from the head, the records of a later batch could end up appended to the Bifrost log before the records of an earlier batch. The producer dedup mechanism uses a monotonic high-water-mark sequence number per producer, so once the higher-sequence records were applied the earlier ones were dropped as outdated and permanently lost. This manifested as the flaky KafkaTest.callObjectHandler (issue #4810), where a counter fed by 3 Kafka records could end up short.

Keep at most one unacknowledged batch in flight per partition in the ingestion session. This guarantees records reach the partition log in the order they were produced, so the dedup high-water-mark never skips a record. The change affects all ingestion-client users (Kafka, HTTP ingress, shuffle).

This is a conservative fix that disables cross-batch pipelining. A follow-up will restore pipelining by tracking per-session state on the server side to reject out-of-order batches.

Adds a Kafka-independent regression test that reproduces the reorder via the session/partition-processor RPC contract.

The issue for properly fixing the problem is #4879.