### PR TITLE
Remove rocksdb_disable_wal from non-relevant sections

### DIFF
--- a/crates/bifrost/src/providers/local_loglet/log_store.rs
+++ b/crates/bifrost/src/providers/local_loglet/log_store.rs
@@ -155,6 +155,10 @@ impl restate_rocksdb::configuration::DbConfigurator for RocksConfigurator {
             local_loglet_config.rocksdb_max_background_compactions(),
         );
 
+        if !local_loglet_config.rocksdb_disable_wal() {
+            // RocksDB does not support recycling wal log files if wal is disabled when writing
+            db_options.set_recycle_log_file_num(4);
+        }
         // local loglet customizations
 
         // Enable atomic flushes.

--- a/crates/bifrost/src/providers/local_loglet/log_store_writer.rs
+++ b/crates/bifrost/src/providers/local_loglet/log_store_writer.rs
@@ -258,7 +258,7 @@ impl LogStoreWriter {
 
     async fn commit(&mut self, opts: &LocalLogletOptions, write_batch: WriteBatch) {
         let mut write_opts = rocksdb::WriteOptions::new();
-        write_opts.disable_wal(opts.rocksdb.rocksdb_disable_wal());
+        write_opts.disable_wal(opts.rocksdb_disable_wal());
         write_opts.set_sync(!opts.rocksdb_disable_wal_fsync());
 
         trace!(

--- a/crates/log-server/src/rocksdb_logstore/builder.rs
+++ b/crates/log-server/src/rocksdb_logstore/builder.rs
@@ -114,6 +114,11 @@ impl restate_rocksdb::configuration::DbConfigurator for RocksConfigurator {
             log_server_config.rocksdb_max_background_compactions(),
         );
 
+        if !log_server_config.rocksdb_disable_wal() {
+            // RocksDB does not support recycling wal log files if wal is disabled when writing
+            db_options.set_recycle_log_file_num(4);
+        }
+
         // log-server specific customizations
 
         // This is Rocksdb's default, it's added here for clarity.

--- a/crates/log-server/src/rocksdb_logstore/writer.rs
+++ b/crates/log-server/src/rocksdb_logstore/writer.rs
@@ -492,12 +492,15 @@ impl LogStoreWriter<'_> {
             .record(write_batch.size_in_bytes() as f64);
 
         let mut write_opts = rocksdb::WriteOptions::new();
-        if batch.sync_write_is_required {
-            write_opts.disable_wal(false);
-            write_opts.set_sync(true);
+        if opts.rocksdb_disable_wal() {
+            write_opts.disable_wal(true);
         } else {
-            write_opts.disable_wal(opts.rocksdb.rocksdb_disable_wal());
-            write_opts.set_sync(!opts.rocksdb_disable_wal_fsync());
+            write_opts.disable_wal(false);
+            if batch.sync_write_is_required {
+                write_opts.set_sync(true);
+            } else {
+                write_opts.set_sync(!opts.rocksdb_disable_wal_fsync());
+            }
         }
 
         // hint to rocksdb to insert the memtable position hint for the batch, our writes per batch

--- a/crates/metadata-server/src/raft/storage/rocksdb_builder.rs
+++ b/crates/metadata-server/src/raft/storage/rocksdb_builder.rs
@@ -68,6 +68,9 @@ impl restate_rocksdb::configuration::DbConfigurator for RocksConfigurator {
         // amend default options from rocksdb_manager
         self.apply_db_opts_from_config(&mut db_options, &metadata_server_config.rocksdb);
 
+        // Recycle wal files
+        db_options.set_recycle_log_file_num(4);
+
         restate_rocksdb::configuration::set_background_work_budget(
             &mut db_options,
             metadata_server_config.rocksdb_max_background_flushes(),

--- a/crates/rocksdb/src/configuration.rs
+++ b/crates/rocksdb/src/configuration.rs
@@ -43,11 +43,6 @@ pub trait DbConfigurator {
                 .set_statistics_level(convert_statistics_level(config.rocksdb_statistics_level()));
         }
 
-        // no need to retain 1000 log files by default.
-        if !config.rocksdb_disable_wal() {
-            // RocksDB does not support recycling wal log files if wal is disabled when writing
-            db_options.set_recycle_log_file_num(4);
-        }
         db_options.set_compaction_readahead_size(config.rocksdb_compaction_readahead_size().get());
 
         // Use Direct I/O for reads, do not use OS page cache to cache compressed blocks.

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -25,9 +25,7 @@ use crate::net::connect_opts::MESSAGE_SIZE_OVERHEAD;
 use crate::retries::RetryPolicy;
 
 use super::networking::DEFAULT_MESSAGE_SIZE_LIMIT;
-use super::{
-    BackgroundWorkBudget, CommonOptions, NetworkingOptions, RocksDbOptions, RocksDbOptionsBuilder,
-};
+use super::{BackgroundWorkBudget, CommonOptions, NetworkingOptions, RocksDbOptions};
 
 /// # Bifrost options
 #[serde_as]
@@ -195,6 +193,12 @@ pub struct LocalLogletOptions {
     /// (See `rocksdb-total-memtables-ratio` in common).
     rocksdb_memory_ratio: f32,
 
+    /// # Disable WAL
+    ///
+    /// Dangerous option, use with caution.
+    #[cfg_attr(feature = "schemars", schemars(skip))]
+    rocksdb_disable_wal: bool,
+
     /// Disable fsync of WAL on every batch
     rocksdb_disable_wal_fsync: bool,
 
@@ -257,6 +261,10 @@ impl LocalLogletOptions {
         }
     }
 
+    pub fn rocksdb_disable_wal(&self) -> bool {
+        self.rocksdb_disable_wal
+    }
+
     pub fn rocksdb_max_background_flushes(&self) -> NonZeroU32 {
         self.rocksdb_max_background_flushes
             .unwrap_or(NonZeroU32::new(1).unwrap())
@@ -288,12 +296,8 @@ impl LocalLogletOptions {
 
 impl Default for LocalLogletOptions {
     fn default() -> Self {
-        let rocksdb = RocksDbOptionsBuilder::default()
-            .rocksdb_disable_wal(Some(false))
-            .build()
-            .unwrap();
         Self {
-            rocksdb,
+            rocksdb: RocksDbOptions::default(),
             // set by apply_common in runtime
             rocksdb_memory_budget: None,
             rocksdb_memory_ratio: 0.5,
@@ -303,6 +307,7 @@ impl Default for LocalLogletOptions {
             always_commit_in_background: false,
             rocksdb_max_background_flushes: None,
             rocksdb_max_background_compactions: None,
+            rocksdb_disable_wal: false,
         }
     }
 }

--- a/crates/types/src/config/log_server.rs
+++ b/crates/types/src/config/log_server.rs
@@ -17,7 +17,7 @@ use serde_with::serde_as;
 use restate_util_bytecount::{ByteCount, NonZeroByteCount};
 use tracing::warn;
 
-use super::{BackgroundWorkBudget, CommonOptions, RocksDbOptions, RocksDbOptionsBuilder};
+use super::{BackgroundWorkBudget, CommonOptions, RocksDbOptions};
 
 const MIN_ROCKSDB_MEMORY: NonZeroByteCount =
     NonZeroByteCount::new(NonZeroUsize::new(32 * 1024 * 1024).unwrap());
@@ -160,9 +160,18 @@ pub struct LogServerOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub write_batch_commit_count: Option<NonZeroUsize>,
 
+    /// Disable WAL for the log-server
+    ///
+    /// [DANGEROUS] Not recommended for production use.
+    #[cfg_attr(feature = "schemars", schemars(skip))]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    rocksdb_disable_wal: bool,
+
     /// Starts in read-only mode
     ///
     /// This is useful for testing, debugging, and development.
+    #[cfg_attr(feature = "schemars", schemars(skip))]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub read_only: bool,
 }
 
@@ -202,6 +211,10 @@ impl LogServerOptions {
     pub fn rocksdb_max_background_compactions(&self) -> NonZeroU32 {
         self.rocksdb_max_background_compactions
             .unwrap_or(NonZeroU32::new(2).unwrap())
+    }
+
+    pub fn rocksdb_disable_wal(&self) -> bool {
+        self.rocksdb_disable_wal
     }
 
     pub fn rocksdb_disable_wal_fsync(&self) -> bool {
@@ -276,17 +289,14 @@ impl LogServerOptions {
 
 impl Default for LogServerOptions {
     fn default() -> Self {
-        let rocksdb = RocksDbOptionsBuilder::default()
-            .rocksdb_disable_wal(Some(false))
-            .build()
-            .unwrap();
         Self {
             read_only: false,
-            rocksdb,
+            rocksdb: RocksDbOptions::default(),
             // set by apply_common in runtime
             rocksdb_memory_budget: None,
             rocksdb_memory_ratio: 0.5,
             rocksdb_max_sub_compactions: 0,
+            rocksdb_disable_wal: false,
             rocksdb_max_wal_size: ByteCount::ZERO,
             rocksdb_disable_wal_fsync: false,
             always_commit_in_background: false,

--- a/crates/types/src/config/metadata_server.rs
+++ b/crates/types/src/config/metadata_server.rs
@@ -18,8 +18,7 @@ use restate_util_bytecount::NonZeroByteCount;
 use restate_util_time::NonZeroFriendlyDuration;
 
 use super::{
-    BackgroundWorkBudget, CommonOptions, Configuration, RocksDbOptions, RocksDbOptionsBuilder,
-    StructWithDefaults,
+    BackgroundWorkBudget, CommonOptions, Configuration, RocksDbOptions, StructWithDefaults,
 };
 
 const MIN_ROCKSDB_MEMORY: NonZeroByteCount =
@@ -137,25 +136,16 @@ impl MetadataServerOptions {
     pub fn request_queue_length(&self) -> usize {
         self.request_queue_length.get()
     }
-
-    fn rocksdb_defaults() -> RocksDbOptionsBuilder {
-        let mut builder = RocksDbOptionsBuilder::default();
-        builder.rocksdb_disable_wal(Some(false));
-        builder
-    }
 }
 
 impl Default for MetadataServerOptions {
     fn default() -> Self {
-        let rocksdb = Self::rocksdb_defaults()
-            .build()
-            .expect("valid RocksDbOptions");
         Self {
             request_queue_length: NonZeroUsize::new(32).unwrap(),
             // set by apply_common in runtime
             rocksdb_memory_budget: None,
             rocksdb_memory_ratio: 0.01,
-            rocksdb,
+            rocksdb: RocksDbOptions::default(),
             raft_options: RaftOptions::default(),
             auto_join: true,
             rocksdb_max_background_flushes: None,
@@ -231,7 +221,7 @@ impl<'de> DeserializeAs<'de, MetadataServerOptions>
 
 #[cfg(test)]
 mod tests {
-    use crate::config::{Configuration, MetadataServerOptions};
+    use crate::config::{Configuration, MetadataServerOptions, RocksDbOptionsBuilder};
     use crate::config_loader::ConfigLoaderBuilder;
     use std::fs;
     use std::num::NonZeroUsize;
@@ -283,7 +273,7 @@ mod tests {
             .disable_apply_cascading_values(true)
             .build()?;
         let configuration = config_loader.load_once()?;
-        let mut rocksdb_defaults = MetadataServerOptions::rocksdb_defaults();
+        let mut rocksdb_defaults = RocksDbOptionsBuilder::default();
         rocksdb_defaults.rocksdb_disable_direct_io_for_reads(Some(false));
         let rocksdb = rocksdb_defaults.build().expect("should build");
 

--- a/crates/types/src/config/rocksdb.rs
+++ b/crates/types/src/config/rocksdb.rs
@@ -39,14 +39,6 @@ pub struct RocksDbOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     rocksdb_disable_direct_io_for_flush_and_compactions: Option<bool>,
 
-    /// # Disable WAL
-    ///
-    /// The default depends on the different rocksdb use-cases at Restate.
-    ///
-    /// Supports hot-reloading (Partial / Bifrost only)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    rocksdb_disable_wal: Option<bool>,
-
     /// Disable rocksdb statistics collection
     ///
     /// Default: False (statistics enabled)
@@ -174,9 +166,6 @@ impl RocksDbOptions {
             self.rocksdb_disable_direct_io_for_flush_and_compactions =
                 Some(common.rocksdb_disable_direct_io_for_flush_and_compaction());
         }
-        if self.rocksdb_disable_wal.is_none() {
-            self.rocksdb_disable_wal = Some(common.rocksdb_disable_wal());
-        }
         if self.rocksdb_disable_statistics.is_none() {
             self.rocksdb_disable_statistics = Some(common.rocksdb_disable_statistics());
         }
@@ -212,10 +201,6 @@ impl RocksDbOptions {
             self.rocksdb_disable_l0_l1_compression =
                 Some(common.rocksdb_disable_l0_l1_compression());
         }
-    }
-
-    pub fn rocksdb_disable_wal(&self) -> bool {
-        self.rocksdb_disable_wal.unwrap_or(false)
     }
 
     pub fn rocksdb_disable_direct_io_for_reads(&self) -> bool {

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -22,7 +22,7 @@ use restate_util_time::{FriendlyDuration, NonZeroFriendlyDuration};
 
 use super::{
     BackgroundWorkBudget, CommonOptions, DEFAULT_MESSAGE_SIZE_LIMIT, NetworkingOptions,
-    ObjectStoreOptions, RocksDbOptions, RocksDbOptionsBuilder,
+    ObjectStoreOptions, RocksDbOptions,
 };
 use crate::config::{
     AwsLambdaOptions, DeprecatedAwsLambdaOptions, DeprecatedHttpOptions, HttpOptions,
@@ -859,14 +859,9 @@ impl StorageOptions {
 
 impl Default for StorageOptions {
     fn default() -> Self {
-        let rocksdb = RocksDbOptionsBuilder::default()
-            .rocksdb_disable_wal(Some(true))
-            .build()
-            .expect("valid RocksDbOptions");
-
         #[allow(deprecated)]
         StorageOptions {
-            rocksdb,
+            rocksdb: RocksDbOptions::default(),
             // set by apply_common in runtime
             rocksdb_memory_budget: None,
             rocksdb_memory_ratio: 0.49,


### PR DESCRIPTION

This adds a hidden option to stop using WAL in log-server which is meant to be used in comparative performance testing but should not be used in any production setup.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4936).
* #4939
* __->__ #4936