### PR TITLE
Drop client-supplied x-restate-* headers at the ingress

### DIFF
--- a/crates/ingress-http/src/handler/service_handler.rs
+++ b/crates/ingress-http/src/handler/service_handler.rs
@@ -382,6 +382,10 @@ fn parse_headers(parts: http::request::Parts) -> Result<Vec<Header>, HandlerErro
             || k == header::HOST
             || k == IDEMPOTENCY_KEY
             || k == IDEMPOTENCY_EXPIRES
+            // Drop any client-supplied `x-restate-*` header. This namespace is
+            // reserved for the ingress (e.g. `x-restate-ingress-path` set above);
+            // forwarding client values would let callers spoof it.
+            || k.as_str().starts_with("x-restate-")
         {
             continue;
         }

--- a/crates/ingress-http/src/handler/tests.rs
+++ b/crates/ingress-http/src/handler/tests.rs
@@ -108,6 +108,75 @@ async fn call_service() {
     assert_eq!(response_value.greeting, "Igal");
 }
 
+// Regression test for https://github.com/restatedev/restate/issues/4187:
+// client-supplied `x-restate-*` headers must not be forwarded to the service.
+// The namespace is reserved for the ingress, so a caller can neither inject
+// arbitrary `x-restate-*` headers nor override the ones the ingress sets.
+#[restate_core::test]
+#[traced_test]
+async fn ingress_overwrites_x_restate_headers() {
+    let greeting_req = GreetingRequest {
+        person: "Francesco".to_string(),
+    };
+
+    let req = hyper::Request::builder()
+        .uri("http://localhost/greeter.Greeter/greet")
+        .method(Method::POST)
+        .header("content-type", "application/json")
+        // Attempt to spoof the ingress-reserved path and inject an arbitrary
+        // `x-restate-*` header.
+        .header("x-restate-ingress-path", "/spoofed")
+        .header("x-restate-foo", "bar")
+        .header("my-header", "my-value")
+        .body(Full::new(Bytes::from(
+            serde_json::to_vec(&greeting_req).unwrap(),
+        )))
+        .unwrap();
+
+    let mut mock_dispatcher = MockRequestDispatcher::default();
+    mock_dispatcher
+        .expect_call()
+        .return_once(|invocation_request| {
+            let headers = &invocation_request.header.headers;
+
+            // Regular user headers are still forwarded.
+            assert!(
+                headers
+                    .iter()
+                    .any(|h| &*h.name == "my-header" && &*h.value == "my-value")
+            );
+
+            // The arbitrary client `x-restate-*` header is dropped.
+            assert!(!headers.iter().any(|h| &*h.name == "x-restate-foo"));
+
+            // `x-restate-ingress-path` is set by the ingress, exactly once, with
+            // the real request path - not the client-supplied "/spoofed" value.
+            let ingress_paths: Vec<_> = headers
+                .iter()
+                .filter(|h| &*h.name == "x-restate-ingress-path")
+                .collect();
+            assert_eq!(ingress_paths.len(), 1);
+            assert_eq!(&*ingress_paths[0].value, "/greeter.Greeter/greet");
+
+            Box::pin(ready(Ok(InvocationOutput {
+                request_id: Default::default(),
+                invocation_id: Some(invocation_request.invocation_id()),
+                completion_expiry_time: None,
+                response: InvocationOutputResponse::Success(
+                    InvocationTarget::service("greeter.Greeter", "greet"),
+                    serde_json::to_vec(&GreetingResponse {
+                        greeting: "Igal".to_string(),
+                    })
+                    .unwrap()
+                    .into(),
+                ),
+            })))
+        });
+
+    let response = handle(req, mock_dispatcher).await;
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
 #[restate_core::test]
 #[traced_test]
 async fn call_service_with_get() {

--- a/release-notes/unreleased/4187-ingress-overwrite-x-restate-headers.md
+++ b/release-notes/unreleased/4187-ingress-overwrite-x-restate-headers.md
@@ -1,9 +1,9 @@
-# Release Notes for Issue #4187: Ingress overwrites reserved `x-restate-*` headers
+# Release Notes for Issue #4187: Ingress drops client-supplied `x-restate-*` headers
 
 ## Bug Fix
 
 ### What Changed
-When the HTTP ingress ingests a request, it now drops any client-supplied
+When the HTTP ingress receives a request, it now drops any client-supplied
 `x-restate-*` headers before forwarding the request to the service. The
 `x-restate-*` namespace is reserved for the ingress (for example,
 `x-restate-ingress-path`), so callers can no longer inject or override these

--- a/release-notes/unreleased/4187-ingress-overwrite-x-restate-headers.md
+++ b/release-notes/unreleased/4187-ingress-overwrite-x-restate-headers.md
@@ -1,0 +1,29 @@
+# Release Notes for Issue #4187: Ingress overwrites reserved `x-restate-*` headers
+
+## Bug Fix
+
+### What Changed
+When the HTTP ingress ingests a request, it now drops any client-supplied
+`x-restate-*` headers before forwarding the request to the service. The
+`x-restate-*` namespace is reserved for the ingress (for example,
+`x-restate-ingress-path`), so callers can no longer inject or override these
+headers.
+
+### Why This Matters
+Previously, a caller could set `x-restate-*` headers on an incoming request and
+have them forwarded to the service (or override the values the ingress sets),
+allowing reserved ingress metadata to be spoofed.
+
+### Impact on Users
+- Existing deployments: requests that relied on passing custom `x-restate-*`
+  headers through the ingress to a service will no longer receive them. This is
+  intentional; the namespace is reserved.
+- New deployments: no action needed.
+
+### Migration Guidance
+If you were forwarding custom metadata to a service via `x-restate-*` headers,
+rename those headers to a non-reserved prefix (any name that does not start with
+`x-restate-`).
+
+### Related Issues
+- Issue #4187: Ingress should overwrite `x-restate-*` headers if present


### PR DESCRIPTION
Closes #4187.

The HTTP ingress forwarded every incoming request header to the service, including caller-supplied `x-restate-*` headers. That namespace is reserved for the ingress (e.g. `x-restate-ingress-path`), so a caller could inject or override reserved metadata.

`parse_headers` now drops any incoming header whose name starts with `x-restate-`, so only ingress-set values are forwarded. (`x-restate-limit-key` is unaffected — it's consumed by `parse_limit_key` before `parse_headers` runs.)

Added a regression test that sends a spoofed `x-restate-ingress-path` plus an arbitrary `x-restate-foo` header and asserts they don't reach the service while normal headers still do. It passes with the fix and fails without it. Also added a release note for the behavior change.

Verified with `cargo test -p restate-ingress-http`, `cargo fmt --check`, and `cargo clippy`.