### PR TITLE
Add incremental snapshot chaos test with corruption-based fallback verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8332,6 +8332,7 @@ dependencies = [
  "restate-workspace-hack",
  "rlimit",
  "rustls",
+ "serde",
  "serde_json",
  "tempfile",
  "test-log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8322,6 +8322,7 @@ dependencies = [
  "restate-metadata-server",
  "restate-metadata-store",
  "restate-node",
+ "restate-object-store-util",
  "restate-rocksdb",
  "restate-service-client",
  "restate-tracing-instrumentation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8166,6 +8166,7 @@ dependencies = [
  "bilrost",
  "bytes",
  "bytestring",
+ "chrono",
  "codederror",
  "criterion",
  "derive_more",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8187,6 +8187,7 @@ dependencies = [
  "restate-errors",
  "restate-limiter",
  "restate-memory",
+ "restate-metadata-server",
  "restate-object-store-util",
  "restate-rocksdb",
  "restate-service-protocol-v4",
@@ -8210,6 +8211,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "ulid",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8183,6 +8183,7 @@ dependencies = [
  "pin-project",
  "prost",
  "rand 0.9.4",
+ "regex",
  "restate-clock",
  "restate-core",
  "restate-errors",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8213,6 +8213,7 @@ dependencies = [
  "tracing-subscriber",
  "ulid",
  "url",
+ "xxhash-rust",
 ]
 
 [[package]]

--- a/crates/clock/src/mock_clock.rs
+++ b/crates/clock/src/mock_clock.rs
@@ -10,6 +10,7 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 use crate::time::MillisSinceEpoch;
 use crate::{Clock, RESTATE_EPOCH, WallClock};
@@ -47,6 +48,13 @@ impl MockClock {
 
     pub fn advance_ms(&self, ms: u64) {
         self.storage.fetch_add(ms, Ordering::SeqCst);
+    }
+
+    pub fn advance(&self, duration: Duration) {
+        self.storage.fetch_add(
+            u64::try_from(duration.as_millis()).expect("fits in u64"),
+            Ordering::SeqCst,
+        );
     }
 
     pub fn refresh_from_wall_clock(&self) {

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -22,7 +22,7 @@ options_schema = [
     "restate-worker/options_schema"
 ]
 kafka-oidc = ["restate-worker/kafka-oidc"]
-test-util = ["restate-worker/test-util"]
+test-util = ["restate-partition-store/test-util", "restate-worker/test-util"]
 # Enables heap flamegraph generation via /debug/heap/flamegraph endpoint.
 # This feature requires debug symbols and adds the symbolize/flamegraph features to jemalloc_pprof.
 heap-flamegraph = ["jemalloc_pprof/flamegraph"]

--- a/crates/partition-store/Cargo.toml
+++ b/crates/partition-store/Cargo.toml
@@ -19,6 +19,7 @@ restate-core = { workspace = true }
 restate-errors = { workspace = true }
 restate-limiter = { workspace = true, features = ["rule-book"] }
 restate-memory = { workspace = true }
+restate-metadata-server = { workspace = true }
 restate-object-store-util = { workspace = true }
 restate-rocksdb = { workspace = true }
 restate-util-bytecount = { workspace = true, features = ["serde"] }
@@ -56,10 +57,13 @@ tokio = { workspace = true, features = ["fs"] }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true, features = ["io-util"] }
 tracing = { workspace = true }
+ulid = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+restate-clock = { workspace = true, features = ["test-util"] }
 restate-core = { workspace = true, features = ["test-util"] }
+restate-metadata-server = { workspace = true, features = ["test-util"] }
 restate-object-store-util = { workspace = true, features = ["test-util"] }
 restate-rocksdb = { workspace = true, features = ["test-util"] }
 restate-test-util = { workspace = true }

--- a/crates/partition-store/Cargo.toml
+++ b/crates/partition-store/Cargo.toml
@@ -45,6 +45,7 @@ paste = { workspace = true }
 pin-project = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }
+regex = { workspace = true }
 rocksdb = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/partition-store/Cargo.toml
+++ b/crates/partition-store/Cargo.toml
@@ -37,6 +37,7 @@ enum-map = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
 jiff = { workspace = true }
+chrono = { workspace = true }
 metrics = { workspace = true }
 object_store = { workspace = true }
 parking_lot = { workspace = true }

--- a/crates/partition-store/Cargo.toml
+++ b/crates/partition-store/Cargo.toml
@@ -59,6 +59,7 @@ tokio-util = { workspace = true, features = ["io-util"] }
 tracing = { workspace = true }
 ulid = { workspace = true }
 url = { workspace = true }
+xxhash-rust = { workspace = true, features = ["xxh3"] }
 
 [dev-dependencies]
 restate-clock = { workspace = true, features = ["test-util"] }

--- a/crates/partition-store/src/error.rs
+++ b/crates/partition-store/src/error.rs
@@ -23,8 +23,6 @@ pub enum OpenError {
     SnapshotRepositoryRequired,
     #[error("a partition snapshot is required")]
     SnapshotRequired,
-    #[error("partition snapshot was found but unsuitable; it was taken before the log trim point")]
-    SnapshotUnsuitable,
     #[error("partition store for partition does not exist in local database")]
     NoLocalStore,
     #[error("open failed due to snapshot-related error: {0:#}")]

--- a/crates/partition-store/src/metric_definitions.rs
+++ b/crates/partition-store/src/metric_definitions.rs
@@ -19,6 +19,10 @@ pub(crate) const SNAPSHOT_DOWNLOAD_DURATION: &str =
     "restate.partition_store.snapshots.download.duration.seconds";
 pub(crate) const SNAPSHOT_DOWNLOAD_FAILED: &str =
     "restate.partition_store.snapshots.download.failed.total";
+pub(crate) const SNAPSHOT_DOWNLOAD_FALLBACK: &str =
+    "restate.partition_store.snapshots.download.fallback.total";
+pub(crate) const SNAPSHOT_FAST_FORWARD_FAILED: &str =
+    "restate.partition_store.snapshots.fast_forward.failed.total";
 
 pub(crate) fn describe_metrics() {
     describe_counter!(
@@ -49,5 +53,17 @@ pub(crate) fn describe_metrics() {
         SNAPSHOT_DOWNLOAD_FAILED,
         Unit::Count,
         "Number of failed partition snapshot download operations"
+    );
+
+    describe_counter!(
+        SNAPSHOT_DOWNLOAD_FALLBACK,
+        Unit::Count,
+        "Number of snapshot downloads that succeeded using a fallback (non-latest) snapshot"
+    );
+
+    describe_counter!(
+        SNAPSHOT_FAST_FORWARD_FAILED,
+        Unit::Count,
+        "Number of failed fast-forwards from trim gap (no suitable snapshot available)"
     );
 }

--- a/crates/partition-store/src/metric_definitions.rs
+++ b/crates/partition-store/src/metric_definitions.rs
@@ -23,6 +23,10 @@ pub(crate) const SNAPSHOT_DOWNLOAD_FALLBACK: &str =
     "restate.partition_store.snapshots.download.fallback.total";
 pub(crate) const SNAPSHOT_FAST_FORWARD_FAILED: &str =
     "restate.partition_store.snapshots.fast_forward.failed.total";
+pub(crate) const SNAPSHOT_UPLOAD_BYTES: &str =
+    "restate.partition_store.snapshots.upload.bytes.total";
+pub(crate) const SNAPSHOT_UPLOAD_BYTES_DEDUPLICATED: &str =
+    "restate.partition_store.snapshots.upload.bytes.deduplicated.total";
 
 pub(crate) fn describe_metrics() {
     describe_counter!(
@@ -35,6 +39,18 @@ pub(crate) fn describe_metrics() {
         SNAPSHOT_UPLOAD_FAILED,
         Unit::Count,
         "Number of failed partition snapshot uploads"
+    );
+
+    describe_counter!(
+        SNAPSHOT_UPLOAD_BYTES,
+        Unit::Bytes,
+        "Total bytes uploaded for partition snapshots"
+    );
+
+    describe_counter!(
+        SNAPSHOT_UPLOAD_BYTES_DEDUPLICATED,
+        Unit::Bytes,
+        "Total bytes deduplicated (not uploaded) for partition snapshots"
     );
 
     describe_histogram!(

--- a/crates/partition-store/src/metric_definitions.rs
+++ b/crates/partition-store/src/metric_definitions.rs
@@ -27,6 +27,12 @@ pub(crate) const SNAPSHOT_UPLOAD_BYTES: &str =
     "restate.partition_store.snapshots.upload.bytes.total";
 pub(crate) const SNAPSHOT_UPLOAD_BYTES_DEDUPLICATED: &str =
     "restate.partition_store.snapshots.upload.bytes.deduplicated.total";
+pub(crate) const SNAPSHOT_ORPHAN_SCAN_TOTAL: &str =
+    "restate.partition_store.snapshots.orphan_scan.total";
+pub(crate) const SNAPSHOT_ORPHAN_SCAN_FAILED: &str =
+    "restate.partition_store.snapshots.orphan_scan.failed.total";
+pub(crate) const SNAPSHOT_ORPHAN_FILES_DELETED: &str =
+    "restate.partition_store.snapshots.orphan_files_deleted.total";
 
 pub(crate) fn describe_metrics() {
     describe_counter!(
@@ -81,5 +87,23 @@ pub(crate) fn describe_metrics() {
         SNAPSHOT_FAST_FORWARD_FAILED,
         Unit::Count,
         "Number of failed fast-forwards from trim gap (no suitable snapshot available)"
+    );
+
+    describe_counter!(
+        SNAPSHOT_ORPHAN_SCAN_TOTAL,
+        Unit::Count,
+        "Number of orphan scan operations performed"
+    );
+
+    describe_counter!(
+        SNAPSHOT_ORPHAN_SCAN_FAILED,
+        Unit::Count,
+        "Number of orphan scan failures"
+    );
+
+    describe_counter!(
+        SNAPSHOT_ORPHAN_FILES_DELETED,
+        Unit::Count,
+        "Number of orphaned files deleted during cleanup"
     );
 }

--- a/crates/partition-store/src/partition_store_manager.rs
+++ b/crates/partition-store/src/partition_store_manager.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Weak};
 use ahash::HashMap;
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use tokio::sync::Mutex as AsyncMutex;
-use tracing::{debug, error, info, instrument, warn};
+use tracing::{debug, error, info, instrument};
 
 use restate_rocksdb::{CfPrefixPattern, DbSpecBuilder, RocksDb, RocksDbManager, RocksError};
 use restate_storage_api::fsm_table::ReadFsmTable;
@@ -255,35 +255,27 @@ impl PartitionStoreManager {
         // target-lsn target higher than our local state (probably due to seeing a log trim-gap).
         // **
 
-        // Attempt to get the latest available snapshot from the snapshot repository:
-        let snapshot = self
+        // Attempt to get a suitable snapshot from the repository:
+        let snapshot_result = self
             .snapshots
-            .download_latest_snapshot(partition.partition_id)
-            .await
-            .map_err(OpenError::Snapshot)?;
+            .download_snapshot(partition.partition_id, target_lsn)
+            .await;
 
-        match (snapshot, target_lsn) {
-            (None, None) => {
-                debug!("No snapshot found for partition, creating new partition store");
-                let db = cell.provision(&mut state_guard, rocksdb.clone()).await?;
-                Ok(PartitionStore::from(db))
-            }
-
-            (Some(snapshot), None) => {
+        match (snapshot_result, target_lsn) {
+            (Ok(Some(snapshot)), None) => {
+                // Found a snapshot when we didn't require one - import it
                 info!("Found partition snapshot, restoring it");
                 let db = cell
                     .import_cf(&mut state_guard, snapshot, rocksdb.clone())
                     .await?;
-
                 Ok(PartitionStore::from(db))
             }
 
-            // Good snapshot
-            (Some(snapshot), Some(fast_forward_lsn))
-                if snapshot.min_applied_lsn >= fast_forward_lsn =>
-            {
+            (Ok(Some(snapshot)), Some(fast_forward_lsn)) => {
+                // Got a snapshot that meets the target LSN requirement (filtered by candidate LSN
+                // and re-verified against the downloaded metadata in `download_snapshot`).
                 info!(
-                    latest_snapshot_lsn = %snapshot.min_applied_lsn,
+                    snapshot_lsn = %snapshot.min_applied_lsn,
                     %fast_forward_lsn,
                     "Found snapshot with LSN >= target LSN, dropping local partition store state",
                 );
@@ -293,22 +285,31 @@ impl PartitionStoreManager {
                     .await?;
                 Ok(PartitionStore::from(db))
             }
+
+            (Ok(None), None) => {
+                debug!("No snapshot found for partition, creating new partition store");
+                let db = cell.provision(&mut state_guard, rocksdb.clone()).await?;
+                Ok(PartitionStore::from(db))
+            }
+
+            (Err(err), None) => {
+                // A snapshot may well exist but we failed to fetch it (transient repository error,
+                // or every retained candidate failed to download). Do NOT provision an empty store
+                // and silently discard data; fail the open so the processor retries later.
+                Err(OpenError::Snapshot(err))
+            }
+
+            // We required a snapshot (fast-forward target) but have none suitable: either none was
+            // found at/above the target LSN (`Ok(None)`) or all candidates failed (`Err`).
             (maybe_snapshot, Some(fast_forward_lsn)) => {
-                // Play it safe and keep the partition store intact; we can't do much else at this
-                // point. We'll likely halt again as soon as the processor starts up.
                 let recovery_guide_msg = "The partition's log is trimmed to a point from which this processor can not resume. \
                 Visit https://docs.restate.dev/operate/clusters#handling-missing-snapshots \
                 to learn more about how to recover this processor.";
 
-                if let Some(snapshot) = maybe_snapshot {
-                    warn!(
-                        latest_snapshot_lsn = %snapshot.min_applied_lsn,
-                        %fast_forward_lsn,
-                        "The latest available snapshot is from an LSN before the target LSN! {}",
-                        recovery_guide_msg,
-                    );
-                    Err(OpenError::SnapshotUnsuitable)
-                } else if !self.snapshots.is_repository_configured() {
+                metrics::counter!(crate::metric_definitions::SNAPSHOT_FAST_FORWARD_FAILED)
+                    .increment(1);
+
+                if !self.snapshots.is_repository_configured() {
                     error!(
                         %fast_forward_lsn,
                         "A log trim gap was encountered, but no snapshot repository is configured! {}",
@@ -316,11 +317,19 @@ impl PartitionStoreManager {
                     );
                     Err(OpenError::SnapshotRepositoryRequired)
                 } else {
-                    error!(
-                        %fast_forward_lsn,
-                        "A log trim gap was encountered, but no snapshot is available for this partition! {}",
-                        recovery_guide_msg,
-                    );
+                    match maybe_snapshot {
+                        Err(err) => error!(
+                            %fast_forward_lsn,
+                            %err,
+                            "A log trim gap was encountered, but no suitable snapshot is available for this partition! {}",
+                            recovery_guide_msg,
+                        ),
+                        Ok(_) => error!(
+                            %fast_forward_lsn,
+                            "A log trim gap was encountered, but no suitable snapshot is available for this partition! {}",
+                            recovery_guide_msg,
+                        ),
+                    }
                     Err(OpenError::SnapshotRequired)
                 }
             }

--- a/crates/partition-store/src/snapshots.rs
+++ b/crates/partition-store/src/snapshots.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod leases;
 mod metadata;
 mod repository;
 mod snapshot_task;
@@ -17,8 +18,16 @@ use std::sync::Arc;
 
 use crate::{PartitionDb, PartitionStore, SnapshotError, SnapshotErrorKind};
 
+#[cfg(any(test, feature = "test-util"))]
+pub use self::leases::NoOpLeaseManager;
+pub use self::leases::{
+    LEASE_DURATION, LEASE_RENEWAL_INTERVAL, LEASE_SAFETY_MARGIN, LeaseError, SnapshotLeaseGuard,
+    SnapshotLeaseManager, SnapshotLeaseValue,
+};
 pub use self::metadata::*;
-pub use self::repository::{PartitionSnapshotStatus, SnapshotReference, SnapshotRepository};
+pub use self::repository::{
+    LeaseProvider, PartitionSnapshotStatus, SnapshotReference, SnapshotRepository,
+};
 pub use self::snapshot_task::*;
 
 use tokio::sync::Semaphore;
@@ -36,7 +45,25 @@ pub struct Snapshots {
 
 impl Snapshots {
     pub async fn create(config: &Configuration) -> anyhow::Result<Self> {
-        let repository = SnapshotRepository::new_from_config(
+        let repository = SnapshotRepository::new_read_only_from_config(
+            &config.worker.snapshots,
+            config.worker.storage.snapshots_staging_dir(),
+        )
+        .await?;
+
+        let concurrency_limit = Arc::new(Semaphore::new(
+            config.worker.snapshots.export_concurrency_limit() as usize,
+        ));
+
+        Ok(Self {
+            repository,
+            concurrency_limit,
+        })
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub async fn create_with_stub_leases(config: &Configuration) -> anyhow::Result<Self> {
+        let repository = SnapshotRepository::new_from_config_with_stub_leases(
             &config.worker.snapshots,
             config.worker.storage.snapshots_staging_dir(),
         )

--- a/crates/partition-store/src/snapshots.rs
+++ b/crates/partition-store/src/snapshots.rs
@@ -18,11 +18,11 @@ use std::sync::Arc;
 use crate::{PartitionDb, PartitionStore, SnapshotError, SnapshotErrorKind};
 
 pub use self::metadata::*;
-pub use self::repository::{PartitionSnapshotStatus, SnapshotRepository};
+pub use self::repository::{PartitionSnapshotStatus, SnapshotReference, SnapshotRepository};
 pub use self::snapshot_task::*;
 
 use tokio::sync::Semaphore;
-use tracing::{debug, instrument};
+use tracing::{debug, error, info, instrument, warn};
 
 use restate_types::config::Configuration;
 use restate_types::identifiers::{PartitionId, SnapshotId};
@@ -104,22 +104,123 @@ impl Snapshots {
     }
 
     #[instrument(level = "error", skip_all, fields(partition_id = %partition_id))]
-    pub async fn download_latest_snapshot(
+    pub async fn download_snapshot(
         &self,
         partition_id: PartitionId,
+        target_lsn: Option<Lsn>,
     ) -> anyhow::Result<Option<LocalPartitionSnapshot>> {
-        // Attempt to get the latest available snapshot from the snapshot repository:
-        let snapshot = match &self.repository {
-            Some(repository) => {
-                debug!("Looking for partition snapshot from which to bootstrap partition store");
-                // todo(pavel): pass target LSN to repository
-                repository.get_latest(partition_id).await?
-            }
-            None => {
-                debug!("No snapshot repository configured");
-                None
-            }
+        use crate::metric_definitions::{
+            SNAPSHOT_DOWNLOAD_DURATION, SNAPSHOT_DOWNLOAD_FAILED, SNAPSHOT_DOWNLOAD_FALLBACK,
         };
-        Ok(snapshot)
+
+        let Some(repository) = &self.repository else {
+            debug!("No snapshot repository configured");
+            return Ok(None);
+        };
+
+        let start = std::time::Instant::now();
+        // A transient error reading the latest-snapshot pointer is propagated as `Err` so the
+        // caller fails the open and retries, rather than mistaking it for "no snapshot exists".
+        let retained = repository.get_snapshot_candidates(partition_id).await?;
+
+        // When a target LSN is required, only snapshots at or above it can satisfy a fast-forward.
+        let candidates: Vec<&SnapshotReference> = match target_lsn {
+            Some(min_lsn) => retained
+                .iter()
+                .filter(|c| c.min_applied_lsn >= min_lsn)
+                .collect(),
+            None => retained.iter().collect(),
+        };
+        let candidate_count = candidates.len();
+
+        if candidate_count == 0 {
+            // No usable snapshot. With a target LSN this is a failure (the caller cannot
+            // fast-forward); without one it simply means a fresh partition store is provisioned.
+            match target_lsn {
+                Some(min_lsn) => {
+                    metrics::counter!(SNAPSHOT_DOWNLOAD_FAILED).increment(1);
+                    match retained.first() {
+                        Some(newest) => warn!(
+                            target_lsn = %min_lsn,
+                            newest_retained_lsn = %newest.min_applied_lsn,
+                            retained_count = retained.len(),
+                            "No retained snapshot reaches the required LSN; the log was trimmed past all available snapshots"
+                        ),
+                        None => warn!(
+                            target_lsn = %min_lsn,
+                            "A snapshot is required but none is present in the repository for this partition"
+                        ),
+                    }
+                }
+                None => debug!("No snapshot present in the repository for this partition"),
+            }
+            return Ok(None);
+        }
+
+        let mut last_error: Option<anyhow::Error> = None;
+        let mut tried_snapshot_ids: Vec<SnapshotId> = Vec::with_capacity(candidate_count);
+        for (i, snapshot_ref) in candidates.into_iter().enumerate() {
+            tried_snapshot_ids.push(snapshot_ref.snapshot_id);
+            match repository.get_snapshot(partition_id, snapshot_ref).await {
+                Ok(snapshot) => {
+                    // Defense-in-depth: candidates were filtered using the LSN recorded in the
+                    // `latest.json` index. Re-verify against the downloaded snapshot's own metadata
+                    // in case the index disagrees (corruption / manual edit), and treat a mismatch
+                    // as a failed candidate so we fall back to an older snapshot.
+                    if let Some(min_lsn) = target_lsn
+                        && snapshot.min_applied_lsn < min_lsn
+                    {
+                        warn!(
+                            snapshot_id = %snapshot_ref.snapshot_id,
+                            snapshot_lsn = %snapshot.min_applied_lsn,
+                            target_lsn = %min_lsn,
+                            "Downloaded snapshot LSN is below the required target; trying next candidate"
+                        );
+                        last_error = Some(anyhow::anyhow!(
+                            "snapshot {} has min_applied_lsn {} below required target {}",
+                            snapshot_ref.snapshot_id,
+                            snapshot.min_applied_lsn,
+                            min_lsn,
+                        ));
+                        continue;
+                    }
+                    metrics::histogram!(SNAPSHOT_DOWNLOAD_DURATION)
+                        .record(start.elapsed().as_secs_f64());
+                    if i > 0 {
+                        metrics::counter!(SNAPSHOT_DOWNLOAD_FALLBACK).increment(1);
+                        info!(
+                            snapshot_id = %snapshot_ref.snapshot_id,
+                            attempt = i + 1,
+                            "Restored from fallback snapshot"
+                        );
+                    }
+                    return Ok(Some(snapshot));
+                }
+                Err(err) => {
+                    warn!(
+                        snapshot_id = %snapshot_ref.snapshot_id,
+                        %err,
+                        remaining = candidate_count - i - 1,
+                        "Snapshot download failed, trying next"
+                    );
+                    last_error = Some(err);
+                }
+            }
+        }
+
+        metrics::histogram!(SNAPSHOT_DOWNLOAD_DURATION).record(start.elapsed().as_secs_f64());
+        metrics::counter!(SNAPSHOT_DOWNLOAD_FAILED).increment(1);
+        let tried = tried_snapshot_ids
+            .iter()
+            .map(|id| id.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let final_err = last_error
+            .unwrap_or_else(|| anyhow::anyhow!("No snapshot available"))
+            .context(format!(
+                "all {candidate_count} available snapshot(s) failed to restore (tried: [{tried}])"
+            ));
+        error!(%final_err, "Exhausted all snapshot candidates");
+        Err(final_err)
     }
 }

--- a/crates/partition-store/src/snapshots/leases.rs
+++ b/crates/partition-store/src/snapshots/leases.rs
@@ -1,0 +1,1128 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Weak};
+use std::time::Duration;
+
+use bytestring::ByteString;
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, instrument, warn};
+use ulid::Ulid;
+
+use restate_clock::{Clock, WallClock};
+use restate_core::task_center::TaskHandle;
+use restate_core::{Metadata, ShutdownError, TaskCenter, TaskKind};
+use restate_metadata_server::{MetadataStoreClient, ReadError, WriteError};
+use restate_types::Version;
+use restate_types::config::Configuration;
+use restate_types::identifiers::PartitionId;
+use restate_types::metadata::Precondition;
+use restate_types::retries::RetryPolicy;
+use restate_types::time::MillisSinceEpoch;
+use restate_types::{GenerationalNodeId, Versioned, flexbuffers_storage_encode_decode};
+
+/// Duration for which a snapshot operation lease is valid (5 minutes).
+///
+/// Note: callers get at most `LEASE_DURATION - LEASE_SAFETY_MARGIN` of useful work time
+/// per acquire before they should refresh or stop, because operations must complete before
+/// `expires_at - LEASE_SAFETY_MARGIN`.
+///
+/// Clock skew assumption: Nodes in the cluster should have clocks synchronized within
+/// `LEASE_SAFETY_MARGIN` (1 minute). Larger clock skew could cause a node to believe a lease has
+/// expired while the holder still considers it valid, leading to concurrent operations. NTP
+/// synchronization typically provides sub-second accuracy, well within this tolerance.
+///
+/// The downside of making this longer is that this is the maximum time during which a zombie lease
+/// whose owner has died can lock out other potential acquirers from making progress.
+pub const LEASE_DURATION: Duration = Duration::from_mins(5);
+
+/// Minimum remaining lease time required to continue operations (1 minute). Lease-covered
+/// operations should aim to complete before `expires_at - LEASE_SAFETY_MARGIN`.
+pub const LEASE_SAFETY_MARGIN: Duration = Duration::from_mins(1);
+
+/// Interval at which lease renewal should occur (2 minutes). This should be well before lease
+/// expiry to ensure smooth operations, but ideally long enough that most operations complete before
+/// we have to renew.
+pub const LEASE_RENEWAL_INTERVAL: Duration = Duration::from_mins(2);
+
+#[derive(Debug, thiserror::Error)]
+pub enum LeaseError {
+    #[error("Lease held by {holder} (lease_id: {lease_id}), expires at: {expires_at}")]
+    Held {
+        holder: GenerationalNodeId,
+        lease_id: Ulid,
+        expires_at: jiff::Timestamp,
+    },
+    #[error("Lease expired or taken over by another node")]
+    Expired,
+    #[error("Snapshot repository is read-only (no lease provider configured)")]
+    Unavailable,
+    #[error(transparent)]
+    Shutdown(#[from] ShutdownError),
+    #[error(transparent)]
+    MetadataRead(#[from] ReadError),
+    #[error(transparent)]
+    MetadataWrite(#[from] WriteError),
+}
+
+impl LeaseError {
+    fn retryable(&self) -> bool {
+        match self {
+            LeaseError::Held { .. }
+            | LeaseError::Expired
+            | LeaseError::Unavailable
+            | LeaseError::Shutdown(_) => false,
+            LeaseError::MetadataRead(ReadError::Other(err)) => err.retryable(),
+            LeaseError::MetadataRead(ReadError::Codec(_)) => false,
+            LeaseError::MetadataWrite(WriteError::FailedPrecondition(_)) => false,
+            LeaseError::MetadataWrite(WriteError::Other(err)) => err.retryable(),
+            LeaseError::MetadataWrite(WriteError::Codec(_)) => false,
+        }
+    }
+}
+
+fn lease_key(partition_id: PartitionId) -> ByteString {
+    ByteString::from(format!("snapshot_lease_{}", partition_id))
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SnapshotLeaseValue {
+    pub holder: GenerationalNodeId,
+    pub lease_id: Ulid,
+    pub expires_at: MillisSinceEpoch,
+    version: Version,
+}
+
+impl SnapshotLeaseValue {
+    fn new(holder: GenerationalNodeId, clock: &impl Clock) -> Self {
+        let expires_at = clock.recent() + LEASE_DURATION;
+        Self {
+            holder,
+            lease_id: Ulid::new(),
+            expires_at,
+            version: Version::MIN,
+        }
+    }
+
+    fn expired(holder: GenerationalNodeId, lease_id: Ulid) -> Self {
+        Self {
+            holder,
+            lease_id,
+            expires_at: MillisSinceEpoch::UNIX_EPOCH,
+            version: Version::MIN,
+        }
+    }
+
+    fn is_expired(&self, clock: &impl Clock) -> bool {
+        clock.recent() >= self.expires_at
+    }
+
+    fn with_version(mut self, version: Version) -> Self {
+        self.version = version;
+        self
+    }
+}
+
+impl Versioned for SnapshotLeaseValue {
+    fn version(&self) -> Version {
+        self.version
+    }
+}
+
+flexbuffers_storage_encode_decode!(SnapshotLeaseValue);
+
+/// Metadata-backed RAII lease which automatically releases when dropped
+pub enum SnapshotLeaseGuard<C: Clock + Clone + Send + Sync + 'static = WallClock> {
+    /// Metadata store-backed lease
+    Lease(inner::MetadataBackedLeaseGuard<C>),
+    /// No-op lease for testing
+    #[cfg(any(test, feature = "test-util"))]
+    NoOp(inner::NoOpLeaseGuard),
+}
+
+impl<C: Clock + Clone + Send + Sync + 'static> std::fmt::Display for SnapshotLeaseGuard<C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Lease(g) => write!(f, "{}", g.lease_id),
+            #[cfg(any(test, feature = "test-util"))]
+            Self::NoOp(_) => write!(f, "noop"),
+        }
+    }
+}
+
+impl<C: Clock + Clone + Send + Sync + 'static> SnapshotLeaseGuard<C> {
+    /// Check if lease is still valid within the safety margin.
+    pub fn is_valid(&self) -> bool {
+        match self {
+            Self::Lease(g) => g.is_valid(),
+            #[cfg(any(test, feature = "test-util"))]
+            Self::NoOp(g) => g.is_valid(),
+        }
+    }
+
+    /// Cancellation token representing lease validity.
+    ///
+    /// Use this to abort long-running lease-guarded operations:
+    /// ```ignore
+    /// tokio::select! {
+    ///     _ = lease_guard.lease_lost().cancelled() => { /* abort work */ }
+    ///     result = do_work() => { /* handle result */ }
+    /// }
+    /// ```
+    pub fn lease_lost(&self) -> CancellationToken {
+        match self {
+            Self::Lease(g) => g.lease_lost.clone(),
+            #[cfg(any(test, feature = "test-util"))]
+            Self::NoOp(g) => g.lease_lost.clone(),
+        }
+    }
+
+    /// Remaining time within the lease (accounting for the safety margin). The returned values are
+    /// not monotonic - refreshing the lease will extend the remaining time. Use `run_under_lease`
+    /// for a convenient wrapper that monitors lease expiry automatically.
+    fn remaining_operation_time(&self) -> Duration {
+        match self {
+            Self::Lease(g) => g.duration_until_deadline(),
+            #[cfg(any(test, feature = "test-util"))]
+            Self::NoOp(g) => g.duration_until_deadline(),
+        }
+    }
+
+    /// Run a future under this lease, aborting if the lease is lost or deadline reached.
+    ///
+    /// This method is conservative about operation deadlines - it respects the shifting deadline
+    /// that can be extended by background lease renewal. If the deadline expires without renewal,
+    /// the work is aborted.
+    pub async fn run_under_lease<F, T>(&self, work: F) -> Option<T>
+    where
+        F: std::future::Future<Output = T>,
+    {
+        let lease_lost = self.lease_lost();
+        tokio::pin!(work);
+
+        loop {
+            let time_until_deadline = self.remaining_operation_time();
+
+            if time_until_deadline.is_zero() && !self.is_valid() {
+                warn!(lease = %self, "Snapshot lease lost (deadline expired), task was canceled");
+                return None;
+            }
+
+            tokio::select! {
+                biased;
+                _ = lease_lost.cancelled() => {
+                    warn!(lease = %self, "Snapshot lease lost (lease_lost cancelled), task was canceled");
+                    return None;
+                }
+                // Deadline sleep BEFORE work for strict enforcement
+                _ = tokio::time::sleep(time_until_deadline), if !time_until_deadline.is_zero() => {
+                    if self.is_valid() {
+                        // background renewal has extended deadline
+                        continue;
+                    }
+                    warn!(lease = %self, "Snapshot lease lost (deadline reached), task was canceled");
+                    return None;
+                }
+                result = &mut work => {
+                    return Some(result);
+                }
+            }
+        }
+    }
+
+    /// Start a background task that renews the lease at a fixed renewal interval.
+    /// The task holds a weak reference to the lease and stops when the guard is dropped.
+    /// The guard ensures that at most one renewal task is spawned.
+    pub fn start_renewal_task(self: &Arc<Self>) -> Result<(), ShutdownError> {
+        match self.as_ref() {
+            Self::Lease(g) => g.start_renewal_task(Arc::downgrade(self)),
+            #[cfg(any(test, feature = "test-util"))]
+            Self::NoOp(_) => Ok(()),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn test_renew(&self) -> Result<(), LeaseError> {
+        match self {
+            Self::Lease(g) => g.renew().await,
+            #[cfg(any(test, feature = "test-util"))]
+            Self::NoOp(_) => Ok(()),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_mark_released(&self) {
+        match self {
+            Self::Lease(g) => g.test_mark_released(),
+            #[cfg(any(test, feature = "test-util"))]
+            Self::NoOp(_) => {}
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn operation_deadline(&self) -> MillisSinceEpoch {
+        match self {
+            Self::Lease(g) => g.operation_deadline(),
+            Self::NoOp(g) => g.operation_deadline(),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-util"))]
+impl SnapshotLeaseGuard {
+    pub fn noop() -> Self {
+        Self::NoOp(inner::NoOpLeaseGuard::new(MillisSinceEpoch::MAX))
+    }
+}
+
+mod inner {
+    use std::ops::Add;
+
+    use super::*;
+
+    pub struct MetadataBackedLeaseGuard<C: Clock + Clone + Send + Sync + 'static = WallClock> {
+        pub(super) partition_id: PartitionId,
+        pub(super) lease_id: Ulid,
+        holder: GenerationalNodeId,
+        expires_at: AtomicU64,
+        metadata_store_client: MetadataStoreClient,
+        version: Mutex<Version>,
+        released: AtomicBool,
+        renewal_task: Mutex<Option<TaskHandle<()>>>,
+        pub(super) lease_lost: CancellationToken,
+        clock: C,
+    }
+
+    impl<C: Clock + Clone + Send + Sync + 'static> MetadataBackedLeaseGuard<C> {
+        pub(super) fn new(
+            partition_id: PartitionId,
+            lease: SnapshotLeaseValue,
+            metadata_store_client: MetadataStoreClient,
+            version: Version,
+            clock: C,
+        ) -> Self {
+            Self {
+                partition_id,
+                lease_id: lease.lease_id,
+                holder: lease.holder,
+                expires_at: AtomicU64::new(lease.expires_at.as_u64()),
+                metadata_store_client,
+                version: Mutex::new(version),
+                released: AtomicBool::new(false),
+                renewal_task: Mutex::new(None),
+                lease_lost: CancellationToken::new(),
+                clock,
+            }
+        }
+
+        fn expires_at(&self) -> MillisSinceEpoch {
+            MillisSinceEpoch::new(self.expires_at.load(Ordering::Acquire))
+        }
+
+        pub(super) fn is_valid(&self) -> bool {
+            self.clock.recent() + LEASE_SAFETY_MARGIN < self.expires_at()
+        }
+
+        pub(super) async fn renew(&self) -> Result<(), LeaseError> {
+            if self.lease_lost.is_cancelled() {
+                debug!(
+                    partition_id = %self.partition_id,
+                    lease_id = %self.lease_id,
+                    "Lease renewal skipped - lease already marked as lost"
+                );
+                return Err(LeaseError::Expired);
+            }
+
+            let key = lease_key(self.partition_id);
+            let current_version = *self.version.lock();
+
+            let stored: Option<SnapshotLeaseValue> =
+                self.metadata_store_client.get(key.clone()).await?;
+            let stored_lease = stored.ok_or(LeaseError::Expired)?;
+
+            if stored_lease.lease_id != self.lease_id {
+                warn!(
+                    partition_id = %self.partition_id,
+                    expected_lease_id = %self.lease_id,
+                    actual_lease_id = %stored_lease.lease_id,
+                    actual_holder = %stored_lease.holder,
+                    "Lease was taken over by another node during renewal"
+                );
+                return Err(LeaseError::Expired);
+            }
+
+            let new_expiration = self.clock.recent().add(LEASE_DURATION);
+            let renewed_lease = SnapshotLeaseValue {
+                holder: self.holder,
+                lease_id: self.lease_id,
+                expires_at: new_expiration,
+                version: current_version.next(),
+            };
+
+            self.metadata_store_client
+                .put(
+                    key,
+                    &renewed_lease,
+                    Precondition::MatchesVersion(current_version),
+                )
+                .await?;
+
+            self.expires_at
+                .store(new_expiration.as_u64(), Ordering::Release);
+            *self.version.lock() = current_version.next();
+
+            debug!(partition_id = %self.partition_id, "Snapshot lease renewed");
+            Ok(())
+        }
+
+        pub(super) fn start_renewal_task(
+            &self,
+            guard: Weak<SnapshotLeaseGuard<C>>,
+        ) -> Result<(), ShutdownError> {
+            let mut renewal_task = self.renewal_task.lock();
+            if renewal_task.is_some() {
+                return Ok(());
+            }
+
+            let lease_lost = self.lease_lost.clone();
+            let partition_id = self.partition_id;
+
+            let handle = TaskCenter::current().spawn_unmanaged_child(
+                TaskKind::Disposable,
+                "snapshot-lease-renewal",
+                async move {
+                    loop {
+                        tokio::select! {
+                            _ = lease_lost.cancelled() => break,
+                            _ = tokio::time::sleep(LEASE_RENEWAL_INTERVAL) => {
+                                let Some(guard) = guard.upgrade() else {
+                                    debug!(%partition_id, "Lease guard dropped, stopping renewal");
+                                    break;
+                                };
+                                match guard.as_ref() {
+                                    SnapshotLeaseGuard::Lease(g) => {
+                                        if let Err(e) = g.renew().await {
+                                            warn!(%partition_id, error = %e, "Lease renewal failed");
+                                            g.lease_lost.cancel();
+                                            break;
+                                        }
+                                    }
+                                    #[cfg(any(test, feature = "test-util"))]
+                                    SnapshotLeaseGuard::NoOp(_) => {}
+                                }
+                            }
+                        }
+                    }
+                },
+            )?;
+            *renewal_task = Some(handle);
+            Ok(())
+        }
+
+        fn spawn_release_task(&mut self) {
+            if !self.released.swap(true, Ordering::AcqRel) {
+                let client = self.metadata_store_client.clone();
+                let partition_id = self.partition_id;
+                let version = *self.version.lock();
+                let lease_id = self.lease_id;
+                let holder = self.holder;
+
+                if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                    handle.spawn(async move {
+                        let key = lease_key(partition_id);
+                        let expired = SnapshotLeaseValue::expired(holder, lease_id)
+                            .with_version(version.next());
+
+                        match client
+                            .put(key, &expired, Precondition::MatchesVersion(version))
+                            .await
+                        {
+                            Ok(()) => {
+                                debug!(%partition_id, "Lease released via Drop");
+                            }
+                            Err(WriteError::FailedPrecondition(_)) => {
+                                debug!(
+                                    %partition_id,
+                                    "Lease release via Drop failed: version mismatch (lease was likely taken over)"
+                                );
+                            }
+                            Err(err) => {
+                                warn!(
+                                    %partition_id,
+                                    %err,
+                                    "Lease release via Drop failed"
+                                );
+                            }
+                        }
+                    });
+                    debug!(
+                        partition_id = %partition_id,
+                        "Snapshot lease dropped, spawned async release"
+                    );
+                } else {
+                    warn!(
+                        partition_id = %partition_id,
+                        "Snapshot lease dropped without release - no runtime available"
+                    );
+                }
+            }
+        }
+
+        #[cfg(test)]
+        pub(super) fn test_mark_released(&self) {
+            self.released.store(true, Ordering::Release);
+            self.lease_lost.cancel();
+        }
+
+        #[cfg(test)]
+        pub(super) fn operation_deadline(&self) -> MillisSinceEpoch {
+            self.expires_at() - LEASE_SAFETY_MARGIN
+        }
+
+        pub(super) fn duration_until_deadline(&self) -> Duration {
+            let now = self.clock.recent();
+            let deadline = self.expires_at() - LEASE_SAFETY_MARGIN;
+            deadline.duration_since(now)
+        }
+    }
+
+    impl<C: Clock + Clone + Send + Sync + 'static> Drop for MetadataBackedLeaseGuard<C> {
+        fn drop(&mut self) {
+            self.lease_lost.cancel();
+            self.spawn_release_task();
+        }
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub struct NoOpLeaseGuard {
+        expires_at: MillisSinceEpoch,
+        /// Cancelled on drop to match MetadataBackedLeaseGuard behavior.
+        pub(super) lease_lost: CancellationToken,
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    impl NoOpLeaseGuard {
+        pub(super) fn new(expires_at: MillisSinceEpoch) -> Self {
+            Self {
+                expires_at,
+                lease_lost: CancellationToken::new(),
+            }
+        }
+
+        pub(super) fn is_valid(&self) -> bool {
+            WallClock.recent() + LEASE_SAFETY_MARGIN < self.expires_at
+        }
+
+        #[cfg(test)]
+        pub(super) fn operation_deadline(&self) -> MillisSinceEpoch {
+            self.expires_at - LEASE_SAFETY_MARGIN
+        }
+
+        pub(super) fn duration_until_deadline(&self) -> Duration {
+            let deadline = self.expires_at - LEASE_SAFETY_MARGIN;
+            deadline.duration_since(WallClock.recent())
+        }
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    impl Drop for NoOpLeaseGuard {
+        fn drop(&mut self) {
+            self.lease_lost.cancel();
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct SnapshotLeaseManager<C: Clock + Clone + Send + Sync + 'static = WallClock> {
+    metadata_store_client: MetadataStoreClient,
+    /// Node id to use for leases. If None, fetched from Metadata at acquire time.
+    node_id: Option<GenerationalNodeId>,
+    clock: C,
+}
+
+impl SnapshotLeaseManager<WallClock> {
+    pub fn new(metadata_store_client: MetadataStoreClient) -> Self {
+        Self {
+            metadata_store_client,
+            node_id: None,
+            clock: WallClock,
+        }
+    }
+}
+
+impl<C: Clock + Clone + Send + Sync + 'static> SnapshotLeaseManager<C> {
+    #[cfg(test)]
+    pub fn new_with_clock(
+        metadata_store_client: MetadataStoreClient,
+        node_id: GenerationalNodeId,
+        clock: C,
+    ) -> Self {
+        Self {
+            metadata_store_client,
+            node_id: Some(node_id),
+            clock,
+        }
+    }
+
+    /// Acquire a lease for the given partition.
+    ///
+    /// Returns error if another valid lease exists or if the metadata store is unavailable.
+    /// Transient metadata store failures are retried with exponential backoff.
+    pub async fn acquire(
+        &self,
+        partition_id: PartitionId,
+    ) -> Result<SnapshotLeaseGuard<C>, LeaseError> {
+        let retry_policy: RetryPolicy = Configuration::pinned()
+            .common
+            .network_error_retry_policy
+            .clone();
+
+        retry_policy
+            .retry_if(|| self.try_acquire(partition_id), LeaseError::retryable)
+            .await
+    }
+
+    #[instrument(level = "debug", skip_all, fields(%partition_id))]
+    async fn try_acquire(
+        &self,
+        partition_id: PartitionId,
+    ) -> Result<SnapshotLeaseGuard<C>, LeaseError> {
+        let my_node_id = self
+            .node_id
+            .unwrap_or_else(|| Metadata::with_current(|m| m.my_node_id()));
+        let key = lease_key(partition_id);
+
+        let new_lease = SnapshotLeaseValue::new(my_node_id, &self.clock);
+        let new_lease_id = new_lease.lease_id;
+
+        let existing: Option<SnapshotLeaseValue> =
+            self.metadata_store_client.get(key.clone()).await?;
+
+        match existing {
+            None => {
+                let written_version = Version::MIN;
+                let lease_to_write = new_lease.with_version(written_version);
+                self.metadata_store_client
+                    .put(key.clone(), &lease_to_write, Precondition::DoesNotExist)
+                    .await?;
+
+                debug!(lease_id = %new_lease_id, "Acquired snapshot lease (new)");
+
+                Ok(SnapshotLeaseGuard::Lease(
+                    inner::MetadataBackedLeaseGuard::new(
+                        partition_id,
+                        lease_to_write,
+                        self.metadata_store_client.clone(),
+                        written_version,
+                        self.clock.clone(),
+                    ),
+                ))
+            }
+            Some(existing_lease) => {
+                if existing_lease.is_expired(&self.clock) {
+                    let written_version = existing_lease.version.next();
+                    let lease_to_write = new_lease.with_version(written_version);
+                    self.metadata_store_client
+                        .put(
+                            key,
+                            &lease_to_write,
+                            Precondition::MatchesVersion(existing_lease.version),
+                        )
+                        .await?;
+
+                    debug!(
+                        lease_id = %new_lease_id,
+                        previous_holder = %existing_lease.holder,
+                        "Acquired snapshot lease (expired takeover)"
+                    );
+
+                    Ok(SnapshotLeaseGuard::Lease(
+                        inner::MetadataBackedLeaseGuard::new(
+                            partition_id,
+                            lease_to_write,
+                            self.metadata_store_client.clone(),
+                            written_version,
+                            self.clock.clone(),
+                        ),
+                    ))
+                } else {
+                    Err(LeaseError::Held {
+                        holder: existing_lease.holder,
+                        lease_id: existing_lease.lease_id,
+                        expires_at: existing_lease.expires_at.into_timestamp(),
+                    })
+                }
+            }
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-util"))]
+#[derive(Clone, Default)]
+pub struct NoOpLeaseManager;
+
+#[cfg(any(test, feature = "test-util"))]
+impl NoOpLeaseManager {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn acquire(
+        &self,
+        _partition_id: PartitionId,
+    ) -> Result<SnapshotLeaseGuard, LeaseError> {
+        let expires_at =
+            MillisSinceEpoch::new(WallClock.recent().as_u64() + 365 * 24 * 60 * 60 * 1000);
+        Ok(SnapshotLeaseGuard::NoOp(inner::NoOpLeaseGuard::new(
+            expires_at,
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use restate_clock::MockClock;
+    use restate_core::TestCoreEnv;
+    use restate_test_util::let_assert;
+    use restate_types::GenerationalNodeId;
+    use restate_types::identifiers::PartitionId;
+
+    use super::*;
+
+    #[restate_core::test]
+    async fn lease_acquire_no_existing() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let clock = MockClock::new();
+        let manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            GenerationalNodeId::new(1, 1),
+            clock.clone(),
+        );
+
+        let guard = manager
+            .acquire(PartitionId::MIN)
+            .await
+            .expect("acquire should succeed");
+
+        assert!(guard.is_valid());
+        assert_eq!(
+            guard.operation_deadline(),
+            clock.recent() + LEASE_DURATION - LEASE_SAFETY_MARGIN
+        );
+
+        // validity window spans (time acquired + lease duration - safety margin)
+        clock.advance(LEASE_DURATION - LEASE_SAFETY_MARGIN - Duration::from_millis(1));
+        assert!(guard.is_valid());
+
+        clock.advance_ms(1);
+        assert!(!guard.is_valid());
+    }
+
+    #[restate_core::test]
+    async fn lease_acquire_expired_takeover() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let clock = MockClock::new();
+        let n1 = GenerationalNodeId::new(1, 1);
+        let n2 = GenerationalNodeId::new(2, 1);
+
+        let n2_manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            n2,
+            clock.clone(),
+        );
+        let _guard = n2_manager
+            .acquire(PartitionId::MIN)
+            .await
+            .expect("initial acquire should succeed");
+
+        clock.advance(LEASE_DURATION + Duration::from_millis(100));
+
+        let n1_manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            n1,
+            clock.clone(),
+        );
+        let guard = n1_manager
+            .acquire(PartitionId::MIN)
+            .await
+            .expect("takeover should succeed");
+        assert!(guard.is_valid());
+    }
+
+    #[restate_core::test]
+    async fn lease_acquire_held_by_other_node() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let clock = MockClock::new();
+        let n1 = GenerationalNodeId::new(1, 1);
+        let n2 = GenerationalNodeId::new(2, 1);
+
+        let n2_manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            n2,
+            clock.clone(),
+        );
+        let _guard = n2_manager
+            .acquire(PartitionId::MIN)
+            .await
+            .expect("initial acquire should succeed");
+
+        let expected_expiry = clock.recent() + LEASE_DURATION;
+        clock.advance_ms(500);
+
+        let n1_manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            n1,
+            clock.clone(),
+        );
+        let result = n1_manager.acquire(PartitionId::MIN).await;
+
+        let_assert!(
+            Err(LeaseError::Held {
+                holder,
+                expires_at,
+                ..
+            }) = result
+        );
+        assert_eq!(holder, n2);
+        assert_eq!(expected_expiry.into_timestamp(), expires_at);
+    }
+
+    #[restate_core::test]
+    async fn lease_renewal_extends_expiry() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let clock = MockClock::new();
+        let manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            GenerationalNodeId::new(1, 1),
+            clock.clone(),
+        );
+        let guard = manager
+            .acquire(PartitionId::MIN)
+            .await
+            .expect("acquire should succeed");
+
+        let initial_deadline = guard.operation_deadline();
+
+        clock.advance(Duration::from_mins(2));
+        guard.test_renew().await.expect("renewal should succeed");
+
+        assert_eq!(
+            guard.operation_deadline(),
+            initial_deadline + Duration::from_mins(2)
+        );
+    }
+
+    #[restate_core::test]
+    async fn lease_renewal_fails_when_taken_over() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let clock = MockClock::new();
+        let n1 = GenerationalNodeId::new(1, 1);
+        let n2 = GenerationalNodeId::new(2, 1);
+
+        let n1_manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            n1,
+            clock.clone(),
+        );
+        let guard = n1_manager
+            .acquire(PartitionId::MIN)
+            .await
+            .expect("acquire should succeed");
+
+        clock.advance(LEASE_DURATION + Duration::from_millis(1000));
+
+        // another node takes over
+        let n2_manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            n2,
+            clock.clone(),
+        );
+        let _n2_guard = n2_manager
+            .acquire(PartitionId::MIN)
+            .await
+            .expect("takeover should succeed");
+
+        // original lease can no longer be renewed
+        let result = guard.test_renew().await;
+        assert!(matches!(result, Err(LeaseError::Expired)));
+    }
+
+    #[restate_core::test]
+    async fn lease_acquire_concurrent_race() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            GenerationalNodeId::new(1, 1),
+            MockClock::new(),
+        );
+
+        for _ in 0..100 {
+            let (result1, result2) = tokio::join!(
+                manager.acquire(PartitionId::MIN),
+                manager.acquire(PartitionId::MIN)
+            );
+
+            // exactly one should succeed
+            let (guard, err) = match (result1, result2) {
+                (Ok(g), Err(e)) | (Err(e), Ok(g)) => (g, e),
+                (Ok(_), Ok(_)) => panic!("Both acquires succeeded"),
+                (Err(e1), Err(e2)) => panic!("Both acquires failed: {e1:?}, {e2:?}"),
+            };
+            assert!(guard.is_valid());
+            assert!(matches!(
+                err,
+                LeaseError::Held { .. }
+                    | LeaseError::MetadataWrite(WriteError::FailedPrecondition(_))
+            ));
+
+            drop(guard);
+            // allow async release task to complete
+            tokio::task::yield_now().await;
+        }
+    }
+
+    #[restate_core::test]
+    async fn lease_renewal_fails_when_released() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            GenerationalNodeId::new(1, 1),
+            MockClock::new(),
+        );
+        let guard = manager
+            .acquire(PartitionId::MIN)
+            .await
+            .expect("acquire should succeed");
+
+        guard.test_mark_released();
+
+        let result = guard.test_renew().await;
+        assert!(matches!(result, Err(LeaseError::Expired)));
+    }
+
+    #[restate_core::test(start_paused = true)]
+    async fn lease_start_renewal_lifecycle() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let clock = TokioClock::new();
+        let manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            GenerationalNodeId::new(1, 1),
+            clock,
+        );
+
+        let guard = Arc::new(
+            manager
+                .acquire(PartitionId::MIN)
+                .await
+                .expect("acquire should succeed"),
+        );
+
+        assert!(guard.is_valid());
+
+        guard.start_renewal_task().expect("starts renewal task");
+        guard.start_renewal_task().expect("no-op");
+
+        let initial_deadline = guard.operation_deadline();
+
+        // Sleep past the renewal interval - the renewal task will wake and extend the deadline
+        tokio::time::sleep(LEASE_RENEWAL_INTERVAL + Duration::from_secs(1)).await;
+
+        let expected_deadline = initial_deadline + LEASE_RENEWAL_INTERVAL;
+
+        assert_eq!(
+            guard.operation_deadline(),
+            expected_deadline,
+            "Lease should have been renewed, extending the operation deadline"
+        );
+
+        assert!(guard.is_valid());
+        drop(guard); // cancel renewal task
+
+        for _ in 0..10 {
+            match manager.acquire(PartitionId::MIN).await {
+                Ok(_) => return,
+                Err(LeaseError::Held { .. }) => tokio::task::yield_now().await,
+                Err(e) => panic!("Unexpected error during acquire: {:?}", e),
+            }
+        }
+        panic!("Should be able to re-acquire after drop");
+    }
+
+    #[restate_core::test]
+    async fn lease_release_on_drop() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let clock = MockClock::new();
+        let n1 = GenerationalNodeId::new(1, 1);
+        let n2 = GenerationalNodeId::new(2, 1);
+
+        {
+            let n1_manager = SnapshotLeaseManager::new_with_clock(
+                env.metadata_store_client.clone(),
+                n1,
+                clock.clone(),
+            );
+            // immediately dropped
+            let _lease = n1_manager
+                .acquire(PartitionId::MIN)
+                .await
+                .expect("acquire should succeed");
+        }
+
+        let n2_manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            n2,
+            clock.clone(),
+        );
+
+        let mut acquired = false;
+        for _ in 0..10 {
+            match n2_manager.acquire(PartitionId::MIN).await {
+                Ok(_) => {
+                    acquired = true;
+                    break;
+                }
+                Err(LeaseError::Held { .. }) => {
+                    // release task might not have completed yet
+                    tokio::task::yield_now().await;
+                }
+                Err(e) => panic!("Unexpected error during acquire: {:?}", e),
+            }
+        }
+
+        assert!(
+            acquired,
+            "other node should be able to acquire after release (within timeout)"
+        );
+    }
+
+    #[restate_core::test]
+    async fn lease_lost_on_drop_and_run_under_lease() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            GenerationalNodeId::new(1, 1),
+            MockClock::new(),
+        );
+
+        let guard = manager
+            .acquire(PartitionId::MIN)
+            .await
+            .expect("acquire should succeed");
+
+        let lease_lost = guard.lease_lost();
+        assert!(!lease_lost.is_cancelled());
+
+        let result = guard.run_under_lease(async { 42 }).await;
+        assert_eq!(result, Some(42));
+
+        guard.test_mark_released();
+        assert!(lease_lost.is_cancelled());
+
+        let result = guard.run_under_lease(async { 42 }).await;
+        assert_eq!(result, None);
+    }
+
+    #[restate_core::test(start_paused = true)]
+    async fn run_under_lease_respects_deadline_with_renewal() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let clock = TokioClock::new();
+        let manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            GenerationalNodeId::new(1, 1),
+            clock,
+        );
+
+        let guard = Arc::new(
+            manager
+                .acquire(PartitionId::MIN)
+                .await
+                .expect("acquire should succeed"),
+        );
+        guard.start_renewal_task().expect("should start renewal");
+        let initial_deadline = guard.operation_deadline();
+
+        // the mock work future sleeps slightly longer than the renewal interval
+        // renewal task's sleep future fires first, extending the deadline
+        let result = guard
+            .run_under_lease(async {
+                tokio::time::sleep(LEASE_RENEWAL_INTERVAL + Duration::from_secs(1)).await;
+                42
+            })
+            .await;
+
+        assert!(
+            guard.operation_deadline() > initial_deadline,
+            "Deadline should have been extended by renewal"
+        );
+        assert_eq!(result, Some(42), "Work should complete with lease renewal");
+    }
+
+    #[restate_core::test(start_paused = true)]
+    async fn run_under_lease_aborts_at_deadline_without_renewal() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let clock = TokioClock::new();
+        let manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            GenerationalNodeId::new(1, 1),
+            clock,
+        );
+
+        let guard = manager
+            .acquire(PartitionId::MIN)
+            .await
+            .expect("acquire should succeed");
+
+        // no lease renewal task started
+
+        let result = guard
+            .run_under_lease(async {
+                tokio::time::sleep(LEASE_DURATION).await;
+                42
+            })
+            .await;
+
+        assert_eq!(result, None, "Work should be aborted at deadline");
+    }
+
+    /// Handy for paused tokio tests, this clock reflects `tokio::time::advance()` calls eliminating
+    /// the need to manipulate two time sources.
+    #[derive(Clone)]
+    struct TokioClock {
+        initial_instant: tokio::time::Instant,
+    }
+
+    impl TokioClock {
+        fn new() -> Self {
+            Self {
+                initial_instant: tokio::time::Instant::now(),
+            }
+        }
+
+        /// Fixed base time for deterministic tests (well after RESTATE_EPOCH)
+        const BASE_TIME: MillisSinceEpoch = MillisSinceEpoch::new(1_700_000_000_000);
+    }
+
+    impl Clock for TokioClock {
+        fn recent(&self) -> MillisSinceEpoch {
+            let elapsed = tokio::time::Instant::now().duration_since(self.initial_instant);
+            Self::BASE_TIME + elapsed
+        }
+
+        fn now(&self) -> MillisSinceEpoch {
+            self.recent()
+        }
+    }
+}

--- a/crates/partition-store/src/snapshots/leases.rs
+++ b/crates/partition-store/src/snapshots/leases.rs
@@ -123,12 +123,16 @@ impl SnapshotLeaseValue {
         }
     }
 
-    fn expired(holder: GenerationalNodeId, lease_id: Ulid) -> Self {
+    /// Constructs a marker value used by the Drop path to release a lease via a
+    /// versioned CAS. The caller must pass the version they expect the metadata
+    /// store slot to currently hold; the resulting record will carry
+    /// `version.next()` once `put` returns Ok.
+    fn expired(holder: GenerationalNodeId, lease_id: Ulid, current_version: Version) -> Self {
         Self {
             holder,
             lease_id,
             expires_at: MillisSinceEpoch::UNIX_EPOCH,
-            version: Version::MIN,
+            version: current_version.next(),
         }
     }
 
@@ -480,8 +484,7 @@ mod inner {
                 if let Ok(handle) = tokio::runtime::Handle::try_current() {
                     handle.spawn(async move {
                         let key = lease_key(partition_id);
-                        let expired = SnapshotLeaseValue::expired(holder, lease_id)
-                            .with_version(version.next());
+                        let expired = SnapshotLeaseValue::expired(holder, lease_id, version);
 
                         match client
                             .put(key, &expired, Precondition::MatchesVersion(version))

--- a/crates/partition-store/src/snapshots/leases.rs
+++ b/crates/partition-store/src/snapshots/leases.rs
@@ -358,6 +358,12 @@ mod inner {
             self.clock.recent() + LEASE_SAFETY_MARGIN < self.expires_at()
         }
 
+        #[instrument(
+            level = "debug",
+            skip_all,
+            fields(partition_id = %self.partition_id, lease_id = %self.lease_id),
+            err,
+        )]
         pub(super) async fn renew(&self) -> Result<(), LeaseError> {
             if self.lease_lost.is_cancelled() {
                 debug!(

--- a/crates/partition-store/src/snapshots/leases.rs
+++ b/crates/partition-store/src/snapshots/leases.rs
@@ -55,6 +55,15 @@ pub const LEASE_SAFETY_MARGIN: Duration = Duration::from_mins(1);
 /// we have to renew.
 pub const LEASE_RENEWAL_INTERVAL: Duration = Duration::from_mins(2);
 
+/// Outcome of `SnapshotLeaseGuard::start_renewal_task`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RenewalTaskStart {
+    /// A new renewal task was spawned by this call.
+    Started,
+    /// A renewal task was already running for this guard; no new task was spawned.
+    AlreadyRunning,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum LeaseError {
     #[error("Lease held by {holder} (lease_id: {lease_id}), expires at: {expires_at}")]
@@ -242,12 +251,13 @@ impl<C: Clock + Clone + Send + Sync + 'static> SnapshotLeaseGuard<C> {
 
     /// Start a background task that renews the lease at a fixed renewal interval.
     /// The task holds a weak reference to the lease and stops when the guard is dropped.
-    /// The guard ensures that at most one renewal task is spawned.
-    pub fn start_renewal_task(self: &Arc<Self>) -> Result<(), ShutdownError> {
+    /// The guard ensures that at most one renewal task is spawned per guard. Subsequent calls
+    /// after the first successful start return `Ok(RenewalTaskStart::AlreadyRunning)`.
+    pub fn start_renewal_task(self: &Arc<Self>) -> Result<RenewalTaskStart, ShutdownError> {
         match self.as_ref() {
             Self::Lease(g) => g.start_renewal_task(Arc::downgrade(self)),
             #[cfg(any(test, feature = "test-util"))]
-            Self::NoOp(_) => Ok(()),
+            Self::NoOp(_) => Ok(RenewalTaskStart::Started),
         }
     }
 
@@ -388,10 +398,10 @@ mod inner {
         pub(super) fn start_renewal_task(
             &self,
             guard: Weak<SnapshotLeaseGuard<C>>,
-        ) -> Result<(), ShutdownError> {
+        ) -> Result<RenewalTaskStart, ShutdownError> {
             let mut renewal_task = self.renewal_task.lock();
             if renewal_task.is_some() {
-                return Ok(());
+                return Ok(RenewalTaskStart::AlreadyRunning);
             }
 
             let lease_lost = self.lease_lost.clone();
@@ -426,7 +436,7 @@ mod inner {
                 },
             )?;
             *renewal_task = Some(handle);
-            Ok(())
+            Ok(RenewalTaskStart::Started)
         }
 
         fn spawn_release_task(&mut self) {

--- a/crates/partition-store/src/snapshots/leases.rs
+++ b/crates/partition-store/src/snapshots/leases.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
 use std::time::Duration;
 
@@ -315,7 +315,6 @@ mod inner {
         expires_at: AtomicU64,
         metadata_store_client: MetadataStoreClient,
         version: Mutex<Version>,
-        released: AtomicBool,
         renewal_task: Mutex<Option<TaskHandle<()>>>,
         pub(super) lease_lost: CancellationToken,
         clock: C,
@@ -336,7 +335,6 @@ mod inner {
                 expires_at: AtomicU64::new(lease.expires_at.as_u64()),
                 metadata_store_client,
                 version: Mutex::new(version),
-                released: AtomicBool::new(false),
                 renewal_task: Mutex::new(None),
                 lease_lost: CancellationToken::new(),
                 clock,
@@ -474,56 +472,53 @@ mod inner {
         }
 
         fn spawn_release_task(&mut self) {
-            if !self.released.swap(true, Ordering::AcqRel) {
-                let client = self.metadata_store_client.clone();
-                let partition_id = self.partition_id;
-                let version = *self.version.lock();
-                let lease_id = self.lease_id;
-                let holder = self.holder;
+            let client = self.metadata_store_client.clone();
+            let partition_id = self.partition_id;
+            let version = *self.version.lock();
+            let lease_id = self.lease_id;
+            let holder = self.holder;
 
-                if let Ok(handle) = tokio::runtime::Handle::try_current() {
-                    handle.spawn(async move {
-                        let key = lease_key(partition_id);
-                        let expired = SnapshotLeaseValue::expired(holder, lease_id, version);
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                handle.spawn(async move {
+                    let key = lease_key(partition_id);
+                    let expired = SnapshotLeaseValue::expired(holder, lease_id, version);
 
-                        match client
-                            .put(key, &expired, Precondition::MatchesVersion(version))
-                            .await
-                        {
-                            Ok(()) => {
-                                debug!(%partition_id, "Lease released via Drop");
-                            }
-                            Err(WriteError::FailedPrecondition(_)) => {
-                                debug!(
-                                    %partition_id,
-                                    "Lease release via Drop failed: version mismatch (lease was likely taken over)"
-                                );
-                            }
-                            Err(err) => {
-                                warn!(
-                                    %partition_id,
-                                    %err,
-                                    "Lease release via Drop failed"
-                                );
-                            }
+                    match client
+                        .put(key, &expired, Precondition::MatchesVersion(version))
+                        .await
+                    {
+                        Ok(()) => {
+                            debug!(%partition_id, "Lease released via Drop");
                         }
-                    });
-                    debug!(
-                        partition_id = %partition_id,
-                        "Snapshot lease dropped, spawned async release"
-                    );
-                } else {
-                    warn!(
-                        partition_id = %partition_id,
-                        "Snapshot lease dropped without release - no runtime available"
-                    );
-                }
+                        Err(WriteError::FailedPrecondition(_)) => {
+                            debug!(
+                                %partition_id,
+                                "Lease release via Drop failed: version mismatch (lease was likely taken over)"
+                            );
+                        }
+                        Err(err) => {
+                            warn!(
+                                %partition_id,
+                                %err,
+                                "Lease release via Drop failed"
+                            );
+                        }
+                    }
+                });
+                debug!(
+                    partition_id = %partition_id,
+                    "Snapshot lease dropped, spawned async release"
+                );
+            } else {
+                warn!(
+                    partition_id = %partition_id,
+                    "Snapshot lease dropped without release - no runtime available"
+                );
             }
         }
 
         #[cfg(test)]
         pub(super) fn test_mark_released(&self) {
-            self.released.store(true, Ordering::Release);
             self.lease_lost.cancel();
         }
 

--- a/crates/partition-store/src/snapshots/leases.rs
+++ b/crates/partition-store/src/snapshots/leases.rs
@@ -980,8 +980,16 @@ mod tests {
 
         assert!(guard.is_valid());
 
-        guard.start_renewal_task().expect("starts renewal task");
-        guard.start_renewal_task().expect("no-op");
+        assert_eq!(
+            guard.start_renewal_task().expect("starts renewal task"),
+            RenewalTaskStart::Started,
+        );
+        assert_eq!(
+            guard
+                .start_renewal_task()
+                .expect("second call must succeed"),
+            RenewalTaskStart::AlreadyRunning,
+        );
 
         let initial_deadline = guard.operation_deadline();
 
@@ -1099,7 +1107,10 @@ mod tests {
                 .await
                 .expect("acquire should succeed"),
         );
-        guard.start_renewal_task().expect("should start renewal");
+        assert_eq!(
+            guard.start_renewal_task().expect("should start renewal"),
+            RenewalTaskStart::Started,
+        );
         let initial_deadline = guard.operation_deadline();
 
         // the mock work future sleeps slightly longer than the renewal interval

--- a/crates/partition-store/src/snapshots/leases.rs
+++ b/crates/partition-store/src/snapshots/leases.rs
@@ -494,17 +494,21 @@ mod inner {
                         .await
                     {
                         Ok(()) => {
-                            debug!(%partition_id, "Lease released via Drop");
+                            debug!(%partition_id, %lease_id, "Lease released via Drop");
                         }
                         Err(WriteError::FailedPrecondition(_)) => {
                             debug!(
                                 %partition_id,
+                                %lease_id,
+                                %holder,
                                 "Lease release via Drop failed: version mismatch (lease was likely taken over)"
                             );
                         }
                         Err(err) => {
                             warn!(
                                 %partition_id,
+                                %lease_id,
+                                %holder,
                                 %err,
                                 "Lease release via Drop failed"
                             );

--- a/crates/partition-store/src/snapshots/leases.rs
+++ b/crates/partition-store/src/snapshots/leases.rs
@@ -407,6 +407,11 @@ mod inner {
             let lease_lost = self.lease_lost.clone();
             let partition_id = self.partition_id;
 
+            let retry_policy: RetryPolicy = Configuration::pinned()
+                .common
+                .network_error_retry_policy
+                .clone();
+
             let handle = TaskCenter::current().spawn_unmanaged_child(
                 TaskKind::Disposable,
                 "snapshot-lease-renewal",
@@ -421,7 +426,19 @@ mod inner {
                                 };
                                 match guard.as_ref() {
                                     SnapshotLeaseGuard::Lease(g) => {
-                                        if let Err(e) = g.renew().await {
+                                        // Retry transient metadata-store errors while the lease
+                                        // is still valid. A single network blip should not cost
+                                        // us the lease - acquire uses the same policy.
+                                        let result = retry_policy
+                                            .clone()
+                                            .retry_if(
+                                                || async { g.renew().await },
+                                                |e: &LeaseError| {
+                                                    e.retryable() && g.is_valid()
+                                                },
+                                            )
+                                            .await;
+                                        if let Err(e) = result {
                                             warn!(%partition_id, error = %e, "Lease renewal failed");
                                             g.lease_lost.cancel();
                                             break;

--- a/crates/partition-store/src/snapshots/leases.rs
+++ b/crates/partition-store/src/snapshots/leases.rs
@@ -132,6 +132,10 @@ impl SnapshotLeaseValue {
         }
     }
 
+    /// Returns true at and after `expires_at`. Used by acquirers to decide
+    /// whether an existing slot is up for takeover. The current holder's
+    /// `is_valid` returns false `LEASE_SAFETY_MARGIN` earlier so that operations
+    /// drain before any other node can take over.
     fn is_expired(&self, clock: &impl Clock) -> bool {
         clock.recent() >= self.expires_at
     }
@@ -339,6 +343,15 @@ mod inner {
             MillisSinceEpoch::new(self.expires_at.load(Ordering::Acquire))
         }
 
+        /// Returns true while the current time is strictly before
+        /// `expires_at - LEASE_SAFETY_MARGIN` - i.e. the lease holder still has
+        /// useful work time before they must stop and let the lease expire.
+        ///
+        /// Acquirers, by contrast, use [`SnapshotLeaseValue::is_expired`] which
+        /// triggers takeover only at the true `expires_at`. The
+        /// `LEASE_SAFETY_MARGIN` gap between the two predicates is intentional:
+        /// it gives the current holder time to drain its operation while
+        /// preventing a different node from believing the lease is up for grabs.
         pub(super) fn is_valid(&self) -> bool {
             self.clock.recent() + LEASE_SAFETY_MARGIN < self.expires_at()
         }

--- a/crates/partition-store/src/snapshots/leases.rs
+++ b/crates/partition-store/src/snapshots/leases.rs
@@ -1156,6 +1156,50 @@ mod tests {
         assert_eq!(result, None, "Work should be aborted at deadline");
     }
 
+    /// If the lease is lost mid-operation (renewal failure, takeover by another node, etc.),
+    /// `run_under_lease` must abort the in-flight work and return `None` instead of letting
+    /// it finish under an invalid lease.
+    #[restate_core::test(start_paused = true)]
+    async fn run_under_lease_aborts_when_lease_lost_mid_operation() {
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let clock = TokioClock::new();
+        let manager = SnapshotLeaseManager::new_with_clock(
+            env.metadata_store_client.clone(),
+            GenerationalNodeId::new(1, 1),
+            clock,
+        );
+
+        let guard = Arc::new(
+            manager
+                .acquire(PartitionId::MIN)
+                .await
+                .expect("acquire should succeed"),
+        );
+
+        let lease_lost = guard.lease_lost();
+        let cancel_guard = guard.clone();
+
+        // Cancel the lease shortly into the work, simulating renewal-task failure.
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            cancel_guard.test_mark_released();
+        });
+
+        let result = guard
+            .run_under_lease(async {
+                // Work that would otherwise complete well within the lease duration.
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                42
+            })
+            .await;
+
+        assert!(lease_lost.is_cancelled());
+        assert_eq!(
+            result, None,
+            "Work must be aborted once the lease is signalled lost"
+        );
+    }
+
     /// Handy for paused tokio tests, this clock reflects `tokio::time::advance()` calls eliminating
     /// the need to manipulate two time sources.
     #[derive(Clone)]

--- a/crates/partition-store/src/snapshots/metadata.rs
+++ b/crates/partition-store/src/snapshots/metadata.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use rocksdb::LiveFile;
@@ -75,6 +76,13 @@ pub struct PartitionSnapshotMetadata {
     /// The RocksDB SST files comprising the snapshot.
     #[serde_as(as = "Vec<SnapshotSstFile>")]
     pub files: Vec<LiveFile>,
+
+    /// Mapping from SST filename to repository object key.
+    /// Key: exact filename as it appears in LiveFile.name (e.g., "/000752.sst")
+    /// Value: relative object store key (e.g., "`ssts/a1b2c3d4e5f67890a1b2c3d4e5f67890.sst`")
+    /// When empty/missing, fallback to legacy path: {lsn}-{snap_id}/{filename}
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub file_keys: BTreeMap<String, String>,
 }
 
 impl PartitionSnapshotMetadata {
@@ -125,6 +133,8 @@ struct PartitionSnapshotMetadataShadow {
     pub db_comparator_name: String,
     #[serde_as(as = "Vec<SnapshotSstFile>")]
     pub files: Vec<LiveFile>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub file_keys: BTreeMap<String, String>,
 }
 
 impl From<PartitionSnapshotMetadataShadow> for PartitionSnapshotMetadata {
@@ -147,6 +157,7 @@ impl From<PartitionSnapshotMetadataShadow> for PartitionSnapshotMetadata {
             min_applied_lsn: value.min_applied_lsn,
             db_comparator_name: value.db_comparator_name,
             files: value.files,
+            file_keys: value.file_keys,
         }
     }
 }

--- a/crates/partition-store/src/snapshots/metadata.rs
+++ b/crates/partition-store/src/snapshots/metadata.rs
@@ -80,12 +80,24 @@ pub struct PartitionSnapshotMetadata {
     /// Mapping from SST filename to repository object key.
     /// Key: exact filename as it appears in LiveFile.name (e.g., "/000752.sst")
     /// Value: relative object store key (e.g., "`ssts/a1b2c3d4e5f67890a1b2c3d4e5f67890.sst`")
-    /// When empty/missing, fallback to legacy path: {lsn}-{snap_id}/{filename}
+    ///
+    /// This map is used as an implicit format discriminator: when empty the snapshot was
+    /// written by the legacy full-snapshot path and SSTs live at `{lsn}-{snap_id}/{filename}`;
+    /// when non-empty the snapshot is incremental and the map must cover every entry in
+    /// `files`. Mixed (partial) coverage is not produced by any writer in this crate;
+    /// readers treat per-file lookup misses as the legacy case for forward compatibility.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub file_keys: BTreeMap<String, String>,
 }
 
 impl PartitionSnapshotMetadata {
+    /// Returns true iff the metadata was written by the incremental snapshot path.
+    /// Detection is based on `file_keys` non-emptiness - kept as a single source of truth
+    /// so reader code does not duplicate the check.
+    pub fn is_incremental(&self) -> bool {
+        !self.file_keys.is_empty()
+    }
+
     pub fn validate(
         &self,
         cluster_name: &str,

--- a/crates/partition-store/src/snapshots/repository.rs
+++ b/crates/partition-store/src/snapshots/repository.rs
@@ -142,7 +142,9 @@ impl SnapshotReference {
 }
 
 impl LatestSnapshot {
-    /// We ensure that retained snapshots is in descending order of archived LSN, most recent snapshot first.
+    /// Returns retained snapshots in descending order of archived LSN, most recent first.
+    /// This relies on the write-time invariant maintained by the snapshot put / eviction logic;
+    /// callers should not assume re-sorting here.
     fn effective_retained_snapshots(&self) -> Vec<SnapshotReference> {
         if self.retained_snapshots.is_empty() {
             // Upgrade path from V1 - implicitly the "latest" snapshot is always retained.
@@ -716,23 +718,37 @@ impl SnapshotRepository {
         &self,
         partition_id: PartitionId,
     ) -> anyhow::Result<Option<LocalPartitionSnapshot>> {
+        let candidates = self.get_snapshot_candidates(partition_id).await?;
+        let Some(latest) = candidates.first() else {
+            return Ok(None);
+        };
+        tracing::Span::current().record("snapshot_id", tracing::field::display(latest.snapshot_id));
+        self.get_snapshot(partition_id, latest).await.map(Some)
+    }
+
+    /// Returns the partition's retained snapshot references, most-recent first (descending archived
+    /// LSN), or an empty vec if the repository holds no snapshot for the partition. Selecting a
+    /// snapshot suitable for a given target LSN is the caller's responsibility.
+    pub(crate) async fn get_snapshot_candidates(
+        &self,
+        partition_id: PartitionId,
+    ) -> anyhow::Result<Vec<SnapshotReference>> {
         let latest_path = self.latest_snapshot_pointer_path(partition_id);
 
         let latest = match self.object_store.get(&latest_path).await {
             Ok(result) => result,
             Err(object_store::Error::NotFound { .. }) => {
                 debug!("Latest snapshot data not found in repository");
-                return Ok(None);
+                return Ok(vec![]);
             }
             Err(err) => return Err(err.into()),
         };
 
         let latest: LatestSnapshot = serde_json::from_slice(&latest.bytes().await?)?;
-        tracing::Span::current().record("snapshot_id", tracing::field::display(latest.snapshot_id));
-        debug!("Latest snapshot metadata: {latest:?}");
+        debug!(snapshot_id = %latest.snapshot_id, "Latest snapshot metadata: {latest:?}");
+
         Metadata::with_current(|m| {
             let nodes_config = m.nodes_config_ref();
-
             latest.validate(
                 nodes_config.cluster_name(),
                 nodes_config.cluster_fingerprint(),
@@ -741,26 +757,37 @@ impl SnapshotRepository {
         })
         .with_context(|| format!("'{latest_path}' has validation errors"))?;
 
+        Ok(latest.effective_retained_snapshots())
+    }
+
+    #[instrument(
+        level = "error",
+        skip_all,
+        fields(%partition_id, snapshot_id = %snapshot_ref.snapshot_id),
+    )]
+    pub(crate) async fn get_snapshot(
+        &self,
+        partition_id: PartitionId,
+        snapshot_ref: &SnapshotReference,
+    ) -> anyhow::Result<LocalPartitionSnapshot> {
         let snapshot_metadata_path = self
             .prefix
             .clone()
             .join(partition_id.to_string())
-            .join(latest.path.as_str())
+            .join(snapshot_ref.path.as_str())
             .join("metadata.json");
-        let snapshot_metadata = self.object_store.get(&snapshot_metadata_path).await;
 
-        let snapshot_metadata = match snapshot_metadata {
-            Ok(result) => result,
-            Err(object_store::Error::NotFound { .. }) => {
-                bail!(
-                    "Latest snapshot points to '{snapshot_metadata_path}' that was not found in the repository!"
-                );
-            }
-            Err(err) => return Err(err.into()),
-        };
+        let snapshot_metadata = self
+            .object_store
+            .get(&snapshot_metadata_path)
+            .await
+            .with_context(|| {
+                format!("Snapshot metadata at '{snapshot_metadata_path}' not found in repository")
+            })?;
 
         let mut snapshot_metadata: PartitionSnapshotMetadata =
             serde_json::from_slice(&snapshot_metadata.bytes().await?)?;
+
         if !matches!(snapshot_metadata.version, SnapshotFormatVersion::V1) {
             bail!(
                 "Unsupported snapshot format version: {:?}",
@@ -770,7 +797,6 @@ impl SnapshotRepository {
 
         Metadata::with_current(|m| {
             let nodes_config = m.nodes_config_ref();
-
             snapshot_metadata.validate(
                 nodes_config.cluster_name(),
                 nodes_config.cluster_fingerprint(),
@@ -800,6 +826,7 @@ impl SnapshotRepository {
         let concurrency_limiter = Arc::new(Semaphore::new(DOWNLOAD_CONCURRENCY_LIMIT));
         let mut downloads = JoinSet::new();
         let mut task_handles = HashMap::with_capacity(snapshot_metadata.files.len());
+
         for file in &mut snapshot_metadata.files {
             let filename = strip_leading_slash(&file.name);
             let expected_size = file.size;
@@ -807,7 +834,7 @@ impl SnapshotRepository {
                 .prefix
                 .clone()
                 .join(partition_id.to_string())
-                .join(latest.path.as_str())
+                .join(snapshot_ref.path.as_str())
                 .join(filename);
             let local_path = snapshot_dir.path().join(filename);
             let concurrency_limiter = Arc::clone(&concurrency_limiter);
@@ -882,14 +909,14 @@ impl SnapshotRepository {
         // Transfer ownership of the staging directory from the `TempDir` (which auto-cleans on
         // an early return mid-download) to the snapshot's `SnapshotDir`, which removes it on drop
         // whether the subsequent import succeeds or fails (see #4838).
-        Ok(Some(LocalPartitionSnapshot {
+        Ok(LocalPartitionSnapshot {
             base_dir: SnapshotDir::new(snapshot_dir.keep()),
             log_id: snapshot_metadata.log_id,
             min_applied_lsn: snapshot_metadata.min_applied_lsn,
             db_comparator_name: snapshot_metadata.db_comparator_name,
             files: snapshot_metadata.files,
             key_range: snapshot_metadata.key_range,
-        }))
+        })
     }
 
     /// Retrieve the latest snapshot metadata from the snapshot repository
@@ -1051,9 +1078,8 @@ impl PutSnapshotError {
     }
 }
 
-// The object_store `put_multipart` method does not currently support PutMode, so we don't pass this
-// at all; however since we upload snapshots to a unique path on every attempt, we don't expect any
-// conflicts to arise.
+// The object_store `put_multipart` method does not currently support PutMode, so we cannot pass
+// a CAS condition here. Snapshots write to per-snapshot-id paths, so collisions are not expected.
 async fn put_snapshot_object(
     file_path: &Path,
     key: &ObjectPath,
@@ -1448,6 +1474,140 @@ mod tests {
         assert_eq!(latest.retained_snapshots[0].min_applied_lsn, Lsn::new(4000));
         assert_eq!(latest.retained_snapshots[1].min_applied_lsn, Lsn::new(3000));
         assert_eq!(latest.retained_snapshots[2].min_applied_lsn, Lsn::new(2000));
+
+        Ok(())
+    }
+
+    #[restate_core::test]
+    async fn get_snapshot_candidates_returns_retained_descending() -> anyhow::Result<()> {
+        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+
+        let snapshots_destination = TempDir::new()?;
+        let destination = Url::from_file_path(snapshots_destination.path())
+            .unwrap()
+            .to_string();
+        let opts = SnapshotsOptions {
+            destination: Some(destination),
+            num_retained: std::num::NonZeroU8::new(3).unwrap(),
+            ..SnapshotsOptions::default()
+        };
+        let repository = SnapshotRepository::new_from_config(&opts, TempDir::new().unwrap().keep())
+            .await?
+            .unwrap();
+
+        // No snapshots yet -> no candidates.
+        assert!(
+            repository
+                .get_snapshot_candidates(PartitionId::MIN)
+                .await?
+                .is_empty()
+        );
+
+        // Put four snapshots; with num_retained = 3 the oldest (1000) is evicted.
+        for i in 1..=4 {
+            let (snapshot, source_dir) =
+                mock_snapshot(format!("snapshot-data-{i}").as_bytes(), Lsn::new(i * 1000)).await?;
+            repository
+                .put(&snapshot, SnapshotDir::new(source_dir))
+                .await?;
+        }
+
+        // Retained candidates are returned most-recent-first.
+        let candidates = repository.get_snapshot_candidates(PartitionId::MIN).await?;
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|c| c.min_applied_lsn)
+                .collect::<Vec<_>>(),
+            vec![Lsn::new(4000), Lsn::new(3000), Lsn::new(2000)],
+        );
+
+        Ok(())
+    }
+
+    #[restate_core::test]
+    async fn download_snapshot_falls_back_to_older_when_latest_fails() -> anyhow::Result<()> {
+        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+
+        let snapshots_destination = TempDir::new()?;
+        let destination = Url::from_file_path(snapshots_destination.path())
+            .unwrap()
+            .to_string();
+        let opts = SnapshotsOptions {
+            destination: Some(destination),
+            num_retained: std::num::NonZeroU8::new(3).unwrap(),
+            ..SnapshotsOptions::default()
+        };
+        let repository = SnapshotRepository::new_from_config(&opts, TempDir::new().unwrap().keep())
+            .await?
+            .unwrap();
+
+        // `SnapshotRepository` is cheaply cloneable and shares the underlying object store, so the
+        // `Snapshots` wrapper observes snapshots we `put` through `repository` below.
+        let snapshots = crate::snapshots::Snapshots {
+            repository: Some(repository.clone()),
+            concurrency_limit: std::sync::Arc::new(tokio::sync::Semaphore::new(1)),
+        };
+
+        // An empty repository is "no snapshot present", not an error.
+        assert!(
+            snapshots
+                .download_snapshot(PartitionId::MIN, None)
+                .await?
+                .is_none()
+        );
+
+        // Older snapshot A (LSN 2000) then latest B (LSN 3000).
+        let (snapshot_a, dir_a) = mock_snapshot(b"snapshot-A", Lsn::new(2000)).await?;
+        repository.put(&snapshot_a, SnapshotDir::new(dir_a)).await?;
+        let (snapshot_b, dir_b) = mock_snapshot(b"snapshot-B", Lsn::new(3000)).await?;
+        repository.put(&snapshot_b, SnapshotDir::new(dir_b)).await?;
+
+        // Happy path: the latest snapshot is restored.
+        let restored = snapshots
+            .download_snapshot(PartitionId::MIN, None)
+            .await?
+            .expect("a snapshot is available");
+        assert_eq!(restored.min_applied_lsn, Lsn::new(3000));
+
+        // A target LSN selects only snapshots at or above it: 2500 still allows the latest (3000).
+        let restored = snapshots
+            .download_snapshot(PartitionId::MIN, Some(Lsn::new(2500)))
+            .await?
+            .expect("latest snapshot satisfies the target LSN");
+        assert_eq!(restored.min_applied_lsn, Lsn::new(3000));
+
+        // A target above every retained snapshot yields no suitable candidate (Ok(None)).
+        assert!(
+            snapshots
+                .download_snapshot(PartitionId::MIN, Some(Lsn::new(5000)))
+                .await?
+                .is_none()
+        );
+
+        // Corrupt the latest by removing its data file; the download must fall back to A.
+        let sst_path = |snapshot: &PartitionSnapshotMetadata| {
+            snapshots_destination
+                .path()
+                .join(PartitionId::MIN.to_string())
+                .join(UniqueSnapshotKey::from_metadata(snapshot).padded_key())
+                .join("data.sst")
+        };
+        std::fs::remove_file(sst_path(&snapshot_b))?;
+        let restored = snapshots
+            .download_snapshot(PartitionId::MIN, None)
+            .await?
+            .expect("falls back to the older snapshot");
+        assert_eq!(restored.min_applied_lsn, Lsn::new(2000));
+
+        // Remove A's data too: every candidate now fails -> error, not a silent "no snapshot".
+        std::fs::remove_file(sst_path(&snapshot_a))?;
+        assert!(
+            snapshots
+                .download_snapshot(PartitionId::MIN, None)
+                .await
+                .is_err()
+        );
 
         Ok(())
     }

--- a/crates/partition-store/src/snapshots/repository.rs
+++ b/crates/partition-store/src/snapshots/repository.rs
@@ -599,7 +599,23 @@ impl SnapshotRepository {
                         .join("ssts")
                         .join(sst_name.as_str());
 
+                    // Content-addressed dedup: if an object already exists at this key, we
+                    // trust that its content matches the local file (xxh3-128 collisions are
+                    // astronomically unlikely on random RocksDB content). We still verify the
+                    // stored object's size matches, which catches truncated/partial uploads
+                    // from a prior crashed put.
                     let must_upload = match self.object_store.head(&sst_key).await {
+                        Ok(meta) if meta.size as usize != file.size => {
+                            warn!(
+                                sst = %filename,
+                                hash = %content_hash,
+                                expected_size = file.size,
+                                actual_size = meta.size,
+                                "Existing object at content-addressed key has unexpected size; \
+                                re-uploading to overwrite the corrupt object"
+                            );
+                            true
+                        }
                         Ok(_) => {
                             debug!(
                                 sst = %filename,

--- a/crates/partition-store/src/snapshots/repository.rs
+++ b/crates/partition-store/src/snapshots/repository.rs
@@ -11,7 +11,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use ahash::{HashMap, HashMapExt};
+use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use anyhow::{Context, anyhow, bail};
 use bytes::BytesMut;
 use object_store::path::Path as ObjectPath;
@@ -66,6 +66,34 @@ impl LeaseProvider {
     }
 }
 
+/// XXH3-128 content hash for SST files. Produces a 128-bit digest (32 hex characters).
+#[derive(Clone, Copy)]
+struct ContentHash(u128);
+
+impl std::fmt::Display for ContentHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:032x}", self.0)
+    }
+}
+
+async fn compute_content_hash(path: &Path) -> io::Result<ContentHash> {
+    use xxhash_rust::xxh3::Xxh3;
+
+    let mut file = tokio::fs::File::open(path).await?;
+    let mut hasher = Xxh3::new();
+    let mut buf = vec![0u8; 256 * 1024]; // 256KB chunks
+
+    loop {
+        let len = file.read(&mut buf).await?;
+        if len == 0 {
+            break;
+        }
+        hasher.update(&buf[..len]);
+    }
+
+    Ok(ContentHash(hasher.digest128()))
+}
+
 /// Provides read and write access to the long-term partition snapshot storage destination.
 ///
 /// The repository wraps access to an object store "bucket" that contains snapshot metadata and data
@@ -77,9 +105,15 @@ impl LeaseProvider {
 /// A single top-level `latest.json` file is the only key which is repeatedly overwritten; all other
 /// data is immutable until the pruning policy allows for deletion.
 ///
+/// Bucket layout:
 /// - `[<prefix>/]<partition_id>/latest.json` - latest snapshot metadata for the partition
 /// - `[<prefix>/]<partition_id>/{lsn}_{snapshot_id}/metadata.json` - snapshot descriptor
-/// - `[<prefix>/]<partition_id>/{lsn}_{snapshot_id}/*.sst` - data files (explicitly named in `metadata.json`)
+/// - `[<prefix>/]<partition_id>/{lsn}_{snapshot_id}/*.sst` - data files for full snapshots
+/// - `[<prefix>/]<partition_id>/ssts/{hash}.sst` - shared SST files for incremental snapshots
+///
+/// Incremental snapshots use content-addressed SST naming where `{hash}` is the xxh3-128 hash
+/// of the file contents. This enables deduplication across snapshots since files with identical
+/// content will have the same key regardless of which snapshot created them.
 #[derive(Clone)]
 pub struct SnapshotRepository {
     object_store: Arc<dyn ObjectStore>,
@@ -87,6 +121,7 @@ pub struct SnapshotRepository {
     prefix: ObjectPath,
     staging_dir: PathBuf,
     num_retained: std::num::NonZeroU8,
+    snapshot_type: restate_types::config::SnapshotType,
     lease_provider: Option<LeaseProvider>,
     #[cfg(any(test, feature = "test-util"))]
     enable_cleanup: bool,
@@ -383,6 +418,7 @@ impl SnapshotRepository {
             prefix: ObjectPath::from(prefix),
             staging_dir,
             num_retained: snapshots_options.num_retained,
+            snapshot_type: snapshots_options.experimental_snapshot_type,
             #[cfg(any(test, feature = "test-util"))]
             enable_cleanup: snapshots_options.enable_cleanup,
             lease_provider,
@@ -418,6 +454,7 @@ impl SnapshotRepository {
             prefix: ObjectPath::from(prefix),
             staging_dir,
             num_retained: snapshots_options.num_retained,
+            snapshot_type: snapshots_options.experimental_snapshot_type,
             enable_cleanup: snapshots_options.enable_cleanup,
             lease_provider: Some(LeaseProvider::NoOp(NoOpLeaseManager::new())),
         }))
@@ -523,6 +560,113 @@ impl SnapshotRepository {
         }
     }
 
+    /// If snapshot type is incremental, we will skip existing existing SST objects in the store
+    /// based on their content hash. Returns a LiveFile SST name to object key mapping, if SSTs are
+    /// uploaded to a path different from their original name (i.e. when part of content-addressed
+    /// incremental snapshots).
+    async fn upload_snapshot_with_dedup(
+        &self,
+        snapshot: &PartitionSnapshotMetadata,
+        local_snapshot_path: &Path,
+        buf: &mut BytesMut,
+        progress: &mut SnapshotUploadProgress,
+    ) -> anyhow::Result<std::collections::BTreeMap<String, String>> {
+        use restate_types::config::SnapshotType;
+
+        let mut file_keys = std::collections::BTreeMap::new();
+        let mut total_size = 0usize;
+        let mut uploaded_size = 0usize;
+        let mut files_uploaded = 0usize;
+        let mut files_skipped = 0usize;
+
+        for file in &snapshot.files {
+            let filename = strip_leading_slash(&file.name);
+            let local_path = local_snapshot_path.join(filename);
+            total_size += file.size;
+
+            let (repository_key, relative_key, must_upload) = match self.snapshot_type {
+                SnapshotType::Full => {
+                    let key = self.snapshot_file_path(snapshot, filename);
+                    (key, None, true)
+                }
+                SnapshotType::Incremental => {
+                    // content-addressed SSTs live in shared ../ssts/ prefix
+                    // key format: {hash}.sst - content-addressed, existence implies identical content
+                    let content_hash = compute_content_hash(&local_path).await?;
+                    let sst_name = format!("{content_hash}.sst");
+                    let sst_key = self
+                        .partition_snapshots_prefix(snapshot.partition_id)
+                        .join("ssts")
+                        .join(sst_name.as_str());
+
+                    let must_upload = match self.object_store.head(&sst_key).await {
+                        Ok(_) => {
+                            debug!(
+                                sst = %filename,
+                                hash = %content_hash,
+                                size = file.size,
+                                "SST already exists in repository (content-addressed), skipping"
+                            );
+                            files_skipped += 1;
+                            false
+                        }
+                        Err(object_store::Error::NotFound { .. }) => true,
+                        Err(e) => {
+                            warn!(
+                                sst = %filename,
+                                error = %e,
+                                "Failed to check if SST exists, uploading to be safe"
+                            );
+                            true
+                        }
+                    };
+
+                    let relative_key = format!("ssts/{sst_name}");
+                    (sst_key, Some(relative_key), must_upload)
+                }
+            };
+
+            if must_upload {
+                put_snapshot_object(&local_path, &repository_key, &self.object_store, buf).await?;
+                debug!(
+                    sst = %filename,
+                    size = file.size,
+                    repository_key = %repository_key,
+                    "Uploaded SST to repository"
+                );
+
+                files_uploaded += 1;
+                uploaded_size += file.size;
+                progress.push(file.name.clone());
+            }
+
+            if let Some(key) = relative_key {
+                file_keys.insert(file.name.clone(), key);
+            }
+        }
+
+        if matches!(self.snapshot_type, SnapshotType::Incremental) && files_skipped > 0 {
+            let dedup_rate = if total_size > 0 {
+                ((total_size - uploaded_size) as f64 / total_size as f64) * 100.0
+            } else {
+                0.0
+            };
+
+            info!(
+                partition_id = %snapshot.partition_id,
+                snapshot_id = %snapshot.snapshot_id,
+                files_uploaded = files_uploaded,
+                files_skipped = files_skipped,
+                bytes_uploaded = uploaded_size,
+                bytes_saved = total_size - uploaded_size,
+                dedup_rate = format!("{:.1}%", dedup_rate),
+                "Snapshot SST upload completed with deduplication"
+            );
+        }
+
+        Ok(file_keys)
+    }
+
     // It is the outer put method's responsibility to clean up partial progress.
     async fn put_snapshot_inner(
         &self,
@@ -589,26 +733,18 @@ impl SnapshotRepository {
         progress: &mut SnapshotUploadProgress,
     ) -> Result<(), PutSnapshotError> {
         let mut buf = BytesMut::new();
-        for file in &snapshot.files {
-            let filename = strip_leading_slash(&file.name);
-            let key = self.snapshot_file_path(snapshot, filename);
 
-            let put_result = put_snapshot_object(
-                local_snapshot_path.join(filename).as_path(),
-                &key,
-                &self.object_store,
-                &mut buf,
-            )
+        let file_keys = self
+            .upload_snapshot_with_dedup(snapshot, local_snapshot_path, &mut buf, progress)
             .await
             .map_err(|e| PutSnapshotError::from(e, progress.clone()))?;
 
-            debug!(etag = %put_result.e_tag.unwrap_or_default(), %key, "Put snapshot object completed");
-            progress.push(file.name.clone());
-        }
+        let mut snapshot_with_keys = snapshot.clone();
+        snapshot_with_keys.file_keys = file_keys;
 
         let metadata_key = self.snapshot_file_path(snapshot, "metadata.json");
         let metadata_json_payload = PutPayload::from(
-            serde_json::to_string_pretty(snapshot).expect("Can always serialize JSON"),
+            serde_json::to_string_pretty(&snapshot_with_keys).expect("Can always serialize JSON"),
         );
 
         let put_result = self
@@ -629,9 +765,8 @@ impl SnapshotRepository {
 
     /// Builds V2 latest snapshot metadata.
     ///
-    /// Returns `(LatestSnapshot, Vec<SnapshotReference>)` where the second element contains
-    /// snapshots that no longer need to be retained following the metadata update.
-    /// If cleanup fails, these snapshots will be orphaned until cleaned up by the sweeper.
+    /// Returns `(LatestSnapshot, Vec<SnapshotReference>)` where the second element contains the
+    /// snapshots that can be evicted from the store following the metadata update.
     fn build_latest_v2(
         &self,
         snapshot: &PartitionSnapshotMetadata,
@@ -748,6 +883,13 @@ impl SnapshotRepository {
             anyhow::bail!("Lease expired before cleanup could start");
         }
 
+        // Get currently retained snapshots to know which SSTs are still in use.
+        // Abort cleanup if we cannot determine this to avoid deleting shared SSTs.
+        let retained_snapshots = self
+            .get_current_retained_snapshots(partition_id)
+            .await
+            .context("Cannot proceed with cleanup; aborting to prevent potential data loss")?;
+
         for snapshot_ref in &evicted_snapshots {
             if !lease_guard.is_valid() {
                 debug!(
@@ -759,10 +901,57 @@ impl SnapshotRepository {
 
             // Errors are logged inside delete_snapshot_files; if cleanup fails,
             // these snapshots become orphans to be cleaned by future scan-sweep.
-            self.delete_snapshot_files(partition_id, snapshot_ref).await;
+            self.delete_snapshot_files(partition_id, snapshot_ref, &retained_snapshots)
+                .await;
         }
 
         Ok(())
+    }
+
+    /// Get retained snapshots for cleanup coordination.
+    ///
+    /// Returns an error if latest.json exists but cannot be read or parsed, since we cannot
+    /// safely determine which SSTs are still referenced by retained snapshots. Cleanup must
+    /// abort in this case to avoid deleting shared SSTs that may still be in use.
+    async fn get_current_retained_snapshots(
+        &self,
+        partition_id: PartitionId,
+    ) -> anyhow::Result<Vec<SnapshotReference>> {
+        let latest_path = self.latest_snapshot_pointer_path(partition_id);
+        match self.object_store.get(&latest_path).await {
+            Ok(result) => {
+                let bytes = result.bytes().await.map_err(|e| {
+                    warn!(
+                        %partition_id,
+                        error = %e,
+                        "Failed to read latest.json bytes; cannot determine retained snapshots"
+                    );
+                    anyhow!("Failed to read latest.json bytes: {}", e)
+                })?;
+                let latest: LatestSnapshot = serde_json::from_slice(&bytes).map_err(|e| {
+                    warn!(
+                        %partition_id,
+                        error = %e,
+                        "Failed to parse latest.json; cannot determine retained snapshots"
+                    );
+                    anyhow!("Failed to parse latest.json: {}", e)
+                })?;
+                Ok(latest.effective_retained_snapshots())
+            }
+            Err(object_store::Error::NotFound { .. }) => {
+                // No latest.json means no snapshots exist yet, so no SSTs to protect
+                debug!(%partition_id, "No latest.json found; no retained snapshots to protect");
+                Ok(vec![])
+            }
+            Err(e) => {
+                warn!(
+                    %partition_id,
+                    error = %e,
+                    "Failed to fetch latest.json; cannot determine retained snapshots"
+                );
+                Err(anyhow!("Failed to fetch latest.json: {}", e))
+            }
+        }
     }
 
     /// Best-effort deletion of snapshot files. Errors are logged but not propagated.
@@ -771,6 +960,7 @@ impl SnapshotRepository {
         &self,
         partition_id: PartitionId,
         snapshot_ref: &SnapshotReference,
+        retained_snapshots: &[SnapshotReference],
     ) {
         let metadata_path = self
             .prefix
@@ -806,18 +996,98 @@ impl SnapshotRepository {
             }
         };
 
+        // Build set of SST keys that are still referenced by retained snapshots
+        let mut referenced_sst_keys = HashSet::new();
+        for retained_ref in retained_snapshots {
+            let retained_metadata_path = self
+                .prefix
+                .clone()
+                .join(partition_id.to_string())
+                .join(retained_ref.path.as_str())
+                .join("metadata.json");
+
+            if let Ok(data) = self.object_store.get(&retained_metadata_path).await
+                && let Ok(bytes) = data.bytes().await
+                && let Ok(retained_metadata) =
+                    serde_json::from_slice::<PartitionSnapshotMetadata>(&bytes)
+            {
+                for file in &retained_metadata.files {
+                    let filename = strip_leading_slash(&file.name);
+                    let sst_key =
+                        if let Some(relative_key) = retained_metadata.file_keys.get(&file.name) {
+                            let parts: Vec<&str> = relative_key.split('/').collect();
+                            if parts.len() == 2 {
+                                self.prefix
+                                    .clone()
+                                    .join(partition_id.to_string())
+                                    .join(parts[0])
+                                    .join(parts[1])
+                            } else {
+                                self.prefix
+                                    .clone()
+                                    .join(partition_id.to_string())
+                                    .join(relative_key.as_str())
+                            }
+                        } else {
+                            self.prefix
+                                .clone()
+                                .join(partition_id.to_string())
+                                .join(retained_ref.path.as_str())
+                                .join(filename)
+                        };
+                    referenced_sst_keys.insert(sst_key);
+                }
+            }
+        }
+
         let mut any_failed = false;
-        for path in metadata
-            .files
-            .iter()
-            .map(|filename| self.snapshot_file_path(&metadata, strip_leading_slash(&filename.name)))
-            .chain(std::iter::once(metadata_path))
-        {
+        for file in &metadata.files {
+            let filename = strip_leading_slash(&file.name);
+            let path = if let Some(relative_key) = metadata.file_keys.get(&file.name) {
+                // Incremental snapshot: SST is in shared ssts/ directory
+                // Format: "ssts/{hash}.sst" (content-addressed) or legacy "ssts/{node_id}_{filename}"
+                let parts: Vec<&str> = relative_key.split('/').collect();
+                if parts.len() == 2 {
+                    self.prefix
+                        .clone()
+                        .join(partition_id.to_string())
+                        .join(parts[0])
+                        .join(parts[1])
+                } else {
+                    self.prefix
+                        .clone()
+                        .join(partition_id.to_string())
+                        .join(relative_key.as_str())
+                }
+            } else {
+                // Legacy full snapshot: SST is in snapshot-specific directory
+                self.snapshot_file_path(&metadata, filename)
+            };
+
+            if referenced_sst_keys.contains(&path) {
+                debug!(%path, "Skipping deletion of SST file still referenced by retained snapshots");
+                continue;
+            }
+
             if let Err(err) = self.object_store.delete(&path).await
                 && !matches!(err, object_store::Error::NotFound { .. })
             {
                 warn!(%path, %err, "Failed to delete snapshot object");
                 any_failed = true;
+            }
+        }
+
+        // Only delete metadata.json after all SST deletions succeed.
+        // This ensures retries can still identify which SSTs need to be deleted.
+        // If we deleted metadata while SSTs remain, subsequent retries would see
+        // NotFound for metadata.json and return Ok(()), leaving orphaned SSTs.
+        #[allow(clippy::collapsible_if)] // Keep separate to make deletion conditional on is_empty()
+        if failed_deletes.is_empty() {
+            if let Err(err) = self.object_store.delete(&metadata_path).await
+                && !matches!(err, object_store::Error::NotFound { .. })
+            {
+                warn!(%metadata_path, %err, "Failed to delete snapshot metadata");
+                failed_deletes.push(err);
             }
         }
 
@@ -969,12 +1239,31 @@ impl SnapshotRepository {
         for file in &mut snapshot_metadata.files {
             let filename = strip_leading_slash(&file.name);
             let expected_size = file.size;
-            let key = self
-                .prefix
-                .clone()
-                .join(partition_id.to_string())
-                .join(snapshot_ref.path.as_str())
-                .join(filename);
+            let key = if let Some(relative_key) = snapshot_metadata.file_keys.get(&file.name) {
+                // Incremental snapshot: parse the relative key and build proper path
+                // Format: "ssts/{hash}.sst" (content-addressed) or legacy "ssts/{node_id}_{filename}"
+                let parts: Vec<&str> = relative_key.split('/').collect();
+                if parts.len() == 2 {
+                    self.prefix
+                        .clone()
+                        .join(partition_id.to_string())
+                        .join(parts[0]) // "ssts"
+                        .join(parts[1]) // "{node_id}_{filename}"
+                } else {
+                    // Fallback if format is unexpected
+                    self.prefix
+                        .clone()
+                        .join(partition_id.to_string())
+                        .join(relative_key.as_str())
+                }
+            } else {
+                // Full/legacy snapshot: use snapshot-specific path
+                self.prefix
+                    .clone()
+                    .join(partition_id.to_string())
+                    .join(snapshot_ref.path.as_str())
+                    .join(filename)
+            };
             let local_path = snapshot_dir.path().join(filename);
             let concurrency_limiter = Arc::clone(&concurrency_limiter);
             let object_store = Arc::clone(&self.object_store);
@@ -1554,6 +1843,7 @@ mod tests {
                 smallest_seqno: 0,
                 largest_seqno: 0,
             }],
+            file_keys: std::collections::BTreeMap::new(),
         }
     }
 

--- a/crates/partition-store/src/snapshots/repository.rs
+++ b/crates/partition-store/src/snapshots/repository.rs
@@ -133,6 +133,7 @@ pub struct SnapshotRepository {
     num_retained: std::num::NonZeroU8,
     snapshot_type: restate_types::config::SnapshotType,
     orphan_cleanup: bool,
+    orphan_min_age: Duration,
     lease_provider: Option<LeaseProvider>,
     #[cfg(any(test, feature = "test-util"))]
     enable_cleanup: bool,
@@ -145,8 +146,8 @@ const MULTIPART_UPLOAD_CHUNK_SIZE_BYTES: usize = 5 * 1024 * 1024;
 /// Maximum number of concurrent downloads when getting snapshots from the repository.
 const DOWNLOAD_CONCURRENCY_LIMIT: usize = 8;
 
-/// Minimum age for files to be considered orphan candidates during repository scan.
-const ORPHAN_MIN_AGE: Duration = Duration::from_hours(24);
+/// Default minimum age for files to be considered orphan candidates during repository scan.
+const DEFAULT_ORPHAN_MIN_AGE: Duration = Duration::from_hours(24);
 
 /// Object store keys eligible for sweeping. Files not matching any pattern are ignored.
 mod sweep_patterns {
@@ -487,6 +488,7 @@ impl SnapshotRepository {
             orphan_cleanup: snapshots_options
                 .experimental_orphan_cleanup
                 .unwrap_or(false),
+            orphan_min_age: DEFAULT_ORPHAN_MIN_AGE,
             #[cfg(any(test, feature = "test-util"))]
             enable_cleanup: snapshots_options.enable_cleanup,
             lease_provider,
@@ -526,6 +528,9 @@ impl SnapshotRepository {
             orphan_cleanup: snapshots_options
                 .experimental_orphan_cleanup
                 .unwrap_or(false),
+            orphan_min_age: snapshots_options
+                .orphan_min_age()
+                .unwrap_or(DEFAULT_ORPHAN_MIN_AGE),
             enable_cleanup: snapshots_options.enable_cleanup,
             lease_provider: Some(LeaseProvider::NoOp(NoOpLeaseManager::new())),
         }))
@@ -1013,7 +1018,7 @@ impl SnapshotRepository {
                 .find_orphaned_files(
                     partition_id,
                     &retained_snapshots,
-                    ORPHAN_MIN_AGE,
+                    self.orphan_min_age,
                     &referenced_sst_keys,
                 )
                 .await

--- a/crates/partition-store/src/snapshots/repository.rs
+++ b/crates/partition-store/src/snapshots/repository.rs
@@ -10,10 +10,13 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
 use anyhow::{Context, anyhow, bail};
 use bytes::BytesMut;
+use chrono::{DateTime, Utc};
+use futures::TryStreamExt;
 use object_store::path::Path as ObjectPath;
 use object_store::{
     MultipartUpload, ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload, UpdateVersion,
@@ -26,7 +29,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 use tokio_util::io::StreamReader;
-use tracing::{Instrument, Span, debug, info, instrument, warn};
+use tracing::{Instrument, Span, debug, info, instrument, trace, warn};
 use url::Url;
 
 use restate_clock::WallClock;
@@ -128,6 +131,7 @@ pub struct SnapshotRepository {
     staging_dir: PathBuf,
     num_retained: std::num::NonZeroU8,
     snapshot_type: restate_types::config::SnapshotType,
+    orphan_cleanup: bool,
     lease_provider: Option<LeaseProvider>,
     #[cfg(any(test, feature = "test-util"))]
     enable_cleanup: bool,
@@ -139,6 +143,9 @@ const MULTIPART_UPLOAD_CHUNK_SIZE_BYTES: usize = 5 * 1024 * 1024;
 
 /// Maximum number of concurrent downloads when getting snapshots from the repository.
 const DOWNLOAD_CONCURRENCY_LIMIT: usize = 8;
+
+/// Minimum age for files to be considered orphan candidates during repository scan.
+const ORPHAN_MIN_AGE: Duration = Duration::from_hours(24);
 
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum LatestSnapshotVersion {
@@ -205,6 +212,23 @@ impl SnapshotReference {
             path: UniqueSnapshotKey::from_metadata(snapshot).padded_key(),
         }
     }
+}
+
+#[derive(Debug, Default)]
+struct SnapshotInventory {
+    /// SST files found in the ssts/ directory with their last modified time.
+    shared_sst_files: HashMap<ObjectPath, DateTime<Utc>>,
+    /// Snapshot prefixes found: (prefix -> (has_metadata, newest_file_modified)).
+    /// We track the newest file to avoid deleting in-flight/partially replicated uploads.
+    snapshot_prefixes: HashMap<String, (bool, DateTime<Utc>)>,
+}
+
+#[derive(Debug, Default)]
+struct OrphanedPaths {
+    /// SST files not referenced by any retained snapshot.
+    ssts: Vec<ObjectPath>,
+    /// Snapshot prefixes not in the retained snapshots list.
+    snapshots: Vec<String>,
 }
 
 impl LatestSnapshot {
@@ -425,6 +449,9 @@ impl SnapshotRepository {
             staging_dir,
             num_retained: snapshots_options.num_retained,
             snapshot_type: snapshots_options.experimental_snapshot_type,
+            orphan_cleanup: snapshots_options
+                .experimental_orphan_cleanup
+                .unwrap_or(false),
             #[cfg(any(test, feature = "test-util"))]
             enable_cleanup: snapshots_options.enable_cleanup,
             lease_provider,
@@ -461,6 +488,9 @@ impl SnapshotRepository {
             staging_dir,
             num_retained: snapshots_options.num_retained,
             snapshot_type: snapshots_options.experimental_snapshot_type,
+            orphan_cleanup: snapshots_options
+                .experimental_orphan_cleanup
+                .unwrap_or(false),
             enable_cleanup: snapshots_options.enable_cleanup,
             lease_provider: Some(LeaseProvider::NoOp(NoOpLeaseManager::new())),
         }))
@@ -912,6 +942,10 @@ impl SnapshotRepository {
             .await
             .context("Cannot proceed with cleanup; aborting to prevent potential data loss")?;
 
+        let referenced_sst_keys = self
+            .build_referenced_sst_keys(partition_id, &retained_snapshots)
+            .await?;
+
         for snapshot_ref in &evicted_snapshots {
             if !lease_guard.is_valid() {
                 debug!(
@@ -923,8 +957,44 @@ impl SnapshotRepository {
 
             // Errors are logged inside delete_snapshot_files; if cleanup fails,
             // these snapshots become orphans to be cleaned by future scan-sweep.
-            self.delete_snapshot_files(partition_id, snapshot_ref, &retained_snapshots)
+            self.delete_snapshot_files(partition_id, snapshot_ref, &referenced_sst_keys)
                 .await;
+        }
+
+        if self.orphan_cleanup && lease_guard.is_valid() {
+            use crate::metric_definitions::{
+                SNAPSHOT_ORPHAN_FILES_DELETED, SNAPSHOT_ORPHAN_SCAN_FAILED,
+                SNAPSHOT_ORPHAN_SCAN_TOTAL,
+            };
+
+            debug!(%partition_id, "Running orphan scan");
+
+            metrics::counter!(SNAPSHOT_ORPHAN_SCAN_TOTAL).increment(1);
+
+            match self
+                .find_orphaned_files(
+                    partition_id,
+                    &retained_snapshots,
+                    ORPHAN_MIN_AGE,
+                    &referenced_sst_keys,
+                )
+                .await
+            {
+                Ok(orphans) if !orphans.ssts.is_empty() || !orphans.snapshots.is_empty() => {
+                    let (deleted_ssts, deleted_dirs) = self
+                        .cleanup_orphaned_files(partition_id, orphans, lease_guard)
+                        .await;
+                    metrics::counter!(SNAPSHOT_ORPHAN_FILES_DELETED)
+                        .increment((deleted_ssts + deleted_dirs) as u64);
+                }
+                Ok(_) => {
+                    debug!(%partition_id, "No orphaned files found during scan");
+                }
+                Err(err) => {
+                    warn!(%partition_id, %err, "Failed to scan for orphaned files");
+                    metrics::counter!(SNAPSHOT_ORPHAN_SCAN_FAILED).increment(1);
+                }
+            }
         }
 
         Ok(())
@@ -977,12 +1047,16 @@ impl SnapshotRepository {
     }
 
     /// Best-effort deletion of snapshot files. Errors are logged but not propagated.
-    #[instrument(level = "warn", skip(self), fields(%partition_id, snapshot_id = %snapshot_ref.snapshot_id))]
+    #[instrument(
+        level = "warn",
+        skip(self, referenced_sst_keys),
+        fields(%partition_id, snapshot_id = %snapshot_ref.snapshot_id)
+    )]
     async fn delete_snapshot_files(
         &self,
         partition_id: PartitionId,
         snapshot_ref: &SnapshotReference,
-        retained_snapshots: &[SnapshotReference],
+        referenced_sst_keys: &HashSet<ObjectPath>,
     ) {
         let metadata_path = self
             .prefix
@@ -1018,73 +1092,15 @@ impl SnapshotRepository {
             }
         };
 
-        // Build set of SST keys that are still referenced by retained snapshots
-        let mut referenced_sst_keys = HashSet::new();
-        for retained_ref in retained_snapshots {
-            let retained_metadata_path = self
-                .prefix
-                .clone()
-                .join(partition_id.to_string())
-                .join(retained_ref.path.as_str())
-                .join("metadata.json");
-
-            if let Ok(data) = self.object_store.get(&retained_metadata_path).await
-                && let Ok(bytes) = data.bytes().await
-                && let Ok(retained_metadata) =
-                    serde_json::from_slice::<PartitionSnapshotMetadata>(&bytes)
-            {
-                for file in &retained_metadata.files {
-                    let filename = strip_leading_slash(&file.name);
-                    let sst_key =
-                        if let Some(relative_key) = retained_metadata.file_keys.get(&file.name) {
-                            let parts: Vec<&str> = relative_key.split('/').collect();
-                            if parts.len() == 2 {
-                                self.prefix
-                                    .clone()
-                                    .join(partition_id.to_string())
-                                    .join(parts[0])
-                                    .join(parts[1])
-                            } else {
-                                self.prefix
-                                    .clone()
-                                    .join(partition_id.to_string())
-                                    .join(relative_key.as_str())
-                            }
-                        } else {
-                            self.prefix
-                                .clone()
-                                .join(partition_id.to_string())
-                                .join(retained_ref.path.as_str())
-                                .join(filename)
-                        };
-                    referenced_sst_keys.insert(sst_key);
-                }
-            }
-        }
-
         let mut any_failed = false;
         for file in &metadata.files {
             let filename = strip_leading_slash(&file.name);
-            let path = if let Some(relative_key) = metadata.file_keys.get(&file.name) {
-                // Incremental snapshot: SST is in shared ssts/ directory
-                // Format: "ssts/{hash}.sst" (content-addressed) or legacy "ssts/{node_id}_{filename}"
-                let parts: Vec<&str> = relative_key.split('/').collect();
-                if parts.len() == 2 {
-                    self.prefix
-                        .clone()
-                        .join(partition_id.to_string())
-                        .join(parts[0])
-                        .join(parts[1])
-                } else {
-                    self.prefix
-                        .clone()
-                        .join(partition_id.to_string())
-                        .join(relative_key.as_str())
-                }
-            } else {
-                // Legacy full snapshot: SST is in snapshot-specific directory
-                self.snapshot_file_path(&metadata, filename)
-            };
+            let path = self.resolve_file_path(
+                partition_id,
+                metadata.file_keys.get(&file.name).map(|s| s.as_str()),
+                &snapshot_ref.path,
+                filename,
+            );
 
             if referenced_sst_keys.contains(&path) {
                 debug!(%path, "Skipping deletion of SST file still referenced by retained snapshots");
@@ -1259,39 +1275,15 @@ impl SnapshotRepository {
         for file in &mut snapshot_metadata.files {
             let filename = strip_leading_slash(&file.name);
             let expected_size = file.size;
-            let key = if let Some(relative_key) = snapshot_metadata.file_keys.get(&file.name) {
-                // Incremental snapshot: parse the relative key and build the object key.
-                // Expected format is exactly two segments: "ssts/{hash}.sst".
-                let parts: Vec<&str> = relative_key.split('/').collect();
-                if parts.len() == 2 {
-                    self.prefix
-                        .clone()
-                        .join(partition_id.to_string())
-                        .join(parts[0])
-                        .join(parts[1])
-                } else {
-                    // Unexpected key shape - join as opaque path and warn. Future writers
-                    // that produce a different layout would need a corresponding download
-                    // path; getting here indicates either metadata corruption or a partial
-                    // upgrade from a future version of the snapshot format.
-                    warn!(
-                        sst = %file.name,
-                        relative_key = %relative_key,
-                        "Unexpected file_keys entry shape; treating as opaque path"
-                    );
-                    self.prefix
-                        .clone()
-                        .join(partition_id.to_string())
-                        .join(relative_key.as_str())
-                }
-            } else {
-                // Full/legacy snapshot: use snapshot-specific path
-                self.prefix
-                    .clone()
-                    .join(partition_id.to_string())
-                    .join(snapshot_ref.path.as_str())
-                    .join(filename)
-            };
+            let key = self.resolve_file_path(
+                partition_id,
+                snapshot_metadata
+                    .file_keys
+                    .get(&file.name)
+                    .map(|s| s.as_str()),
+                &snapshot_ref.path,
+                filename,
+            );
             let local_path = snapshot_dir.path().join(filename);
             let concurrency_limiter = Arc::clone(&concurrency_limiter);
             let object_store = Arc::clone(&self.object_store);
@@ -1467,6 +1459,331 @@ impl SnapshotRepository {
         filename: &str,
     ) -> ObjectPath {
         self.base_prefix(snapshot_metadata).join(filename)
+    }
+
+    /// Resolves a file reference to its full object path.
+    ///
+    /// Handles two storage formats:
+    /// - Incremental snapshots: `relative_key` contains "ssts/{hash}.sst" (content-addressed)
+    /// - Legacy full snapshots: file is stored at `{snapshot_path}/{filename}`
+    fn resolve_file_path(
+        &self,
+        partition_id: PartitionId,
+        relative_key: Option<&str>,
+        snapshot_path: &str,
+        filename: &str,
+    ) -> ObjectPath {
+        if let Some(key) = relative_key {
+            // Incremental snapshot: SST is in shared ssts/ directory.
+            // Format: "ssts/{hash}.sst" (two segments). Any other shape is treated as opaque
+            // and joined as-is for forward compatibility, but the upload path only produces
+            // the two-segment form.
+            let parts: Vec<&str> = key.split('/').collect();
+            if parts.len() == 2 {
+                self.prefix
+                    .clone()
+                    .join(partition_id.to_string())
+                    .join(parts[0])
+                    .join(parts[1])
+            } else {
+                warn!(
+                    %filename,
+                    relative_key = %key,
+                    "Unexpected file_keys entry shape; treating as opaque path"
+                );
+                self.prefix.clone().join(partition_id.to_string()).join(key)
+            }
+        } else {
+            // Legacy full snapshot: SST is in snapshot-specific directory
+            self.prefix
+                .clone()
+                .join(partition_id.to_string())
+                .join(snapshot_path)
+                .join(filename)
+        }
+    }
+
+    /// Scans the repository to enumerate files for orphan detection.
+    ///
+    /// # Scanned patterns (IMPORTANT: keep in sync with bucket layout docs)
+    ///
+    /// Only these specific patterns are considered orphan candidates:
+    ///
+    /// 1. **SST files**: `{partition_id}/ssts/*.sst`
+    ///    - Match: `path.contains("/ssts/") && path.ends_with(".sst")`
+    ///    - Used by incremental snapshots for content-addressed SST storage
+    ///
+    /// 2. **Snapshot directories**: `{partition_id}/lsn_*-*/`
+    ///    - Match: path segment `starts_with("lsn_") && contains('-')`
+    ///    - Standard snapshot directory format: `lsn_{padded_lsn}-{snapshot_id}`
+    ///
+    /// # Explicitly NOT scanned (safe for future use)
+    ///
+    /// - `{partition_id}/latest.json` - the pointer file
+    /// - `{partition_id}/*.json` - any other root-level JSON files
+    /// - `{partition_id}/{other_prefix}_*/` - directories not starting with `lsn_`
+    /// - `{partition_id}/{other_dir}/` - e.g., `indices/`, `metadata/`, etc.
+    ///
+    /// When adding new storage patterns, avoid `ssts/` and `lsn_*` prefixes to
+    /// ensure orphan cleanup doesn't interfere.
+    async fn scan_partition_files(
+        &self,
+        partition_id: PartitionId,
+    ) -> anyhow::Result<SnapshotInventory> {
+        let prefix = self.partition_snapshots_prefix(partition_id);
+        let stream = self.object_store.list(Some(&prefix));
+
+        let mut scan = SnapshotInventory::default();
+
+        futures::pin_mut!(stream);
+        while let Some(meta) = stream.try_next().await? {
+            let path_str = meta.location.as_ref();
+
+            // SST files in ssts/ directory (incremental snapshot storage)
+            if path_str.contains("/ssts/") && path_str.ends_with(".sst") {
+                scan.shared_sst_files
+                    .insert(meta.location, meta.last_modified);
+                continue;
+            }
+
+            // Snapshot directories matching lsn_*-* pattern
+            if let Some(dir_name) = Self::extract_snapshot_prefix_from_path(path_str) {
+                let is_metadata = path_str.ends_with("/metadata.json");
+                scan.snapshot_prefixes
+                    .entry(dir_name)
+                    .and_modify(|(has_meta, newest)| {
+                        *has_meta = *has_meta || is_metadata;
+                        // Track the newest file to protect in-flight uploads
+                        if meta.last_modified > *newest {
+                            *newest = meta.last_modified;
+                        }
+                    })
+                    .or_insert((is_metadata, meta.last_modified));
+            }
+        }
+
+        trace!(
+            %partition_id,
+            sst_count = scan.shared_sst_files.len(),
+            dir_count = scan.snapshot_prefixes.len(),
+            "Scanned partition files"
+        );
+
+        Ok(scan)
+    }
+
+    fn extract_snapshot_prefix_from_path(path: &str) -> Option<String> {
+        // Path format: {prefix}/{partition_id}/{lsn}_{snap_id}/...
+        // We want to extract the {lsn}_{snap_id} part
+        for segment in path.split('/') {
+            // Snapshot directories start with "lsn_" (padded format)
+            // Legacy format may use different patterns, but lsn_ is the current standard
+            if segment.starts_with("lsn_") && segment.contains('-') {
+                return Some(segment.to_string());
+            }
+        }
+        None
+    }
+
+    /// Builds the set of SST keys referenced by the given retained snapshots.
+    ///
+    /// Returns an error if any retained snapshot's metadata cannot be read or parsed
+    /// to prevent orphan cleanup from deleting SSTs that are still referenced.
+    async fn build_referenced_sst_keys(
+        &self,
+        partition_id: PartitionId,
+        retained_snapshots: &[SnapshotReference],
+    ) -> anyhow::Result<HashSet<ObjectPath>> {
+        let mut referenced_sst_keys = HashSet::new();
+
+        for retained_ref in retained_snapshots {
+            let retained_metadata_path = self
+                .prefix
+                .clone()
+                .join(partition_id.to_string())
+                .join(retained_ref.path.as_str())
+                .join("metadata.json");
+
+            let data = match self.object_store.get(&retained_metadata_path).await {
+                Ok(data) => data,
+                Err(object_store::Error::NotFound { .. }) => {
+                    // Metadata missing - could be race condition or transient failure.
+                    // Bail to prevent potential data loss as we can't know which SSTs are retained.
+                    warn!(
+                        path = %retained_ref.path,
+                        "Retained snapshot metadata not found - aborting to prevent data loss"
+                    );
+                    return Err(anyhow::anyhow!(
+                        "Cannot verify retained snapshot {}: metadata not found",
+                        retained_ref.path
+                    ));
+                }
+                Err(err) => {
+                    return Err(anyhow::anyhow!(
+                        "Failed to read metadata for retained snapshot {}: {}",
+                        retained_ref.path,
+                        err
+                    ));
+                }
+            };
+
+            let bytes = data.bytes().await.context(format!(
+                "Failed to read metadata bytes for retained snapshot {}",
+                retained_ref.path
+            ))?;
+
+            let retained_metadata: PartitionSnapshotMetadata = serde_json::from_slice(&bytes)
+                .context(format!(
+                    "Failed to parse metadata for retained snapshot {}",
+                    retained_ref.path
+                ))?;
+
+            for file in &retained_metadata.files {
+                let filename = strip_leading_slash(&file.name);
+                let sst_key = self.resolve_file_path(
+                    partition_id,
+                    retained_metadata
+                        .file_keys
+                        .get(&file.name)
+                        .map(|s| s.as_str()),
+                    &retained_ref.path,
+                    filename,
+                );
+                referenced_sst_keys.insert(sst_key);
+            }
+        }
+
+        Ok(referenced_sst_keys)
+    }
+
+    /// Finds orphaned files in the repository by scanning all files and comparing
+    /// against the retained snapshots list.
+    ///
+    /// Files are only considered orphaned if they are older than `min_age` to avoid
+    /// deleting files from in-flight uploads or CRR replication.
+    async fn find_orphaned_files(
+        &self,
+        partition_id: PartitionId,
+        retained_snapshots: &[SnapshotReference],
+        min_age: Duration,
+        referenced_ssts: &HashSet<ObjectPath>,
+    ) -> anyhow::Result<OrphanedPaths> {
+        let scan = self.scan_partition_files(partition_id).await?;
+        let now = Utc::now();
+        let age_threshold = now - chrono::Duration::from_std(min_age)?;
+
+        let retained_prefixes: HashSet<&str> =
+            retained_snapshots.iter().map(|r| r.path.as_str()).collect();
+
+        let orphaned_ssts: Vec<ObjectPath> = scan
+            .shared_sst_files
+            .into_iter()
+            .filter(|(path, modified)| !referenced_ssts.contains(path) && *modified < age_threshold)
+            .map(|(path, _)| path)
+            .collect();
+
+        let orphaned_snapshots: Vec<String> = scan
+            .snapshot_prefixes
+            .into_iter()
+            .filter(|(prefix, (_has_metadata, newest_modified))| {
+                !retained_prefixes.contains(prefix.as_str()) && *newest_modified < age_threshold
+            })
+            .map(|(prefix, _)| prefix)
+            .collect();
+
+        if !orphaned_ssts.is_empty() || !orphaned_snapshots.is_empty() {
+            info!(
+                %partition_id,
+                orphaned_sst_count = orphaned_ssts.len(),
+                orphaned_snapshot_count = orphaned_snapshots.len(),
+                "Found orphaned files during repository scan"
+            );
+        }
+
+        Ok(OrphanedPaths {
+            ssts: orphaned_ssts,
+            snapshots: orphaned_snapshots,
+        })
+    }
+
+    /// Cleans up orphaned files discovered during a repository scan.
+    /// Should be called with an active lease to prevent races.
+    async fn cleanup_orphaned_files(
+        &self,
+        partition_id: PartitionId,
+        orphans: OrphanedPaths,
+        lease_guard: &Arc<SnapshotLeaseGuard>,
+    ) -> (usize, usize) {
+        let mut deleted_ssts = 0;
+        let mut deleted_snapshots = 0;
+
+        for sst_path in orphans.ssts {
+            if !lease_guard.is_valid() {
+                debug!(%partition_id, "Lease expired during orphan cleanup, aborting");
+                break;
+            }
+
+            if let Err(err) = self.object_store.delete(&sst_path).await {
+                if !matches!(err, object_store::Error::NotFound { .. }) {
+                    warn!(%sst_path, %err, "Failed to delete orphaned SST");
+                }
+            } else {
+                debug!(%sst_path, "Deleted orphaned SST");
+                deleted_ssts += 1;
+            }
+        }
+
+        for snapshot_prefix in orphans.snapshots {
+            if !lease_guard.is_valid() {
+                debug!(%partition_id, "Lease expired during orphan cleanup, aborting");
+                break;
+            }
+
+            let snapshot_path = self
+                .prefix
+                .clone()
+                .join(partition_id.to_string())
+                .join(snapshot_prefix.as_str());
+
+            let stream = self.object_store.list(Some(&snapshot_path));
+            futures::pin_mut!(stream);
+
+            let mut prefix_deleted = true;
+            loop {
+                match stream.try_next().await {
+                    Ok(Some(meta)) => {
+                        if let Err(err) = self.object_store.delete(&meta.location).await
+                            && !matches!(err, object_store::Error::NotFound { .. })
+                        {
+                            warn!(path = %meta.location, %err, "Failed to delete file in orphaned snapshot prefix");
+                            prefix_deleted = false;
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(err) => {
+                        warn!(%snapshot_prefix, %err, "Failed to list files in orphaned snapshot prefix");
+                        prefix_deleted = false;
+                        break;
+                    }
+                }
+            }
+
+            if prefix_deleted {
+                debug!(%snapshot_prefix, "Deleted orphaned snapshot directory");
+                deleted_snapshots += 1;
+            }
+        }
+
+        if deleted_ssts > 0 || deleted_snapshots > 0 {
+            info!(
+                %partition_id,
+                deleted_ssts,
+                deleted_snapshots,
+                "Cleaned up orphaned files"
+            );
+        }
+
+        (deleted_ssts, deleted_snapshots)
     }
 }
 
@@ -2419,6 +2736,109 @@ mod tests {
             status.latest_snapshot_created_at,
             MillisSinceEpoch::UNIX_EPOCH + Duration::from_secs(2),
             "reports the latest retained snapshot's created-at time"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn extract_snapshot_prefix_from_path() {
+        assert_eq!(
+            SnapshotRepository::extract_snapshot_prefix_from_path(
+                "prefix/0/lsn_00000000000000001234-abc123/metadata.json"
+            ),
+            Some("lsn_00000000000000001234-abc123".to_string())
+        );
+        assert_eq!(
+            SnapshotRepository::extract_snapshot_prefix_from_path(
+                "0/lsn_00000000000000000100-snap1/data.sst"
+            ),
+            Some("lsn_00000000000000000100-snap1".to_string())
+        );
+
+        assert_eq!(
+            SnapshotRepository::extract_snapshot_prefix_from_path("0/ssts/abc123.sst"),
+            None
+        );
+
+        assert_eq!(
+            SnapshotRepository::extract_snapshot_prefix_from_path("0/latest.json"),
+            None
+        );
+
+        assert_eq!(
+            SnapshotRepository::extract_snapshot_prefix_from_path("random/path/file.txt"),
+            None
+        );
+    }
+
+    #[restate_core::test]
+    async fn scan_partition_files() -> anyhow::Result<()> {
+        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+
+        let snapshots_destination = TempDir::new()?;
+        let destination_url = Url::from_file_path(snapshots_destination.path())
+            .unwrap()
+            .to_string();
+
+        let opts = SnapshotsOptions {
+            destination: Some(destination_url.clone()),
+            ..SnapshotsOptions::default()
+        };
+        let repository = SnapshotRepository::new_from_config_with_stub_leases(
+            &opts,
+            TempDir::new().unwrap().keep(),
+        )
+        .await?
+        .unwrap();
+
+        let partition_id = PartitionId::MIN;
+
+        let ssts_path = snapshots_destination
+            .path()
+            .join(partition_id.to_string())
+            .join("ssts");
+        tokio::fs::create_dir_all(&ssts_path).await?;
+        tokio::fs::write(ssts_path.join("abc123.sst"), b"sst1").await?;
+        tokio::fs::write(ssts_path.join("def456.sst"), b"sst2").await?;
+
+        let snapshot_prefix = snapshots_destination
+            .path()
+            .join(partition_id.to_string())
+            .join("lsn_00000000000000000100-snap1");
+        tokio::fs::create_dir_all(&snapshot_prefix).await?;
+        tokio::fs::write(snapshot_prefix.join("metadata.json"), b"{}").await?;
+        tokio::fs::write(snapshot_prefix.join("data.sst"), b"data").await?;
+
+        let incomplete_snapshot_path = snapshots_destination
+            .path()
+            .join(partition_id.to_string())
+            .join("lsn_00000000000000000200-snap2");
+        tokio::fs::create_dir_all(&incomplete_snapshot_path).await?;
+        tokio::fs::write(incomplete_snapshot_path.join("data.sst"), b"data").await?;
+
+        // Scan the partition
+        let scan = repository.scan_partition_files(partition_id).await?;
+
+        assert_eq!(scan.shared_sst_files.len(), 2, "should find 2 SST files");
+        assert_eq!(
+            scan.snapshot_prefixes.len(),
+            2,
+            "should find 2 snapshot directories"
+        );
+        assert_eq!(
+            scan.snapshot_prefixes
+                .get("lsn_00000000000000000100-snap1")
+                .map(|(has_meta, _)| *has_meta),
+            Some(true),
+            "snap1 should have metadata"
+        );
+        assert_eq!(
+            scan.snapshot_prefixes
+                .get("lsn_00000000000000000200-snap2")
+                .map(|(has_meta, _)| *has_meta),
+            Some(false),
+            "snap2 should not have metadata"
         );
 
         Ok(())

--- a/crates/partition-store/src/snapshots/repository.rs
+++ b/crates/partition-store/src/snapshots/repository.rs
@@ -2163,4 +2163,30 @@ mod tests {
 
         Ok(())
     }
+
+    #[restate_core::test]
+    async fn acquire_lease_read_only_repository_returns_unavailable() -> anyhow::Result<()> {
+        use crate::snapshots::LeaseError;
+        let snapshots_destination = TempDir::new()?;
+        let destination = Url::from_file_path(snapshots_destination.path())
+            .unwrap()
+            .to_string();
+
+        let opts = SnapshotsOptions {
+            destination: Some(destination),
+            ..SnapshotsOptions::default()
+        };
+
+        let repository =
+            SnapshotRepository::new_read_only_from_config(&opts, TempDir::new().unwrap().keep())
+                .await?
+                .unwrap();
+
+        let result = repository.acquire_lease(PartitionId::MIN).await;
+        assert!(
+            matches!(result, Err(LeaseError::Unavailable)),
+            "expected Err(LeaseError::Unavailable) from a read-only repository"
+        );
+        Ok(())
+    }
 }

--- a/crates/partition-store/src/snapshots/repository.rs
+++ b/crates/partition-store/src/snapshots/repository.rs
@@ -31,6 +31,7 @@ use url::Url;
 
 use restate_clock::WallClock;
 use restate_core::Metadata;
+use restate_metadata_server::MetadataStoreClient;
 use restate_object_store_util::create_object_store_client;
 use restate_types::config::SnapshotsOptions;
 use restate_types::identifiers::{PartitionId, SnapshotId};
@@ -38,9 +39,32 @@ use restate_types::logs::{LogId, Lsn};
 use restate_types::nodes_config::ClusterFingerprint;
 use restate_types::time::MillisSinceEpoch;
 
+#[cfg(any(test, feature = "test-util"))]
+use super::leases::NoOpLeaseManager;
+use super::leases::{LeaseError, SnapshotLeaseGuard, SnapshotLeaseManager};
 use super::{
     LocalPartitionSnapshot, PartitionSnapshotMetadata, SnapshotDir, SnapshotFormatVersion,
 };
+
+#[derive(Clone)]
+pub enum LeaseProvider {
+    Real(SnapshotLeaseManager),
+    #[cfg(any(test, feature = "test-util"))]
+    NoOp(NoOpLeaseManager),
+}
+
+impl LeaseProvider {
+    pub async fn acquire(
+        &self,
+        partition_id: PartitionId,
+    ) -> Result<SnapshotLeaseGuard, super::leases::LeaseError> {
+        match self {
+            Self::Real(m) => m.acquire(partition_id).await,
+            #[cfg(any(test, feature = "test-util"))]
+            Self::NoOp(m) => m.acquire(partition_id).await,
+        }
+    }
+}
 
 /// Provides read and write access to the long-term partition snapshot storage destination.
 ///
@@ -63,6 +87,7 @@ pub struct SnapshotRepository {
     prefix: ObjectPath,
     staging_dir: PathBuf,
     num_retained: std::num::NonZeroU8,
+    lease_provider: Option<LeaseProvider>,
     #[cfg(any(test, feature = "test-util"))]
     enable_cleanup: bool,
 }
@@ -302,10 +327,27 @@ impl UniqueSnapshotKey {
 }
 
 impl SnapshotRepository {
-    /// Creates an instance of the repository if a snapshots destination is configured.
+    /// Creates a writable repository with a default metadata-backed lease manager
     pub async fn new_from_config(
         snapshots_options: &SnapshotsOptions,
         staging_dir: PathBuf,
+        metadata_store_client: MetadataStoreClient,
+    ) -> anyhow::Result<Option<SnapshotRepository>> {
+        Self::new_internal(snapshots_options, staging_dir, Some(metadata_store_client)).await
+    }
+
+    /// Creates a repository without a lease manager; can not be used to upload snapshots
+    pub async fn new_read_only_from_config(
+        snapshots_options: &SnapshotsOptions,
+        staging_dir: PathBuf,
+    ) -> anyhow::Result<Option<SnapshotRepository>> {
+        Self::new_internal(snapshots_options, staging_dir, None).await
+    }
+
+    async fn new_internal(
+        snapshots_options: &SnapshotsOptions,
+        staging_dir: PathBuf,
+        metadata_store_client: Option<MetadataStoreClient>,
     ) -> anyhow::Result<Option<SnapshotRepository>> {
         let mut destination = if let Some(ref destination) = snapshots_options.destination {
             Url::parse(destination).context("Failed parsing snapshot repository URL")?
@@ -332,6 +374,9 @@ impl SnapshotRepository {
         // See https://github.com/restatedev/restate/issues/4838.
         Self::sweep_staging_dir(&staging_dir).await;
 
+        let lease_provider = metadata_store_client
+            .map(|client| LeaseProvider::Real(SnapshotLeaseManager::new(client)));
+
         Ok(Some(SnapshotRepository {
             object_store,
             destination,
@@ -340,7 +385,62 @@ impl SnapshotRepository {
             num_retained: snapshots_options.num_retained,
             #[cfg(any(test, feature = "test-util"))]
             enable_cleanup: snapshots_options.enable_cleanup,
+            lease_provider,
         }))
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub async fn new_from_config_with_stub_leases(
+        snapshots_options: &SnapshotsOptions,
+        staging_dir: PathBuf,
+    ) -> anyhow::Result<Option<SnapshotRepository>> {
+        let mut destination = if let Some(ref destination) = snapshots_options.destination {
+            Url::parse(destination).context("Failed parsing snapshot repository URL")?
+        } else {
+            return Ok(None);
+        };
+        destination
+            .query()
+            .inspect(|params| info!("Snapshot destination parameters ignored: {params}"));
+        destination.set_query(None);
+
+        let prefix = destination.path().to_string();
+        let object_store = create_object_store_client(
+            destination.clone(),
+            &snapshots_options.object_store,
+            &snapshots_options.object_store_retry_policy,
+        )
+        .await?;
+
+        Ok(Some(SnapshotRepository {
+            object_store,
+            destination,
+            prefix: ObjectPath::from(prefix),
+            staging_dir,
+            num_retained: snapshots_options.num_retained,
+            enable_cleanup: snapshots_options.enable_cleanup,
+            lease_provider: Some(LeaseProvider::NoOp(NoOpLeaseManager::new())),
+        }))
+    }
+
+    /// Acquire a lease for snapshot operations on this partition
+    ///
+    /// On success, returns a guard with background renewal already started. The guard should be
+    /// held for the duration of snapshot operations and passed to `put`.
+    ///
+    /// Returns `LeaseError::Unavailable` if the repository was created without a lease provider.
+    pub async fn acquire_lease(
+        &self,
+        partition_id: PartitionId,
+    ) -> Result<Arc<SnapshotLeaseGuard>, LeaseError> {
+        let provider = self
+            .lease_provider
+            .as_ref()
+            .ok_or(LeaseError::Unavailable)?;
+        let guard = provider.acquire(partition_id).await?;
+        let guard = Arc::new(guard);
+        guard.start_renewal_task()?;
+        Ok(guard)
     }
 
     /// Removes any entries left over in the snapshot staging directory by a previous run.
@@ -367,10 +467,11 @@ impl SnapshotRepository {
     /// Write a partition snapshot to the snapshot repository
     ///
     /// Returns the latest snapshot status on successful upload. Depending on retention settings,
-    /// the archived LSN may be earlier than that of the snapshot which was just uploaded.
-    /// Uploads a local snapshot to the repository. Takes ownership of the local snapshot
-    /// directory via [`SnapshotDir`] and removes it once the upload completes (success or
-    /// failure), so callers cannot leak it.
+    /// the archived LSN may be earlier than that of the snapshot which was just uploaded. This
+    /// operation requires a valid lease obtained by calling `acquire_lease`.
+    ///
+    /// Takes ownership of the local snapshot directory via [`SnapshotDir`] and removes it once
+    /// the upload completes (success or failure), so callers cannot leak it.
     #[instrument(
         level = "error",
         err,
@@ -381,6 +482,7 @@ impl SnapshotRepository {
         &self,
         snapshot: &PartitionSnapshotMetadata,
         local_snapshot: SnapshotDir,
+        lease_guard: Arc<SnapshotLeaseGuard>,
     ) -> anyhow::Result<PartitionSnapshotStatus> {
         use crate::metric_definitions::{
             SNAPSHOT_UPLOAD_DURATION, SNAPSHOT_UPLOAD_FAILED, SNAPSHOT_UPLOAD_SUCCESS,
@@ -390,7 +492,7 @@ impl SnapshotRepository {
 
         let start = tokio::time::Instant::now();
         let put_result = self
-            .put_snapshot_inner(snapshot, local_snapshot.path())
+            .put_snapshot_inner(snapshot, local_snapshot.path(), lease_guard)
             .await;
 
         // We own the local snapshot directory; remove it asynchronously (it may hold large SST
@@ -426,6 +528,7 @@ impl SnapshotRepository {
         &self,
         snapshot: &PartitionSnapshotMetadata,
         local_snapshot_path: &Path,
+        lease_guard: Arc<SnapshotLeaseGuard>,
     ) -> Result<PartitionSnapshotStatus, PutSnapshotError> {
         let snapshot_prefix = self.base_prefix(snapshot);
         debug!(
@@ -439,39 +542,10 @@ impl SnapshotRepository {
             .await?;
 
         let latest_path = self.latest_snapshot_pointer_path(snapshot.partition_id);
-
         let maybe_stored = self
             .get_latest_snapshot_metadata_for_update(&latest_path)
             .await
             .map_err(|e| PutSnapshotError::from(e, progress.clone()))?;
-
-        if let Some((latest_stored, _)) = &maybe_stored
-            && latest_stored.min_applied_lsn >= snapshot.min_applied_lsn
-        {
-            info!(
-                repository_latest_lsn = ?latest_stored.min_applied_lsn,
-                new_snapshot_lsn = ?snapshot.min_applied_lsn,
-                "The newly uploaded snapshot is no newer than the already-stored latest snapshot, \
-                will not update latest pointer"
-            );
-
-            let snapshot_ref = SnapshotReference::from_metadata(snapshot);
-            let partition_id = snapshot.partition_id;
-            let repository = self.clone();
-            let _ = restate_core::TaskCenter::spawn_unmanaged_child(
-                restate_core::TaskKind::Disposable,
-                "snapshot-cleanup-superseded",
-                async move {
-                    repository
-                        .delete_snapshot_files(partition_id, &snapshot_ref)
-                        .await;
-                    Ok::<(), anyhow::Error>(())
-                },
-            );
-
-            return PartitionSnapshotStatus::try_from(latest_stored)
-                .map_err(|e| PutSnapshotError::from(e, progress.clone()));
-        }
 
         let (new_latest, evicted_snapshots) = self
             .build_latest_v2(snapshot, maybe_stored.as_ref().map(|(l, _)| l))
@@ -482,9 +556,7 @@ impl SnapshotRepository {
                 .map_err(|e| PutSnapshotError::from(e, progress.clone()))?,
         );
 
-        let conditions =
-            self.conditional_put_options(maybe_stored.as_ref().map(|(_, version)| version));
-
+        let conditions = self.conditional_put_options(maybe_stored.map(|(_, v)| v));
         let put_result = self
             .object_store
             .put_opts(&latest_path, latest_payload, conditions)
@@ -503,7 +575,7 @@ impl SnapshotRepository {
         let enable_cleanup = self.enable_cleanup;
 
         if !evicted_snapshots.is_empty() && enable_cleanup {
-            self.spawn_cleanup_task(snapshot.partition_id, evicted_snapshots);
+            self.spawn_cleanup_task(snapshot.partition_id, evicted_snapshots, lease_guard);
         }
 
         PartitionSnapshotStatus::try_from(&new_latest)
@@ -594,10 +666,28 @@ impl SnapshotRepository {
         Ok((latest, evicted_snapshots))
     }
 
+    fn conditional_put_options(&self, version: Option<UpdateVersion>) -> PutOptions {
+        // The object_store file provider supports create-if-not-exists but not update-version on
+        // put. The file:// protocol is only be enabled in test because of this.
+        let use_conditional_update = !matches!(self.destination.scheme(), "file");
+
+        let mode = match (use_conditional_update, version) {
+            (true, Some(v)) if v.e_tag.is_some() || v.version.is_some() => PutMode::Update(v),
+            (false, _) => PutMode::Overwrite,
+            _ => PutMode::Create,
+        };
+
+        PutOptions {
+            mode,
+            ..PutOptions::default()
+        }
+    }
+
     fn spawn_cleanup_task(
         &self,
         partition_id: PartitionId,
         cleanup_snapshots: Vec<SnapshotReference>,
+        lease_guard: Arc<SnapshotLeaseGuard>,
     ) {
         let repository = self.clone();
         let task_name = format!("snapshot-cleanup-{}", partition_id);
@@ -607,23 +697,72 @@ impl SnapshotRepository {
             task_name,
             async move {
                 repository
-                    .cleanup_pending_deletions(partition_id, cleanup_snapshots)
+                    .cleanup_evicted_snapshots(partition_id, cleanup_snapshots, lease_guard)
                     .await;
                 Ok::<(), anyhow::Error>(())
             },
         );
     }
 
-    async fn cleanup_pending_deletions(
+    #[instrument(level = "debug", skip_all, fields(%partition_id))]
+    async fn cleanup_evicted_snapshots(
         &self,
         partition_id: PartitionId,
-        cleanup_snapshots: Vec<SnapshotReference>,
+        evicted_snapshots: Vec<SnapshotReference>,
+        lease_guard: Arc<SnapshotLeaseGuard>,
     ) {
-        for snapshot_ref in &cleanup_snapshots {
+        if !lease_guard.is_valid() {
+            debug!("Lease expired before cleanup, aborting");
+            return;
+        }
+
+        let result = lease_guard
+            .run_under_lease(self.cleanup_evicted_snapshots_inner(
+                partition_id,
+                evicted_snapshots,
+                &lease_guard,
+            ))
+            .await;
+
+        match result {
+            Some(Ok(())) => {
+                debug!("Cleanup completed successfully");
+            }
+            Some(Err(e)) => {
+                debug!(error = %e, "Cleanup failed");
+            }
+            None => {
+                warn!("Cleanup aborted due to lease loss");
+            }
+        }
+        // lease_guard dropped
+    }
+
+    async fn cleanup_evicted_snapshots_inner(
+        &self,
+        partition_id: PartitionId,
+        evicted_snapshots: Vec<SnapshotReference>,
+        lease_guard: &Arc<SnapshotLeaseGuard>,
+    ) -> anyhow::Result<()> {
+        if !lease_guard.is_valid() {
+            anyhow::bail!("Lease expired before cleanup could start");
+        }
+
+        for snapshot_ref in &evicted_snapshots {
+            if !lease_guard.is_valid() {
+                debug!(
+                    %partition_id,
+                    "Lease approaching deadline, aborting remaining cleanup"
+                );
+                break;
+            }
+
             // Errors are logged inside delete_snapshot_files; if cleanup fails,
             // these snapshots become orphans to be cleaned by future scan-sweep.
             self.delete_snapshot_files(partition_id, snapshot_ref).await;
         }
+
+        Ok(())
     }
 
     /// Best-effort deletion of snapshot files. Errors are logged but not propagated.
@@ -1012,25 +1151,6 @@ impl SnapshotRepository {
     ) -> ObjectPath {
         self.base_prefix(snapshot_metadata).join(filename)
     }
-
-    fn conditional_put_options(&self, version: Option<&UpdateVersion>) -> PutOptions {
-        // The object_store file provider supports create-if-not-exists but not update-version on
-        // put. The file:// protocol is only be enabled in test because of this.
-        let use_conditional_update = !matches!(self.destination.scheme(), "file");
-
-        let mode = match (use_conditional_update, version) {
-            (true, Some(v)) if v.e_tag.is_some() || v.version.is_some() => {
-                PutMode::Update(v.clone())
-            }
-            (false, _) => PutMode::Overwrite,
-            _ => PutMode::Create,
-        };
-
-        PutOptions {
-            mode,
-            ..PutOptions::default()
-        }
-    }
 }
 
 // Strip the leading "/" character from RocksDB LiveFile names
@@ -1142,6 +1262,7 @@ async fn abort_tasks<T: 'static>(mut join_set: JoinSet<T>) {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+    use std::sync::Arc;
     use std::time::{Duration, SystemTime};
 
     use ahash::HashSet;
@@ -1164,6 +1285,7 @@ mod tests {
     use restate_types::retries::RetryPolicy;
     use restate_types::sharding::KeyRange;
 
+    use crate::snapshots::SnapshotLeaseGuard;
     use crate::snapshots::repository::{LatestSnapshotVersion, SnapshotUploadProgress};
 
     use super::{LatestSnapshot, SnapshotReference, SnapshotRepository, UniqueSnapshotKey};
@@ -1171,7 +1293,7 @@ mod tests {
 
     #[restate_core::test]
     async fn overwrite_unparsable_latest() -> anyhow::Result<()> {
-        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
 
         let snapshot_source = TempDir::new()?;
         let source_dir = snapshot_source.path().to_path_buf();
@@ -1197,9 +1319,13 @@ mod tests {
             ),
             ..SnapshotsOptions::default()
         };
-        let repository = SnapshotRepository::new_from_config(&opts, TempDir::new().unwrap().keep())
-            .await?
-            .unwrap();
+        let repository = SnapshotRepository::new_from_config(
+            &opts,
+            TempDir::new().unwrap().keep(),
+            env.metadata_store_client.clone(),
+        )
+        .await?
+        .unwrap();
 
         // Write invalid JSON to latest.json
         let latest_path = destination_dir
@@ -1213,7 +1339,11 @@ mod tests {
 
         assert!(
             repository
-                .put(&snapshot, SnapshotDir::new(source_dir))
+                .put(
+                    &snapshot,
+                    SnapshotDir::new(source_dir),
+                    Arc::new(SnapshotLeaseGuard::noop()),
+                )
                 .await
                 .is_err()
         );
@@ -1242,7 +1372,7 @@ mod tests {
     }
 
     async fn test_put_snapshot(destination: String) -> anyhow::Result<()> {
-        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
 
         let snapshot_source = TempDir::new()?;
         let source_dir = snapshot_source.path().to_path_buf();
@@ -1282,12 +1412,20 @@ mod tests {
             ..SnapshotsOptions::default()
         };
 
-        let repository = SnapshotRepository::new_from_config(&opts, TempDir::new().unwrap().keep())
-            .await?
-            .unwrap();
+        let repository = SnapshotRepository::new_from_config(
+            &opts,
+            TempDir::new().unwrap().keep(),
+            env.metadata_store_client.clone(),
+        )
+        .await?
+        .unwrap();
 
         repository
-            .put(&snapshot1, SnapshotDir::new(source_dir.clone()))
+            .put(
+                &snapshot1,
+                SnapshotDir::new(source_dir.clone()),
+                Arc::new(SnapshotLeaseGuard::noop()),
+            )
             .await?;
 
         let partition_prefix =
@@ -1333,7 +1471,11 @@ mod tests {
         snapshot2.min_applied_lsn = snapshot1.min_applied_lsn.next();
 
         repository
-            .put(&snapshot2, SnapshotDir::new(source_dir))
+            .put(
+                &snapshot2,
+                SnapshotDir::new(source_dir),
+                Arc::new(SnapshotLeaseGuard::noop()),
+            )
             .await?;
 
         let latest = object_store
@@ -1417,7 +1559,7 @@ mod tests {
 
     #[restate_core::test]
     async fn snapshot_retention_v2() -> anyhow::Result<()> {
-        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
 
         let snapshots_destination = TempDir::new()?;
         let destination = Url::from_file_path(snapshots_destination.path())
@@ -1430,9 +1572,13 @@ mod tests {
             ..SnapshotsOptions::default()
         };
 
-        let repository = SnapshotRepository::new_from_config(&opts, TempDir::new().unwrap().keep())
-            .await?
-            .unwrap();
+        let repository = SnapshotRepository::new_from_config(
+            &opts,
+            TempDir::new().unwrap().keep(),
+            env.metadata_store_client.clone(),
+        )
+        .await?
+        .unwrap();
 
         for i in 1..=4 {
             let snapshot_source = TempDir::new()?;
@@ -1451,7 +1597,11 @@ mod tests {
             snapshot.min_applied_lsn = Lsn::new(i * 1000);
 
             repository
-                .put(&snapshot, SnapshotDir::new(source_dir))
+                .put(
+                    &snapshot,
+                    SnapshotDir::new(source_dir),
+                    Arc::new(SnapshotLeaseGuard::noop()),
+                )
                 .await?;
         }
 
@@ -1480,7 +1630,7 @@ mod tests {
 
     #[restate_core::test]
     async fn get_snapshot_candidates_returns_retained_descending() -> anyhow::Result<()> {
-        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
 
         let snapshots_destination = TempDir::new()?;
         let destination = Url::from_file_path(snapshots_destination.path())
@@ -1491,9 +1641,13 @@ mod tests {
             num_retained: std::num::NonZeroU8::new(3).unwrap(),
             ..SnapshotsOptions::default()
         };
-        let repository = SnapshotRepository::new_from_config(&opts, TempDir::new().unwrap().keep())
-            .await?
-            .unwrap();
+        let repository = SnapshotRepository::new_from_config(
+            &opts,
+            TempDir::new().unwrap().keep(),
+            env.metadata_store_client.clone(),
+        )
+        .await?
+        .unwrap();
 
         // No snapshots yet -> no candidates.
         assert!(
@@ -1508,7 +1662,11 @@ mod tests {
             let (snapshot, source_dir) =
                 mock_snapshot(format!("snapshot-data-{i}").as_bytes(), Lsn::new(i * 1000)).await?;
             repository
-                .put(&snapshot, SnapshotDir::new(source_dir))
+                .put(
+                    &snapshot,
+                    SnapshotDir::new(source_dir),
+                    Arc::new(SnapshotLeaseGuard::noop()),
+                )
                 .await?;
         }
 
@@ -1527,7 +1685,7 @@ mod tests {
 
     #[restate_core::test]
     async fn download_snapshot_falls_back_to_older_when_latest_fails() -> anyhow::Result<()> {
-        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
 
         let snapshots_destination = TempDir::new()?;
         let destination = Url::from_file_path(snapshots_destination.path())
@@ -1538,9 +1696,13 @@ mod tests {
             num_retained: std::num::NonZeroU8::new(3).unwrap(),
             ..SnapshotsOptions::default()
         };
-        let repository = SnapshotRepository::new_from_config(&opts, TempDir::new().unwrap().keep())
-            .await?
-            .unwrap();
+        let repository = SnapshotRepository::new_from_config(
+            &opts,
+            TempDir::new().unwrap().keep(),
+            env.metadata_store_client.clone(),
+        )
+        .await?
+        .unwrap();
 
         // `SnapshotRepository` is cheaply cloneable and shares the underlying object store, so the
         // `Snapshots` wrapper observes snapshots we `put` through `repository` below.
@@ -1559,9 +1721,21 @@ mod tests {
 
         // Older snapshot A (LSN 2000) then latest B (LSN 3000).
         let (snapshot_a, dir_a) = mock_snapshot(b"snapshot-A", Lsn::new(2000)).await?;
-        repository.put(&snapshot_a, SnapshotDir::new(dir_a)).await?;
+        repository
+            .put(
+                &snapshot_a,
+                SnapshotDir::new(dir_a),
+                Arc::new(SnapshotLeaseGuard::noop()),
+            )
+            .await?;
         let (snapshot_b, dir_b) = mock_snapshot(b"snapshot-B", Lsn::new(3000)).await?;
-        repository.put(&snapshot_b, SnapshotDir::new(dir_b)).await?;
+        repository
+            .put(
+                &snapshot_b,
+                SnapshotDir::new(dir_b),
+                Arc::new(SnapshotLeaseGuard::noop()),
+            )
+            .await?;
 
         // Happy path: the latest snapshot is restored.
         let restored = snapshots
@@ -1614,7 +1788,7 @@ mod tests {
 
     #[restate_core::test]
     async fn v1_to_v2_migration() -> anyhow::Result<()> {
-        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
 
         let snapshots_destination = TempDir::new()?;
         let destination = Url::from_file_path(snapshots_destination.path())
@@ -1648,9 +1822,13 @@ mod tests {
             ..SnapshotsOptions::default()
         };
 
-        let repository = SnapshotRepository::new_from_config(&opts, TempDir::new().unwrap().keep())
-            .await?
-            .unwrap();
+        let repository = SnapshotRepository::new_from_config(
+            &opts,
+            TempDir::new().unwrap().keep(),
+            env.metadata_store_client.clone(),
+        )
+        .await?
+        .unwrap();
 
         let mut progress =
             SnapshotUploadProgress::with_snapshot_path(repository.base_prefix(&snapshot));
@@ -1697,7 +1875,11 @@ mod tests {
         snapshot_v2.min_applied_lsn = Lsn::new(2000);
 
         repository
-            .put(&snapshot_v2, SnapshotDir::new(source_dir_2))
+            .put(
+                &snapshot_v2,
+                SnapshotDir::new(source_dir_2),
+                Arc::new(SnapshotLeaseGuard::noop()),
+            )
             .await?;
 
         let latest_data = object_store.get(&latest_path).await?;
@@ -1710,7 +1892,7 @@ mod tests {
 
     #[restate_core::test]
     async fn archived_lsn_v2() -> anyhow::Result<()> {
-        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let env = TestCoreEnv::create_with_single_node(1, 1).await;
 
         let snapshots_destination = TempDir::new()?;
         let destination = Url::from_file_path(snapshots_destination.path())
@@ -1723,9 +1905,13 @@ mod tests {
             ..SnapshotsOptions::default()
         };
 
-        let repository = SnapshotRepository::new_from_config(&opts, TempDir::new().unwrap().keep())
-            .await?
-            .unwrap();
+        let repository = SnapshotRepository::new_from_config(
+            &opts,
+            TempDir::new().unwrap().keep(),
+            env.metadata_store_client.clone(),
+        )
+        .await?
+        .unwrap();
 
         for i in 1..=3 {
             let snapshot_source = TempDir::new()?;
@@ -1744,7 +1930,11 @@ mod tests {
             snapshot.min_applied_lsn = Lsn::new(i * 1000);
 
             repository
-                .put(&snapshot, SnapshotDir::new(source_dir))
+                .put(
+                    &snapshot,
+                    SnapshotDir::new(source_dir),
+                    Arc::new(SnapshotLeaseGuard::noop()),
+                )
                 .await?;
         }
 
@@ -1762,6 +1952,7 @@ mod tests {
 
     #[restate_core::test]
     async fn cleanup() -> anyhow::Result<()> {
+        // Required for mock_snapshot's use of Metadata::with_current
         let _env = TestCoreEnv::create_with_single_node(1, 1).await;
 
         let snapshots_destination = TempDir::new()?;
@@ -1776,9 +1967,12 @@ mod tests {
             ..SnapshotsOptions::default()
         };
 
-        let repository = SnapshotRepository::new_from_config(&opts, TempDir::new().unwrap().keep())
-            .await?
-            .unwrap();
+        let repository = SnapshotRepository::new_from_config_with_stub_leases(
+            &opts,
+            TempDir::new().unwrap().keep(),
+        )
+        .await?
+        .unwrap();
 
         let mut all_snapshot_paths = Vec::new();
         for i in 1..=5 {
@@ -1786,7 +1980,11 @@ mod tests {
                 mock_snapshot(format!("data-{}", i).as_bytes(), Lsn::new(100 * i)).await?;
             all_snapshot_paths.push(SnapshotReference::from_metadata(&snapshot).path);
             repository
-                .put(&snapshot, SnapshotDir::new(source_dir))
+                .put(
+                    &snapshot,
+                    SnapshotDir::new(source_dir),
+                    Arc::new(SnapshotLeaseGuard::noop()),
+                )
                 .await?;
         }
 

--- a/crates/partition-store/src/snapshots/repository.rs
+++ b/crates/partition-store/src/snapshots/repository.rs
@@ -67,6 +67,12 @@ impl LeaseProvider {
 }
 
 /// XXH3-128 content hash for SST files. Produces a 128-bit digest (32 hex characters).
+///
+/// XXH3 is a non-cryptographic hash. We rely on a 128-bit digest's collision space being
+/// large enough that random RocksDB SSTs do not collide in practice; the input is trusted
+/// data produced by this process (not attacker-controlled), so chosen-prefix collision
+/// resistance is not required. If snapshot inputs ever become reachable from untrusted
+/// sources, this hash must be replaced with a cryptographic one.
 #[derive(Clone, Copy)]
 struct ContentHash(u128);
 

--- a/crates/partition-store/src/snapshots/repository.rs
+++ b/crates/partition-store/src/snapshots/repository.rs
@@ -9,7 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
 use ahash::{HashMap, HashMapExt, HashSet, HashSetExt};
@@ -21,6 +21,7 @@ use object_store::path::Path as ObjectPath;
 use object_store::{
     MultipartUpload, ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload, UpdateVersion,
 };
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use tempfile::TempDir;
@@ -146,6 +147,40 @@ const DOWNLOAD_CONCURRENCY_LIMIT: usize = 8;
 
 /// Minimum age for files to be considered orphan candidates during repository scan.
 const ORPHAN_MIN_AGE: Duration = Duration::from_hours(24);
+
+/// Object store keys eligible for sweeping. Files not matching any pattern are ignored.
+mod sweep_patterns {
+    use super::*;
+
+    /// SST files from incremental snapshots: `ssts/{32-char-hex-xxh3-128}.sst`.
+    /// Hash length matches `ContentHash`'s `{:032x}` format - keep these in sync.
+    pub static SHARED_SST: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^ssts/[0-9a-f]{32}\.sst$").unwrap());
+
+    /// Snapshot prefix: `lsn_{20-digit}-snap_1{base62}`
+    pub static SNAPSHOT_PREFIX: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"lsn_\d{20}-snap_1[A-Za-z0-9]+").unwrap());
+
+    /// Snapshot metadata files: `lsn_{lsn}-snap_1{base62}/metadata.json`
+    pub static SNAPSHOT_METADATA: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^lsn_\d{20}-snap_1[A-Za-z0-9]+/metadata\.json$").unwrap());
+
+    /// SST files from full snapshots: `lsn_{lsn}-snap_1{base62}/{number}.sst`
+    pub static SNAPSHOT_SST: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^lsn_\d{20}-snap_1[A-Za-z0-9]+/\d+\.sst$").unwrap());
+
+    pub fn is_shared_sst(relative_path: &str) -> bool {
+        SHARED_SST.is_match(relative_path)
+    }
+
+    pub fn is_snapshot_file(relative_path: &str) -> bool {
+        SNAPSHOT_METADATA.is_match(relative_path) || SNAPSHOT_SST.is_match(relative_path)
+    }
+
+    pub fn extract_snapshot_prefix(path: &str) -> Option<&str> {
+        SNAPSHOT_PREFIX.find(path).map(|m| m.as_str())
+    }
+}
 
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum LatestSnapshotVersion {
@@ -770,7 +805,10 @@ impl SnapshotRepository {
         #[cfg(any(test, feature = "test-util"))]
         let enable_cleanup = self.enable_cleanup;
 
-        if !evicted_snapshots.is_empty() && enable_cleanup {
+        if enable_cleanup && (!evicted_snapshots.is_empty() || self.orphan_cleanup) {
+            // Cleanup task handles both evicted snapshot deletion and orphan sweep.
+            // We spawn it even when no snapshots are evicted so orphan sweep runs
+            // after every successful upload.
             self.spawn_cleanup_task(snapshot.partition_id, evicted_snapshots, lease_guard);
         }
 
@@ -1531,6 +1569,7 @@ impl SnapshotRepository {
         partition_id: PartitionId,
     ) -> anyhow::Result<SnapshotInventory> {
         let prefix = self.partition_snapshots_prefix(partition_id);
+        let prefix_str = format!("{}/", prefix.as_ref());
         let stream = self.object_store.list(Some(&prefix));
 
         let mut scan = SnapshotInventory::default();
@@ -1539,16 +1578,18 @@ impl SnapshotRepository {
         while let Some(meta) = stream.try_next().await? {
             let path_str = meta.location.as_ref();
 
-            // SST files in ssts/ directory (incremental snapshot storage)
-            if path_str.contains("/ssts/") && path_str.ends_with(".sst") {
+            let object_path = match path_str.strip_prefix(&prefix_str) {
+                Some(path) => path,
+                None => continue,
+            };
+
+            if sweep_patterns::is_shared_sst(object_path) {
                 scan.shared_sst_files
                     .insert(meta.location, meta.last_modified);
-                continue;
-            }
-
-            // Snapshot directories matching lsn_*-* pattern
-            if let Some(dir_name) = Self::extract_snapshot_prefix_from_path(path_str) {
-                let is_metadata = path_str.ends_with("/metadata.json");
+            } else if sweep_patterns::is_snapshot_file(object_path)
+                && let Some(dir_name) = Self::extract_snapshot_prefix_from_path(path_str)
+            {
+                let is_metadata = object_path.ends_with("/metadata.json");
                 scan.snapshot_prefixes
                     .entry(dir_name)
                     .and_modify(|(has_meta, newest)| {
@@ -1572,17 +1613,11 @@ impl SnapshotRepository {
         Ok(scan)
     }
 
+    /// Extracts the snapshot directory name from a path if it matches the production format.
+    ///
+    /// Only matches directories with format `lsn_{20-digit}-snap_1{base62}`.
     fn extract_snapshot_prefix_from_path(path: &str) -> Option<String> {
-        // Path format: {prefix}/{partition_id}/{lsn}_{snap_id}/...
-        // We want to extract the {lsn}_{snap_id} part
-        for segment in path.split('/') {
-            // Snapshot directories start with "lsn_" (padded format)
-            // Legacy format may use different patterns, but lsn_ is the current standard
-            if segment.starts_with("lsn_") && segment.contains('-') {
-                return Some(segment.to_string());
-            }
-        }
-        None
+        sweep_patterns::extract_snapshot_prefix(path).map(String::from)
     }
 
     /// Builds the set of SST keys referenced by the given retained snapshots.
@@ -2744,32 +2779,41 @@ mod tests {
     #[test]
     fn extract_snapshot_prefix_from_path() {
         assert_eq!(
-            SnapshotRepository::extract_snapshot_prefix_from_path(
-                "prefix/0/lsn_00000000000000001234-abc123/metadata.json"
+            super::sweep_patterns::extract_snapshot_prefix(
+                "prefix/0/lsn_00000000000000001234-snap_1abc123DEF456ghi789/file"
             ),
-            Some("lsn_00000000000000001234-abc123".to_string())
+            Some("lsn_00000000000000001234-snap_1abc123DEF456ghi789")
         );
-        assert_eq!(
-            SnapshotRepository::extract_snapshot_prefix_from_path(
-                "0/lsn_00000000000000000100-snap1/data.sst"
-            ),
-            Some("lsn_00000000000000000100-snap1".to_string())
-        );
+    }
 
-        assert_eq!(
-            SnapshotRepository::extract_snapshot_prefix_from_path("0/ssts/abc123.sst"),
-            None
-        );
+    #[test]
+    fn sweep_eligible_patterns() {
+        use super::sweep_patterns::*;
 
-        assert_eq!(
-            SnapshotRepository::extract_snapshot_prefix_from_path("0/latest.json"),
-            None
-        );
+        // Exactly 32 lowercase hex chars (xxh3-128 digest) is required.
+        assert!(is_shared_sst("ssts/0123456789abcdef0123456789abcdef.sst"));
+        assert!(is_shared_sst("ssts/fedcba9876543210fedcba9876543210.sst"));
 
-        assert_eq!(
-            SnapshotRepository::extract_snapshot_prefix_from_path("random/path/file.txt"),
-            None
-        );
+        assert!(!is_shared_sst("ssts/ignored.sst"));
+        assert!(!is_shared_sst("ssts/abc123def456789012345678901234.sst")); // 30 chars
+        assert!(!is_shared_sst(
+            "ssts/0123456789abcdef0123456789abcdef00.sst"
+        )); // 34 chars
+        assert!(!is_shared_sst("ssts/0123456789ABCDEF0123456789ABCDEF.sst")); // uppercase not allowed
+        assert!(!is_shared_sst("ssts/file with spaces.sst"));
+
+        assert!(is_snapshot_file(
+            "lsn_00000000000000001234-snap_1abc123DEF456ghi789/metadata.json"
+        ));
+        assert!(is_snapshot_file(
+            "lsn_00000000000000001234-snap_1abc123DEF456ghi789/123456.sst"
+        ));
+
+        assert!(!is_snapshot_file("data.json"));
+        assert!(!is_snapshot_file("something-else/metadata.json"));
+        assert!(!is_snapshot_file(
+            "lsn_00000000000000001234-snap1/metadata.json"
+        ));
     }
 
     #[restate_core::test]
@@ -2799,46 +2843,75 @@ mod tests {
             .join(partition_id.to_string())
             .join("ssts");
         tokio::fs::create_dir_all(&ssts_path).await?;
-        tokio::fs::write(ssts_path.join("abc123.sst"), b"sst1").await?;
-        tokio::fs::write(ssts_path.join("def456.sst"), b"sst2").await?;
+        tokio::fs::write(
+            ssts_path.join("0123456789abcdef0123456789abcdef.sst"),
+            b"sst1",
+        )
+        .await?;
+        tokio::fs::write(
+            ssts_path.join("fedcba9876543210fedcba9876543210.sst"),
+            b"sst2",
+        )
+        .await?;
+        tokio::fs::write(ssts_path.join("ignored.sst"), b"ignored").await?;
 
-        let snapshot_prefix = snapshots_destination
+        let snapshot_path = snapshots_destination
             .path()
             .join(partition_id.to_string())
-            .join("lsn_00000000000000000100-snap1");
-        tokio::fs::create_dir_all(&snapshot_prefix).await?;
-        tokio::fs::write(snapshot_prefix.join("metadata.json"), b"{}").await?;
-        tokio::fs::write(snapshot_prefix.join("data.sst"), b"data").await?;
+            .join("lsn_00000000000000000100-snap_1abc123DEF456ghi789");
+        tokio::fs::create_dir_all(&snapshot_path).await?;
+        tokio::fs::write(snapshot_path.join("metadata.json"), b"{}").await?;
+        tokio::fs::write(snapshot_path.join("000001.sst"), b"data").await?;
 
+        // missing metadata.json
         let incomplete_snapshot_path = snapshots_destination
             .path()
             .join(partition_id.to_string())
-            .join("lsn_00000000000000000200-snap2");
+            .join("lsn_00000000000000000200-snap_1xyz789ABC456def123");
         tokio::fs::create_dir_all(&incomplete_snapshot_path).await?;
-        tokio::fs::write(incomplete_snapshot_path.join("data.sst"), b"data").await?;
+        tokio::fs::write(incomplete_snapshot_path.join("000001.sst"), b"data").await?;
 
-        // Scan the partition
+        // invalid snapshot name
+        let non_snapshot_path = snapshots_destination
+            .path()
+            .join(partition_id.to_string())
+            .join("lsn_00000000000000000300-something");
+        tokio::fs::create_dir_all(&non_snapshot_path).await?;
+        tokio::fs::write(non_snapshot_path.join("metadata.json"), b"{}").await?;
+
         let scan = repository.scan_partition_files(partition_id).await?;
 
-        assert_eq!(scan.shared_sst_files.len(), 2, "should find 2 SST files");
+        assert_eq!(
+            scan.shared_sst_files.len(),
+            2,
+            "should find 2 hex-named SST files"
+        );
+
         assert_eq!(
             scan.snapshot_prefixes.len(),
             2,
-            "should find 2 snapshot directories"
+            "should find 2 production-format snapshot directories"
         );
         assert_eq!(
             scan.snapshot_prefixes
-                .get("lsn_00000000000000000100-snap1")
-                .map(|(has_meta, _)| *has_meta),
+                .get("lsn_00000000000000000100-snap_1abc123DEF456ghi789")
+                .map(|(has_metadata, _)| *has_metadata),
             Some(true),
-            "snap1 should have metadata"
+            "first snapshot should have metadata"
         );
         assert_eq!(
             scan.snapshot_prefixes
-                .get("lsn_00000000000000000200-snap2")
-                .map(|(has_meta, _)| *has_meta),
+                .get("lsn_00000000000000000200-snap_1xyz789ABC456def123")
+                .map(|(has_metadata, _)| *has_metadata),
             Some(false),
-            "snap2 should not have metadata"
+            "second snapshot should not have metadata"
+        );
+
+        assert!(
+            !scan
+                .snapshot_prefixes
+                .contains_key("lsn_00000000000000000300-snap1"),
+            "invalid snapshot prefix should be ignored"
         );
 
         Ok(())

--- a/crates/partition-store/src/snapshots/repository.rs
+++ b/crates/partition-store/src/snapshots/repository.rs
@@ -661,7 +661,7 @@ impl SnapshotRepository {
             }
         }
 
-        if matches!(self.snapshot_type, SnapshotType::Incremental) && files_skipped > 0 {
+        if matches!(self.snapshot_type, SnapshotType::Incremental) {
             let dedup_rate = if total_size > 0 {
                 ((total_size - uploaded_size) as f64 / total_size as f64) * 100.0
             } else {
@@ -676,7 +676,7 @@ impl SnapshotRepository {
                 bytes_uploaded = uploaded_size,
                 bytes_saved = total_size - uploaded_size,
                 dedup_rate = format!("{:.1}%", dedup_rate),
-                "Snapshot SST upload completed with deduplication"
+                "Snapshot SST upload completed"
             );
         }
 

--- a/crates/partition-store/src/snapshots/repository.rs
+++ b/crates/partition-store/src/snapshots/repository.rs
@@ -1254,17 +1254,25 @@ impl SnapshotRepository {
             let filename = strip_leading_slash(&file.name);
             let expected_size = file.size;
             let key = if let Some(relative_key) = snapshot_metadata.file_keys.get(&file.name) {
-                // Incremental snapshot: parse the relative key and build proper path
-                // Format: "ssts/{hash}.sst" (content-addressed) or legacy "ssts/{node_id}_{filename}"
+                // Incremental snapshot: parse the relative key and build the object key.
+                // Expected format is exactly two segments: "ssts/{hash}.sst".
                 let parts: Vec<&str> = relative_key.split('/').collect();
                 if parts.len() == 2 {
                     self.prefix
                         .clone()
                         .join(partition_id.to_string())
-                        .join(parts[0]) // "ssts"
-                        .join(parts[1]) // "{node_id}_{filename}"
+                        .join(parts[0])
+                        .join(parts[1])
                 } else {
-                    // Fallback if format is unexpected
+                    // Unexpected key shape - join as opaque path and warn. Future writers
+                    // that produce a different layout would need a corresponding download
+                    // path; getting here indicates either metadata corruption or a partial
+                    // upgrade from a future version of the snapshot format.
+                    warn!(
+                        sst = %file.name,
+                        relative_key = %relative_key,
+                        "Unexpected file_keys entry shape; treating as opaque path"
+                    );
                     self.prefix
                         .clone()
                         .join(partition_id.to_string())

--- a/crates/partition-store/src/snapshots/repository.rs
+++ b/crates/partition-store/src/snapshots/repository.rs
@@ -1081,14 +1081,12 @@ impl SnapshotRepository {
         // This ensures retries can still identify which SSTs need to be deleted.
         // If we deleted metadata while SSTs remain, subsequent retries would see
         // NotFound for metadata.json and return Ok(()), leaving orphaned SSTs.
-        #[allow(clippy::collapsible_if)] // Keep separate to make deletion conditional on is_empty()
-        if failed_deletes.is_empty() {
-            if let Err(err) = self.object_store.delete(&metadata_path).await
-                && !matches!(err, object_store::Error::NotFound { .. })
-            {
-                warn!(%metadata_path, %err, "Failed to delete snapshot metadata");
-                failed_deletes.push(err);
-            }
+        if !any_failed
+            && let Err(err) = self.object_store.delete(&metadata_path).await
+            && !matches!(err, object_store::Error::NotFound { .. })
+        {
+            warn!(%metadata_path, %err, "Failed to delete snapshot metadata");
+            any_failed = true;
         }
 
         if any_failed {

--- a/crates/partition-store/src/snapshots/snapshot_task.rs
+++ b/crates/partition-store/src/snapshots/snapshot_task.rs
@@ -21,8 +21,8 @@ use restate_types::logs::Lsn;
 use restate_types::nodes_config::ClusterFingerprint;
 
 use super::{
-    LocalPartitionSnapshot, PartitionSnapshotMetadata, PartitionSnapshotStatus, SnapshotError,
-    SnapshotErrorKind, SnapshotFormatVersion, SnapshotRepository,
+    LeaseError, LocalPartitionSnapshot, PartitionSnapshotMetadata, PartitionSnapshotStatus,
+    SnapshotError, SnapshotErrorKind, SnapshotFormatVersion, SnapshotRepository,
 };
 use crate::PartitionStoreManager;
 
@@ -74,6 +74,28 @@ impl SnapshotPartitionTask {
     }
 
     async fn create_snapshot_inner(&self) -> Result<PartitionSnapshotStatus, SnapshotError> {
+        // Acquire lease BEFORE export to avoid dedup/delete races with cleanup while uploading SSTs.
+        // Also eliminates the possibility of concurrent snapshots for the same partition at close LSNs.
+        let lease_guard = self
+            .snapshot_repository
+            .acquire_lease(self.partition_id)
+            .await
+            .map_err(|e| {
+                let kind = if matches!(e, LeaseError::Unavailable) {
+                    warn!(
+                        "Create snapshot unavailable due to read-only repository; \
+                        this indicates an internal misconfiguration bug"
+                    );
+                    SnapshotErrorKind::RepositoryNotConfigured
+                } else {
+                    SnapshotErrorKind::RepositoryIo(anyhow::Error::new(e))
+                };
+                SnapshotError {
+                    partition_id: self.partition_id,
+                    kind,
+                }
+            })?;
+
         let snapshot = self
             .partition_store_manager
             .export_partition(
@@ -89,7 +111,7 @@ impl SnapshotPartitionTask {
         let status = self
             .snapshot_repository
             // `put` takes ownership of the snapshot directory and removes it after upload.
-            .put(&metadata, snapshot.base_dir)
+            .put(&metadata, snapshot.base_dir, lease_guard)
             .await
             .map_err(|e| SnapshotError {
                 partition_id: self.partition_id,

--- a/crates/partition-store/src/snapshots/snapshot_task.rs
+++ b/crates/partition-store/src/snapshots/snapshot_task.rs
@@ -147,6 +147,7 @@ impl SnapshotPartitionTask {
             min_applied_lsn: snapshot.min_applied_lsn,
             db_comparator_name: snapshot.db_comparator_name.clone(),
             files: snapshot.files.clone(),
+            file_keys: std::collections::BTreeMap::new(),
         }
     }
 }

--- a/crates/partition-store/src/tests/snapshots_test/mod.rs
+++ b/crates/partition-store/src/tests/snapshots_test/mod.rs
@@ -54,6 +54,7 @@ pub(crate) async fn run_tests(
         min_applied_lsn: snapshot.min_applied_lsn,
         db_comparator_name: snapshot.db_comparator_name.clone(),
         files: snapshot.files.clone(),
+        file_keys: std::collections::BTreeMap::new(),
     };
     let metadata_json = serde_json::to_string_pretty(&snapshot_meta).unwrap();
 

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -1022,6 +1022,19 @@ pub struct SnapshotsOptions {
     /// Since v1.7.0
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub experimental_orphan_cleanup: Option<bool>,
+
+    /// # Orphan minimum age
+    ///
+    /// Minimum age for files to be considered orphan candidates during repository scan.
+    /// Files younger than this are protected to avoid deleting in-flight uploads or
+    /// cross-region replication lagged files.
+    ///
+    /// Default: 24 hours
+    ///
+    /// Since v1.7.0
+    #[cfg(any(test, feature = "test-util"))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub experimental_orphan_min_age: Option<FriendlyDuration>,
 }
 
 fn default_num_retained() -> NonZero<u8> {
@@ -1043,6 +1056,8 @@ impl Default for SnapshotsOptions {
             experimental_snapshot_type: SnapshotType::default(),
             check_interval: None,
             experimental_orphan_cleanup: None,
+            #[cfg(any(test, feature = "test-util"))]
+            experimental_orphan_min_age: None,
         }
     }
 }
@@ -1072,6 +1087,12 @@ impl SnapshotsOptions {
 
     pub fn snapshots_dir(&self, partition_id: PartitionId) -> PathBuf {
         super::data_dir("db-snapshots").join(partition_id.to_string())
+    }
+
+    /// Returns the configured orphan min age for tests, or None to use the default (24 hours).
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn orphan_min_age(&self) -> Option<Duration> {
+        self.experimental_orphan_min_age.map(|d| d.into())
     }
 }
 

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -885,6 +885,20 @@ impl Default for StorageOptions {
     }
 }
 
+/// # Snapshot type
+///
+/// Controls whether snapshots use full or incremental mode.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(rename_all = "kebab-case")]
+pub enum SnapshotType {
+    /// Store each snapshot as a complete copy.
+    #[default]
+    Full,
+    /// Reuse unchanged data between snapshots to reduce upload and storage costs.
+    Incremental,
+}
+
 /// # Snapshot options
 ///
 /// Partition store object-store snapshotting settings. At a minimum, set `destination` to enable
@@ -972,6 +986,31 @@ pub struct SnapshotsOptions {
 
     #[cfg(any(test, feature = "test-util"))]
     pub enable_cleanup: bool,
+
+    /// # Snapshot type
+    ///
+    /// Controls whether snapshots use full or incremental mode.
+    /// - Full: Each snapshot is stored as a complete copy (default)
+    /// - Incremental: Snapshots reuse unchanged data to reduce uploads and storage
+    ///
+    /// Incremental mode reduces network and storage usage for frequent snapshots.
+    ///
+    /// Default: `Full`
+    ///
+    /// Since v1.7.0
+    #[serde(default)]
+    pub experimental_snapshot_type: SnapshotType,
+
+    /// # Snapshot check interval
+    ///
+    /// How frequently to check snapshot trigger conditions. Lower values will result in snapshots
+    /// kicked off sooner, once preconditions are met. Jitter will be added to configured value.
+    ///
+    /// Default: `30s`
+    ///
+    /// Since v1.7.0
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub check_interval: Option<FriendlyDuration>,
 }
 
 fn default_num_retained() -> NonZero<u8> {
@@ -990,6 +1029,8 @@ impl Default for SnapshotsOptions {
             export_concurrency_limit: None,
             #[cfg(any(test, feature = "test-util"))]
             enable_cleanup: true,
+            experimental_snapshot_type: SnapshotType::default(),
+            check_interval: None,
         }
     }
 }
@@ -1006,6 +1047,11 @@ impl SnapshotsOptions {
 
     pub fn export_concurrency_limit(&self) -> u32 {
         self.export_concurrency_limit.map(|v| v.get()).unwrap_or(4)
+    }
+    pub fn check_interval(&self) -> Duration {
+        self.check_interval
+            .map(|d| d.into())
+            .unwrap_or_else(|| Duration::from_secs(30))
     }
 
     pub fn snapshots_base_dir(&self) -> PathBuf {

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -1011,6 +1011,17 @@ pub struct SnapshotsOptions {
     /// Since v1.7.0
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub check_interval: Option<FriendlyDuration>,
+
+    /// # Orphan cleanup
+    ///
+    /// Prune orphaned SST files and snapshot directories after each cleanup.
+    /// Orphans can accumulate from crashes, failed uploads, or interrupted cleanups.
+    ///
+    /// Default: `false`
+    ///
+    /// Since v1.7.0
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub experimental_orphan_cleanup: Option<bool>,
 }
 
 fn default_num_retained() -> NonZero<u8> {
@@ -1031,6 +1042,7 @@ impl Default for SnapshotsOptions {
             enable_cleanup: true,
             experimental_snapshot_type: SnapshotType::default(),
             check_interval: None,
+            experimental_orphan_cleanup: None,
         }
     }
 }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -179,6 +179,7 @@ where
             SnapshotRepository::new_from_config(
                 snapshots_options,
                 config.worker.storage.snapshots_staging_dir(),
+                metadata_store_client.clone(),
             )
             .await
             .map_err(BuildError::SnapshotRepository)?,

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -306,10 +306,10 @@ where
         let mut partition_table_version_watcher = metadata.watch(MetadataKind::PartitionTable);
         gauge!(NUM_PARTITIONS).set(self.partition_table.live_load().len() as f64);
 
-        let mut snapshot_check_interval = tokio::time::interval_at(
-            tokio::time::Instant::now() + Duration::from_secs(rand::rng().random_range(30..60)), // delay scheduled snapshots on startup
-            with_jitter(Duration::from_secs(1), 0.1),
-        );
+        let snapshots_config = &self.updateable_config.pinned().worker.snapshots;
+        let check_interval = with_jitter(snapshots_config.check_interval(), 0.1);
+        let mut snapshot_check_interval =
+            tokio::time::interval_at(tokio::time::Instant::now() + check_interval, check_interval);
         snapshot_check_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         let mut update_target_tail_lsns = tokio::time::interval(Duration::from_secs(1));
@@ -1037,7 +1037,13 @@ where
             });
 
         for partition_id in &unknown_latest_snapshot {
-            self.spawn_update_latest_snapshot(*partition_id);
+            // Skip if we already have a pending refresh for this partition
+            if !self
+                .pending_snapshot_status_refreshes
+                .contains(partition_id)
+            {
+                self.spawn_update_latest_snapshot(*partition_id);
+            }
         }
 
         // Limit the number of snapshots we schedule automatically
@@ -1150,7 +1156,18 @@ where
                 let jitter = if sender.is_some() {
                     Duration::ZERO
                 } else {
-                    Duration::from_millis(rand::rng().random_range(0..10_000))
+                    config
+                        .worker
+                        .snapshots
+                        .check_interval()
+                        .as_millis()
+                        .try_into()
+                        .map(|check_interval_ms: u64| {
+                            Duration::from_millis(
+                                rand::rng().random_range(0..=(check_interval_ms / 10)),
+                            )
+                        })
+                        .unwrap_or(Duration::from_secs(10))
                 };
                 let spawn_task_result = TaskCenter::spawn_unmanaged_child(
                     TaskKind::PartitionSnapshotProducer,
@@ -1199,7 +1216,6 @@ where
         if !self.pending_snapshot_status_refreshes.insert(partition_id) {
             return;
         }
-
         let psm = self.partition_store_manager.clone();
         self.asynchronous_operations
             .build_task()

--- a/release-notes/unreleased/4205-incremental-snapshots.md
+++ b/release-notes/unreleased/4205-incremental-snapshots.md
@@ -1,0 +1,54 @@
+# Release Notes for PR #4205: Incremental snapshots
+
+## New Feature (Experimental)
+
+### What Changed
+
+Restate now supports incremental snapshots, which use content-addressed SST file naming to deduplicate data across snapshots. When enabled, SST files are uploaded to a shared `ssts/` directory using their content hash (xxh3-128) as the filename. Files with identical content are automatically skipped during upload.
+
+New configuration options:
+
+```toml
+[worker.snapshots]
+# Enable incremental snapshots (default: "full")
+experimental-snapshot-type = "incremental"
+
+# destination, frequency settings as usual
+```
+
+### Why This Matters
+
+Incremental snapshots provide significant cost savings for deployments with frequent snapshotting:
+
+- **Reduced upload costs**: Only new or changed SST files are uploaded; unchanged files are skipped
+- **Reduced storage costs**: Identical SST files are stored once regardless of how many snapshots reference them
+- **Works with retention**: When combined with `experimental-num-retained`, old snapshots can be pruned while shared SSTs remain available to newer snapshots
+
+### Bucket Layout Change
+
+When `experimental-snapshot-type = "incremental"` is enabled, the object store layout changes:
+
+| Mode        | SST file location                                            |
+| ----------- | ------------------------------------------------------------ |
+| Full        | `<partition_id>/<lsn>_<snapshot_id>/<filename>.sst`          |
+| Incremental | `<partition_id>/ssts/<content_hash>.sst` (content-addressed) |
+
+The snapshot metadata file (`metadata.json`) now includes a `file_keys` field that maps original filenames to their repository keys, enabling the repository to locate files during restore.
+
+### Impact on Users
+
+- **Existing deployments**: No change unless you enable `experimental-snapshot-type = "incremental"`
+- **New deployments**: Opt-in feature, defaults to `full` mode
+- **Enabling incremental**: Safe to enable at any time; existing full snapshots continue to work
+- **Mixed modes**: The repository supports both full and incremental snapshots coexisting
+
+### Migration Guidance
+
+- **Enabling**: Add `experimental-snapshot-type = "incremental"` to your configuration
+- **Reverting to full**: Set `experimental-snapshot-type = "full"`; new snapshots will use full mode, existing incremental snapshots remain readable
+- **Cleanup coordination**: When using incremental mode with `experimental-num-retained`, SST cleanup is coordinated to ensure shared files are only deleted when no retained snapshot references them
+
+### Related Issues
+
+- [#4204](https://github.com/restatedev/restate/pull/4205): Add incremental snapshot support
+- [#3942](https://github.com/restatedev/restate/pull/3942): Snapshot retention (companion feature)

--- a/release-notes/unreleased/4212-scan-sweep-snapshot-pruning.md
+++ b/release-notes/unreleased/4212-scan-sweep-snapshot-pruning.md
@@ -1,0 +1,56 @@
+# Release Notes for PR #4212: Scan-sweep snapshot pruning
+
+## Improvement
+
+### What Changed
+
+Added a scan-and-sweep cleanup mechanism that automatically prunes orphaned SST files and snapshot directories from the object store. The system scans for and deletes files that are no longer referenced by any retained snapshot after every successful snapshot upload.
+
+A new configuration option `experimental-orphan-cleanup` (default: `true`) allows disabling the cleanup if the S3 LIST overhead is a concern.
+
+### Why This Matters
+
+When using incremental snapshots with retention policies, certain edge cases (crashes during upload, failed cleanups, etc.) could leave orphaned SST files in the shared `ssts/` directory. These files consume storage but are never cleaned up by normal retention. The new scan-sweep mechanism ensures these orphans are eventually removed.
+
+### What Gets Scanned
+
+Explicit regex patterns determine which files are eligible for orphan sweep. Only files matching these exact patterns under `{partition_id}/` are considered:
+
+| Pattern | Regex | Description |
+|---------|-------|-------------|
+| `ssts/{hex}.sst` | `^ssts/[0-9a-f]+\.sst$` | Content-addressed SST files (xxh3-128 hash) |
+| `lsn_{lsn}-snap_1{base62}/metadata.json` | `^lsn_\d{20}-snap_1[A-Za-z0-9]+/metadata\.json$` | Snapshot metadata |
+| `lsn_{lsn}-snap_1{base62}/{num}.sst` | `^lsn_\d{20}-snap_1[A-Za-z0-9]+/\d+\.sst$` | RocksDB SST files |
+
+**Never swept** (safe for other uses):
+- `latest.json` - pointer file
+- SST files with non-hex names (e.g., `legacy_name.sst`)
+- Snapshot directories with non-standard IDs (e.g., `snap1` instead of `snap_1...`)
+- Any files not matching the strict patterns above
+
+### Safety Measures
+
+- **Pattern-based boundary**: Only files matching explicit regex patterns are considered for deletion. This provides an auditable safety boundary—unexpected files are never touched.
+- Only files older than 24 hours are considered for deletion
+- Validates all retained snapshots before deleting any shared SSTs
+- Aborts scan if any retained snapshot's metadata cannot be read (prevents data loss from transient failures)
+
+Performance optimizations:
+- Referenced SST keys are computed once per cleanup and reused for all snapshot deletions and the orphan sweep
+- Avoids redundant metadata fetches from the object store
+
+### Impact on Users
+
+- **Existing deployments**: No configuration changes required; orphan cleanup happens automatically after every snapshot upload
+- **Without retention configured**: When `experimental-num-retained` is not set, the retained set is effectively just the latest snapshot. Older `lsn_*` snapshot directories will be cleaned up once they exceed the 24-hour age threshold.
+- **New configuration**: Set `worker.snapshots.experimental-orphan-cleanup: false` to disable orphan cleanup if the S3 LIST overhead (~11 API calls/partition/cleanup) causes issues
+- **Observability**: New metrics available:
+  - `restate.partition_store.snapshots.orphan_scan.total` - count of scan operations
+  - `restate.partition_store.snapshots.orphan_scan.failed.total` - count of scan failures (transient errors, missing metadata)
+  - `restate.partition_store.snapshots.orphan_files_deleted.total` - count of orphaned files deleted
+
+### Related Issues
+
+- [#4212](https://github.com/restatedev/restate/pull/4212): Add scan-and-sweep pruning of orphaned snapshot objects
+- [#3942](https://github.com/restatedev/restate/pull/3942): Snapshot retention
+- [#4205](https://github.com/restatedev/restate/pull/4205): Incremental snapshots

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -87,6 +87,7 @@ tonic = { workspace = true, features = ["transport"] }
 tracing-subscriber = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 url = { workspace = true }
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -74,6 +74,7 @@ restate-metadata-server = { workspace = true, features = ["test-util"] }
 restate-metadata-store = { workspace = true, features = ["test-util"] }
 restate-metadata-providers = { workspace = true, features = ["replicated"] }
 restate-node = { workspace = true, features = ["memory-loglet", "test-util"] }
+restate-object-store-util = { workspace = true, features = ["test-util"] }
 restate-types = { workspace = true, features = ["test-util"] }
 mock-service-endpoint = { workspace = true }
 

--- a/server/tests/incremental_snapshot_chaos.rs
+++ b/server/tests/incremental_snapshot_chaos.rs
@@ -8,16 +8,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::num::NonZeroU8;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::path::Path;
 use std::time::{Duration, Instant};
 
 use anyhow::anyhow;
 use enumset::EnumSet;
 use futures_util::StreamExt;
 use googletest::{IntoTestResult, fail};
+use serde::Deserialize;
 use tempfile::TempDir;
 use tokio::net::TcpListener;
 use tokio::sync::{oneshot, watch};
@@ -40,17 +41,67 @@ use restate_types::net::address::PeerNetAddress;
 use restate_types::protobuf::cluster::RunMode;
 use restate_types::protobuf::cluster::node_state::State;
 use restate_types::replication::ReplicationProperty;
-use restate_types::retries::RetryPolicy;
 
-/// Chaos test for incremental snapshots that exercises snapshot import paths during node restarts.
-///
-/// This test:
-/// 1. Runs a 3-node cluster with incremental snapshots enabled
-/// 2. Generates workload across multiple partitions
-/// 3. Creates snapshots with `trim_log: true` to force log trimming
-/// 4. Randomly restarts nodes, forcing them to import snapshots to catch up
-/// 5. Verifies snapshot imports occurred and LSNs converged
-#[restate_core::test(flavor = "multi_thread", worker_threads = 4)]
+#[derive(Deserialize)]
+struct LatestSnapshotRef {
+    retained_snapshots: Vec<SnapshotRef>,
+}
+
+#[derive(Deserialize)]
+struct SnapshotRef {
+    path: String,
+}
+
+#[derive(Deserialize)]
+struct SnapshotMetadata {
+    #[serde(default)]
+    file_keys: std::collections::BTreeMap<String, String>,
+}
+
+fn corrupt_latest_snapshot(snapshots_dir: &Path, partition_id: u32) -> anyhow::Result<bool> {
+    let partition_dir = snapshots_dir.join(partition_id.to_string());
+    let latest_json = partition_dir.join("latest.json");
+
+    let latest: LatestSnapshotRef = serde_json::from_str(&std::fs::read_to_string(&latest_json)?)?;
+
+    if latest.retained_snapshots.len() < 2 {
+        return Ok(false);
+    }
+
+    let latest_metadata_path = partition_dir
+        .join(&latest.retained_snapshots[0].path)
+        .join("metadata.json");
+    let latest_metadata: SnapshotMetadata =
+        serde_json::from_str(&std::fs::read_to_string(&latest_metadata_path)?)?;
+    let latest_ssts: HashSet<_> = latest_metadata.file_keys.values().collect();
+
+    let mut older_ssts = HashSet::new();
+    for older_ref in &latest.retained_snapshots[1..] {
+        let metadata_path = partition_dir.join(&older_ref.path).join("metadata.json");
+        if let Ok(content) = std::fs::read_to_string(&metadata_path)
+            && let Ok(metadata) = serde_json::from_str::<SnapshotMetadata>(&content)
+        {
+            older_ssts.extend(metadata.file_keys.values().cloned());
+        }
+    }
+
+    let exclusive_ssts: Vec<_> = latest_ssts
+        .iter()
+        .filter(|sst| !older_ssts.contains(**sst))
+        .collect();
+
+    if exclusive_ssts.is_empty() {
+        return Ok(false);
+    }
+
+    let sst_to_delete = partition_dir.join(exclusive_ssts[0]);
+    std::fs::remove_file(&sst_to_delete)?;
+    info!("Corrupted latest snapshot by deleting: {:?}", sst_to_delete);
+
+    Ok(true)
+}
+
+#[test_log::test(restate_core::test(flavor = "multi_thread", worker_threads = 4))]
 async fn incremental_snapshot_chaos() -> googletest::Result<()> {
     const NUM_NODES: u32 = 3;
     const NUM_PARTITIONS: u32 = 3;
@@ -59,26 +110,20 @@ async fn incremental_snapshot_chaos() -> googletest::Result<()> {
     const RETAIN_SNAPSHOTS: u8 = 3;
     const MAX_WAIT_TIMEOUT: Duration = Duration::from_secs(60);
 
-    // Allow overriding chaos duration via environment variable (in seconds)
     let chaos_duration_secs: u64 = std::env::var("CHAOS_DURATION_SECS")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(DEFAULT_CHAOS_DURATION_SECS);
     let chaos_duration = Duration::from_secs(chaos_duration_secs);
-    eprintln!(
-        "[CHAOS] Starting test with duration: {} seconds",
-        chaos_duration_secs
-    );
     info!("Chaos test duration: {} seconds", chaos_duration_secs);
 
     let mut base_config = Configuration::new_unix_sockets();
     base_config.common.default_num_partitions = NUM_PARTITIONS.try_into()?;
     base_config.bifrost.default_provider = Replicated;
-    base_config.common.log_filter = "warn,restate=debug".to_owned();
+    base_config.common.log_filter = "warn,restate=info,restate_partition_store=debug".to_owned();
     base_config.common.log_format = LogFormat::Compact;
     base_config.common.log_disable_ansi_codes = true;
 
-    // Configure snapshot repository for all nodes
     let snapshots_dir = TempDir::new()?;
     base_config.worker.snapshots.destination = Some(
         Url::from_file_path(snapshots_dir.path())
@@ -87,7 +132,6 @@ async fn incremental_snapshot_chaos() -> googletest::Result<()> {
     );
     base_config.worker.snapshots.experimental_snapshot_type = SnapshotType::Incremental;
     base_config.worker.snapshots.num_retained = NonZeroU8::new(RETAIN_SNAPSHOTS).unwrap();
-    // Fast check interval for responsive snapshot triggering
     base_config.worker.snapshots.check_interval = Some(Duration::from_millis(100).into());
 
     let nodes = NodeSpec::new_test_nodes(
@@ -106,13 +150,11 @@ async fn incremental_snapshot_chaos() -> googletest::Result<()> {
         .start()
         .await?;
 
-    // Partition replication = 2 to force snapshot imports on node restarts
     let replicated_loglet_config = ReplicatedLogletConfig {
         target_nodeset_size: NodeSetSize::default(),
         replication_property: ReplicationProperty::new_unchecked(2),
     };
 
-    eprintln!("[CHAOS] Cluster started, provisioning...");
     info!("Provisioning the cluster");
     cluster.nodes[0]
         .provision_cluster(
@@ -127,10 +169,8 @@ async fn incremental_snapshot_chaos() -> googletest::Result<()> {
     let worker_1 = &cluster.nodes[0];
     let mut worker_1_ready = worker_1.lines("Partition [0-9]+ started".parse()?);
 
-    eprintln!("[CHAOS] Provisioned, waiting for healthy cluster...");
     info!("Waiting until the cluster is healthy");
     cluster.wait_healthy(Duration::from_secs(60)).await?;
-    eprintln!("[CHAOS] Cluster healthy");
 
     info!("Waiting until node-1 has started the partition processor");
     worker_1_ready.next().await;
@@ -145,12 +185,9 @@ async fn incremental_snapshot_chaos() -> googletest::Result<()> {
         &base_config.networking,
     );
 
-    eprintln!("[CHAOS] Waiting for partitions to become active...");
     info!("Waiting until partition processors have become leaders");
     wait_all_partitions_active(&mut client, NUM_PARTITIONS, MAX_WAIT_TIMEOUT).await?;
-    eprintln!("[CHAOS] All partitions active");
 
-    // Start mock service
     let (running_tx, running_rx) = oneshot::channel();
     let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
     let listener = TcpListener::bind(addr).await?;
@@ -170,7 +207,6 @@ async fn incremental_snapshot_chaos() -> googletest::Result<()> {
 
     running_rx.await?;
 
-    // Register deployment on first node
     let worker_1 = &cluster.nodes[0];
     let admin_uds = worker_1
         .admin_address()
@@ -190,7 +226,6 @@ async fn incremental_snapshot_chaos() -> googletest::Result<()> {
         .await?;
     assert!(registration_response.status().is_success());
 
-    // Create ingress clients for each node
     let ingress_clients: Vec<_> = cluster
         .nodes
         .iter()
@@ -211,84 +246,78 @@ async fn incremental_snapshot_chaos() -> googletest::Result<()> {
         })
         .collect();
 
-    // Warm up the service with a request (max 60 attempts = 30 seconds)
-    info!("Warming up the service");
-    let mut retry = RetryPolicy::fixed_delay(Duration::from_millis(500), Some(60)).into_iter();
-    loop {
-        let response = ingress_clients[0]
-            .post("http://localhost/Counter/0/get")
-            .send()
-            .await?;
-        if response.status().is_success() {
-            break;
-        }
-        if let Some(delay) = retry.next() {
-            tokio::time::sleep(delay).await;
-        } else {
-            fail!("Failed to invoke worker")?;
-        }
-    }
-
-    // Create initial snapshots for all partitions to establish a baseline
+    // make sure we have at least one snapshot per partition before chaos starts
     info!("Creating initial snapshots for all partitions");
     for partition_id in 0..NUM_PARTITIONS {
-        let _ = client
-            .create_partition_snapshot(CreatePartitionSnapshotRequest {
-                partition_id,
-                min_target_lsn: None,
-                trim_log: true,
-            })
-            .await;
+        let partition_dir = snapshots_dir.path().join(partition_id.to_string());
+        let latest_json = partition_dir.join("latest.json");
+        let start = Instant::now();
+        while !latest_json.exists() && start.elapsed() < Duration::from_secs(5) {
+            let _ = client
+                .create_partition_snapshot(CreatePartitionSnapshotRequest {
+                    partition_id,
+                    min_target_lsn: None,
+                    trim_log: false,
+                })
+                .await;
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+        assert!(
+            latest_json.exists(),
+            "Initial snapshot should have been created for partition {}",
+            partition_id
+        );
     }
     info!("Initial snapshots created for all partitions");
 
     let (success_tx, success_rx) = watch::channel(0u32);
-    let successful_operations = Arc::new(AtomicUsize::new(0));
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
 
-    eprintln!("[CHAOS] Starting chaos loop...");
     info!("Starting incremental snapshot chaos test");
 
-    // Spawn background health check task that distributes requests across nodes
-    let health_check_abort = {
+    let health_check_task = {
         let ingress_clients = ingress_clients.clone();
         let success_tx = success_tx.clone();
         let num_nodes = ingress_clients.len();
         tokio::spawn(async move {
-            let mut counter = 0u64;
-            loop {
-                let partition = (counter as u32) % NUM_PARTITIONS;
-                let node_idx = (counter as usize) % num_nodes;
-                counter = counter.wrapping_add(1);
+            tokio::select! {
+                biased;
+                _ = shutdown_rx => {}
+                _ = async {
+                    let mut counter = 0u64;
+                    loop {
+                        let partition = (counter as u32) % NUM_PARTITIONS;
+                        let node_idx = (counter as usize) % num_nodes;
+                        counter = counter.wrapping_add(1);
 
-                let url = format!("http://localhost/Counter/{partition}/get");
-                // Try the selected node, fall back to trying all nodes
-                let mut success = false;
-                let result: Result<reqwest::Response, _> =
-                    ingress_clients[node_idx].post(&url).send().await;
-                if result.is_ok_and(|r| r.status().is_success()) {
-                    success = true;
-                } else {
-                    // Try other nodes if the primary fails
-                    for (i, client) in ingress_clients.iter().enumerate() {
-                        if i == node_idx {
-                            continue;
-                        }
-                        let result: Result<reqwest::Response, _> = client.post(&url).send().await;
+                        let url = format!("http://localhost/Counter/{partition}/get");
+                        let mut success = false;
+                        let result: Result<reqwest::Response, _> =
+                            ingress_clients[node_idx].post(&url).send().await;
                         if result.is_ok_and(|r| r.status().is_success()) {
                             success = true;
-                            break;
+                        } else {
+                            for (i, client) in ingress_clients.iter().enumerate() {
+                                if i == node_idx {
+                                    continue;
+                                }
+                                let result: Result<reqwest::Response, _> = client.post(&url).send().await;
+                                if result.is_ok_and(|r| r.status().is_success()) {
+                                    success = true;
+                                    break;
+                                }
+                            }
                         }
+                        if success {
+                            success_tx.send_modify(|v| *v += 1);
+                        }
+                        tokio::time::sleep(Duration::from_millis(100)).await;
                     }
-                }
-                if success {
-                    success_tx.send_modify(|v| *v += 1);
-                }
-                tokio::time::sleep(Duration::from_millis(100)).await;
+                } => {}
             }
         })
     };
 
-    // Run chaos loop inline with a time-based termination
     let chaos_start = Instant::now();
     let num_nodes = cluster.nodes.len();
     let mut invocation_counter = 0u64;
@@ -296,23 +325,15 @@ async fn incremental_snapshot_chaos() -> googletest::Result<()> {
     let mut success_rx = success_rx.clone();
 
     while chaos_start.elapsed() < chaos_duration {
-        eprintln!(
-            "[CHAOS] Iteration {} (elapsed: {:?})",
-            iteration,
-            chaos_start.elapsed()
-        );
         info!("Chaos iteration {}", iteration);
 
-        // 1. Generate workload across partitions and nodes
         for i in 0..10u64 {
             let partition = ((invocation_counter + i) % NUM_PARTITIONS as u64) as u32;
-            let node_idx = ((invocation_counter + i) as usize) % num_nodes;
+            let node_idx = (iteration as usize) % num_nodes;
             let url = format!("http://localhost/Counter/{partition}/add");
-            // Try the selected node, or fall back to a running node
             let client = if cluster.nodes[node_idx].pid().is_some() {
                 &ingress_clients[node_idx]
             } else {
-                // Find a running node
                 cluster
                     .nodes
                     .iter()
@@ -327,15 +348,13 @@ async fn incremental_snapshot_chaos() -> googletest::Result<()> {
                 .send()
                 .await;
             if result.is_ok_and(|r| r.status().is_success()) {
-                successful_operations.fetch_add(1, Ordering::Relaxed);
+                success_tx.send_modify(|v| *v += 1);
             }
             invocation_counter += 1;
         }
 
-        // 2. Create snapshot for partition (rotate through partitions)
         let partition_id = (iteration % NUM_PARTITIONS as u64) as u32;
 
-        // Find a healthy node to send the request to
         let client_node_idx = cluster
             .nodes
             .iter()
@@ -351,7 +370,6 @@ async fn incremental_snapshot_chaos() -> googletest::Result<()> {
             &base_config.networking,
         );
 
-        // Try to create snapshot, ignore errors (node might be down)
         let snapshot_result = client
             .create_partition_snapshot(CreatePartitionSnapshotRequest {
                 partition_id,
@@ -366,40 +384,56 @@ async fn incremental_snapshot_chaos() -> googletest::Result<()> {
                 partition_id,
                 response.into_inner().min_applied_lsn
             );
+
+            if iteration >= 2 && iteration.is_multiple_of(2) {
+                match corrupt_latest_snapshot(snapshots_dir.path(), partition_id) {
+                    Ok(true) => {
+                        info!(
+                            "Corrupted latest snapshot for partition {}, fallback should be used",
+                            partition_id
+                        );
+                    }
+                    Ok(false) => {
+                        info!(
+                            "Could not corrupt partition {} (no exclusive SSTs or < 2 retained snapshots)",
+                            partition_id
+                        );
+                    }
+                    Err(e) => {
+                        info!("Failed to corrupt partition {}: {}", partition_id, e);
+                    }
+                }
+            }
         }
 
-        // 3. Restart node (rotate through nodes) with data wipe to force snapshot restore
         let node_to_restart = (iteration as usize) % num_nodes;
         let node_name;
         let db_dir;
         {
             let node = &mut cluster.nodes[node_to_restart];
             node_name = node.node_name().to_owned();
-            // Node data is stored in base_dir/<node_name>/db
             db_dir = node.config().common.base_dir().join(&node_name).join("db");
 
             info!("Restarting node '{}' with data wipe", node_name);
 
-            // Stop the node first
             node.terminate()?;
             let _ = node.status().await;
 
-            // Delete the RocksDB partition store directory to force snapshot restore
             if db_dir.exists() {
                 std::fs::remove_dir_all(&db_dir)?;
             }
 
-            // Start the node again (restart will be a no-op for stopping since already stopped)
+            // killing a node can potentially leave stale leases lying around, causing flakiness
             if let Err(e) = node.restart(TerminationSignal::Sigterm).await {
                 fail!("Failed to restart node: {e}")?;
             }
         }
 
         // Set up watcher for snapshot restore log message (needs fresh borrow after restart)
-        let mut snapshot_restore_watcher =
-            cluster.nodes[node_to_restart].lines("Found partition snapshot, restoring it".parse()?);
+        let mut snapshot_restore_watcher = cluster.nodes[node_to_restart].lines(
+            "(Found partition snapshot, restoring it|Restored from fallback snapshot)".parse()?,
+        );
 
-        // 4. Wait for health
         if let Err(e) = cluster
             .wait_check_healthy(HealthCheck::Worker, Duration::from_secs(30))
             .await
@@ -407,8 +441,6 @@ async fn incremental_snapshot_chaos() -> googletest::Result<()> {
             fail!("Failed to wait for cluster health: {e}")?;
         }
 
-        // 5. Verify snapshot restore happened (we wiped the db, so it must restore from snapshot)
-        // We expect at least one partition to be restored from snapshot
         let restore_result =
             tokio::time::timeout(Duration::from_secs(5), snapshot_restore_watcher.next()).await;
         if restore_result.is_err() {
@@ -420,7 +452,6 @@ async fn incremental_snapshot_chaos() -> googletest::Result<()> {
         drop(snapshot_restore_watcher);
         info!("Node '{}' restored from snapshot", node_name);
 
-        // 6. Gate on successful operation
         success_rx.mark_unchanged();
         tokio::time::timeout(EXPECTED_RECOVERY_DURATION, success_rx.changed())
             .await
@@ -432,11 +463,9 @@ async fn incremental_snapshot_chaos() -> googletest::Result<()> {
         iteration += 1;
     }
 
-    // Stop health check task
-    health_check_abort.abort();
+    let _ = shutdown_tx.send(());
+    let _ = health_check_task.await;
 
-    eprintln!("[CHAOS] Chaos loop completed, verifying LSN convergence...");
-    // Verify applied LSN convergence for all partitions
     info!("Waiting for applied LSN convergence");
     let mut final_client = new_cluster_ctrl_client(
         create_tonic_channel(
@@ -447,13 +476,8 @@ async fn incremental_snapshot_chaos() -> googletest::Result<()> {
         &base_config.networking,
     );
 
-    // With partition replication = 2, we expect 2 processors per partition to converge
     const PARTITION_REPLICATION: usize = 2;
     for partition_id in 0..NUM_PARTITIONS {
-        eprintln!(
-            "[CHAOS] Checking LSN convergence for partition {}",
-            partition_id
-        );
         applied_lsn_converged(
             &mut final_client,
             PARTITION_REPLICATION,
@@ -461,11 +485,10 @@ async fn incremental_snapshot_chaos() -> googletest::Result<()> {
             MAX_WAIT_TIMEOUT,
         )
         .await?;
-        eprintln!("[CHAOS] Partition {} converged", partition_id);
+        info!("Partition {} converged", partition_id);
     }
 
-    // Verify we processed some requests successfully
-    let total_ops = successful_operations.load(Ordering::Relaxed);
+    let total_ops = *success_rx.borrow();
     info!(
         "Chaos test completed. Total successful operations: {}",
         total_ops
@@ -475,8 +498,6 @@ async fn incremental_snapshot_chaos() -> googletest::Result<()> {
         "Should have processed at least some operations successfully"
     );
 
-    eprintln!("[CHAOS] LSN convergence complete, verifying snapshots exist...");
-    // Verify snapshots exist in the repository
     for partition_id in 0..NUM_PARTITIONS {
         let partition_dir = snapshots_dir.path().join(partition_id.to_string());
         let latest_json = partition_dir.join("latest.json");
@@ -487,10 +508,8 @@ async fn incremental_snapshot_chaos() -> googletest::Result<()> {
         );
     }
 
-    eprintln!("[CHAOS] Snapshots verified, shutting down cluster...");
     info!("Incremental snapshot chaos test passed!");
     cluster.graceful_shutdown(Duration::from_secs(10)).await?;
-    eprintln!("[CHAOS] Test complete!");
 
     Ok(())
 }

--- a/server/tests/incremental_snapshot_chaos.rs
+++ b/server/tests/incremental_snapshot_chaos.rs
@@ -1,0 +1,607 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::net::SocketAddr;
+use std::num::NonZeroU8;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use anyhow::anyhow;
+use enumset::EnumSet;
+use futures_util::StreamExt;
+use googletest::{IntoTestResult, fail};
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+use tokio::sync::{oneshot, watch};
+use tonic::transport::Channel;
+use tracing::info;
+use url::Url;
+
+use restate_core::network::net_util::{DNSResolution, create_tonic_channel};
+use restate_core::protobuf::cluster_ctrl_svc::{
+    ClusterStateRequest, CreatePartitionSnapshotRequest,
+    cluster_ctrl_svc_client::ClusterCtrlSvcClient, new_cluster_ctrl_client,
+};
+use restate_local_cluster_runner::cluster::Cluster;
+use restate_local_cluster_runner::node::{BinarySource, HealthCheck, NodeSpec, TerminationSignal};
+use restate_types::config::{Configuration, LogFormat, NetworkingOptions, SnapshotType};
+use restate_types::identifiers::PartitionId;
+use restate_types::logs::metadata::ProviderKind::Replicated;
+use restate_types::logs::metadata::{NodeSetSize, ProviderConfiguration, ReplicatedLogletConfig};
+use restate_types::net::address::PeerNetAddress;
+use restate_types::protobuf::cluster::RunMode;
+use restate_types::protobuf::cluster::node_state::State;
+use restate_types::replication::ReplicationProperty;
+use restate_types::retries::RetryPolicy;
+
+/// Chaos test for incremental snapshots that exercises snapshot import paths during node restarts.
+///
+/// This test:
+/// 1. Runs a 3-node cluster with incremental snapshots enabled
+/// 2. Generates workload across multiple partitions
+/// 3. Creates snapshots with `trim_log: true` to force log trimming
+/// 4. Randomly restarts nodes, forcing them to import snapshots to catch up
+/// 5. Verifies snapshot imports occurred and LSNs converged
+#[restate_core::test(flavor = "multi_thread", worker_threads = 4)]
+async fn incremental_snapshot_chaos() -> googletest::Result<()> {
+    const NUM_NODES: u32 = 3;
+    const NUM_PARTITIONS: u32 = 3;
+    const DEFAULT_CHAOS_DURATION_SECS: u64 = 30;
+    const EXPECTED_RECOVERY_DURATION: Duration = Duration::from_secs(15);
+    const RETAIN_SNAPSHOTS: u8 = 3;
+    const MAX_WAIT_TIMEOUT: Duration = Duration::from_secs(60);
+
+    // Allow overriding chaos duration via environment variable (in seconds)
+    let chaos_duration_secs: u64 = std::env::var("CHAOS_DURATION_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_CHAOS_DURATION_SECS);
+    let chaos_duration = Duration::from_secs(chaos_duration_secs);
+    eprintln!(
+        "[CHAOS] Starting test with duration: {} seconds",
+        chaos_duration_secs
+    );
+    info!("Chaos test duration: {} seconds", chaos_duration_secs);
+
+    let mut base_config = Configuration::new_unix_sockets();
+    base_config.common.default_num_partitions = NUM_PARTITIONS.try_into()?;
+    base_config.bifrost.default_provider = Replicated;
+    base_config.common.log_filter = "warn,restate=debug".to_owned();
+    base_config.common.log_format = LogFormat::Compact;
+    base_config.common.log_disable_ansi_codes = true;
+
+    // Configure snapshot repository for all nodes
+    let snapshots_dir = TempDir::new()?;
+    base_config.worker.snapshots.destination = Some(
+        Url::from_file_path(snapshots_dir.path())
+            .unwrap()
+            .to_string(),
+    );
+    base_config.worker.snapshots.experimental_snapshot_type = SnapshotType::Incremental;
+    base_config.worker.snapshots.num_retained = NonZeroU8::new(RETAIN_SNAPSHOTS).unwrap();
+    // Fast check interval for responsive snapshot triggering
+    base_config.worker.snapshots.check_interval = Some(Duration::from_millis(100).into());
+
+    let nodes = NodeSpec::new_test_nodes(
+        base_config.clone(),
+        BinarySource::CargoTest,
+        EnumSet::all(),
+        NUM_NODES,
+        false,
+    );
+
+    let mut cluster = Cluster::builder()
+        .cluster_name("incremental-snapshot-chaos")
+        .nodes(nodes)
+        .temp_base_dir("incremental_snapshot_chaos")
+        .build()
+        .start()
+        .await?;
+
+    // Partition replication = 2 to force snapshot imports on node restarts
+    let replicated_loglet_config = ReplicatedLogletConfig {
+        target_nodeset_size: NodeSetSize::default(),
+        replication_property: ReplicationProperty::new_unchecked(2),
+    };
+
+    eprintln!("[CHAOS] Cluster started, provisioning...");
+    info!("Provisioning the cluster");
+    cluster.nodes[0]
+        .provision_cluster(
+            None,
+            ReplicationProperty::new_unchecked(2),
+            Some(ProviderConfiguration::Replicated(replicated_loglet_config)),
+            EnumSet::empty(),
+        )
+        .await
+        .into_test_result()?;
+
+    let worker_1 = &cluster.nodes[0];
+    let mut worker_1_ready = worker_1.lines("Partition [0-9]+ started".parse()?);
+
+    eprintln!("[CHAOS] Provisioned, waiting for healthy cluster...");
+    info!("Waiting until the cluster is healthy");
+    cluster.wait_healthy(Duration::from_secs(60)).await?;
+    eprintln!("[CHAOS] Cluster healthy");
+
+    info!("Waiting until node-1 has started the partition processor");
+    worker_1_ready.next().await;
+    drop(worker_1_ready);
+
+    let mut client = new_cluster_ctrl_client(
+        create_tonic_channel(
+            cluster.nodes[0].advertised_address().clone(),
+            &NetworkingOptions::default(),
+            DNSResolution::Gai,
+        ),
+        &base_config.networking,
+    );
+
+    eprintln!("[CHAOS] Waiting for partitions to become active...");
+    info!("Waiting until partition processors have become leaders");
+    wait_all_partitions_active(&mut client, NUM_PARTITIONS, MAX_WAIT_TIMEOUT).await?;
+    eprintln!("[CHAOS] All partitions active");
+
+    // Start mock service
+    let (running_tx, running_rx) = oneshot::channel();
+    let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
+    let listener = TcpListener::bind(addr).await?;
+    let addr = listener.local_addr()?;
+    let mock_svc_port = addr.port();
+
+    tokio::spawn(async move {
+        info!("Starting mock service on http://{}", addr);
+        if let Err(e) = mock_service_endpoint::listener::run_listener(listener, || {
+            let _ = running_tx.send(());
+        })
+        .await
+        {
+            panic!("Error running listener: {e:?}");
+        }
+    });
+
+    running_rx.await?;
+
+    // Register deployment on first node
+    let worker_1 = &cluster.nodes[0];
+    let admin_uds = worker_1
+        .admin_address()
+        .clone()
+        .unwrap()
+        .into_address()
+        .unwrap();
+    let PeerNetAddress::Uds(admin_uds) = admin_uds else {
+        panic!("admin address must be a unix domain socket");
+    };
+    let admin_http_client = reqwest::Client::builder().unix_socket(admin_uds).build()?;
+    let registration_response = admin_http_client
+        .post("http://localhost/deployments")
+        .header("content-type", "application/json")
+        .json(&serde_json::json!({ "uri": format!("http://127.0.0.1:{mock_svc_port}") }))
+        .send()
+        .await?;
+    assert!(registration_response.status().is_success());
+
+    // Create ingress clients for each node
+    let ingress_clients: Vec<_> = cluster
+        .nodes
+        .iter()
+        .map(|node| {
+            let ingress_uds = node
+                .ingress_address()
+                .clone()
+                .unwrap()
+                .into_address()
+                .unwrap();
+            let PeerNetAddress::Uds(ingress_uds) = ingress_uds else {
+                panic!("ingress address must be a unix domain socket");
+            };
+            reqwest::Client::builder()
+                .unix_socket(ingress_uds)
+                .build()
+                .unwrap()
+        })
+        .collect();
+
+    // Warm up the service with a request (max 60 attempts = 30 seconds)
+    info!("Warming up the service");
+    let mut retry = RetryPolicy::fixed_delay(Duration::from_millis(500), Some(60)).into_iter();
+    loop {
+        let response = ingress_clients[0]
+            .post("http://localhost/Counter/0/get")
+            .send()
+            .await?;
+        if response.status().is_success() {
+            break;
+        }
+        if let Some(delay) = retry.next() {
+            tokio::time::sleep(delay).await;
+        } else {
+            fail!("Failed to invoke worker")?;
+        }
+    }
+
+    // Create initial snapshots for all partitions to establish a baseline
+    info!("Creating initial snapshots for all partitions");
+    for partition_id in 0..NUM_PARTITIONS {
+        let _ = client
+            .create_partition_snapshot(CreatePartitionSnapshotRequest {
+                partition_id,
+                min_target_lsn: None,
+                trim_log: true,
+            })
+            .await;
+    }
+    info!("Initial snapshots created for all partitions");
+
+    let (success_tx, success_rx) = watch::channel(0u32);
+    let successful_operations = Arc::new(AtomicUsize::new(0));
+
+    eprintln!("[CHAOS] Starting chaos loop...");
+    info!("Starting incremental snapshot chaos test");
+
+    // Spawn background health check task that distributes requests across nodes
+    let health_check_abort = {
+        let ingress_clients = ingress_clients.clone();
+        let success_tx = success_tx.clone();
+        let num_nodes = ingress_clients.len();
+        tokio::spawn(async move {
+            let mut counter = 0u64;
+            loop {
+                let partition = (counter as u32) % NUM_PARTITIONS;
+                let node_idx = (counter as usize) % num_nodes;
+                counter = counter.wrapping_add(1);
+
+                let url = format!("http://localhost/Counter/{partition}/get");
+                // Try the selected node, fall back to trying all nodes
+                let mut success = false;
+                let result: Result<reqwest::Response, _> =
+                    ingress_clients[node_idx].post(&url).send().await;
+                if result.is_ok_and(|r| r.status().is_success()) {
+                    success = true;
+                } else {
+                    // Try other nodes if the primary fails
+                    for (i, client) in ingress_clients.iter().enumerate() {
+                        if i == node_idx {
+                            continue;
+                        }
+                        let result: Result<reqwest::Response, _> = client.post(&url).send().await;
+                        if result.is_ok_and(|r| r.status().is_success()) {
+                            success = true;
+                            break;
+                        }
+                    }
+                }
+                if success {
+                    success_tx.send_modify(|v| *v += 1);
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        })
+    };
+
+    // Run chaos loop inline with a time-based termination
+    let chaos_start = Instant::now();
+    let num_nodes = cluster.nodes.len();
+    let mut invocation_counter = 0u64;
+    let mut iteration = 0u64;
+    let mut success_rx = success_rx.clone();
+
+    while chaos_start.elapsed() < chaos_duration {
+        eprintln!(
+            "[CHAOS] Iteration {} (elapsed: {:?})",
+            iteration,
+            chaos_start.elapsed()
+        );
+        info!("Chaos iteration {}", iteration);
+
+        // 1. Generate workload across partitions and nodes
+        for i in 0..10u64 {
+            let partition = ((invocation_counter + i) % NUM_PARTITIONS as u64) as u32;
+            let node_idx = ((invocation_counter + i) as usize) % num_nodes;
+            let url = format!("http://localhost/Counter/{partition}/add");
+            // Try the selected node, or fall back to a running node
+            let client = if cluster.nodes[node_idx].pid().is_some() {
+                &ingress_clients[node_idx]
+            } else {
+                // Find a running node
+                cluster
+                    .nodes
+                    .iter()
+                    .position(|n| n.pid().is_some())
+                    .map(|idx| &ingress_clients[idx])
+                    .unwrap_or(&ingress_clients[0])
+            };
+            let result: Result<reqwest::Response, _> = client
+                .post(&url)
+                .header("content-type", "application/json")
+                .body(invocation_counter.to_string())
+                .send()
+                .await;
+            if result.is_ok_and(|r| r.status().is_success()) {
+                successful_operations.fetch_add(1, Ordering::Relaxed);
+            }
+            invocation_counter += 1;
+        }
+
+        // 2. Create snapshot for partition (rotate through partitions)
+        let partition_id = (iteration % NUM_PARTITIONS as u64) as u32;
+
+        // Find a healthy node to send the request to
+        let client_node_idx = cluster
+            .nodes
+            .iter()
+            .position(|n| n.pid().is_some())
+            .unwrap_or(0);
+
+        let mut client = new_cluster_ctrl_client(
+            create_tonic_channel(
+                cluster.nodes[client_node_idx].advertised_address().clone(),
+                &NetworkingOptions::default(),
+                DNSResolution::Gai,
+            ),
+            &base_config.networking,
+        );
+
+        // Try to create snapshot, ignore errors (node might be down)
+        let snapshot_result = client
+            .create_partition_snapshot(CreatePartitionSnapshotRequest {
+                partition_id,
+                min_target_lsn: None,
+                trim_log: true,
+            })
+            .await;
+
+        if let Ok(response) = snapshot_result {
+            info!(
+                "Snapshot created for partition {} at LSN {}",
+                partition_id,
+                response.into_inner().min_applied_lsn
+            );
+        }
+
+        // 3. Restart node (rotate through nodes) with data wipe to force snapshot restore
+        let node_to_restart = (iteration as usize) % num_nodes;
+        let node_name;
+        let db_dir;
+        {
+            let node = &mut cluster.nodes[node_to_restart];
+            node_name = node.node_name().to_owned();
+            // Node data is stored in base_dir/<node_name>/db
+            db_dir = node.config().common.base_dir().join(&node_name).join("db");
+
+            info!("Restarting node '{}' with data wipe", node_name);
+
+            // Stop the node first
+            node.terminate()?;
+            let _ = node.status().await;
+
+            // Delete the RocksDB partition store directory to force snapshot restore
+            if db_dir.exists() {
+                std::fs::remove_dir_all(&db_dir)?;
+            }
+
+            // Start the node again (restart will be a no-op for stopping since already stopped)
+            if let Err(e) = node.restart(TerminationSignal::Sigterm).await {
+                fail!("Failed to restart node: {e}")?;
+            }
+        }
+
+        // Set up watcher for snapshot restore log message (needs fresh borrow after restart)
+        let mut snapshot_restore_watcher =
+            cluster.nodes[node_to_restart].lines("Found partition snapshot, restoring it".parse()?);
+
+        // 4. Wait for health
+        if let Err(e) = cluster
+            .wait_check_healthy(HealthCheck::Worker, Duration::from_secs(30))
+            .await
+        {
+            fail!("Failed to wait for cluster health: {e}")?;
+        }
+
+        // 5. Verify snapshot restore happened (we wiped the db, so it must restore from snapshot)
+        // We expect at least one partition to be restored from snapshot
+        let restore_result =
+            tokio::time::timeout(Duration::from_secs(5), snapshot_restore_watcher.next()).await;
+        if restore_result.is_err() {
+            fail!(
+                "Node '{}' did not restore any partition from snapshot after data wipe",
+                node_name
+            )?;
+        }
+        drop(snapshot_restore_watcher);
+        info!("Node '{}' restored from snapshot", node_name);
+
+        // 6. Gate on successful operation
+        success_rx.mark_unchanged();
+        tokio::time::timeout(EXPECTED_RECOVERY_DURATION, success_rx.changed())
+            .await
+            .map_err(|_| {
+                anyhow!("Failed to process requests within the expected recovery duration")
+            })
+            .into_test_result()??;
+
+        iteration += 1;
+    }
+
+    // Stop health check task
+    health_check_abort.abort();
+
+    eprintln!("[CHAOS] Chaos loop completed, verifying LSN convergence...");
+    // Verify applied LSN convergence for all partitions
+    info!("Waiting for applied LSN convergence");
+    let mut final_client = new_cluster_ctrl_client(
+        create_tonic_channel(
+            cluster.nodes[0].advertised_address().clone(),
+            &NetworkingOptions::default(),
+            DNSResolution::Gai,
+        ),
+        &base_config.networking,
+    );
+
+    // With partition replication = 2, we expect 2 processors per partition to converge
+    const PARTITION_REPLICATION: usize = 2;
+    for partition_id in 0..NUM_PARTITIONS {
+        eprintln!(
+            "[CHAOS] Checking LSN convergence for partition {}",
+            partition_id
+        );
+        applied_lsn_converged(
+            &mut final_client,
+            PARTITION_REPLICATION,
+            PartitionId::from(partition_id as u16),
+            MAX_WAIT_TIMEOUT,
+        )
+        .await?;
+        eprintln!("[CHAOS] Partition {} converged", partition_id);
+    }
+
+    // Verify we processed some requests successfully
+    let total_ops = successful_operations.load(Ordering::Relaxed);
+    info!(
+        "Chaos test completed. Total successful operations: {}",
+        total_ops
+    );
+    assert!(
+        total_ops > 0,
+        "Should have processed at least some operations successfully"
+    );
+
+    eprintln!("[CHAOS] LSN convergence complete, verifying snapshots exist...");
+    // Verify snapshots exist in the repository
+    for partition_id in 0..NUM_PARTITIONS {
+        let partition_dir = snapshots_dir.path().join(partition_id.to_string());
+        let latest_json = partition_dir.join("latest.json");
+        assert!(
+            latest_json.exists(),
+            "Snapshot metadata should exist for partition {}",
+            partition_id
+        );
+    }
+
+    eprintln!("[CHAOS] Snapshots verified, shutting down cluster...");
+    info!("Incremental snapshot chaos test passed!");
+    cluster.graceful_shutdown(Duration::from_secs(10)).await?;
+    eprintln!("[CHAOS] Test complete!");
+
+    Ok(())
+}
+
+async fn wait_all_partitions_active(
+    client: &mut ClusterCtrlSvcClient<Channel>,
+    expected_partitions: u32,
+    timeout: Duration,
+) -> googletest::Result<()> {
+    let start = Instant::now();
+    loop {
+        if start.elapsed() > timeout {
+            fail!(
+                "Timeout waiting for {} partitions to become active",
+                expected_partitions
+            )?;
+        }
+
+        let cluster_state = client
+            .get_cluster_state(ClusterStateRequest {})
+            .await?
+            .into_inner()
+            .cluster_state
+            .unwrap();
+
+        let active_partitions: u32 = cluster_state
+            .nodes
+            .values()
+            .map(|n| {
+                n.state
+                    .as_ref()
+                    .map(|s| match s {
+                        State::Alive(s) => s
+                            .partitions
+                            .values()
+                            .filter(|p| {
+                                RunMode::try_from(p.effective_mode)
+                                    .is_ok_and(|m| m == RunMode::Leader)
+                            })
+                            .count() as u32,
+                        _ => 0,
+                    })
+                    .unwrap_or(0)
+            })
+            .sum();
+
+        if active_partitions >= expected_partitions {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    Ok(())
+}
+
+async fn applied_lsn_converged(
+    client: &mut ClusterCtrlSvcClient<Channel>,
+    expected_processors: usize,
+    partition_id: PartitionId,
+    timeout: Duration,
+) -> googletest::Result<()> {
+    assert!(expected_processors > 0);
+    info!(
+        "Waiting for {} partition processor(s) to converge on the same applied LSN for partition {}",
+        expected_processors, partition_id
+    );
+
+    let start = Instant::now();
+    loop {
+        if start.elapsed() > timeout {
+            fail!(
+                "Timeout waiting for {} processors to converge on partition {}",
+                expected_processors,
+                partition_id
+            )?;
+        }
+
+        let cluster_state = match client.get_cluster_state(ClusterStateRequest {}).await {
+            Ok(response) => response.into_inner().cluster_state.unwrap(),
+            Err(_) => {
+                tokio::time::sleep(Duration::from_millis(250)).await;
+                continue;
+            }
+        };
+
+        let applied_lsns: Vec<_> = cluster_state
+            .nodes
+            .values()
+            .filter_map(|n| {
+                n.state.as_ref().and_then(|s| match s {
+                    State::Alive(s) => s
+                        .partitions
+                        .get(&partition_id.into())
+                        .and_then(|p| p.last_applied_log_lsn)
+                        .map(|lsn| lsn.value),
+                    _ => None,
+                })
+            })
+            .collect();
+
+        if applied_lsns.len() >= expected_processors
+            && !applied_lsns.is_empty()
+            && applied_lsns.iter().all(|lsn| *lsn == applied_lsns[0])
+        {
+            info!(
+                "Partition {} converged at LSN {}",
+                partition_id, applied_lsns[0]
+            );
+            break;
+        }
+
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    Ok(())
+}

--- a/server/tests/incremental_snapshots.rs
+++ b/server/tests/incremental_snapshots.rs
@@ -1,0 +1,943 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::HashSet;
+use std::net::SocketAddr;
+use std::num::NonZeroU64;
+use std::time::Duration;
+
+use enumset::EnumSet;
+use futures_util::StreamExt;
+use googletest::{IntoTestResult, fail};
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tonic::transport::Channel;
+use tracing::info;
+use url::Url;
+
+use restate_core::network::net_util::{DNSResolution, create_tonic_channel};
+use restate_core::protobuf::cluster_ctrl_svc::{
+    ClusterStateRequest, CreatePartitionSnapshotRequest,
+    cluster_ctrl_svc_client::ClusterCtrlSvcClient, new_cluster_ctrl_client,
+};
+use restate_local_cluster_runner::{
+    cluster::Cluster,
+    node::{BinarySource, NodeSpec},
+};
+use restate_types::config::Configuration;
+use restate_types::config::{LogFormat, NetworkingOptions, SnapshotType};
+use restate_types::logs::metadata::ProviderKind::Replicated;
+use restate_types::logs::metadata::{NodeSetSize, ProviderConfiguration, ReplicatedLogletConfig};
+use restate_types::net::address::PeerNetAddress;
+use restate_types::protobuf::cluster::RunMode;
+use restate_types::protobuf::cluster::node_state::State;
+use restate_types::replication::ReplicationProperty;
+use restate_types::retries::RetryPolicy;
+
+#[restate_core::test(flavor = "multi_thread", worker_threads = 4)]
+async fn incremental_snapshot_cleanup() -> googletest::Result<()> {
+    const RETAIN_SNAPSHOTS: usize = 5;
+    const TOTAL_SNAPSHOTS: usize = 10;
+    // Each invocation generates ~3 log records
+    const RECORDS_PER_SNAPSHOT: u64 = 10;
+    // Send enough invocations to exceed the threshold
+    const INVOCATIONS_PER_BURST: usize = 5; // ~15 records, exceeds threshold of 10
+
+    let mut base_config = Configuration::new_unix_sockets();
+    base_config.common.default_num_partitions = 1.try_into()?;
+    base_config.bifrost.default_provider = Replicated;
+    base_config.common.log_filter = "warn,restate=debug".to_owned();
+    base_config.common.log_format = LogFormat::Compact;
+    base_config.common.log_disable_ansi_codes = true;
+
+    let snapshots_dir = TempDir::new()?;
+    base_config.worker.snapshots.destination = Some(
+        Url::from_file_path(snapshots_dir.path())
+            .unwrap()
+            .to_string(),
+    );
+    base_config.worker.snapshots.experimental_snapshot_type = SnapshotType::Incremental;
+    base_config.worker.snapshots.num_retained =
+        std::num::NonZeroU8::new(RETAIN_SNAPSHOTS as u8).unwrap();
+    // Enable automatic snapshots based on record count
+    base_config.worker.snapshots.snapshot_interval_num_records =
+        Some(NonZeroU64::new(RECORDS_PER_SNAPSHOT).unwrap());
+    // Fast check interval for responsive snapshot triggering (jitter will be 10% = 5ms)
+    base_config.worker.snapshots.check_interval = Some(Duration::from_millis(50).into());
+
+    let nodes = NodeSpec::new_test_nodes(
+        base_config.clone(),
+        BinarySource::CargoTest,
+        EnumSet::all(),
+        1,
+        false,
+    );
+
+    let mut cluster = Cluster::builder()
+        .cluster_name("incremental-snapshot-cleanup")
+        .nodes(nodes)
+        .temp_base_dir("incremental_snapshot_cleanup")
+        .build()
+        .start()
+        .await?;
+
+    let replicated_loglet_config = ReplicatedLogletConfig {
+        target_nodeset_size: NodeSetSize::default(),
+        replication_property: ReplicationProperty::new_unchecked(1),
+    };
+
+    info!("Provisioning the cluster");
+    cluster.nodes[0]
+        .provision_cluster(
+            None,
+            ReplicationProperty::new_unchecked(1),
+            Some(ProviderConfiguration::Replicated(replicated_loglet_config)),
+            EnumSet::empty(),
+        )
+        .await
+        .into_test_result()?;
+
+    let worker_1 = &cluster.nodes[0];
+    let mut worker_1_ready = worker_1.lines("Partition [0-9]+ started".parse()?);
+
+    info!("Waiting until the cluster is healthy");
+    cluster.wait_healthy(Duration::from_secs(60)).await?;
+
+    info!("Waiting until node-1 has started the partition processor");
+    worker_1_ready.next().await;
+    drop(worker_1_ready);
+
+    let mut client = new_cluster_ctrl_client(
+        create_tonic_channel(
+            cluster.nodes[0].advertised_address().clone(),
+            &NetworkingOptions::default(),
+            DNSResolution::Gai,
+        ),
+        &base_config.networking,
+    );
+
+    info!("Waiting until the partition processor has become the leader");
+    any_partition_active(&mut client).await?;
+
+    // Start mock service and register it
+    let (running_tx, running_rx) = oneshot::channel();
+    let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
+    let listener = TcpListener::bind(addr).await?;
+    let addr = listener.local_addr()?;
+    let mock_svc_port = addr.port();
+
+    tokio::spawn(async move {
+        info!("Starting mock service on http://{}", addr);
+        if let Err(e) = mock_service_endpoint::listener::run_listener(listener, || {
+            let _ = running_tx.send(());
+        })
+        .await
+        {
+            panic!("Error running listener: {e:?}");
+        }
+    });
+
+    running_rx.await?;
+
+    let admin_uds = worker_1
+        .admin_address()
+        .clone()
+        .unwrap()
+        .into_address()
+        .unwrap();
+    let PeerNetAddress::Uds(admin_uds) = admin_uds else {
+        panic!("admin address must be a unix domain socket");
+    };
+    let admin_http_client = reqwest::Client::builder().unix_socket(admin_uds).build()?;
+    let registration_response = admin_http_client
+        .post("http://localhost/deployments")
+        .header("content-type", "application/json")
+        .json(&serde_json::json!({ "uri": format!("http://127.0.0.1:{mock_svc_port}") }))
+        .send()
+        .await?;
+    assert!(registration_response.status().is_success());
+
+    let ingress_uds = worker_1
+        .ingress_address()
+        .clone()
+        .unwrap()
+        .into_address()
+        .unwrap();
+    let PeerNetAddress::Uds(ingress_uds) = ingress_uds else {
+        panic!("ingress address must be a unix domain socket");
+    };
+    let ingress_http_client = reqwest::Client::builder()
+        .unix_socket(ingress_uds)
+        .build()?;
+
+    // Initial request to warm up the service
+    info!("Sending initial request");
+    let mut retry = RetryPolicy::fixed_delay(Duration::from_millis(500), None).into_iter();
+    loop {
+        let response = ingress_http_client
+            .post("http://localhost/Counter/0/get")
+            .send()
+            .await?;
+        if response.status().is_success() {
+            break;
+        }
+        if let Some(delay) = retry.next() {
+            tokio::time::sleep(delay).await;
+        } else {
+            fail!("Failed to invoke worker")?;
+        }
+    }
+
+    let partition_dir = snapshots_dir.path().join("0");
+
+    info!(
+        "Creating {} automatic snapshots with {} invocations per burst",
+        TOTAL_SNAPSHOTS, INVOCATIONS_PER_BURST
+    );
+    let mut invocation_counter = 0;
+    for snapshot_num in 0..TOTAL_SNAPSHOTS {
+        let snapshot_id_before = get_latest_snapshot_id(&partition_dir);
+
+        for _ in 0..INVOCATIONS_PER_BURST {
+            let response = ingress_http_client
+                .post("http://localhost/Counter/0/add")
+                .header("content-type", "application/json")
+                .body(invocation_counter.to_string())
+                .send()
+                .await?;
+            assert!(
+                response.status().is_success(),
+                "Invocation {} failed: {}",
+                invocation_counter,
+                response.status()
+            );
+            invocation_counter += 1;
+        }
+
+        // Wait for automatic snapshot to be created (detected by snapshot_id change)
+        let snapshot_created = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let current_id = get_latest_snapshot_id(&partition_dir);
+                if let Some(id) = current_id
+                    && Some(&id) != snapshot_id_before.as_ref()
+                {
+                    return id;
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await;
+
+        match snapshot_created {
+            Ok(snapshot_id) => {
+                let retained_count = count_retained_snapshots(&partition_dir);
+                info!(
+                    "Snapshot {}/{} created: {} (retained: {})",
+                    snapshot_num + 1,
+                    TOTAL_SNAPSHOTS,
+                    snapshot_id,
+                    retained_count
+                );
+            }
+            Err(_) => {
+                fail!(
+                    "Timeout waiting for snapshot {}/{} to be created",
+                    snapshot_num + 1,
+                    TOTAL_SNAPSHOTS
+                )?;
+            }
+        }
+    }
+
+    // Wait for cleanup
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let (retained_snapshots, referenced_ssts) =
+        verify_snapshot_state(&partition_dir, RETAIN_SNAPSHOTS)?;
+
+    info!(
+        "After {} automatic snapshots: {} retained, {} SSTs referenced",
+        TOTAL_SNAPSHOTS,
+        retained_snapshots.len(),
+        referenced_ssts.len()
+    );
+
+    info!("Incremental snapshot cleanup test passed!");
+    cluster.graceful_shutdown(Duration::from_secs(10)).await?;
+
+    Ok(())
+}
+
+fn get_latest_snapshot_id(partition_dir: &std::path::Path) -> Option<String> {
+    let latest_json_path = partition_dir.join("latest.json");
+    if !latest_json_path.exists() {
+        return None;
+    }
+
+    let content = std::fs::read_to_string(&latest_json_path).ok()?;
+    let latest_json: serde_json::Value = serde_json::from_str(&content).ok()?;
+
+    latest_json["snapshot_id"].as_str().map(|s| s.to_string())
+}
+
+fn count_retained_snapshots(partition_dir: &std::path::Path) -> usize {
+    let latest_json_path = partition_dir.join("latest.json");
+    if !latest_json_path.exists() {
+        return 0;
+    }
+
+    let Ok(content) = std::fs::read_to_string(&latest_json_path) else {
+        return 0;
+    };
+    let Ok(latest_json) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return 0;
+    };
+
+    latest_json["retained_snapshots"]
+        .as_array()
+        .map(|arr| arr.len())
+        .unwrap_or(0)
+}
+
+fn verify_snapshot_state(
+    partition_dir: &std::path::Path,
+    expected_retained: usize,
+) -> googletest::Result<(HashSet<String>, HashSet<String>)> {
+    let latest_json_path = partition_dir.join("latest.json");
+    assert!(
+        latest_json_path.exists(),
+        "latest.json should exist in partition directory"
+    );
+
+    let latest_json: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&latest_json_path)?)?;
+
+    // Check retained snapshots count
+    let retained_snapshots = latest_json["retained_snapshots"]
+        .as_array()
+        .expect("retained_snapshots should be an array");
+    assert_eq!(
+        retained_snapshots.len(),
+        expected_retained,
+        "Should retain exactly {} snapshots, found {}",
+        expected_retained,
+        retained_snapshots.len()
+    );
+
+    // Check pending deletions is empty
+    let empty_vec = vec![];
+    let pending_deletions = latest_json["pending_deletions"]
+        .as_array()
+        .unwrap_or(&empty_vec);
+    assert!(
+        pending_deletions.is_empty(),
+        "Pending deletions should be empty after cleanup, found: {:?}",
+        pending_deletions
+    );
+
+    // Collect retained snapshot IDs
+    let retained_ids: HashSet<String> = retained_snapshots
+        .iter()
+        .map(|s| s["snapshot_id"].as_str().unwrap().to_string())
+        .collect();
+
+    // Collect all SSTs referenced by retained snapshots
+    let mut referenced_ssts: HashSet<String> = HashSet::new();
+    for retained in retained_snapshots {
+        let snapshot_path = retained["path"].as_str().unwrap();
+        let metadata_path = partition_dir.join(snapshot_path).join("metadata.json");
+
+        assert!(
+            metadata_path.exists(),
+            "Retained snapshot metadata should exist: {}",
+            metadata_path.display()
+        );
+
+        let metadata: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&metadata_path)?)?;
+
+        // Collect SST keys from file_keys (incremental snapshots)
+        if let Some(file_keys) = metadata["file_keys"].as_object() {
+            for sst_key in file_keys.values() {
+                if let Some(key) = sst_key.as_str() {
+                    // Extract just the filename from "ssts/N1_000001.sst"
+                    if let Some(filename) = key.split('/').next_back() {
+                        referenced_ssts.insert(filename.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    // Check for orphaned SSTs in the ssts/ directory
+    let ssts_dir = partition_dir.join("ssts");
+    if ssts_dir.exists() {
+        let sst_files: Vec<_> = std::fs::read_dir(&ssts_dir)?
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "sst"))
+            .collect();
+
+        for sst_file in &sst_files {
+            let filename = sst_file.file_name().to_string_lossy().to_string();
+            assert!(
+                referenced_ssts.contains(&filename),
+                "Orphaned SST file found: {} (not referenced by any retained snapshot)",
+                filename
+            );
+        }
+
+        info!(
+            "Verified {} SST files in ssts/ directory, all referenced",
+            sst_files.len()
+        );
+    }
+
+    Ok((retained_ids, referenced_ssts))
+}
+
+async fn any_partition_active(
+    client: &mut ClusterCtrlSvcClient<Channel>,
+) -> googletest::Result<()> {
+    loop {
+        let cluster_state = client
+            .get_cluster_state(ClusterStateRequest {})
+            .await?
+            .into_inner()
+            .cluster_state
+            .unwrap();
+
+        if cluster_state.nodes.values().any(|n| {
+            n.state.as_ref().is_some_and(|s| match s {
+                State::Alive(s) => s.partitions.values().any(|p| {
+                    RunMode::try_from(p.effective_mode).is_ok_and(|m| m == RunMode::Leader)
+                }),
+                _ => false,
+            })
+        }) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    Ok(())
+}
+
+#[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn sequential_snapshots() -> googletest::Result<()> {
+    const RETAIN_SNAPSHOTS: usize = 3;
+    const NUM_SNAPSHOTS: usize = 4;
+
+    let mut base_config = Configuration::new_unix_sockets();
+    base_config.common.default_num_partitions = 1.try_into()?;
+    base_config.bifrost.default_provider = Replicated;
+    base_config.common.log_filter = "warn,restate=debug".to_owned();
+    base_config.common.log_format = LogFormat::Compact;
+    base_config.common.log_disable_ansi_codes = true;
+
+    let snapshots_dir = TempDir::new()?;
+    base_config.worker.snapshots.destination = Some(
+        Url::from_file_path(snapshots_dir.path())
+            .unwrap()
+            .to_string(),
+    );
+    base_config.worker.snapshots.experimental_snapshot_type = SnapshotType::Incremental;
+    base_config.worker.snapshots.num_retained =
+        std::num::NonZeroU8::new(RETAIN_SNAPSHOTS as u8).unwrap();
+    // No snapshot_interval_num_records - we trigger manually via RPC
+    // Fast check interval for responsive snapshot triggering
+    base_config.worker.snapshots.check_interval = Some(Duration::from_millis(50).into());
+
+    let nodes = NodeSpec::new_test_nodes(
+        base_config.clone(),
+        BinarySource::CargoTest,
+        EnumSet::all(),
+        1,
+        false,
+    );
+
+    let mut cluster = Cluster::builder()
+        .cluster_name("back-to-back-manual-snapshots")
+        .nodes(nodes)
+        .temp_base_dir("back_to_back_manual_snapshots")
+        .build()
+        .start()
+        .await?;
+
+    let replicated_loglet_config = ReplicatedLogletConfig {
+        target_nodeset_size: NodeSetSize::default(),
+        replication_property: ReplicationProperty::new_unchecked(1),
+    };
+
+    info!("Provisioning the cluster");
+    cluster.nodes[0]
+        .provision_cluster(
+            None,
+            ReplicationProperty::new_unchecked(1),
+            Some(ProviderConfiguration::Replicated(replicated_loglet_config)),
+            EnumSet::empty(),
+        )
+        .await
+        .into_test_result()?;
+
+    let worker_1 = &cluster.nodes[0];
+    let mut worker_1_ready = worker_1.lines("Partition [0-9]+ started".parse()?);
+
+    info!("Waiting until the cluster is healthy");
+    cluster.wait_healthy(Duration::from_secs(60)).await?;
+
+    info!("Waiting until node-1 has started the partition processor");
+    worker_1_ready.next().await;
+    drop(worker_1_ready);
+
+    let mut client = new_cluster_ctrl_client(
+        create_tonic_channel(
+            cluster.nodes[0].advertised_address().clone(),
+            &NetworkingOptions::default(),
+            DNSResolution::Gai,
+        ),
+        &base_config.networking,
+    );
+
+    info!("Waiting until the partition processor has become the leader");
+    any_partition_active(&mut client).await?;
+
+    // Start mock service and register it
+    let (running_tx, running_rx) = oneshot::channel();
+    let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
+    let listener = TcpListener::bind(addr).await?;
+    let addr = listener.local_addr()?;
+    let mock_svc_port = addr.port();
+
+    tokio::spawn(async move {
+        info!("Starting mock service on http://{}", addr);
+        if let Err(e) = mock_service_endpoint::listener::run_listener(listener, || {
+            let _ = running_tx.send(());
+        })
+        .await
+        {
+            panic!("Error running listener: {e:?}");
+        }
+    });
+
+    running_rx.await?;
+
+    let admin_uds = worker_1
+        .admin_address()
+        .clone()
+        .unwrap()
+        .into_address()
+        .unwrap();
+    let PeerNetAddress::Uds(admin_uds) = admin_uds else {
+        panic!("admin address must be a unix domain socket");
+    };
+    let admin_http_client = reqwest::Client::builder().unix_socket(admin_uds).build()?;
+    let registration_response = admin_http_client
+        .post("http://localhost/deployments")
+        .header("content-type", "application/json")
+        .json(&serde_json::json!({ "uri": format!("http://127.0.0.1:{mock_svc_port}") }))
+        .send()
+        .await?;
+    assert!(registration_response.status().is_success());
+
+    let ingress_uds = worker_1
+        .ingress_address()
+        .clone()
+        .unwrap()
+        .into_address()
+        .unwrap();
+    let PeerNetAddress::Uds(ingress_uds) = ingress_uds else {
+        panic!("ingress address must be a unix domain socket");
+    };
+    let ingress_http_client = reqwest::Client::builder()
+        .unix_socket(ingress_uds)
+        .build()?;
+
+    info!("Sending initial request");
+    let mut retry = RetryPolicy::fixed_delay(Duration::from_millis(500), None).into_iter();
+    loop {
+        let response = ingress_http_client
+            .post("http://localhost/Counter/0/get")
+            .send()
+            .await?;
+        if response.status().is_success() {
+            break;
+        }
+        if let Some(delay) = retry.next() {
+            tokio::time::sleep(delay).await;
+        } else {
+            fail!("Failed to invoke worker")?;
+        }
+    }
+
+    let partition_dir = snapshots_dir.path().join("0");
+
+    // Trigger rapid back-to-back snapshots via RPC
+    info!("Triggering {} back-to-back manual snapshots", NUM_SNAPSHOTS);
+    let mut snapshot_ids: Vec<String> = Vec::new();
+
+    for i in 0..NUM_SNAPSHOTS {
+        // Send a request to generate state changes before snapshot
+        let response = ingress_http_client
+            .post("http://localhost/Counter/0/add")
+            .header("content-type", "application/json")
+            .body(i.to_string())
+            .send()
+            .await?;
+        assert!(response.status().is_success());
+
+        // Trigger snapshot via RPC with retry logic for lease contention.
+        // The previous snapshot's lease may not have been released yet (async release),
+        // so retry with a short delay if we get a "same node" lease error.
+        let mut retry = RetryPolicy::fixed_delay(Duration::from_millis(50), Some(20)).into_iter();
+        let snapshot_response = loop {
+            match client
+                .create_partition_snapshot(CreatePartitionSnapshotRequest {
+                    partition_id: 0,
+                    min_target_lsn: None,
+                    trim_log: false,
+                })
+                .await
+            {
+                Ok(response) => break response.into_inner(),
+                Err(status) => {
+                    let msg = status.message().to_lowercase();
+                    // Retry if the previous lease hasn't been released yet
+                    if (msg.contains("same node") || msg.contains("concurrent"))
+                        && let Some(delay) = retry.next()
+                    {
+                        tokio::time::sleep(delay).await;
+                        continue;
+                    }
+                    return Err(status.into());
+                }
+            }
+        };
+
+        info!(
+            "Snapshot {}/{} created: id={}, lsn={}",
+            i + 1,
+            NUM_SNAPSHOTS,
+            snapshot_response.snapshot_id,
+            snapshot_response.min_applied_lsn
+        );
+
+        snapshot_ids.push(snapshot_response.snapshot_id);
+    }
+
+    // Verify all snapshot IDs are unique
+    let unique_ids: HashSet<_> = snapshot_ids.iter().collect();
+    assert_eq!(
+        unique_ids.len(),
+        snapshot_ids.len(),
+        "All snapshot IDs should be unique"
+    );
+
+    // Wait for cleanup to complete
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Verify snapshot state
+    let (retained_snapshots, referenced_ssts) =
+        verify_snapshot_state(&partition_dir, RETAIN_SNAPSHOTS)?;
+
+    info!(
+        "Verified: {} retained snapshots, {} SSTs referenced",
+        retained_snapshots.len(),
+        referenced_ssts.len()
+    );
+
+    info!("Back-to-back manual snapshots test passed!");
+    cluster.graceful_shutdown(Duration::from_secs(10)).await?;
+
+    Ok(())
+}
+
+#[restate_core::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_snapshot_requests() -> googletest::Result<()> {
+    const RETAIN_SNAPSHOTS: usize = 3;
+    const CONCURRENT_REQUESTS: usize = 3;
+
+    let mut base_config = Configuration::new_unix_sockets();
+    base_config.common.default_num_partitions = 1.try_into()?;
+    base_config.bifrost.default_provider = Replicated;
+    base_config.common.log_filter = "warn,restate=debug".to_owned();
+    base_config.common.log_format = LogFormat::Compact;
+    base_config.common.log_disable_ansi_codes = true;
+
+    let snapshots_dir = TempDir::new()?;
+    base_config.worker.snapshots.destination = Some(
+        Url::from_file_path(snapshots_dir.path())
+            .unwrap()
+            .to_string(),
+    );
+    base_config.worker.snapshots.experimental_snapshot_type = SnapshotType::Incremental;
+    base_config.worker.snapshots.num_retained =
+        std::num::NonZeroU8::new(RETAIN_SNAPSHOTS as u8).unwrap();
+    base_config.worker.snapshots.check_interval = Some(Duration::from_millis(50).into());
+
+    let nodes = NodeSpec::new_test_nodes(
+        base_config.clone(),
+        BinarySource::CargoTest,
+        EnumSet::all(),
+        1,
+        false,
+    );
+
+    let mut cluster = Cluster::builder()
+        .cluster_name("concurrent-snapshot-requests")
+        .nodes(nodes)
+        .temp_base_dir("concurrent_snapshot_requests")
+        .build()
+        .start()
+        .await?;
+
+    let replicated_loglet_config = ReplicatedLogletConfig {
+        target_nodeset_size: NodeSetSize::default(),
+        replication_property: ReplicationProperty::new_unchecked(1),
+    };
+
+    info!("Provisioning the cluster");
+    cluster.nodes[0]
+        .provision_cluster(
+            None,
+            ReplicationProperty::new_unchecked(1),
+            Some(ProviderConfiguration::Replicated(replicated_loglet_config)),
+            EnumSet::empty(),
+        )
+        .await
+        .into_test_result()?;
+
+    let worker_1 = &cluster.nodes[0];
+    let mut worker_1_ready = worker_1.lines("Partition [0-9]+ started".parse()?);
+
+    info!("Waiting until the cluster is healthy");
+    cluster.wait_healthy(Duration::from_secs(60)).await?;
+
+    info!("Waiting until node-1 has started the partition processor");
+    worker_1_ready.next().await;
+    drop(worker_1_ready);
+
+    let client = new_cluster_ctrl_client(
+        create_tonic_channel(
+            cluster.nodes[0].advertised_address().clone(),
+            &NetworkingOptions::default(),
+            DNSResolution::Gai,
+        ),
+        &base_config.networking,
+    );
+
+    let mut leader_client = client.clone();
+    info!("Waiting until the partition processor has become the leader");
+    any_partition_active(&mut leader_client).await?;
+
+    // Start mock service and register it
+    let (running_tx, running_rx) = oneshot::channel();
+    let addr: SocketAddr = ([127, 0, 0, 1], 0).into();
+    let listener = TcpListener::bind(addr).await?;
+    let addr = listener.local_addr()?;
+    let mock_svc_port = addr.port();
+
+    tokio::spawn(async move {
+        info!("Starting mock service on http://{}", addr);
+        if let Err(e) = mock_service_endpoint::listener::run_listener(listener, || {
+            let _ = running_tx.send(());
+        })
+        .await
+        {
+            panic!("Error running listener: {e:?}");
+        }
+    });
+
+    running_rx.await?;
+
+    let admin_uds = worker_1
+        .admin_address()
+        .clone()
+        .unwrap()
+        .into_address()
+        .unwrap();
+    let PeerNetAddress::Uds(admin_uds) = admin_uds else {
+        panic!("admin address must be a unix domain socket");
+    };
+    let admin_http_client = reqwest::Client::builder().unix_socket(admin_uds).build()?;
+    let registration_response = admin_http_client
+        .post("http://localhost/deployments")
+        .header("content-type", "application/json")
+        .json(&serde_json::json!({ "uri": format!("http://127.0.0.1:{mock_svc_port}") }))
+        .send()
+        .await?;
+    assert!(registration_response.status().is_success());
+
+    let ingress_uds = worker_1
+        .ingress_address()
+        .clone()
+        .unwrap()
+        .into_address()
+        .unwrap();
+    let PeerNetAddress::Uds(ingress_uds) = ingress_uds else {
+        panic!("ingress address must be a unix domain socket");
+    };
+    let ingress_http_client = reqwest::Client::builder()
+        .unix_socket(ingress_uds)
+        .build()?;
+
+    // Initial request to warm up the service
+    info!("Sending initial request");
+    let mut retry = RetryPolicy::fixed_delay(Duration::from_millis(500), None).into_iter();
+    loop {
+        let response = ingress_http_client
+            .post("http://localhost/Counter/0/get")
+            .send()
+            .await?;
+        if response.status().is_success() {
+            break;
+        }
+        if let Some(delay) = retry.next() {
+            tokio::time::sleep(delay).await;
+        } else {
+            fail!("Failed to invoke worker")?;
+        }
+    }
+
+    let partition_dir = snapshots_dir.path().join("0");
+
+    // Record initial state (may be None if no snapshot exists yet)
+    let snapshot_id_before = get_latest_snapshot_id(&partition_dir);
+    let retained_before = count_retained_snapshots(&partition_dir);
+    info!(
+        "Initial state: snapshot_id={:?}, retained_count={}",
+        snapshot_id_before, retained_before
+    );
+
+    // Spawn concurrent snapshot requests
+    info!(
+        "Spawning {} concurrent snapshot requests",
+        CONCURRENT_REQUESTS
+    );
+
+    let mut handles = Vec::new();
+    for i in 0..CONCURRENT_REQUESTS {
+        let mut client_clone = client.clone();
+        let handle = tokio::spawn(async move {
+            let result = client_clone
+                .create_partition_snapshot(CreatePartitionSnapshotRequest {
+                    partition_id: 0,
+                    min_target_lsn: None,
+                    trim_log: false,
+                })
+                .await;
+            (i, result)
+        });
+        handles.push(handle);
+    }
+
+    // Collect results
+    let mut successes = Vec::new();
+    let mut in_progress_errors = 0;
+    let mut other_errors = Vec::new();
+
+    for handle in handles {
+        let (i, result) = handle.await?;
+        match result {
+            Ok(response) => {
+                let snapshot_id = response.into_inner().snapshot_id;
+                info!("Request {}: succeeded with snapshot_id={}", i, snapshot_id);
+                successes.push(snapshot_id);
+            }
+            Err(status) => {
+                let msg = status.message().to_lowercase();
+                // Check if it's a SnapshotInProgress error (message: "Snapshot export in progress")
+                if msg.contains("in progress") {
+                    info!("Request {}: blocked (snapshot in progress)", i);
+                    in_progress_errors += 1;
+                } else {
+                    info!("Request {}: failed with error: {}", i, status);
+                    other_errors.push(status.to_string());
+                }
+            }
+        }
+    }
+
+    info!(
+        "Results: {} successes, {} in-progress rejections, {} other errors",
+        successes.len(),
+        in_progress_errors,
+        other_errors.len()
+    );
+
+    // Verify at least one snapshot was created
+    assert!(
+        !successes.is_empty(),
+        "At least one snapshot request should succeed"
+    );
+
+    // Verify no unexpected errors
+    assert!(
+        other_errors.is_empty(),
+        "No unexpected errors should occur: {:?}",
+        other_errors
+    );
+
+    // All concurrent requests should either succeed or get SnapshotInProgress.
+    // Multiple successes are possible if requests serialize (first completes before
+    // second arrives), but typically we expect 1 success and rest blocked.
+    assert_eq!(
+        successes.len() + in_progress_errors,
+        CONCURRENT_REQUESTS,
+        "All requests should either succeed or be blocked"
+    );
+
+    // The single-writer guarantee means concurrent requests hitting during an
+    // in-progress snapshot should be blocked. Verify we got some blocking.
+    assert!(
+        in_progress_errors > 0 || successes.len() == 1,
+        "Either some requests should be blocked, or only one request succeeded"
+    );
+
+    // Wait for cleanup
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Verify only one new snapshot was created
+    let snapshot_id_after = get_latest_snapshot_id(&partition_dir);
+    assert!(
+        snapshot_id_after.is_some(),
+        "A snapshot should exist after concurrent requests"
+    );
+
+    let retained_after = count_retained_snapshots(&partition_dir);
+    info!(
+        "After state: snapshot_id={:?}, retained_count={}",
+        snapshot_id_after, retained_after
+    );
+
+    // Retained count should increase by the number of successful requests, capped by
+    // the retention limit. With RETAIN_SNAPSHOTS=3 and starting from 0, all 3 concurrent
+    // requests succeeding would give us 3 retained. But typically only 1 succeeds.
+    let new_snapshots = retained_after.saturating_sub(retained_before);
+    assert!(
+        new_snapshots <= successes.len(),
+        "Retained count increase ({}) should not exceed successful requests ({})",
+        new_snapshots,
+        successes.len()
+    );
+
+    // Verify snapshot state is consistent
+    let (retained_ids, referenced_ssts) = verify_snapshot_state(&partition_dir, retained_after)?;
+
+    info!(
+        "Verified: {} retained snapshots, {} SSTs referenced",
+        retained_ids.len(),
+        referenced_ssts.len()
+    );
+
+    info!("Concurrent snapshot requests test passed!");
+    cluster.graceful_shutdown(Duration::from_secs(10)).await?;
+
+    Ok(())
+}

--- a/server/tests/incremental_snapshots.rs
+++ b/server/tests/incremental_snapshots.rs
@@ -42,6 +42,8 @@ use restate_types::protobuf::cluster::node_state::State;
 use restate_types::replication::ReplicationProperty;
 use restate_types::retries::RetryPolicy;
 
+const TEST_LOG_FILTER: &str = "warn,restate=debug";
+
 #[restate_core::test(flavor = "multi_thread", worker_threads = 4)]
 async fn incremental_snapshot_cleanup() -> googletest::Result<()> {
     const RETAIN_SNAPSHOTS: usize = 5;
@@ -54,7 +56,7 @@ async fn incremental_snapshot_cleanup() -> googletest::Result<()> {
     let mut base_config = Configuration::new_unix_sockets();
     base_config.common.default_num_partitions = 1.try_into()?;
     base_config.bifrost.default_provider = Replicated;
-    base_config.common.log_filter = "warn,restate=debug".to_owned();
+    base_config.common.log_filter = TEST_LOG_FILTER.to_owned();
     base_config.common.log_format = LogFormat::Compact;
     base_config.common.log_disable_ansi_codes = true;
 
@@ -437,7 +439,7 @@ async fn sequential_snapshots() -> googletest::Result<()> {
     let mut base_config = Configuration::new_unix_sockets();
     base_config.common.default_num_partitions = 1.try_into()?;
     base_config.bifrost.default_provider = Replicated;
-    base_config.common.log_filter = "warn,restate=debug".to_owned();
+    base_config.common.log_filter = TEST_LOG_FILTER.to_owned();
     base_config.common.log_format = LogFormat::Compact;
     base_config.common.log_disable_ansi_codes = true;
 
@@ -666,7 +668,7 @@ async fn concurrent_snapshot_requests() -> googletest::Result<()> {
     let mut base_config = Configuration::new_unix_sockets();
     base_config.common.default_num_partitions = 1.try_into()?;
     base_config.bifrost.default_provider = Replicated;
-    base_config.common.log_filter = "warn,restate=debug".to_owned();
+    base_config.common.log_filter = TEST_LOG_FILTER.to_owned();
     base_config.common.log_format = LogFormat::Compact;
     base_config.common.log_disable_ansi_codes = true;
 


### PR DESCRIPTION
Adds an in-tree chaos test that stresses incremental snapshots and the restore path by repeatedly killing nodes and corrupting the **latest** snapshot (deleting some of its SSTs), then asserting the cluster recovers by falling back to an earlier retained snapshot.

Contains:
- `Add incremental snapshot chaos test` — the chaos harness (multi-node cluster, node kills, snapshot/restore cycling).
- `Add snapshot corruption to chaos test to verify fallback restore` — corrupts the latest snapshot's SSTs and verifies the fallback-restore path (from #4917) recovers.

This is the "integration test" half split out of the original #4222. It sits on top of the snapshot stack (leases → incremental snapshots → pruning) and exercises the fallback restore introduced in #4917.

Stack (bottom → top):
- #4917 — Enable restoring an earlier snapshot if latest fails (base `main`)
- #4204 — Introduce leases for snapshot coordination
- #4198 — Add incremental snapshot support
- #4212 — Add orphaned snapshot objects pruning
- this PR — incremental snapshot chaos test
