### PR TITLE
Expose getting the known leader_epoch through PartitionRouting

### DIFF
--- a/crates/core/src/partitions.rs
+++ b/crates/core/src/partitions.rs
@@ -9,8 +9,8 @@
 // by the Apache License, Version 2.0.
 
 use restate_types::GenerationalNodeId;
-use restate_types::identifiers::PartitionId;
-use restate_types::partitions::state::PartitionReplicaSetStates;
+use restate_types::identifiers::{LeaderEpoch, PartitionId};
+use restate_types::partitions::state::{LeadershipState, PartitionReplicaSetStates};
 
 use crate::task_center;
 
@@ -52,5 +52,70 @@ impl PartitionRouting {
         // otherwise, overlay the current configuration with the cluster state and take the first
         // node alive
         membership.first_alive_node(self.task_center.cluster_state())
+    }
+
+    /// The currently observed leader epoch for a given partition, subject to propagation delays
+    /// through the cluster in distributed deployments.
+    ///
+    /// A `None` response indicates that we have no knowledge about a leader for this partition.
+    pub fn get_leader_epoch(&self, partition_id: PartitionId) -> Option<LeaderEpoch> {
+        let leadership_state = self
+            .partition_replica_set_states
+            .membership_state(partition_id)
+            .current_leader();
+
+        if leadership_state.current_leader_epoch == LeaderEpoch::INVALID {
+            return None;
+        }
+
+        Some(leadership_state.current_leader_epoch)
+    }
+
+    /// The currently observed leader node and its leader epoch for a given partition, subject to
+    /// propagation delays through the cluster in distributed deployments.
+    ///
+    /// A `None` response indicates that we have no knowledge about a leader for this partition,
+    /// or that we know the leader epoch but not which node holds it.
+    pub fn get_leader(
+        &self,
+        partition_id: PartitionId,
+    ) -> Option<(GenerationalNodeId, LeaderEpoch)> {
+        let leadership_state = self
+            .partition_replica_set_states
+            .membership_state(partition_id)
+            .current_leader();
+
+        if leadership_state.current_leader_epoch == LeaderEpoch::INVALID
+            || !leadership_state.current_leader.is_valid()
+        {
+            return None;
+        }
+
+        Some((
+            leadership_state.current_leader,
+            leadership_state.current_leader_epoch,
+        ))
+    }
+
+    /// Waits until a leader epoch of at least `min_epoch` has been observed for the given
+    /// partition, and returns the corresponding leadership state.
+    ///
+    /// Note that the leadership state is propagated through the cluster asynchronously, so this
+    /// may wait longer than it takes the actual leader to win the election. This future never
+    /// completes if no such epoch is observed; callers should apply their own timeout or
+    /// cancellation.
+    pub async fn wait_for_leader_epoch(
+        &self,
+        partition_id: PartitionId,
+        min_epoch: LeaderEpoch,
+    ) -> LeadershipState {
+        let mut watch = self
+            .partition_replica_set_states
+            .watch_leadership_state(partition_id);
+        let state = watch
+            .wait_for(|leadership_state| leadership_state.current_leader_epoch >= min_epoch)
+            .await
+            .expect("partition replica set states are never dropped while in use");
+        *state
     }
 }


### PR DESCRIPTION

Adds three methods to `PartitionRouting`, all based on the gossip-propagated
`PartitionReplicaSetStates` (best-effort hints, not for fencing):

- `get_leader_epoch()` returns the observed leader epoch, `None` if unknown
- `get_leader()` returns `(GenerationalNodeId, LeaderEpoch)` only when both are valid
- `wait_for_leader_epoch()` awaits until an epoch `>= min_epoch` is observed;
  callers should apply their own timeout/cancellation
