### PR TITLE
ingestion-client: Configurable seuqential mode

### DIFF
--- a/crates/ingestion-client/src/session.rs
+++ b/crates/ingestion-client/src/session.rs
@@ -177,6 +177,13 @@ pub struct SessionOptions {
     /// Connection swimlane
     #[cfg_attr(any(test, feature = "test-util"), builder(default=Swimlane::General))]
     pub(crate) swimlane: Swimlane,
+    /// Force sequential mode. In sequential
+    /// mode, a max of a single batch can be
+    /// in-flight.
+    ///
+    /// Default: false
+    #[builder(default)]
+    pub(crate) sequential_mode: bool,
 }
 
 impl SessionOptions {
@@ -200,6 +207,7 @@ impl Default for SessionOptions {
                 None,
                 Some(Duration::from_secs(1)),
             ),
+            sequential_mode: false,
         }
     }
 }
@@ -371,7 +379,8 @@ where
         match result {
             Ok(connection) => {
                 debug!("Connection established to node {}", node_id);
-                if connection.protocol_version() <= ProtocolVersion::V3 {
+                if connection.protocol_version() <= ProtocolVersion::V3 || self.opts.sequential_mode
+                {
                     Some(SessionState::ConnectedSequentialMode { connection })
                 } else {
                     Some(SessionState::ConnectedPipeliningMode { connection })

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -301,6 +301,7 @@ impl Node {
                 .record_size_limit(config.ingress.request_size_limit())
                 .connection_retry_policy(config.ingress.ingestion.connection_retry_policy.clone())
                 .swimlane(Swimlane::IngressData)
+                .sequential_mode(config.ingress.ingestion.sequential_mode)
                 .build()
                 .expect("Ingestion session options to build"),
         );

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -1246,6 +1246,20 @@ pub struct IngestionOptions {
     ///
     /// Defaults to 50 KiB.
     pub request_batch_size: NonZeroByteCount,
+
+    /// # Force Sequential Ingestion Mode
+    ///
+    /// By default, the ingestion client pipelines batches, keeping multiple
+    /// uncommitted batches in flight at once for higher throughput. When this
+    /// is enabled, the client instead runs in sequential mode: it sends one
+    /// batch and waits for it to be committed before sending the next, so at
+    /// most a single uncommitted batch is in flight at any time.
+    ///
+    /// Note that sequential mode is always used when talking to nodes running
+    /// protocol version V3 or older, regardless of this setting.
+    ///
+    /// Default: false
+    pub sequential_mode: bool,
 }
 
 impl Default for IngestionOptions {
@@ -1255,14 +1269,15 @@ impl Default for IngestionOptions {
                 NonZeroUsize::new(1024 * 1024).expect("non zero"),
             ), //1 MiB
             connection_retry_policy: RetryPolicy::exponential(
-                Duration::from_millis(10),
+                Duration::from_millis(250),
                 2.0,
                 None,
-                Some(Duration::from_secs(2)),
+                Some(Duration::from_secs(3)),
             ),
             request_batch_size: NonZeroByteCount::new(
                 NonZeroUsize::new(50 * 1024).expect("non zero"),
             ),
+            sequential_mode: false,
         }
     }
 }

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -191,14 +191,15 @@ impl Default for WorkerOptions {
                     NonZeroUsize::new(10 * 1024 * 1024).expect("non zero"),
                 ), // 10 MiB
                 connection_retry_policy: RetryPolicy::exponential(
-                    Duration::from_millis(10),
+                    Duration::from_millis(250),
                     2.0,
                     None,
-                    Some(Duration::from_secs(1)),
+                    Some(Duration::from_secs(3)),
                 ),
                 request_batch_size: NonZeroByteCount::new(
                     NonZeroUsize::new(50 * 1024).expect("non zero"),
                 ),
+                sequential_mode: false,
             },
             data_service_memory_limit: NonZeroByteCount::new(
                 NonZeroUsize::new(256 * 1024 * 1024).unwrap(),

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -162,6 +162,7 @@ where
                 .connection_retry_policy(config.worker.shuffle.connection_retry_policy.clone())
                 .record_size_limit(config.networking.message_size_limit())
                 .swimlane(Swimlane::IngressData)
+                .sequential_mode(config.worker.shuffle.sequential_mode)
                 .build()
                 .expect("Ingestion session options to build"),
         );


### PR DESCRIPTION

Summary:
This adds support to enable sequential mode via
a configuraiton flag

To enable sequential mode for shuffler set
```
RESTATE_WORKER__SHUFFLE__SEQUENTIAL_MODE=true
```

For kafka ingress
```
RESTATE_INGRESS__INGESTION__SEQUENTIAL_MODE=true
```
