### PR TITLE
ingestion-client: Backout pipelining ingestion

### DIFF
--- a/crates/ingestion-client/src/chunks_size.rs
+++ b/crates/ingestion-client/src/chunks_size.rs
@@ -30,6 +30,7 @@ impl<F, S: Stream> ChunksSize<F, S>
 where
     F: Fn(&S::Item) -> usize,
 {
+    #[allow(dead_code)]
     pub fn new(stream: S, max_size: usize, size_fn: F) -> Self {
         Self::with_buffered(stream, max_size, size_fn, Vec::default())
     }

--- a/crates/ingestion-client/src/client.rs
+++ b/crates/ingestion-client/src/client.rs
@@ -438,6 +438,39 @@ mod test {
         commit.await.expect("to resolve");
     }
 
+    // A persistent `NotLeader` rejection must not produce a busy reconnect loop: the
+    // session backs off (escalating) before replaying the in-flight batch. With the
+    // clock paused, the elapsed virtual time proves a sleep was inserted between the
+    // rejection and the replay; an `Ack` then resolves the commit.
+    #[test(restate_core::test(start_paused = true))]
+    async fn not_leader_backs_off_before_replay() {
+        let (mut incoming, mut client) = init_env(10).await;
+
+        let mut commit = client
+            .ingest(0, InputRecord::from_str("hello world"))
+            .await
+            .unwrap();
+
+        // First attempt reaches the (stale) leader and is rejected.
+        let msg = must_next(&mut incoming).await;
+        let (rx, _) = msg.split();
+        rx.send(ResponseStatus::NotLeader { of: 0.into() }.into());
+        assert!((&mut commit).now_or_never().is_none());
+
+        // The replay must be preceded by a backoff (>= the 25ms first step) rather than
+        // an immediate resend that would tight-loop while routing is stale.
+        let start = tokio::time::Instant::now();
+        let msg = must_next(&mut incoming).await;
+        assert!(
+            start.elapsed() >= Duration::from_millis(25),
+            "expected a backoff before replay, but the resend was immediate"
+        );
+
+        let (rx, _) = msg.split();
+        rx.send(ResponseStatus::Ack.into());
+        commit.await.expect("to resolve");
+    }
+
     #[test(restate_core::test)]
     async fn client_close() {
         let (_, mut client) = init_env(10).await;
@@ -492,18 +525,26 @@ mod test {
         );
     }
 
-    // Pipelining is restored (#4879): on a V4 connection the session keeps multiple batches in
-    // flight at once. Ordering no longer relies on an at-most-one-in-flight cap — see the invariant
-    // documented in `connected_pipelining`. This pins that a second batch reaches the wire before
-    // the head batch is acknowledged, and that every batch carries the leader epoch.
+    // Sequential mode is the only mode the session runs today (see `connected_sequential_mode`):
+    // it keeps at most one batch in flight, sending the next batch only after the head is acked.
+    // This pins that invariant — the tail batch must not reach the wire while the head is unacked —
+    // and that every batch carries the leader epoch. It is the dual of the (ignored)
+    // `pipelines_multiple_unacked_batches`.
     #[test(restate_core::test(start_paused = true))]
-    async fn pipelines_multiple_unacked_batches() {
+    async fn sequential_mode_one_batch_in_flight() {
         let mut buf = BytesMut::new();
-        let (mut incoming, mut client) = init_env(1024).await;
+        // Cap fits exactly one record, so r0 and r1 form two separate batches.
+        let one_record = InputRecord::from_str("r0")
+            .into_record(&mut buf)
+            .estimate_size();
+        let (mut incoming, mut client) = init_env(one_record).await;
 
-        // Ingest the head record; it is sent as its own batch (the only record available when the
-        // batch is formed).
+        // Queue both records before the session forms a batch: `ingest().await` does not yield to
+        // the session task, so both are in the channel when the chunker first runs.
         let c0 = client.ingest(0, InputRecord::from_str("r0")).await.unwrap();
+        let c1 = client.ingest(0, InputRecord::from_str("r1")).await.unwrap();
+
+        // Only the head batch B1=[r0] reaches the wire; r1 is held back by the chunker.
         let head = must_next(&mut incoming).await;
         let (head_rx, head_body) = head.split();
         assert_that!(
@@ -513,11 +554,19 @@ mod test {
                 contains(eq(InputRecord::from_str("r0").into_record(&mut buf)))
             )
         );
-        assert_eq!(head_body.target_leader_epoch, Some(LeaderEpoch::INITIAL));
 
-        // Ingest a second record while the head is still unacked. With pipelining the session puts
-        // it on the wire without waiting for the head's acknowledgement.
-        let c1 = client.ingest(0, InputRecord::from_str("r1")).await.unwrap();
+        // While the head is unacked, the tail must not be sent. Advance time to let the session
+        // settle, then assert nothing else is on the wire.
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        assert!(
+            incoming.next().now_or_never().is_none(),
+            "tail batch must not be sent before the head is acked"
+        );
+
+        // Ack the head; only now does the tail batch B2=[r1] reach the wire.
+        head_rx.send(ResponseStatus::Ack.into());
+        c0.await.expect("r0 commits");
+
         let tail = must_next(&mut incoming).await;
         let (tail_rx, tail_body) = tail.split();
         assert_that!(
@@ -527,23 +576,20 @@ mod test {
                 contains(eq(InputRecord::from_str("r1").into_record(&mut buf)))
             )
         );
-        assert_eq!(tail_body.target_leader_epoch, Some(LeaderEpoch::INITIAL));
 
-        // Acknowledge both in order; both records commit.
-        head_rx.send(ResponseStatus::Ack.into());
         tail_rx.send(ResponseStatus::Ack.into());
-        c0.await.expect("r0 commits");
         c1.await.expect("r1 commits");
     }
 
-    // Regression test for #4810 under restored pipelining (#4879): a leadership transition must not
-    // reorder records. With two batches in flight, a `NotLeaderWithEpoch` on the head causes the
-    // session to carry over *all* in-flight batches and replay them — in produced order — against
-    // the new epoch. Nothing is failed/cancelled (the Kafka ingress and shuffle have no cheap
-    // retry), so out-of-order appends that the dedup high-water-mark would silently drop cannot
-    // happen.
+    // Regression coverage for #4810 under sequential mode (the mode in force today): a leadership
+    // transition must not reorder or drop records. The head batch is rejected with
+    // `NotLeaderWithEpoch`; the session carries it over together with the record the chunker
+    // over-pulled, then replays both — in produced order — against the new epoch, still one batch
+    // at a time. Nothing is failed/cancelled (the Kafka ingress and shuffle have no cheap retry),
+    // so out-of-order appends the dedup high-water-mark would silently drop cannot happen. This is
+    // the sequential dual of the (ignored) `leadership_change_replays_inflight_in_order`.
     #[test(restate_core::test(start_paused = true))]
-    async fn leadership_change_replays_inflight_in_order() {
+    async fn sequential_mode_leadership_change_replays_in_order() {
         // Cap fits exactly one record, so r0 and r1 form two separate batches.
         let mut buf = BytesMut::new();
         let one_record = InputRecord::from_str("r0")
@@ -551,13 +597,11 @@ mod test {
             .estimate_size();
         let (mut incoming, mut client, states, my_node_id) = init_env_with_states(one_record).await;
 
-        // Queue both records before the session forms a batch: `ingest().await` does not yield to
-        // the session task, so both are in the channel when the chunker first runs.
         let c0 = client.ingest(0, InputRecord::from_str("r0")).await.unwrap();
         let c1 = client.ingest(0, InputRecord::from_str("r1")).await.unwrap();
         tokio::time::sleep(Duration::from_secs(1)).await;
 
-        // Both batches are pipelined: B1=[r0] then B2=[r1], each at the initial epoch.
+        // Sequential mode: only the head batch B1=[r0] is on the wire; r1 is held by the chunker.
         let b1 = must_next(&mut incoming).await;
         let (b1_rx, b1_body) = b1.split();
         assert_that!(
@@ -567,16 +611,11 @@ mod test {
                 contains(eq(InputRecord::from_str("r0").into_record(&mut buf)))
             )
         );
-        assert_eq!(b1_body.target_leader_epoch, Some(LeaderEpoch::INITIAL));
 
-        let b2 = must_next(&mut incoming).await;
-        let (_b2_rx, b2_body) = b2.split();
-        assert_that!(
-            b2_body.records,
-            all!(
-                len(eq(1)),
-                contains(eq(InputRecord::from_str("r1").into_record(&mut buf)))
-            )
+        // No second batch is in flight while the head is unacked.
+        assert!(
+            incoming.next().now_or_never().is_none(),
+            "tail batch must not be in flight under sequential mode"
         );
 
         // A new leader wins the election. Make routing observe the new epoch so the session can
@@ -588,18 +627,11 @@ mod test {
         };
         states.note_observed_leader(PartitionId::from(0), leadership_state);
 
-        b1_rx.send(
-            ResponseStatus::NotLeaderWithEpoch {
-                of: 0.into(),
-                last_seen_leadership_state: leadership_state,
-            }
-            .into(),
-        );
-        // Dropping `_b2_rx` here would not matter: replies are consumed head-first, so the session
-        // never observes B2's outcome before reconnecting.
+        b1_rx.send(ResponseStatus::NotLeader { of: 0.into() }.into());
         tokio::time::sleep(Duration::from_secs(1)).await;
 
-        // Replay re-sends B1 then B2 in produced order, now targeting the new epoch.
+        // Replay re-sends B1=[r0] then B2=[r1] in produced order at the new epoch — and still one
+        // at a time, so B2 only appears after B1 is acked.
         let b1 = must_next(&mut incoming).await;
         let (b1_rx, b1_body) = b1.split();
         assert_that!(
@@ -609,7 +641,7 @@ mod test {
                 contains(eq(InputRecord::from_str("r0").into_record(&mut buf)))
             )
         );
-        assert_eq!(b1_body.target_leader_epoch, Some(new_epoch));
+        b1_rx.send(ResponseStatus::Ack.into());
 
         let b2 = must_next(&mut incoming).await;
         let (b2_rx, b2_body) = b2.split();
@@ -620,17 +652,10 @@ mod test {
                 contains(eq(InputRecord::from_str("r1").into_record(&mut buf)))
             )
         );
-        assert_eq!(b2_body.target_leader_epoch, Some(new_epoch));
-
-        b1_rx.send(ResponseStatus::Ack.into());
         b2_rx.send(ResponseStatus::Ack.into());
 
         // Nothing was failed/cancelled: both records eventually commit, in order.
         c0.await.expect("r0 commits");
         c1.await.expect("r1 commits");
     }
-
-    // Note: the ≤V3 sequential fallback (`connected_sequential_mode`) cannot be exercised here
-    // because the in-process test connection always negotiates `CURRENT_PROTOCOL_VERSION` (V4). Its
-    // carry-over/remainder handling mirrors the pipelining path covered above.
 }

--- a/crates/ingestion-client/src/session.rs
+++ b/crates/ingestion-client/src/session.rs
@@ -8,30 +8,23 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::{collections::VecDeque, num::NonZeroUsize, sync::Arc, time::Duration};
+use std::{mem, num::NonZeroUsize, sync::Arc, time::Duration};
 
 use dashmap::DashMap;
-use futures::{FutureExt, StreamExt, future::OptionFuture, ready};
+use futures::{FutureExt, StreamExt, ready, stream};
 use tokio::sync::{OwnedSemaphorePermit, mpsc, oneshot};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, instrument, trace, warn};
+use tracing::{debug, instrument, trace, warn};
 
 use restate_core::{
     TaskCenter, TaskKind,
-    network::{
-        ConnectError, Connection, ConnectionClosed, NetworkSender, Networking, ReplyRx, Swimlane,
-        TransportConnect,
-    },
+    network::{ConnectError, Connection, NetworkSender, Networking, Swimlane, TransportConnect},
     partitions::PartitionRouting,
 };
 use restate_types::{
-    identifiers::{LeaderEpoch, PartitionId},
-    net::{
-        ProtocolVersion,
-        ingest::{IngestRecord, IngestRequest, IngestResponse, ResponseStatus},
-    },
-    partitions::state::LeadershipState,
+    identifiers::PartitionId,
+    net::ingest::{IngestRecord, IngestRequest, ResponseStatus},
     retries::RetryPolicy,
 };
 
@@ -39,8 +32,6 @@ use crate::chunks_size::ChunksSize;
 
 #[cfg(any(test, feature = "test-util"))]
 const DEFAULT_MAX_RECORD_SIZE: usize = 32 * 1024 * 1024; // 32MiB
-
-type InflightQueue = VecDeque<(IngestionBatch, Option<ReplyRx<IngestResponse>>)>;
 
 /// Error returned when attempting to use a session that has already been closed.
 #[derive(Clone, Copy, Debug, thiserror::Error)]
@@ -53,7 +44,7 @@ pub struct SessionClosed;
 pub struct CancelledError;
 
 /// Future that is resolved to the commit result
-/// A [`CommitError::Cancelled`] might be returned
+/// A [`CancelledError`] might be returned
 /// if [`IngestionClient`] is closed while record is in
 /// flight. This does not guarantee that the record
 /// was not processed or committed.
@@ -122,7 +113,7 @@ impl RecordCommitResolver {
 
     /// explicitly cancel the RecordCommit
     /// If resolver is dropped, the RecordCommit
-    /// will resolve to [`CommitError::Cancelled`]
+    /// will resolve to [`CancelledError`]
     #[allow(dead_code)]
     pub fn cancelled(self) {
         let _ = self.tx.send(Err(CancelledError));
@@ -148,10 +139,6 @@ impl IngestionBatch {
             resolver.committed();
         }
     }
-
-    fn len(&self) -> usize {
-        self.records.len()
-    }
 }
 
 /// Tunable parameters for batching and networking behaviour of partition sessions.
@@ -163,7 +150,7 @@ pub struct SessionOptions {
     pub(crate) batch_size: NonZeroUsize,
     /// Connection retry policy
     /// Retry policy must be infinite (retries forever)
-    /// If not, the retry will fallback to 2 seconds intervals
+    /// If not, the retry will fallback to 3 seconds intervals
     #[builder(default=RetryPolicy::exponential(
         Duration::from_millis(250),
         2.0,
@@ -171,19 +158,25 @@ pub struct SessionOptions {
         Some(Duration::from_secs(3)),
     ))]
     pub(crate) connection_retry_policy: RetryPolicy,
+    /// Backoff applied before reconnecting after a connected session made no
+    /// progress (e.g. an immediate `NotLeader` rejection). Must be infinite;
+    /// it is reset once a batch is acknowledged. This avoids a busy reconnect
+    /// loop while `PartitionRouting` catches up to a new leader, while still
+    /// retrying quickly the first few times in case the rejecting node wins
+    /// leadership shortly.
+    #[builder(default=RetryPolicy::exponential(
+        Duration::from_millis(25),
+        2.0,
+        None,
+        Some(Duration::from_secs(1)),
+    ))]
+    pub(crate) reconnect_retry_policy: RetryPolicy,
     /// Maximum allowed record size
     #[cfg_attr(any(test, feature = "test-util"), builder(default=NonZeroUsize::new(DEFAULT_MAX_RECORD_SIZE).unwrap()))]
     pub(crate) record_size_limit: NonZeroUsize,
     /// Connection swimlane
     #[cfg_attr(any(test, feature = "test-util"), builder(default=Swimlane::General))]
     pub(crate) swimlane: Swimlane,
