### PR TITLE
Enable restoring an earlier snapshot if latest fails

### DIFF
--- a/crates/partition-store/src/error.rs
+++ b/crates/partition-store/src/error.rs
@@ -23,8 +23,6 @@ pub enum OpenError {
     SnapshotRepositoryRequired,
     #[error("a partition snapshot is required")]
     SnapshotRequired,
-    #[error("partition snapshot was found but unsuitable; it was taken before the log trim point")]
-    SnapshotUnsuitable,
     #[error("partition store for partition does not exist in local database")]
     NoLocalStore,
     #[error("open failed due to snapshot-related error: {0:#}")]

--- a/crates/partition-store/src/metric_definitions.rs
+++ b/crates/partition-store/src/metric_definitions.rs
@@ -22,6 +22,10 @@ pub(crate) const SNAPSHOT_DOWNLOAD_FAILED: &str =
 pub(crate) const PARTITION_MEMTABLE_BUDGET: &str = "restate.partition_store.memtable_budget.bytes";
 pub(crate) const NUM_OPEN_PARTITIONS: &str = "restate.partition_store.num_open";
 pub(crate) const RECLAIM_FLUSH: &str = "restate.partition_store.reclaim_flush.total";
+pub(crate) const SNAPSHOT_DOWNLOAD_FALLBACK: &str =
+    "restate.partition_store.snapshots.download.fallback.total";
+pub(crate) const SNAPSHOT_FAST_FORWARD_FAILED: &str =
+    "restate.partition_store.snapshots.fast_forward.failed.total";
 
 pub(crate) fn describe_metrics() {
     describe_counter!(
@@ -70,5 +74,17 @@ pub(crate) fn describe_metrics() {
         RECLAIM_FLUSH,
         Unit::Count,
         "How many flushes were triggered by the partition store memory reclaimer"
+    );
+
+    describe_counter!(
+        SNAPSHOT_DOWNLOAD_FALLBACK,
+        Unit::Count,
+        "Number of snapshot downloads that succeeded using a fallback (non-latest) snapshot"
+    );
+
+    describe_counter!(
+        SNAPSHOT_FAST_FORWARD_FAILED,
+        Unit::Count,
+        "Number of failed fast-forwards from trim gap (no suitable snapshot available)"
     );
 }

--- a/crates/partition-store/src/partition_store_manager.rs
+++ b/crates/partition-store/src/partition_store_manager.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Weak};
 use ahash::HashMap;
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use tokio::sync::Mutex as AsyncMutex;
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, error, info, instrument};
 
 use restate_rocksdb::{CfPrefixPattern, DbSpecBuilder, RocksDb, RocksDbManager, RocksError};
 use restate_storage_api::fsm_table::ReadFsmTable;
