### PR TITLE
[docs] Output snapshot num-retained config in the server config docs

### DIFF
--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -956,7 +956,6 @@ pub struct SnapshotsOptions {
     /// Default: `1`
     ///
     /// Since v1.7.0
-    #[cfg_attr(feature = "schemars", schemars(skip))]
     #[serde(default = "default_num_retained")]
     pub num_retained: NonZeroU8,
 


### PR DESCRIPTION
Now that we've sthbilized `num-retained`, we should document it in the server config docs. So this PR removes the `schemars skip` for this field.

```
$ cargo xtask generate-config-schema > /tmp/restate_config_schema.json
$ jq '."$defs".SnapshotsOptions.properties["num-retained"]' /tmp/restate_config_schema.json

{
  "title": "Snapshot retention count",
  "description": "Number of most recent snapshots to retain. Older snapshots will be\ndeleted automatically. Only snapshots created after this setting is enabled will\nbe considered for pruning.\n\nRetaining multiple snapshots causes the partition archived LSN to be reported as that of the\noldest retained snapshot. Therefore, retaining multiple snapshots will cause increased disk\nusage on log-server nodes.\n\nDefault: `1`\n\nSince v1.7.0",
  "type": "integer",
  "format": "uint8",
  "default": 1,
  "maximum": 255,
  "minimum": 1
}

``` 