-    /// Force sequential mode. In sequential
-    /// mode, a max of a single batch can be
-    /// in-flight.
-    ///
-    /// Default: false
-    #[builder(default)]
-    pub(crate) sequential_mode: bool,
 }
 
 impl SessionOptions {
@@ -207,7 +200,12 @@ impl Default for SessionOptions {
                 None,
                 Some(Duration::from_secs(1)),
             ),
-            sequential_mode: false,
+            reconnect_retry_policy: RetryPolicy::exponential(
+                Duration::from_millis(10),
+                2.0,
+                None,
+                Some(Duration::from_millis(100)),
+            ),
         }
     }
 }
@@ -236,8 +234,7 @@ impl SessionHandle {
 
 enum SessionState {
     Connecting,
-    ConnectedSequentialMode { connection: Connection },
-    ConnectedPipeliningMode { connection: Connection },
+    Connected { connection: Connection },
     Shutdown,
 }
 
@@ -250,12 +247,12 @@ pub struct PartitionSession<T> {
     opts: SessionOptions,
     rx: UnboundedReceiverStream<(RecordCommitResolver, IngestRecord)>,
     tx: mpsc::UnboundedSender<(RecordCommitResolver, IngestRecord)>,
-    // Batches that were unacked (or never sent) when the previous connection ended, kept in
-    // produced order. On the next connection they are re-sent ahead of any newly chunked batch so
-    // records reach the partition log in the order they were produced. Includes the record the
-    // chunker over-pulled to detect a batch boundary, wrapped as its own trailing batch.
-    carry_over: VecDeque<IngestionBatch>,
-    target_leader_epoch: LeaderEpoch,
+    // It carries the single un-acked batch and is sent ahead of what's stored in carry over to
+    // ensure ingestion batches can't overtake each other.
+    in_flight: Option<IngestionBatch>,
+    // Records pulled from `rx` while detecting a batch boundary but not yet sent. Carried across
+    // reconnects and fed back into the chunker so they lead the next batch. See #4810.
+    carry_over: Vec<(RecordCommitResolver, IngestRecord)>,
 }
 
 impl<T> PartitionSession<T> {
@@ -277,8 +274,8 @@ impl<T> PartitionSession<T> {
             opts,
             rx,
             tx,
-            carry_over: VecDeque::default(),
-            target_leader_epoch: LeaderEpoch::INITIAL,
+            in_flight: None,
+            carry_over: Vec::default(),
         }
     }
 
@@ -316,6 +313,13 @@ where
     async fn run_inner(mut self) {
         let mut state = SessionState::Connecting;
 
+        // Backoff applied before reconnecting when a connected session made no progress
+        // (e.g. an immediate `NotLeader` rejection). Cloned into a local so the iterator
+        // doesn't borrow `self` across the `&mut self` calls below. Reset on every acked
+        // batch; advanced on every no-progress return.
+        let reconnect_policy = self.opts.reconnect_retry_policy.clone();
+        let mut reconnect_retry = reconnect_policy.iter();
+
         loop {
             state = match state {
                 SessionState::Connecting => {
@@ -327,19 +331,29 @@ where
                             None => {
                                 // retry
                                 // this assumes that retry policy is infinite. If it's not it falls back
-                                // to a fixed 2 seconds sleep between retries
+                                // to a fixed 3 seconds sleep between retries
                                 tokio::time::sleep(retry.next().unwrap_or(Duration::from_secs(3)))
                                     .await;
                             }
                         }
                     }
                 }
-                SessionState::ConnectedSequentialMode { connection } => {
-                    self.connected_sequential_mode(connection).await;
-                    SessionState::Connecting
-                }
-                SessionState::ConnectedPipeliningMode { connection } => {
-                    self.connected_pipelining(connection).await;
+                SessionState::Connected { connection } => {
+                    if self.connected_sequential_mode(connection).await {
+                        // Committed at least one batch: reset the no-progress backoff.
+                        reconnect_retry = reconnect_policy.iter();
+                    } else {
+                        // No batch committed: likely an immediate rejection (e.g.
+                        // `NotLeader`) from a stale/candidate leader that `connect()` will
+                        // reach again right away. Back off (escalating) before reconnecting
+                        // so we don't busy-loop while `PartitionRouting` catches up, while
+                        // still retrying quickly the first few times in case the rejecting
+                        // node wins leadership shortly.
+                        tokio::time::sleep(
+                            reconnect_retry.next().unwrap_or(Duration::from_secs(1)),
+                        )
+                        .await;
+                    }
                     SessionState::Connecting
                 }
                 SessionState::Shutdown => {
@@ -351,25 +365,11 @@ where
     }
 
     async fn connect(&mut self) -> Option<SessionState> {
-        // Block until routing has observed a leader epoch at least as new as the one we're
-        // targeting. `target_leader_epoch` starts at `INITIAL` and is bumped whenever a
-        // `NotLeaderWithEpoch` response tells us a newer leader has won (see
-        // `note_leadership_state`). Waiting on it here ensures that after a leadership change we
-        // don't reconnect to the stale leader; instead we hold off until the cluster has
-        // independently propagated the new leadership state into routing.
-        let leader_epoch = self
-            .partition_routing
-            .wait_for_leader_epoch(self.partition, self.target_leader_epoch)
-            .await
-            .current_leader_epoch;
-
         // Resolve the node separately: routing returns the current leader if known, otherwise it
         // falls back to a live replica-set member.
         let node_id = self
             .partition_routing
             .get_node_by_partition(self.partition)?;
-
-        self.target_leader_epoch = leader_epoch;
 
         let result = self
             .networking
@@ -379,12 +379,7 @@ where
         match result {
             Ok(connection) => {
                 debug!("Connection established to node {}", node_id);
-                if connection.protocol_version() <= ProtocolVersion::V3 || self.opts.sequential_mode
-                {
-                    Some(SessionState::ConnectedSequentialMode { connection })
-                } else {
-                    Some(SessionState::ConnectedPipeliningMode { connection })
-                }
+                Some(SessionState::Connected { connection })
             }
             Err(ConnectError::Shutdown(_)) => Some(SessionState::Shutdown),
             Err(err) => {
@@ -394,166 +389,76 @@ where
         }
     }
 
+    /// Processes batches one at a time, keeping at most a single batch inflight.
+    ///
+    /// Each batch must be acknowledged (committed) before the next one is sent.
+    ///
+    /// The method only returns when the connection is lost or an error is
+    /// encountered. On return, any batch that has not yet been committed remains
+    /// in [`self.in_flight`] and is replayed first on the next connection.
+    ///
+    /// Returns `true` if at least one batch was acknowledged during this session,
+    /// `false` if it returned without making progress (used by the caller to decide
+    /// whether to back off before reconnecting).
     #[instrument(
-        level="info",
+        level="debug",
         skip_all,
         name="connected",
         fields(
             mode="sequential",
             partition=%self.partition,
-            leader_epoch=%self.target_leader_epoch,
         )
     )]
-    async fn connected_sequential_mode(&mut self, connection: Connection) {
-        // replay carry over one by one
-        debug!("Carry-over batches: {}", self.carry_over.len());
+    async fn connected_sequential_mode(&mut self, connection: Connection) -> bool {
+        let mut made_progress = false;
+        let mut chunked = ChunksSize::with_buffered(
+            &mut self.rx,
+            self.opts.batch_size.get(),
+            |(_, item)| item.estimate_size(),
+            mem::take(&mut self.carry_over),
+        );
 
-        while let Some(batch) = self.carry_over.front() {
+        // prepend a possible in_flight batch to make sure that this is being sent first!
+        let mut batch_stream =
+            stream::iter(self.in_flight.take()).chain((&mut chunked).map(IngestionBatch::new));
+
+        while let Some(batch) = batch_stream.next().await {
             let records = Arc::clone(&batch.records);
 
             let Some(permit) = connection.reserve().await else {
-                warn!(
-                    carry_over_batches = self.carry_over.len(),
-                    "Connection to {} closed while replaying ingest batches; will reconnect and replay",
+                debug!(
+                    "Connection to {} closed while reserving capacity; will reconnect and replay",
                     connection.peer()
                 );
-                return;
-            };
-
-            trace!("Sending ingest batch, len: {}", records.len());
-            // Nodes running protocol version V3 doesn't support
-            // target_leader_epoch. We mainly sending this to be
-            // able to use sequential mode against nodes with >= V4
-            // if needed
-            let reply_rx = permit
-                .send_rpc(
-                    IngestRequest {
-                        records,
-                        target_leader_epoch: Some(self.target_leader_epoch),
-                    },
-                    Some(self.partition.into()),
-                )
-                .expect("encoding version to match");
-
-            match reply_rx.await.map(|r| r.status) {
-                Ok(ResponseStatus::Ack) => {
-                    // remove committed batch from carry_over
-                    let batch = self.carry_over.pop_front().unwrap();
-                    batch.committed();
-                }
-                Ok(ResponseStatus::NotLeaderWithEpoch {
-                    last_seen_leadership_state,
-                    ..
-                }) => {
-                    // Note that this error kind is never returned
-                    // by partition processor < v1.7. This is mainly
-                    // defensive coding, but also allows us to switch
-                    // to sequential mode for protocol version >= V4
-                    // if needed.
-                    info!(
-                        new_leader_epoch = %last_seen_leadership_state.current_leader_epoch,
-                        carry_over_batches = self.carry_over.len(),
-                        "Ingestion batch rejected by leadership change; will reconnect and replay"
-                    );
-                    self.target_leader_epoch
-                        .note_leadership_state(&last_seen_leadership_state);
-
-                    return;
-                }
-                Ok(ResponseStatus::Internal { msg }) => {
-                    warn!("Ingestion internal error from {}: {msg}", connection.peer());
-                    return;
-                }
-                Ok(response) => {
-                    // Handle any other response code as a connection loss
-                    // and retry all inflight batches.
-                    warn!(
-                        "Ingestion response error status from {}: {:?}",
-                        connection.peer(),
-                        response
-                    );
-
-                    return;
-                }
-                Err(err) => {
-                    // we can assume that for any error
-                    // we need to retry all the inflight batches.
-                    // special case for load shedding we could
-                    // throttle the stream a little bit then
-                    // speed up over a period of time.
-                    warn!("Ingestion RPC error from {}: {}", connection.peer(), err);
-                    return;
-                }
-            }
-        }
-
-        debug_assert!(self.carry_over.is_empty());
-
-        let mut chunked = ChunksSize::new(&mut self.rx, self.opts.batch_size.get(), |(_, item)| {
-            item.estimate_size()
-        });
-
-        while let Some(batch) = chunked.next().await {
-            let batch = IngestionBatch::new(batch);
-            let records = Arc::clone(&batch.records);
-
-            let Some(permit) = connection.reserve().await else {
-                warn!(
-                    "Connection to {} closed while sending ingest batch; will reconnect and replay",
-                    connection.peer()
-                );
-                self.carry_over.push_back(batch);
+                self.in_flight = Some(batch);
                 break;
             };
 
             trace!("Sending ingest batch, len: {}", records.len());
             let reply_rx = permit
-                .send_rpc(
-                    IngestRequest {
-                        records,
-                        target_leader_epoch: Some(self.target_leader_epoch),
-                    },
-                    Some(self.partition.into()),
-                )
+                .send_rpc(IngestRequest { records }, Some(self.partition.into()))
                 .expect("encoding version to match");
 
             match reply_rx.await.map(|r| r.status) {
                 Ok(ResponseStatus::Ack) => {
                     batch.committed();
+                    made_progress = true;
                 }
-                Ok(ResponseStatus::NotLeaderWithEpoch {
-                    last_seen_leadership_state,
-                    ..
-                }) => {
-                    // Note that this error kind is never returned
-                    // by partition processor < v1.7. This is mainly
-                    // defensive coding, but also allows us to switch
-                    // to sequential mode for protocol version >= V4
-                    // if needed.
-                    info!(
-                        new_leader_epoch = %last_seen_leadership_state.current_leader_epoch,
-                        "Ingestion batch rejected by leadership change; will reconnect and replay"
-                    );
-                    self.target_leader_epoch
-                        .note_leadership_state(&last_seen_leadership_state);
 
-                    self.carry_over.push_back(batch);
-                    break;
-                }
                 Ok(ResponseStatus::Internal { msg }) => {
                     warn!("Ingestion internal error from {}: {msg}", connection.peer());
-                    self.carry_over.push_back(batch);
+                    self.in_flight = Some(batch);
                     break;
                 }
                 Ok(response) => {
                     // Handle any other response code as a connection loss
                     // and retry all inflight batches.
-                    warn!(
+                    debug!(
                         "Ingestion response error status from {}: {:?}",
                         connection.peer(),
                         response
                     );
-                    self.carry_over.push_back(batch);
+                    self.in_flight = Some(batch);
                     break;
                 }
                 Err(err) => {
@@ -562,8 +467,8 @@ where
                     // special case for load shedding we could
                     // throttle the stream a little bit then
                     // speed up over a period of time.
-                    warn!("Ingestion RPC error from {}: {}", connection.peer(), err);
-                    self.carry_over.push_back(batch);
+                    debug!("Ingestion RPC error from {}: {}", connection.peer(), err);
+                    self.in_flight = Some(batch);
                     break;
                 }
             }
@@ -571,194 +476,10 @@ where
 
         // Carry over the record the chunker over-pulled to detect the batch boundary so it leads
         // the next connection's first batch instead of being dropped (which would surface to the
-        // caller as a spurious cancellation). Mirrors the pipelining path.
-        let remainder = chunked.into_remainder();
-        if !remainder.is_empty() {
-            self.carry_over.push_back(IngestionBatch::new(remainder));
-        }
-    }
+        // caller as a spurious cancellation).
+        self.carry_over = chunked.into_remainder();
 
-    #[instrument(
-        level="info",
-        skip_all,
-        name="connected",
-        fields(
-            mode="pipelining",
-            partition=%self.partition,
-            leader_epoch=%self.target_leader_epoch,
-        )
-    )]
-    async fn connected_pipelining(&mut self, connection: Connection) {
-        debug!("Carry-over batches: {}", self.carry_over.len(),);
-
-        let Ok(mut inflight) = self.replay(&connection).await else {
-            return;
-        };
-
-        debug_assert!(self.carry_over.is_empty());
-
-        // Carry-over batches were already re-sent in order by `replay()`; new batches are chunked
-        // fresh from the stream.
-        let mut chunked = ChunksSize::new(&mut self.rx, self.opts.batch_size.get(), |(_, item)| {
-            item.estimate_size()
-        });
-
-        loop {
-            // Multiple batches may be in flight at once. Ordering is preserved without an
-            // at-most-one-in-flight cap because: the connection is FIFO, the leader appends each
-            // batch sequentially in arrival order, and every in-flight batch carries the same
-            // `target_leader_epoch` so a leadership change rejects the whole pipeline atomically
-            // (rather than rejecting an earlier batch while appending a later one, which the dedup
-            // high-water-mark would then silently drop — see #4810). Replies are consumed strictly
-            // head-first, so on any rejection the head and everything behind it are carried over and
-            // replayed in produced order.
-            let head: OptionFuture<_> = inflight
-                .front_mut()
-                .and_then(|(_, reply_rx)| reply_rx.as_mut())
-                .into();
-
-            tokio::select! {
-                Some(batch) = chunked.next() => {
-                    let batch = IngestionBatch::new(batch);
-                    let records = Arc::clone(&batch.records);
-
-                    let batch = inflight.push_back_mut((batch, None));
-
-                    let Some(permit) = connection.reserve().await else {
-                        warn!(
-                            inflight_batches = inflight.len(),
-                            "Connection to {} closed while sending ingest batch; carrying over in-flight batches",
-                            connection.peer()
-                        );
-                        break;
-                    };
-
-                    trace!("Sending ingest batch, len: {}", records.len());
-                    let reply_rx = permit
-                        .send_rpc(
-                            IngestRequest{
-                                records,
-                                target_leader_epoch: Some(self.target_leader_epoch)
-                            },
-                            Some(self.partition.into())
-                        ).expect("encoding version to match");
-
-                    batch.1 = Some(reply_rx);
-                }
-                Some(result) = head => {
-                    match result.map(|r|r.status) {
-                        Ok(ResponseStatus::Ack) => {
-                            let batch = inflight.pop_front().expect("not empty").0;
-                            batch.committed();
-                        }
-                        Ok(ResponseStatus::NotLeaderWithEpoch{
-                            last_seen_leadership_state,
-                            ..
-                        })=> {
-                            info!(
-                                new_leader_epoch = %last_seen_leadership_state.current_leader_epoch,
-                                inflight_batches = inflight.len(),
-                                "Ingestion pipeline rejected by leadership change; carrying over in-flight batches"
-                            );
-                            self.target_leader_epoch
-                                .note_leadership_state(&last_seen_leadership_state);
-
-                            break;
-                        }
-                        Ok(ResponseStatus::Internal{msg}) => {
-                            warn!("Ingestion internal error from {}: {msg}", connection.peer());
-                            break;
-                        }
-                        Ok(response) => {
-                            // Handle any other response code as a connection loss
-                            // and retry all inflight batches.
-                            warn!("Ingestion response error status from {}: {:?}", connection.peer(), response);
-                            break;
-                        }
-                        Err(err) => {
-                            // we can assume that for any error
-                            // we need to retry all the inflight batches.
-                            // special case for load shedding we could
-                            // throttle the stream a little bit then
-                            // speed up over a period of time.
-                            warn!("Ingestion RPC error from {}: {}", connection.peer(),  err);
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-
-        for batch in inflight.into_iter().map(|(batch, _)| batch) {
-            self.carry_over.push_back(batch);
-        }
-
-        let remainder = chunked.into_remainder();
-        if !remainder.is_empty() {
-            self.carry_over.push_back(IngestionBatch::new(remainder));
-        }
-    }
-
-    /// Re-sends all inflight batches after a connection is restored.
-    async fn replay(&mut self, connection: &Connection) -> Result<InflightQueue, ConnectionClosed> {
-        if !self.carry_over.is_empty() {
-            info!(
-                batches = self.carry_over.len(),
-                records = self.carry_over.iter().map(|i| i.len()).sum::<usize>(),
-                "Replaying inflight records after connection was restored"
-            );
-        }
-
-        let mut inflight = InflightQueue::new();
-
-        while let Some(batch) = self.carry_over.front() {
-            let Some(permit) = connection.reserve().await else {
-                warn!(
-                    batches_sent = inflight.len(),
-                    "Connection to {} closed while replaying ingest batches; restoring carry-over",
-                    connection.peer()
-                );
-                // restore the carry over back to original state.
-                // maintaining the original order.
-                // todo(azmy): Avoid resending All the batches by trying to drain
-                // the reply_rx channel until the first error.
-                while let Some((batch, _)) = inflight.pop_back() {
-                    self.carry_over.push_front(batch);
-                }
-
-                return Err(ConnectionClosed);
-            };
-
-            // resend batch
-            let reply_rx = permit
-                .send_rpc(
-                    IngestRequest {
-                        records: Arc::clone(&batch.records),
-                        target_leader_epoch: Some(self.target_leader_epoch),
-                    },
-                    Some(self.partition.into()),
-                )
-                .expect("encoding version to match");
-
-            let batch = self.carry_over.pop_front().unwrap();
-            inflight.push_back((batch, Some(reply_rx)));
-        }
-
-        Ok(inflight)
-    }
-}
-
-trait LeaderEpochExt {
-    /// Monotonically bumps the targeted leader epoch to the one carried by a learned leadership
-    /// state, ignoring stale (older) states. Never lowers the epoch.
-    fn note_leadership_state(&mut self, state: &LeadershipState);
-}
-
-impl LeaderEpochExt for LeaderEpoch {
-    fn note_leadership_state(&mut self, state: &LeadershipState) {
-        if *self < state.current_leader_epoch {
-            *self = state.current_leader_epoch
-        }
+        made_progress
     }
 }
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -301,7 +301,6 @@ impl Node {
                 .record_size_limit(config.ingress.request_size_limit())
                 .connection_retry_policy(config.ingress.ingestion.connection_retry_policy.clone())
                 .swimlane(Swimlane::IngressData)
-                .sequential_mode(config.ingress.ingestion.sequential_mode)
                 .build()
                 .expect("Ingestion session options to build"),
         );

--- a/crates/types/protobuf/restate/common.proto
+++ b/crates/types/protobuf/restate/common.proto
@@ -22,14 +22,6 @@ enum ProtocolVersion {
   // Release in v1.6. Support custom `Record`
   // encoding that uses Bytes instead of PolyBytes
   V3 = 3;
-
-  // Release in v1.7
-  // Ingress client can differentiate v1.6 PPs 
-  // from v1.7 PPs to choose which ingestion mode 
-  // to use. For v1.6 only single inflight batch
-  // is allowed. In v1.7 multiple inflight batches
-  // are allowed.
-  V4 = 4;
 }
 
 message NodeId {

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -1246,20 +1246,6 @@ pub struct IngestionOptions {
     ///
     /// Defaults to 50 KiB.
     pub request_batch_size: NonZeroByteCount,
-
-    /// # Force Sequential Ingestion Mode
-    ///
-    /// By default, the ingestion client pipelines batches, keeping multiple
-    /// uncommitted batches in flight at once for higher throughput. When this
-    /// is enabled, the client instead runs in sequential mode: it sends one
-    /// batch and waits for it to be committed before sending the next, so at
-    /// most a single uncommitted batch is in flight at any time.
-    ///
-    /// Note that sequential mode is always used when talking to nodes running
-    /// protocol version V3 or older, regardless of this setting.
-    ///
-    /// Default: false
-    pub sequential_mode: bool,
 }
 
 impl Default for IngestionOptions {
@@ -1277,7 +1263,6 @@ impl Default for IngestionOptions {
             request_batch_size: NonZeroByteCount::new(
                 NonZeroUsize::new(50 * 1024).expect("non zero"),
             ),
-            sequential_mode: false,
         }
     }
 }

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -199,7 +199,6 @@ impl Default for WorkerOptions {
                 request_batch_size: NonZeroByteCount::new(
                     NonZeroUsize::new(50 * 1024).expect("non zero"),
                 ),
-                sequential_mode: false,
             },
             data_service_memory_limit: NonZeroByteCount::new(
                 NonZeroUsize::new(256 * 1024 * 1024).unwrap(),

--- a/crates/types/src/net/ingest.rs
+++ b/crates/types/src/net/ingest.rs
@@ -14,12 +14,11 @@ use bytes::Bytes;
 
 use restate_encoding::{ArcedSlice, RestateEncoding};
 
-use crate::identifiers::{LeaderEpoch, PartitionId};
+use crate::identifiers::PartitionId;
 use crate::logs::{HasRecordKeys, Keys};
 use crate::message::MessageIndex;
 use crate::net::partition_processor::PartitionLeaderService;
 use crate::net::{RpcRequest, bilrost_wire_codec, define_rpc};
-use crate::partitions::state::LeadershipState;
 
 #[derive(Debug, Eq, PartialEq, Clone, bilrost::Message)]
 pub struct IngestRecord {
@@ -49,16 +48,6 @@ impl HasRecordKeys for IngestRecord {
 pub struct IngestRequest {
     #[bilrost(tag(1), encoding(ArcedSlice<packed>))]
     pub records: Arc<[IngestRecord]>,
-
-    /// The expected leader epoch of the target partition.
-    ///
-    /// When set, the partition processor only accepts the request if this
-    /// matches its current leader epoch. This lets it atomically reject an
-    /// entire stream of ingest requests across a leadership change.
-    ///
-    /// Since v1.7 + protocol V4
-    #[bilrost(tag(2))]
-    pub target_leader_epoch: Option<LeaderEpoch>,
 }
 
 impl IngestRequest {
@@ -76,8 +65,6 @@ pub enum ResponseStatus {
     Unknown,
     #[bilrost(tag = 1, message)]
     Ack,
-    // Retained for wire-compat with <=V3 (pre-v1.7) peers. New code sends/handles
-    // `NotLeaderWithEpoch` instead.
     #[bilrost(tag = 2, message)]
     NotLeader {
         of: PartitionId,
@@ -85,11 +72,6 @@ pub enum ResponseStatus {
     #[bilrost(tag = 3, message)]
     Internal {
         msg: String,
-    },
-    #[bilrost(tag = 4, message)]
-    NotLeaderWithEpoch {
-        of: PartitionId,
-        last_seen_leadership_state: LeadershipState,
     },
 }
 
@@ -122,9 +104,6 @@ define_rpc! {
 pub struct ReceivedIngestRequest {
     #[bilrost(tag(1), encoding(packed))]
     pub records: Vec<IngestRecord>,
-    // todo(azmy): make non-optional in Restate v1.8
-    #[bilrost(tag(2))]
-    pub target_leader_epoch: Option<LeaderEpoch>,
 }
 
 bilrost_wire_codec!(ReceivedIngestRequest);

--- a/crates/types/src/net/log_server.rs
+++ b/crates/types/src/net/log_server.rs
@@ -397,7 +397,7 @@ impl WireEncode for Store {
                 let msg: compat::Store = self.clone().into();
                 Ok(encode_as_bilrost(&msg))
             }
-            ProtocolVersion::V3 | ProtocolVersion::V4 => Ok(encode_as_bilrost(self)),
+            ProtocolVersion::V3 => Ok(encode_as_bilrost(self)),
         }
     }
 }
@@ -422,9 +422,7 @@ impl WireDecode for Store {
                     crate::net::codec::decode_as_bilrost(buf, protocol_version)?;
                 Ok(msg.into())
             }
-            ProtocolVersion::V3 | ProtocolVersion::V4 => {
-                crate::net::codec::decode_as_bilrost(buf, protocol_version)
-            }
+            ProtocolVersion::V3 => crate::net::codec::decode_as_bilrost(buf, protocol_version),
         }
     }
 }

--- a/crates/types/src/net/mod.rs
+++ b/crates/types/src/net/mod.rs
@@ -25,7 +25,7 @@ pub use crate::protobuf::common::ProtocolVersion;
 pub use crate::protobuf::common::ServiceTag;
 
 pub const MIN_SUPPORTED_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V2;
-pub const CURRENT_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V4;
+pub const CURRENT_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V3;
 
 pub trait Service: Send + Unpin + 'static {
     const TAG: ServiceTag;

--- a/crates/types/src/net/replicated_loglet.rs
+++ b/crates/types/src/net/replicated_loglet.rs
@@ -163,7 +163,7 @@ impl WireEncode for Append {
                 let msg: compat::Append = self.clone().into();
                 Ok(encode_as_bilrost(&msg))
             }
-            ProtocolVersion::V3 | ProtocolVersion::V4 => Ok(encode_as_bilrost(self)),
+            ProtocolVersion::V3 => Ok(encode_as_bilrost(self)),
         }
     }
 }
@@ -188,9 +188,7 @@ impl WireDecode for Append {
                     crate::net::codec::decode_as_bilrost(buf, protocol_version)?;
                 Ok(msg.into())
             }
-            ProtocolVersion::V3 | ProtocolVersion::V4 => {
-                crate::net::codec::decode_as_bilrost(buf, protocol_version)
-            }
+            ProtocolVersion::V3 => crate::net::codec::decode_as_bilrost(buf, protocol_version),
         }
     }
 }

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -162,7 +162,6 @@ where
                 .connection_retry_policy(config.worker.shuffle.connection_retry_policy.clone())
                 .record_size_limit(config.networking.message_size_limit())
                 .swimlane(Swimlane::IngressData)
-                .sequential_mode(config.worker.shuffle.sequential_mode)
                 .build()
                 .expect("Ingestion session options to build"),
         );

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -844,7 +844,6 @@ impl<T> LeadershipState<T> {
     /// Forward externally-created records to this partition.
     pub async fn forward_many_with_callback<F>(
         &mut self,
-        target_leader_epoch: LeaderEpoch,
         records: impl ExactSizeIterator<Item = IngestRecord>,
         callback: F,
     ) where
@@ -855,15 +854,6 @@ impl<T> LeadershipState<T> {
                 PartitionProcessorRpcError::NotLeader(self.partition.partition_id),
             )),
             State::Leader(leader_state) => {
-                // Defensive check. Make sure that the target epoch
-                // matches the leader state epoch
-                if target_leader_epoch != leader_state.leader_epoch {
-                    callback(Err(PartitionProcessorRpcError::NotLeader(
-                        self.partition.partition_id,
-                    )));
-                    return;
-                }
-
                 leader_state
                     .forward_many_with_callback(records, callback)
                     .await;

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -962,70 +962,15 @@ where
     async fn on_pp_ingest_request(&mut self, msg: Incoming<Rpc<ReceivedIngestRequest>>) {
         let (reciprocal, request) = msg.split();
 
-        // todo(azmy): Once target_leader_epoch becomes mandatory, we need to remove
-        // this hack.
-        let Some(target_leader_epoch) = request.target_leader_epoch else {
-            // Old clients don't send a target leader epoch, so we
-            // reject these writes to avoid data loss. When such a
-            // client pipelines requests, a leadership change could
-            // cause one request to be rejected while later requests
-            // in the pipeline are accepted, silently dropping data.
-            // See #4879 for details.
-            let _ = TaskCenter::spawn_child(TaskKind::Disposable, "reject-ingestion", async move {
-                // clients will try immediately
-                // so we need to put some back pressure here
-                // by delaying the response so they don't
-                // retry immediately
-                tokio::time::sleep(Duration::from_secs(1)).await;
-
-                // Older clients (if enabled) will print this error message as debug
-                // message so it might be a good idea to print this here also as a warn
-                // to make sure it's visible during a rolling upgrade.
-                warn!(
-                    "Rejecting ingestion requests from old ingestion \
-                    clients to prevent data loss. Please upgrade to v1.7 \
-                    or disable the experimental ingestion feature(s) \
-                    `experimental_*_batch_ingestion`"
-                );
-
-                reciprocal.send(
-                    ResponseStatus::Internal {
-                        msg: "Rejecting ingestion requests from old ingestion \
-                                clients to prevent data loss. Please upgrade to v1.7 \
-                                or disable the experimental ingestion feature(s) \
-                                `experimental_*_batch_ingestion`"
-                            .into(),
-                    }
-                    .into(),
-                );
-                Ok(())
-            });
-
-            return;
-        };
-
-        let replica_set_states = self.replica_set_states.clone();
         self.leadership_state
             .forward_many_with_callback(
-                target_leader_epoch,
                 request.records.into_iter(),
                 move |result: Result<(), PartitionProcessorRpcError>| match result {
                     Ok(_) => reciprocal.send(ResponseStatus::Ack.into()),
                     Err(err) => match err {
                         PartitionProcessorRpcError::NotLeader(id)
                         | PartitionProcessorRpcError::LostLeadership(id) => {
-                            // get and return the most up to date view of the
-                            // leader state.
-                            let leadership_state =
-                                replica_set_states.membership_state(id).current_leader();
-
-                            reciprocal.send(
-                                ResponseStatus::NotLeaderWithEpoch {
-                                    of: id,
-                                    last_seen_leadership_state: leadership_state,
-                                }
-                                .into(),
-                            )
+                            reciprocal.send(ResponseStatus::NotLeader { of: id }.into())
                         }
                         PartitionProcessorRpcError::Internal(msg) => {
                             reciprocal.send(ResponseStatus::Internal { msg }.into())
@@ -1112,7 +1057,7 @@ where
 
         if !self.is_targeted_to_me(&record.keys) {
             self.status.num_skipped_records += 1;
-            warn!(
+            debug!(
                 "Ignore message which is not targeted to me Partition Range: {:?} Key: {:?}, Header: {:?}",
                 self.key_filter,
                 record.keys,
@@ -1127,7 +1072,7 @@ where
         // deduplicate if deduplication information has been provided
         if let Some(dedup_information) = dedup_information {
             if Self::is_outdated_or_duplicate(&dedup_information, transaction).await? {
-                warn!(
+                debug!(
                     "Ignoring outdated or duplicate message: {:?}",
                     record.envelope.header()
                 );


### PR DESCRIPTION

Summary
This also backout wire-protocol V4 since it's no longer
needed