@@ -267,35 +267,27 @@ impl PartitionStoreManager {
         // target-lsn target higher than our local state (probably due to seeing a log trim-gap).
         // **
 
-        // Attempt to get the latest available snapshot from the snapshot repository:
-        let snapshot = self
+        // Attempt to get a suitable snapshot from the repository:
+        let snapshot_result = self
             .snapshots
-            .download_latest_snapshot(partition.partition_id)
-            .await
-            .map_err(OpenError::Snapshot)?;
+            .download_snapshot(partition.partition_id, target_lsn)
+            .await;
 
-        match (snapshot, target_lsn) {
-            (None, None) => {
-                debug!("No snapshot found for partition, creating new partition store");
-                let db = cell.provision(&mut state_guard, rocksdb.clone()).await?;
-                Ok(PartitionStore::from(db))
-            }
-
-            (Some(snapshot), None) => {
+        match (snapshot_result, target_lsn) {
+            (Ok(Some(snapshot)), None) => {
+                // Found a snapshot when we didn't require one - import it
                 info!("Found partition snapshot, restoring it");
                 let db = cell
                     .import_cf(&mut state_guard, snapshot, rocksdb.clone())
                     .await?;
-
                 Ok(PartitionStore::from(db))
             }
 
-            // Good snapshot
-            (Some(snapshot), Some(fast_forward_lsn))
-                if snapshot.min_applied_lsn >= fast_forward_lsn =>
-            {
+            (Ok(Some(snapshot)), Some(fast_forward_lsn)) => {
+                // Got a snapshot that meets the target LSN requirement (filtered by candidate LSN
+                // and re-verified against the downloaded metadata in `download_snapshot`).
                 info!(
-                    latest_snapshot_lsn = %snapshot.min_applied_lsn,
+                    snapshot_lsn = %snapshot.min_applied_lsn,
                     %fast_forward_lsn,
                     "Found snapshot with LSN >= target LSN, dropping local partition store state",
                 );
@@ -305,22 +297,31 @@ impl PartitionStoreManager {
                     .await?;
                 Ok(PartitionStore::from(db))
             }
+
+            (Ok(None), None) => {
+                debug!("No snapshot found for partition, creating new partition store");
+                let db = cell.provision(&mut state_guard, rocksdb.clone()).await?;
+                Ok(PartitionStore::from(db))
+            }
+
+            (Err(err), None) => {
+                // A snapshot may well exist but we failed to fetch it (transient repository error,
+                // or every retained candidate failed to download). Do NOT provision an empty store
+                // and silently discard data; fail the open so the processor retries later.
+                Err(OpenError::Snapshot(err))
+            }
+
+            // We required a snapshot (fast-forward target) but have none suitable: either none was
+            // found at/above the target LSN (`Ok(None)`) or all candidates failed (`Err`).
             (maybe_snapshot, Some(fast_forward_lsn)) => {
-                // Play it safe and keep the partition store intact; we can't do much else at this
-                // point. We'll likely halt again as soon as the processor starts up.
                 let recovery_guide_msg = "The partition's log is trimmed to a point from which this processor can not resume. \
                 Visit https://docs.restate.dev/operate/clusters#handling-missing-snapshots \
                 to learn more about how to recover this processor.";
 
-                if let Some(snapshot) = maybe_snapshot {
-                    warn!(
-                        latest_snapshot_lsn = %snapshot.min_applied_lsn,
-                        %fast_forward_lsn,
-                        "The latest available snapshot is from an LSN before the target LSN! {}",
-                        recovery_guide_msg,
-                    );
-                    Err(OpenError::SnapshotUnsuitable)
-                } else if !self.snapshots.is_repository_configured() {
+                metrics::counter!(crate::metric_definitions::SNAPSHOT_FAST_FORWARD_FAILED)
+                    .increment(1);
+
+                if !self.snapshots.is_repository_configured() {
                     error!(
                         %fast_forward_lsn,
                         "A log trim gap was encountered, but no snapshot repository is configured! {}",
@@ -328,11 +329,19 @@ impl PartitionStoreManager {
                     );
                     Err(OpenError::SnapshotRepositoryRequired)
                 } else {
-                    error!(
-                        %fast_forward_lsn,
-                        "A log trim gap was encountered, but no snapshot is available for this partition! {}",
-                        recovery_guide_msg,
-                    );
+                    match maybe_snapshot {
+                        Err(err) => error!(
+                            %fast_forward_lsn,
+                            %err,
+                            "A log trim gap was encountered, but no suitable snapshot is available for this partition! {}",
+                            recovery_guide_msg,
+                        ),
+                        Ok(_) => error!(
+                            %fast_forward_lsn,
+                            "A log trim gap was encountered, but no suitable snapshot is available for this partition! {}",
+                            recovery_guide_msg,
+                        ),
+                    }
                     Err(OpenError::SnapshotRequired)
                 }
             }

--- a/crates/partition-store/src/snapshots.rs
+++ b/crates/partition-store/src/snapshots.rs
@@ -18,11 +18,11 @@ use std::sync::Arc;
 use crate::{PartitionDb, PartitionStore, SnapshotError, SnapshotErrorKind};
 
 pub use self::metadata::*;
-pub use self::repository::{PartitionSnapshotStatus, SnapshotRepository};
+pub use self::repository::{PartitionSnapshotStatus, SnapshotReference, SnapshotRepository};
 pub use self::snapshot_task::*;
 
 use tokio::sync::Semaphore;
-use tracing::{debug, instrument};
+use tracing::{debug, error, info, instrument, warn};
 
 use restate_types::config::Configuration;
 use restate_types::identifiers::{PartitionId, SnapshotId};
@@ -104,22 +104,118 @@ impl Snapshots {
     }
 
     #[instrument(level = "error", skip_all, fields(partition_id = %partition_id))]
-    pub async fn download_latest_snapshot(
+    pub async fn download_snapshot(
         &self,
         partition_id: PartitionId,
+        target_lsn: Option<Lsn>,
     ) -> anyhow::Result<Option<LocalPartitionSnapshot>> {
-        // Attempt to get the latest available snapshot from the snapshot repository:
-        let snapshot = match &self.repository {
-            Some(repository) => {
-                debug!("Looking for partition snapshot from which to bootstrap partition store");
-                // todo(pavel): pass target LSN to repository
-                repository.get_latest(partition_id).await?
-            }
-            None => {
-                debug!("No snapshot repository configured");
-                None
-            }
+        use crate::metric_definitions::{
+            SNAPSHOT_DOWNLOAD_DURATION, SNAPSHOT_DOWNLOAD_FAILED, SNAPSHOT_DOWNLOAD_FALLBACK,
         };
-        Ok(snapshot)
+
+        let Some(repository) = &self.repository else {
+            debug!("No snapshot repository configured");
+            return Ok(None);
+        };
+
+        let start = std::time::Instant::now();
+        // A transient error reading the latest-snapshot pointer is propagated as `Err` so the
+        // caller fails the open and retries, rather than mistaking it for "no snapshot exists".
+        let retained = repository.get_snapshot_candidates(partition_id).await?;
+
+        // When a target LSN is required, only snapshots at or above it can satisfy a fast-forward.
+        let candidates: Vec<&SnapshotReference> = retained
+            .iter()
+            .filter(|c| target_lsn.is_none_or(|min_lsn| c.min_applied_lsn >= min_lsn))
+            .collect();
+        let candidate_count = candidates.len();
+
+        if candidate_count == 0 {
+            // No usable snapshot. With a target LSN this is a failure (the caller cannot
+            // fast-forward); without one it simply means a fresh partition store is provisioned.
+            match target_lsn {
+                Some(min_lsn) => {
+                    metrics::counter!(SNAPSHOT_DOWNLOAD_FAILED).increment(1);
+                    match retained.first() {
+                        Some(newest) => warn!(
+                            target_lsn = %min_lsn,
+                            newest_retained_lsn = %newest.min_applied_lsn,
+                            retained_count = retained.len(),
+                            "No retained snapshot reaches the required LSN; the log was trimmed past all available snapshots"
+                        ),
+                        None => warn!(
+                            target_lsn = %min_lsn,
+                            "A snapshot is required but none is present in the repository for this partition"
+                        ),
+                    }
+                }
+                None => debug!("No snapshot present in the repository for this partition"),
+            }
+            return Ok(None);
+        }
+
+        let mut last_error: Option<anyhow::Error> = None;
+        for (i, snapshot_ref) in candidates.iter().enumerate() {
+            match repository.get_snapshot(partition_id, snapshot_ref).await {
+                Ok(snapshot) => {
+                    // Defense-in-depth: candidates were filtered using the LSN recorded in the
+                    // `latest.json` index. Re-verify against the downloaded snapshot's own metadata
+                    // in case the index disagrees (corruption / manual edit), and treat a mismatch
+                    // as a failed candidate so we fall back to an older snapshot.
+                    if let Some(min_lsn) = target_lsn
+                        && snapshot.min_applied_lsn < min_lsn
+                    {
+                        warn!(
+                            snapshot_id = %snapshot_ref.snapshot_id,
+                            snapshot_lsn = %snapshot.min_applied_lsn,
+                            target_lsn = %min_lsn,
+                            "Downloaded snapshot LSN is below the required target; trying next candidate"
+                        );
+                        last_error = Some(anyhow::anyhow!(
+                            "snapshot {} has min_applied_lsn {} below required target {}",
+                            snapshot_ref.snapshot_id,
+                            snapshot.min_applied_lsn,
+                            min_lsn,
+                        ));
+                        continue;
+                    }
+                    metrics::histogram!(SNAPSHOT_DOWNLOAD_DURATION)
+                        .record(start.elapsed().as_secs_f64());
+                    if i > 0 {
+                        metrics::counter!(SNAPSHOT_DOWNLOAD_FALLBACK).increment(1);
+                        info!(
+                            snapshot_id = %snapshot_ref.snapshot_id,
+                            attempt = i + 1,
+                            "Restored from fallback snapshot"
+                        );
+                    }
+                    return Ok(Some(snapshot));
+                }
+                Err(err) => {
+                    warn!(
+                        snapshot_id = %snapshot_ref.snapshot_id,
+                        %err,
+                        remaining = candidate_count - i - 1,
+                        "Snapshot download failed, trying next"
+                    );
+                    last_error = Some(err);
+                }
+            }
+        }
+
+        metrics::histogram!(SNAPSHOT_DOWNLOAD_DURATION).record(start.elapsed().as_secs_f64());
+        metrics::counter!(SNAPSHOT_DOWNLOAD_FAILED).increment(1);
+        let tried = candidates
+            .iter()
+            .map(|c| c.snapshot_id.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let final_err = last_error
+            .unwrap_or_else(|| anyhow::anyhow!("No snapshot available"))
+            .context(format!(
+                "all {candidate_count} available snapshot(s) failed to restore (tried: [{tried}])"
+            ));
+        error!(%final_err, "Exhausted all snapshot candidates");
+        Err(final_err)
     }
 }

--- a/crates/partition-store/src/snapshots/repository.rs
+++ b/crates/partition-store/src/snapshots/repository.rs
@@ -142,7 +142,9 @@ impl SnapshotReference {
 }
 
 impl LatestSnapshot {
-    /// We ensure that retained snapshots is in descending order of archived LSN, most recent snapshot first.
+    /// Returns retained snapshots in descending order of archived LSN, most recent first.
+    /// This relies on the write-time invariant maintained by the snapshot put / eviction logic;
+    /// callers should not assume re-sorting here.
     fn effective_retained_snapshots(&self) -> Vec<SnapshotReference> {
         if self.retained_snapshots.is_empty() {
             // Upgrade path from V1 - implicitly the "latest" snapshot is always retained.
@@ -716,23 +718,37 @@ impl SnapshotRepository {
         &self,
         partition_id: PartitionId,
     ) -> anyhow::Result<Option<LocalPartitionSnapshot>> {
+        let candidates = self.get_snapshot_candidates(partition_id).await?;
+        let Some(latest) = candidates.first() else {
+            return Ok(None);
+        };
+        tracing::Span::current().record("snapshot_id", tracing::field::display(latest.snapshot_id));
+        self.get_snapshot(partition_id, latest).await.map(Some)
+    }
+
+    /// Returns the partition's retained snapshot references, most-recent first (descending archived
+    /// LSN), or an empty vec if the repository holds no snapshot for the partition. Selecting a
+    /// snapshot suitable for a given target LSN is the caller's responsibility.
+    pub(crate) async fn get_snapshot_candidates(
+        &self,
+        partition_id: PartitionId,
+    ) -> anyhow::Result<Vec<SnapshotReference>> {
         let latest_path = self.latest_snapshot_pointer_path(partition_id);
 
         let latest = match self.object_store.get(&latest_path).await {
             Ok(result) => result,
             Err(object_store::Error::NotFound { .. }) => {
                 debug!("Latest snapshot data not found in repository");
-                return Ok(None);
+                return Ok(vec![]);
             }
             Err(err) => return Err(err.into()),
         };
 
         let latest: LatestSnapshot = serde_json::from_slice(&latest.bytes().await?)?;
-        tracing::Span::current().record("snapshot_id", tracing::field::display(latest.snapshot_id));
-        debug!("Latest snapshot metadata: {latest:?}");
+        debug!(snapshot_id = %latest.snapshot_id, "Latest snapshot metadata: {latest:?}");
+
         Metadata::with_current(|m| {
             let nodes_config = m.nodes_config_ref();
-
             latest.validate(
                 nodes_config.cluster_name(),
                 nodes_config.cluster_fingerprint(),
@@ -741,26 +757,37 @@ impl SnapshotRepository {
         })
         .with_context(|| format!("'{latest_path}' has validation errors"))?;
 
+        Ok(latest.effective_retained_snapshots())
+    }
+
+    #[instrument(
+        level = "error",
+        skip_all,
+        fields(%partition_id, snapshot_id = %snapshot_ref.snapshot_id),
+    )]
+    pub(crate) async fn get_snapshot(
+        &self,
+        partition_id: PartitionId,
+        snapshot_ref: &SnapshotReference,
+    ) -> anyhow::Result<LocalPartitionSnapshot> {
         let snapshot_metadata_path = self
             .prefix
             .clone()
             .join(partition_id.to_string())
-            .join(latest.path.as_str())
+            .join(snapshot_ref.path.as_str())
             .join("metadata.json");
-        let snapshot_metadata = self.object_store.get(&snapshot_metadata_path).await;
 
-        let snapshot_metadata = match snapshot_metadata {
-            Ok(result) => result,
-            Err(object_store::Error::NotFound { .. }) => {
-                bail!(
-                    "Latest snapshot points to '{snapshot_metadata_path}' that was not found in the repository!"
-                );
-            }
-            Err(err) => return Err(err.into()),
-        };
+        let snapshot_metadata = self
+            .object_store
+            .get(&snapshot_metadata_path)
+            .await
+            .with_context(|| {
+                format!("Snapshot metadata at '{snapshot_metadata_path}' not found in repository")
+            })?;
 
         let mut snapshot_metadata: PartitionSnapshotMetadata =
             serde_json::from_slice(&snapshot_metadata.bytes().await?)?;
+
         if !matches!(snapshot_metadata.version, SnapshotFormatVersion::V1) {
             bail!(
                 "Unsupported snapshot format version: {:?}",
@@ -770,7 +797,6 @@ impl SnapshotRepository {
 
         Metadata::with_current(|m| {
             let nodes_config = m.nodes_config_ref();
-
             snapshot_metadata.validate(
                 nodes_config.cluster_name(),
                 nodes_config.cluster_fingerprint(),
@@ -800,6 +826,7 @@ impl SnapshotRepository {
         let concurrency_limiter = Arc::new(Semaphore::new(DOWNLOAD_CONCURRENCY_LIMIT));
         let mut downloads = JoinSet::new();
         let mut task_handles = HashMap::with_capacity(snapshot_metadata.files.len());
+
         for file in &mut snapshot_metadata.files {
             let filename = strip_leading_slash(&file.name);
             let expected_size = file.size;
@@ -807,7 +834,7 @@ impl SnapshotRepository {
                 .prefix
                 .clone()
                 .join(partition_id.to_string())
-                .join(latest.path.as_str())
+                .join(snapshot_ref.path.as_str())
                 .join(filename);
             let local_path = snapshot_dir.path().join(filename);
             let concurrency_limiter = Arc::clone(&concurrency_limiter);
@@ -882,14 +909,14 @@ impl SnapshotRepository {
         // Transfer ownership of the staging directory from the `TempDir` (which auto-cleans on
         // an early return mid-download) to the snapshot's `SnapshotDir`, which removes it on drop
         // whether the subsequent import succeeds or fails (see #4838).
-        Ok(Some(LocalPartitionSnapshot {
+        Ok(LocalPartitionSnapshot {
             base_dir: SnapshotDir::new(snapshot_dir.keep()),
             log_id: snapshot_metadata.log_id,
             min_applied_lsn: snapshot_metadata.min_applied_lsn,
             db_comparator_name: snapshot_metadata.db_comparator_name,
             files: snapshot_metadata.files,
             key_range: snapshot_metadata.key_range,
-        }))
+        })
     }
 
     /// Retrieve the latest snapshot metadata from the snapshot repository
@@ -1051,9 +1078,8 @@ impl PutSnapshotError {
     }
 }
 
-// The object_store `put_multipart` method does not currently support PutMode, so we don't pass this
-// at all; however since we upload snapshots to a unique path on every attempt, we don't expect any
-// conflicts to arise.
+// The object_store `put_multipart` method does not currently support PutMode, so we cannot pass
+// a CAS condition here. Snapshots write to per-snapshot-id paths, so collisions are not expected.
 async fn put_snapshot_object(
     file_path: &Path,
     key: &ObjectPath,
@@ -1448,6 +1474,140 @@ mod tests {
         assert_eq!(latest.retained_snapshots[0].min_applied_lsn, Lsn::new(4000));
         assert_eq!(latest.retained_snapshots[1].min_applied_lsn, Lsn::new(3000));
         assert_eq!(latest.retained_snapshots[2].min_applied_lsn, Lsn::new(2000));
+
+        Ok(())
+    }
+
+    #[restate_core::test]
+    async fn get_snapshot_candidates_returns_retained_descending() -> anyhow::Result<()> {
+        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+
+        let snapshots_destination = TempDir::new()?;
+        let destination = Url::from_file_path(snapshots_destination.path())
+            .unwrap()
+            .to_string();
+        let opts = SnapshotsOptions {
+            destination: Some(destination),
+            num_retained: std::num::NonZeroU8::new(3).unwrap(),
+            ..SnapshotsOptions::default()
+        };
+        let repository = SnapshotRepository::new_from_config(&opts, TempDir::new().unwrap().keep())
+            .await?
+            .unwrap();
+
+        // No snapshots yet -> no candidates.
+        assert!(
+            repository
+                .get_snapshot_candidates(PartitionId::MIN)
+                .await?
+                .is_empty()
+        );
+
+        // Put four snapshots; with num_retained = 3 the oldest (1000) is evicted.
+        for i in 1..=4 {
+            let (snapshot, source_dir) =
+                mock_snapshot(format!("snapshot-data-{i}").as_bytes(), Lsn::new(i * 1000)).await?;
+            repository
+                .put(&snapshot, SnapshotDir::new(source_dir))
+                .await?;
+        }
+
+        // Retained candidates are returned most-recent-first.
+        let candidates = repository.get_snapshot_candidates(PartitionId::MIN).await?;
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|c| c.min_applied_lsn)
+                .collect::<Vec<_>>(),
+            vec![Lsn::new(4000), Lsn::new(3000), Lsn::new(2000)],
+        );
+
+        Ok(())
+    }
+
+    #[restate_core::test]
+    async fn download_snapshot_falls_back_to_older_when_latest_fails() -> anyhow::Result<()> {
+        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+
+        let snapshots_destination = TempDir::new()?;
+        let destination = Url::from_file_path(snapshots_destination.path())
+            .unwrap()
+            .to_string();
+        let opts = SnapshotsOptions {
+            destination: Some(destination),
+            num_retained: std::num::NonZeroU8::new(3).unwrap(),
+            ..SnapshotsOptions::default()
+        };
+        let repository = SnapshotRepository::new_from_config(&opts, TempDir::new().unwrap().keep())
+            .await?
+            .unwrap();
+
+        // `SnapshotRepository` is cheaply cloneable and shares the underlying object store, so the
+        // `Snapshots` wrapper observes snapshots we `put` through `repository` below.
+        let snapshots = crate::snapshots::Snapshots {
+            repository: Some(repository.clone()),
+            concurrency_limit: std::sync::Arc::new(tokio::sync::Semaphore::new(1)),
+        };
+
+        // An empty repository is "no snapshot present", not an error.
+        assert!(
+            snapshots
+                .download_snapshot(PartitionId::MIN, None)
+                .await?
+                .is_none()
+        );
+
+        // Older snapshot A (LSN 2000) then latest B (LSN 3000).
+        let (snapshot_a, dir_a) = mock_snapshot(b"snapshot-A", Lsn::new(2000)).await?;
+        repository.put(&snapshot_a, SnapshotDir::new(dir_a)).await?;
+        let (snapshot_b, dir_b) = mock_snapshot(b"snapshot-B", Lsn::new(3000)).await?;
+        repository.put(&snapshot_b, SnapshotDir::new(dir_b)).await?;
+
+        // Happy path: the latest snapshot is restored.
+        let restored = snapshots
+            .download_snapshot(PartitionId::MIN, None)
+            .await?
+            .expect("a snapshot is available");
+        assert_eq!(restored.min_applied_lsn, Lsn::new(3000));
+
+        // A target LSN selects only snapshots at or above it: 2500 still allows the latest (3000).
+        let restored = snapshots
+            .download_snapshot(PartitionId::MIN, Some(Lsn::new(2500)))
+            .await?
+            .expect("latest snapshot satisfies the target LSN");
+        assert_eq!(restored.min_applied_lsn, Lsn::new(3000));
+
+        // A target above every retained snapshot yields no suitable candidate (Ok(None)).
+        assert!(
+            snapshots
+                .download_snapshot(PartitionId::MIN, Some(Lsn::new(5000)))
+                .await?
+                .is_none()
+        );
+
+        // Corrupt the latest by removing its data file; the download must fall back to A.
+        let sst_path = |snapshot: &PartitionSnapshotMetadata| {
+            snapshots_destination
+                .path()
+                .join(PartitionId::MIN.to_string())
+                .join(UniqueSnapshotKey::from_metadata(snapshot).padded_key())
+                .join("data.sst")
+        };
+        std::fs::remove_file(sst_path(&snapshot_b))?;
+        let restored = snapshots
+            .download_snapshot(PartitionId::MIN, None)
+            .await?
+            .expect("falls back to the older snapshot");
+        assert_eq!(restored.min_applied_lsn, Lsn::new(2000));
+
+        // Remove A's data too: every candidate now fails -> error, not a silent "no snapshot".
+        std::fs::remove_file(sst_path(&snapshot_a))?;
+        assert!(
+            snapshots
+                .download_snapshot(PartitionId::MIN, None)
+                .await
+                .is_err()
+        );
 
         Ok(())
     }

--- a/release-notes/unreleased/4917-snapshot-restore-fallback.md
+++ b/release-notes/unreleased/4917-snapshot-restore-fallback.md
@@ -1,0 +1,50 @@
+# Release Notes for PR #4917: Restore an earlier snapshot if the latest one fails
+
+## Behavioral Change
+
+### What Changed
+
+When a partition bootstraps from the snapshot repository and the latest snapshot cannot be
+restored — network error, corrupt or unreadable metadata, missing SST files — Restate now falls
+back to the next older retained snapshot instead of failing the restore outright. Candidates are
+tried in descending LSN order until one succeeds or all are exhausted.
+
+Two metrics were added so operators can see when this happens:
+
+| Metric | Meaning |
+|---|---|
+| `restate.partition_store.snapshots.download.fallback.total` | A partition started from a non-latest snapshot |
+| `restate.partition_store.snapshots.fast_forward.failed.total` | No retained snapshot could satisfy a fast-forward from a trim gap |
+
+A repository error that leaves the latest snapshot indeterminate no longer results in provisioning
+an empty partition store. Previously an inconclusive repository lookup could be treated as "no
+snapshot exists", which risked starting a partition from scratch on a transient error.
+
+### Why This Matters
+
+A single damaged or partially uploaded snapshot previously blocked a partition from starting even
+when perfectly good older snapshots were still retained. Because `experimental-num-retained`
+already keeps several snapshots, the recovery data was usually present — it just was not being
+used.
+
+Falling back is safe with respect to log trimming: the trim point is driven by the *earliest*
+retained snapshot's LSN, so every candidate advertised in the repository is at or after the trim
+point and the remaining log is available to replay the gap.
+
+### Impact on Users
+
+- Existing deployments: no configuration change required; the fallback is always enabled.
+- Restores that would previously have failed may now succeed from a slightly older snapshot, at
+  the cost of replaying more of the log.
+- A non-zero `snapshots.download.fallback.total` is a signal to investigate the repository — the
+  restore succeeded, but the latest snapshot is damaged and should be looked at.
+
+### Migration Guidance
+
+None. Consider alerting on `restate.partition_store.snapshots.download.fallback.total` and
+`restate.partition_store.snapshots.fast_forward.failed.total`, since both indicate a snapshot
+repository that needs attention.
+
+### Related Issues
+
+- PR #4917: Enable restoring an earlier snapshot if latest fails


### PR DESCRIPTION
This change makes partition store restore resilient to a missing or corrupt **latest** snapshot: when the most recent retained snapshot fails to download (e.g. missing or corrupt SSTs), the partition processor now falls back to trying older retained snapshots instead of giving up.

Key changes:
- `SnapshotRepository::get_snapshot_candidates(partition_id)` returns the partition's retained snapshot references (descending LSN). Selecting a snapshot suitable for a given target LSN is the caller's job.
- `SnapshotRepository::get_snapshot(partition_id, snapshot_ref)` downloads one specific snapshot (refactored out of the old `download_latest_snapshot`).
- `Snapshots::download_snapshot(partition_id, target_lsn)` filters candidates by the required LSN and loops over them, returning the first that downloads successfully.
- `partition_store_manager` open path handles the new semantics.

Correctness hardening (from review):
- `download_snapshot` returns `Result<Option<..>>`: `Ok(None)` means "no snapshot present" (provision an empty store), while a transient repository error or an all-candidates-failed outcome returns `Err` so the open **fails and retries** rather than silently provisioning an empty partition.
- Defense-in-depth: after downloading a candidate, its `min_applied_lsn` is re-verified against the required target LSN; a mismatch falls back to the next candidate.
- Diagnostics distinguish "no snapshot present in the repository" from "snapshots exist but all predate the required LSN (log trimmed past them)" — different operator remediations.
- Unit tests for candidate ordering and the fallback path (latest fails → older restored; all fail → error; target above all retained → `Ok(None)`).

## Metrics
- `restate.partition_store.snapshots.download.fallback.total` (`SNAPSHOT_DOWNLOAD_FALLBACK`) — incremented when a restore succeeds using a non-latest (fallback) snapshot.
- `restate.partition_store.snapshots.fast_forward.failed.total` (`SNAPSHOT_FAST_FORWARD_FAILED`) — incremented when a fast-forward past a log trim gap cannot be satisfied (no suitable snapshot available).
- `SNAPSHOT_DOWNLOAD_FAILED` is now also incremented when a *required* snapshot (target LSN present) cannot be obtained — i.e. every candidate failed to download, or none reaches the target LSN.

This is the "quick fix" half of the original #4222, split out so it can merge against `main` on its own. The incremental-snapshot chaos test that stresses this path is in a separate follow-up PR (#4918). (#4222 was inadvertently auto-closed as merged during the stack reorder; this PR supersedes it.)

Fixes #3930
