### PR TITLE
[Restate UI] Update to v1.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8833,8 +8833,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "1.0.5"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v1.0.5#1bdc2355eea4928541a1f980895868688255d31d"
+version = "1.0.6"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v1.0.6#504fd947d67810d0941ee6573d39955752f533a6"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -39,7 +39,7 @@ restate-util-time = { workspace = true }
 restate-types = { workspace = true }
 restate-util-string = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "1.0.5", tag = "v1.0.5" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "1.0.6", tag = "v1.0.6" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v1.0.6
published at https://github.com/restatedev/restate-web-ui/releases/download/v1.0.6/ui-v1.0.6.zip