### PR TITLE
[cli] Render a more descriptive error message in state get when state is not JSON serializable

### DIFF
--- a/cli/src/commands/state/patch.rs
+++ b/cli/src/commands/state/patch.rs
@@ -23,6 +23,10 @@ use crate::commands::state::util::{
 #[derive(Run, Parser, Collect, Clone)]
 #[cling(run = "patch")]
 pub struct Patch {
+    /// Don't try to convert the values to a UTF-8 string
+    #[clap(long, alias = "bin")]
+    binary: bool,
+
     /// Force means, ignore the current version
     #[clap(long, short)]
     force: bool,
@@ -45,7 +49,7 @@ pub async fn patch(State(env): State<CliEnv>, opts: &Patch) -> Result<()> {
     let current_state = get_current_state(&env, &opts.service, &opts.key, false).await?;
     let current_version = compute_version(&current_state);
 
-    let mut state = as_json(current_state, false)?;
+    let mut state = as_json(current_state, opts.binary)?;
 
     json_patch::patch(&mut state, &patch).context("Patch failed")?;
 
@@ -54,6 +58,7 @@ pub async fn patch(State(env): State<CliEnv>, opts: &Patch) -> Result<()> {
     table.add_row(vec![Cell::new("Service"), Cell::new(&opts.service)]);
     table.add_row(vec![Cell::new("Key"), Cell::new(&opts.key)]);
     table.add_row(vec![Cell::new("Force?"), Cell::new(opts.force)]);
+    table.add_row(vec![Cell::new("Binary?"), Cell::new(opts.binary)]);
 
     c_title!("ℹ️ ", "Patch State");
     c_println!("{table}");
@@ -72,7 +77,7 @@ pub async fn patch(State(env): State<CliEnv>, opts: &Patch) -> Result<()> {
 
     c_println!();
 
-    let modified_state = from_json(state, false)?;
+    let modified_state = from_json(state, opts.binary)?;
     let version = if opts.force {
         None
     } else {

--- a/cli/src/commands/state/util.rs
+++ b/cli/src/commands/state/util.rs
@@ -118,7 +118,11 @@ pub(crate) fn compute_version(user_state: &HashMap<String, Bytes>) -> String {
 pub(crate) fn as_json(state: HashMap<String, Bytes>, binary_values: bool) -> anyhow::Result<Value> {
     let current_state_json: HashMap<String, Value> = state
         .into_iter()
-        .map(|(k, v)| bytes_as_json(v, binary_values).map(|v| (k, v)))
+        .map(|(k, v)| {
+            bytes_as_json(v, binary_values)
+                .context(format!("unable to convert the value of state key \"{k}\" to JSON. Pass --binary to render it as a base64 string instead"))
+                .map(|v| (k, v))
+        })
         .try_collect()?;
 
     serde_json::to_value(current_state_json).context("unable to create a JSON object.")


### PR DESCRIPTION
Currently, `state get` for non-valid JSON values will fail with a generic error message. This PR adds a more descriptive error message suggesting the use of `--binary` (which works fine). Moreover, the `state patch` command now also supports `--binary` which wasn't supported before. With that, all `state` commands should be able to handle non-json values just fine.

To replicate the issue, I set the state to a bytes of non JSON compatible chars (`"\u{2764}".as_bytes()` for example).

### Before

#### State get
```
❯❯❯ cargo run -p restate-cli --bin restate -- state get Counter mbassem                                                                           

Error: unable to convert a value to json
  ├─ expected value at line 1 column 1
```

and works fine with `--binary`:

```
❯❯❯ cargo run -p restate-cli --bin restate -- state get --binary Counter mbassem                                                            ✘ 130 main ✭
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.27s
     Running `target/debug/restate state get --binary Counter mbassem`

🤖 State:
―――――――――

 Service  Counter
 Key      mbassem

 KEY      VALUE
 counter  "4p2k"
```

#### State Patch

State patch was similarly broken:

```
❯❯❯ cargo run -p restate-cli --bin restate -- state patch Counter mbassem \                                                                   ✘ 1 main ✭
    --patch '[ { "op": "replace", "path": "/counter", "value": "MTM=" } ]'
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.27s
     Running `target/debug/restate state patch Counter mbassem --patch '[ { "op": "replace", "path": "/counter", "value": "MTM=" } ]'`
Error: unable to convert a value to json
  ├─ expected value at line 1 column 1
```

---

### After

#### State get

A more descriptive error message is now rendered when the value is not valid:

```
~/repos/restate/restate ❯❯❯ cargo run -p restate-cli --bin restate -- state get Counter mbassem                                                             fix/cli-state-json ✭
...

Error: unable to convert the value of state key "counter" to JSON. Pass --binary to render it as a base64 string instead

Caused by:
  ├─ unable to convert a value to json
  └─ expected value at line 1 column 1
```

#### State patch

You can now patch with a base64 value:

```
❯❯❯ cargo run -p restate-cli --bin restate -- state patch --binary Counter mbassem \                                                fix/cli-state-json ✭
    --patch '[ { "op": "replace", "path": "/counter", "value": "MTM=" } ]'
   Compiling restate-cli v1.7.0-rc.2 (/Users/mbassem/repos/restate/restate/cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.12s
     Running `target/debug/restate state patch --binary Counter mbassem --patch '[ { "op": "replace", "path": "/counter", "value": "MTM=" } ]'`

ℹ️  Patch State:
――――――――――――――――

 Service  Counter
 Key      mbassem
 Force?   false
 Binary?  true


ℹ️  New State:
――――――――――――――
 KEY      VALUE
 counter  "MTM="

About to submit the new state mutation to the system for processing.
If there are ongoing invocations for this key this mutation will be enqueued to be processed after them.

✔ Are you sure? · yes
```

and read it just fine afterwards:

```
❯❯❯ cargo run -p restate-cli --bin restate -- state get Counter mbassem                                                         ✘ 2 fix/cli-state-json ✭
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.30s
     Running `target/debug/restate state get Counter mbassem`

🤖 State:
―――――――――

 Service  Counter
 Key      mbassem

 KEY      VALUE
 counter  13
```

Fixes: #1152