### PR TITLE
[ingress] Add breakdown by ingress call type to latency histogram

### DIFF
--- a/crates/ingress-http/src/handler/path_parsing.rs
+++ b/crates/ingress-http/src/handler/path_parsing.rs
@@ -159,6 +159,15 @@ pub(crate) enum InvokeType {
     Send,
 }
 
+impl InvokeType {
+    pub(crate) const fn as_static_str(&self) -> &'static str {
+        match self {
+            InvokeType::Call => "call",
+            InvokeType::Send => "send",
+        }
+    }
+}
+
 pub(crate) struct ServiceRequestType {
     pub(crate) name: ServiceName,
     pub(crate) handler: String,

--- a/crates/ingress-http/src/handler/service_handler.rs
+++ b/crates/ingress-http/src/handler/service_handler.rs
@@ -204,6 +204,7 @@ where
         .with_scope(scope);
 
         let invocation_id = InvocationId::generate(&invocation_target, idempotency_key.as_deref());
+        let invoke_ty_str = invoke_ty.as_static_str();
 
         let result = async move {
             let ingress_span_context =
@@ -299,6 +300,7 @@ where
         histogram!(
             INGRESS_REQUEST_DURATION,
             "rpc.service" => service_name.to_string(),
+            "rpc.type" => invoke_ty_str,
         )
         .record(start_time.elapsed());
 
@@ -306,6 +308,7 @@ where
             INGRESS_REQUESTS,
             "status" => REQUEST_COMPLETED,
             "rpc.service" => service_name.to_string(),
+            "rpc.type" => invoke_ty_str,
         )
         .increment(1);
         result

--- a/monitoring/grafana/restate-internals.json
+++ b/monitoring/grafana/restate-internals.json
@@ -731,8 +731,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "avg by (node_name) (restate_ingress_request_duration_seconds{cluster_name=\"$cluster\", node_name=~\"$node\", quantile=\"0.5\"})",
-          "legendFormat": "{{node_name}} P50",
+          "expr": "avg by (node_name, rpc_type) (restate_ingress_request_duration_seconds{cluster_name=\"$cluster\", node_name=~\"$node\", quantile=\"0.5\"})",
+          "legendFormat": "{{node_name}} {{rpc_type}} P50",
           "refId": "A"
         },
         {
@@ -740,12 +740,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "avg by (node_name) (restate_ingress_request_duration_seconds{cluster_name=\"$cluster\", node_name=~\"$node\", quantile=\"0.99\"})",
-          "legendFormat": "{{node_name}} P99",
+          "expr": "avg by (node_name, rpc_type) (restate_ingress_request_duration_seconds{cluster_name=\"$cluster\", node_name=~\"$node\", quantile=\"0.99\"})",
+          "legendFormat": "{{node_name}} {{rpc_type}} P99",
           "refId": "B"
         }
       ],
-      "title": "HTTP Latency by Node",
+      "title": "HTTP Latency by Node and Type",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
The ingress' reported latency histogram report both send and call latencies mixed together although they typically have very different latency implications. In a workload that has a mix of sends and calls, it's hard to debug the latency of a particular type. This PR adds a new label `rpc.type` to breakdown the latency reporting by whether it's a `call` or `send`.

Tested locally, notice the new `rpc_type` dimension in the reported metrics:

```
❯❯❯ curl http://localhost:5122/metrics | grep ingress 
# TYPE restate_ingress_requests_total counter
restate_ingress_requests_total{cluster_name="localcluster",node_name="Mohameds-Restate-MacBook-Pro.local",status="completed",rpc_service="Counter"} 2
restate_ingress_requests_total{cluster_name="localcluster",node_name="Mohameds-Restate-MacBook-Pro.local",status="admitted"} 2
# HELP restate_ingress_request_duration_seconds Total latency of Ingress request processing in seconds
# TYPE restate_ingress_request_duration_seconds summary
restate_ingress_request_duration_seconds{cluster_name="localcluster",node_name="Mohameds-Restate-MacBook-Pro.local",rpc_service="Counter",rpc_type="call",quantile="0.5"} 0.00721
7114776142592
restate_ingress_request_duration_seconds{cluster_name="localcluster",node_name="Mohameds-Restate-MacBook-Pro.local",rpc_service="Counter",rpc_type="call",quantile="0.9"} 0.00721
7114776142592
restate_ingress_request_duration_seconds{cluster_name="localcluster",node_name="Mohameds-Restate-MacBook-Pro.local",rpc_service="Counter",rpc_type="call",quantile="0.99"} 0.0072
17114776142592
restate_ingress_request_duration_seconds{cluster_name="localcluster",node_name="Mohameds-Restate-MacBook-Pro.local",rpc_service="Counter",rpc_type="call",quantile="1"} 0.0072165
84
restate_ingress_request_duration_seconds_sum{cluster_name="localcluster",node_name="Mohameds-Restate-MacBook-Pro.local",rpc_service="Counter",rpc_type="call"} 0.007216584
restate_ingress_request_duration_seconds_count{cluster_name="localcluster",node_name="Mohameds-Restate-MacBook-Pro.local",rpc_service="Counter",rpc_type="call"} 1
restate_ingress_request_duration_seconds{cluster_name="localcluster",node_name="Mohameds-Restate-MacBook-Pro.local",rpc_service="Counter",rpc_type="send",quantile="0.5"} 0.00203
12578939049118
restate_ingress_request_duration_seconds{cluster_name="localcluster",node_name="Mohameds-Restate-MacBook-Pro.local",rpc_service="Counter",rpc_type="send",quantile="0.9"} 0.00203
12578939049118
restate_ingress_request_duration_seconds{cluster_name="localcluster",node_name="Mohameds-Restate-MacBook-Pro.local",rpc_service="Counter",rpc_type="send",quantile="0.99"} 0.0020
312578939049118
restate_ingress_request_duration_seconds{cluster_name="localcluster",node_name="Mohameds-Restate-MacBook-Pro.local",rpc_service="Counter",rpc_type="send",quantile="1"} 0.0020314
58
restate_ingress_request_duration_seconds_sum{cluster_name="localcluster",node_name="Mohameds-Restate-MacBook-Pro.local",rpc_service="Counter",rpc_type="send"} 0.002031458
restate_ingress_request_duration_seconds_count{cluster_name="localcluster",node_name="Mohameds-Restate-MacBook-Pro.local",rpc_service="Counter",rpc_type="send"} 1
```