### PR TITLE
memory: memory: fix leak from std::mem::forget on leases

### DIFF
--- a/crates/memory/src/local_pool.rs
+++ b/crates/memory/src/local_pool.rs
@@ -435,8 +435,8 @@ impl Drop for LocalMemoryPool {
             // individually by orphaned LocalMemoryLease drops (which detect the dead bit).
             // Note: we cannot use `shrink()` here because that returns bytes to the
             // pool immediately — we need to withhold them.
-            let withheld = self.local_capacity.split(in_flight);
-            std::mem::forget(withheld);
+            let mut withheld = self.local_capacity.split(in_flight);
+            withheld.forget();
         }
 
         // self.local_capacity drops here, returning (capacity - in_flight) to the pool.
@@ -464,14 +464,14 @@ impl LocalMemoryLease {
     /// Both leases must originate from the same [`LocalMemoryPool`] (debug-asserted).
     /// After the merge, `other` is consumed without decrementing in-flight — the
     /// combined in-flight is now tracked by `self` alone.
-    pub fn merge(&mut self, other: LocalMemoryLease) {
+    pub fn merge(&mut self, mut other: LocalMemoryLease) {
         debug_assert!(
             Arc::ptr_eq(&self.shared, &other.shared),
             "cannot merge leases from different budgets"
         );
         self.size += other.size;
-        // Prevent `other`'s Drop from decrementing in-flight.
-        std::mem::forget(other);
+        // forget the `other` memory
+        other.size = 0;
     }
 
     /// Splits off `amount` bytes into a new lease.

--- a/crates/memory/src/pool.rs
+++ b/crates/memory/src/pool.rs
@@ -380,6 +380,13 @@ impl MemoryLease {
             size: 0,
         }
     }
+
+    /// Leak leased memory. It's up to the caller to make
+    /// sure the leaked memory is returned to the pool.
+    #[inline]
+    pub(crate) fn forget(&mut self) {
+        self.size = 0;
+    }
 }
 
 impl Drop for MemoryLease {


### PR DESCRIPTION

Summary:
Both MemoryLease and LocalMemoryLease own an Arc (the budget /
SharedState). We used std::mem::forget to withhold a lease's bytes
from the pool by suppressing its Drop. But forgetting the lease also
skips dropping its Arc (and the entire object data), so the strong count is never decremented and
the backing allocation leaks.

Instead, zero the lease's size and let it drop normally. The Drop
guard (if size > 0) skips returning bytes to the pool — same
withholding behavior — while the Arc is released correctly. This also
aligns LocalMemoryLease::merge with the existing MemoryLease::merge,
which already used this idiom.

I also reviewed the atomic operation memory order and it is sound.
