### PR TITLE
Remove e2e env variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,13 +299,6 @@ jobs:
         with:
           testArtifactOutput: e2e-test-report
           restateContainerImage: localhost/restatedev/restate-commit-download:latest
-          # RESTATE_WORKER__INVOKER__experimental_features_allow_protocol_v6=true is needed for forward compatibility
-          # tests 1.6 -> 1.5. The e2e tests create a v1.5 Restate server which gets the same env variables passed in,
-          # and we need to enable the protocol v6 which is being used by 1.6.
-          # todo remove once we use v1.6 as the LAST_COMPATIBLE_RESTATE_SERVER_VERSION in the e2e tests
-          envVars: |
-            RESTATE_WORKER__INVOKER__experimental_features_allow_protocol_v6=true
-            RESTATE_disable_controlled_idempotent_sharding=true
 
   e2e-vqueues:
     name: Run E2E tests with vqueues


### PR DESCRIPTION
Removing RESTATE_WORKER__INVOKER__experimental_features_allow_protocol_v6=true because the last compatible Restate server version is v1.6.2.

Removing RESTATE_disable_controlled_idempotent_sharding=true because we disable controlled idempotent sharding for all e2e test runs via https://github.com/restatedev/e2e/pull/431.