### PR TITLE
[Restate UI] Update to v1.0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8833,8 +8833,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "1.0.7"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v1.0.7#441658e931299c60d77ff46d55865002be00a6ed"
+version = "1.0.8"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v1.0.8#ab2766a07a6ab2e067a016cf1b9c8e88683c1bd4"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -39,7 +39,7 @@ restate-util-time = { workspace = true }
 restate-types = { workspace = true }
 restate-util-string = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "1.0.7", tag = "v1.0.7" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "1.0.8", tag = "v1.0.8" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v1.0.8
published at https://github.com/restatedev/restate-web-ui/releases/download/v1.0.8/ui-v1.0.8.zip