### PR TITLE
ingestion-client: increase the log level for rpc errors to warn

### DIFF
--- a/crates/ingestion-client/src/session.rs
+++ b/crates/ingestion-client/src/session.rs
@@ -448,8 +448,8 @@ where
                 Ok(response) => {
                     // Handle any other response code as a connection loss
                     // and retry all inflight batches.
-                    debug!(
-                        "Ingestion response from {}: {:?}",
+                    warn!(
+                        "Ingestion response error status from {}: {:?}",
                         connection.peer(),
                         response
                     );
@@ -462,7 +462,7 @@ where
                     // special case for load shedding we could
                     // throttle the stream a little bit then
                     // speed up over a period of time.
-                    debug!("Ingestion error from {}: {}", connection.peer(), err);
+                    warn!("Ingestion RPC error from {}: {}", connection.peer(), err);
                     return;
                 }
             }
@@ -521,8 +521,8 @@ where
                 Ok(response) => {
                     // Handle any other response code as a connection loss
                     // and retry all inflight batches.
-                    debug!(
-                        "Ingestion response from {}: {:?}",
+                    warn!(
+                        "Ingestion response error status from {}: {:?}",
                         connection.peer(),
                         response
                     );
@@ -535,7 +535,7 @@ where
                     // special case for load shedding we could
                     // throttle the stream a little bit then
                     // speed up over a period of time.
-                    debug!("Ingestion error from {}: {}", connection.peer(), err);
+                    warn!("Ingestion RPC error from {}: {}", connection.peer(), err);
                     self.carry_over.push_back(batch);
                     break;
                 }

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -1112,7 +1112,7 @@ where
 
         if !self.is_targeted_to_me(&record.keys) {
             self.status.num_skipped_records += 1;
-            trace!(
+            warn!(
                 "Ignore message which is not targeted to me Partition Range: {:?} Key: {:?}, Header: {:?}",
                 self.key_filter,
                 record.keys,
@@ -1127,7 +1127,7 @@ where
         // deduplicate if deduplication information has been provided
         if let Some(dedup_information) = dedup_information {
             if Self::is_outdated_or_duplicate(&dedup_information, transaction).await? {
-                debug!(
+                warn!(
                     "Ignoring outdated or duplicate message: {:?}",
                     record.envelope.header()
                 );


### PR DESCRIPTION

Summary:
This to make sure RPC related error or un handled status are visible
in the logs

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4915).
* #4911
* __->__ #4915