### PR TITLE
[docs][local-cluster] Update the README about connecting to the local…

### DIFF
--- a/crates/local-cluster-runner/README.md
+++ b/crates/local-cluster-runner/README.md
@@ -11,7 +11,7 @@ Featureset:
 
 The cluster runner adds some extra files to the base dir:
 - `$BASE_DIR/$NODE_NAME/config.toml`: The configuration for the node, passed via env var `RESTATE_CONFIG`
-- `$BASE_DIR/$NODE_NAME/node.sock`: The gRPC node service. This is advertised as a absolute unix path.
+- `$BASE_DIR/$NODE_NAME/fabric.sock`: The gRPC node service. This is advertised as a absolute unix path.
 - `$BASE_DIR/$NODE_NAME/restate.log`: The stdout and stderr of the server process
 
 # Debugging
@@ -32,6 +32,5 @@ You can watch node logs with `tail -f restate-data/*/restate.log`
 To interact with the running cluster using `restatectl`, use the following configuration:
 
 ```shell
-export RESTATE_CLUSTER_CONTROLLER_ADDRESS=unix:restate-data/metadata-node/node.sock
-export RESTATE_METADATA_ADDRESS=unix:restate-data/metadata.sock
+export RESTATECTL_ADDRESS=unix:restate-data/node-1/fabric.sock
 ```


### PR DESCRIPTION
… cluster

While playing with the local restate cluster, I noticed that the docs for connecting to this cluster are outdated. It's referring to some local unix sockets that don't seem to exist, and I couldn't find references to `RESTATE_CLUSTER_CONTROLLER_ADDRESS` in the code.

Pointing restatectl to the fabric socket of one of the nodes works though. So updating the readme to use that instead.

```
❯❯ RESTATECTL_ADDRESS=unix:restate-data/node-1/fabric.sock restatectl status                                             ✘ 130 fix/local-cluster-docs ✭
Node Configuration (v12)
 NODE-ID  NAME    UPTIME      METADATA  LEADER  FOLLOWER  NODESET-MEMBER  SEQUENCER  ROLES
 N1:2     node-1  3h 16m 59s  Member    2       0         4               2          admin | http-ingress | log-server | metadata-server | worker
 N2:1     node-2  3h 16m 59s  Member    0       0         2               0          admin | http-ingress | log-server | metadata-server | worker
 N3:1     node-3  3h 16m 59s  Member    2       0         2               2          admin | http-ingress | log-server | metadata-server | worker
```