### PR TITLE
Surface an actionable error when ambient ADC cannot mint a GCP ID token

### DIFF
--- a/crates/service-client/src/gcp.rs
+++ b/crates/service-client/src/gcp.rs
@@ -217,10 +217,7 @@ impl GcpTokenClient {
                     .build()
                     .map_err(|e| {
                         // authorized_user (gcloud) and external_account (Workload Identity
-                        // Federation) ADC sources cannot mint ID tokens directly. Map that
-                        // specific case to an actionable error instead of leaking the
-                        // crate-internal hint carried by the underlying message; keep the raw
-                        // error at debug level for operator diagnosis.
+                        // Federation) ADC sources cannot mint ID tokens directly
                         if e.is_not_supported() {
                             tracing::debug!(
                                 audience = %audience,

--- a/crates/service-client/src/gcp.rs
+++ b/crates/service-client/src/gcp.rs
@@ -56,6 +56,14 @@ pub enum GcpAuthError {
     #[error("failed to build ID token credentials for audience '{audience}': {message}")]
     Build { audience: String, message: String },
     #[error(
+        "the ambient Application Default Credentials identity cannot mint an ID token for audience '{audience}'. \
+         User credentials (from `gcloud auth application-default login`) and Workload Identity Federation \
+         (`external_account`) sources cannot mint ID tokens directly; set `--gcp-impersonate-service-account` to \
+         mint the token via impersonation, or run Restate with a service-account key (`GOOGLE_APPLICATION_CREDENTIALS`) \
+         or a GCE/GKE/Cloud Run metadata-server identity"
+    )]
+    AmbientUnsupported { audience: String },
+    #[error(
         "failed to mint ID token (audience '{audience}', impersonating '{impersonate}'): {message}"
     )]
     Mint {
@@ -207,9 +215,27 @@ impl GcpTokenClient {
             None => {
                 let creds = idtoken::Builder::new(audience.to_owned())
                     .build()
-                    .map_err(|e| GcpAuthError::Build {
-                        audience: audience.to_owned(),
-                        message: e.to_string(),
+                    .map_err(|e| {
+                        // authorized_user (gcloud) and external_account (Workload Identity
+                        // Federation) ADC sources cannot mint ID tokens directly. Map that
+                        // specific case to an actionable error instead of leaking the
+                        // crate-internal hint carried by the underlying message; keep the raw
+                        // error at debug level for operator diagnosis.
+                        if e.is_not_supported() {
+                            tracing::debug!(
+                                audience = %audience,
+                                error = %e,
+                                "ambient ADC identity cannot mint an ID token; impersonation required"
+                            );
+                            GcpAuthError::AmbientUnsupported {
+                                audience: audience.to_owned(),
+                            }
+                        } else {
+                            GcpAuthError::Build {
+                                audience: audience.to_owned(),
+                                message: e.to_string(),
+                            }
+                        }
                     })?;
                 creds.id_token().await.map_err(|e| GcpAuthError::Mint {
                     audience: audience.to_owned(),
@@ -329,6 +355,20 @@ mod tests {
         let dur = parse_jwt_exp(&token).expect("expected Some");
         assert!(dur > Duration::from_secs(3500));
         assert!(dur <= Duration::from_secs(3600));
+    }
+
+    #[test]
+    fn ambient_unsupported_error_is_actionable_and_leak_free() {
+        let err = GcpAuthError::AmbientUnsupported {
+            audience: "https://svc-abc-uc.a.run.app".into(),
+        };
+        let msg = err.to_string();
+        // Actionable: names the audience and the fix.
+        assert!(msg.contains("https://svc-abc-uc.a.run.app"), "{msg}");
+        assert!(msg.contains("--gcp-impersonate-service-account"), "{msg}");
+        // Leak-free: must not surface the google-cloud-auth internal API hint.
+        assert!(!msg.contains("idtoken::user_account"), "{msg}");
+        assert!(!msg.to_lowercase().contains("builder directly"), "{msg}");
     }
 
     #[test]

--- a/crates/service-client/src/lib.rs
+++ b/crates/service-client/src/lib.rs
@@ -261,11 +261,15 @@ impl ServiceClientError {
             //   retry-and-fail-consistently rather than fail-fast; this is acceptable because the
             //   discovery / invoker retry loops already bound the attempt count so the worst-case
             //   overhead is bounded.
+            // - `AmbientUnsupported` is a misconfiguration (the ambient ADC source cannot mint
+            //   ID tokens directly); retrying cannot help.
             ServiceClientError::GcpAuth(_, gcp_error) => match gcp_error {
                 gcp::GcpAuthError::Adc { .. }
                 | gcp::GcpAuthError::Timeout { .. }
                 | gcp::GcpAuthError::Mint { .. } => true,
-                gcp::GcpAuthError::Build { .. } => false,
+                gcp::GcpAuthError::Build { .. } | gcp::GcpAuthError::AmbientUnsupported { .. } => {
+                    false
+                }
             },
             ServiceClientError::IdentityV1(_) => false, // this really should never happen
         }
@@ -430,6 +434,12 @@ mod tests {
                 false,
             ),
             (
+                gcp::GcpAuthError::AmbientUnsupported {
+                    audience: "https://svc.example.com".into(),
+                },
+                false,
+            ),
+            (
                 gcp::GcpAuthError::Mint {
                     audience: "https://svc.example.com".into(),
                     impersonate: "sa@p.iam.gserviceaccount.com".into(),
@@ -473,6 +483,11 @@ mod tests {
                     audience: audience.clone(),
                     message: message.clone(),
                 },
+                gcp::GcpAuthError::AmbientUnsupported { audience } => {
+                    gcp::GcpAuthError::AmbientUnsupported {
+                        audience: audience.clone(),
+                    }
+                }
                 gcp::GcpAuthError::Mint {
                     audience,
                     impersonate,


### PR DESCRIPTION
Adding some polish to hide an ugly error when

## Problem

When an HTTP deployment is registered with native Google OIDC auth (`--gcp-id-token`) but the ambient Application Default Credentials are an `authorized_user` (gcloud user creds) or `external_account` (Workload Identity Federation) source, token minting fails. The failure surfaced to the operator with a leaked, crate-internal hint from `google-cloud-auth`:

```
error minting GCP ID token for '<url>': failed to build ID token credentials for audience '<url>': credentials type not supported: authorized_user, use idtoken::user_account::Builder directly.
```

`use idtoken::user_account::Builder directly` is meaningless to an operator. (Observed while testing the docs for this feature against a real private Cloud Run service.)

## Fix

In the ambient (non-impersonated) mint path, detect the unsupported-credential case structurally via `google-cloud-auth`'s `BuilderError::is_not_supported()` (which fires for both `authorized_user` and `external_account`) and return a dedicated `GcpAuthError::AmbientUnsupported` whose message is actionable and free of internal API references:

```
the ambient Application Default Credentials identity cannot mint an ID token for audience '<url>'. User credentials (from `gcloud auth application-default login`) and Workload Identity Federation (`external_account`) sources cannot mint ID tokens directly; set `--gcp-impersonate-service-account` to mint the token via impersonation, or run Restate with a service-account key (`GOOGLE_APPLICATION_CREDENTIALS`) or a GCE/GKE/Cloud Run metadata-server identity
```

The raw underlying error is preserved at `debug` level for operator diagnosis. Other build failures (missing/unparseable ADC, etc.) keep the existing `Build` error. The new variant is classified non-retryable (it is a misconfiguration), matching `Build`.