### PR TITLE
[Restate UI] Update to v1.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8832,8 +8832,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "1.0.3"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v1.0.3#647a7e2b669926105c0b56c43d0ba26cea505df2"
+version = "1.0.4"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v1.0.4#77d2b38d58df4ede66b1a453833f7fec030ef46f"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -39,7 +39,7 @@ restate-util-time = { workspace = true }
 restate-types = { workspace = true }
 restate-util-string = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "1.0.3", tag = "v1.0.3" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "1.0.4", tag = "v1.0.4" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v1.0.4
published at https://github.com/restatedev/restate-web-ui/releases/download/v1.0.4/ui-v1.0.4.zip