### PR TITLE
[Tuning] Changes to rocksdb tuning and options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6741,7 +6741,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/bifrost/src/providers/local_loglet/log_store.rs
+++ b/crates/bifrost/src/providers/local_loglet/log_store.rs
@@ -141,10 +141,10 @@ impl restate_rocksdb::configuration::DbConfigurator for RocksConfigurator {
         let mut db_options = restate_rocksdb::configuration::create_default_db_options(
             env,
             db_name,
-            true, /* create_db_if_missing */
             write_buffer_manager,
             limiter,
         );
+
         let local_loglet_config = &Configuration::pinned().bifrost.local;
         // amend default options from rocksdb_manager
         self.apply_db_opts_from_config(&mut db_options, &local_loglet_config.rocksdb);

--- a/crates/bifrost/src/providers/replicated_loglet/provider.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/provider.rs
@@ -60,9 +60,10 @@ impl<T: TransportConnect> Factory<T> {
                 // NOTE: This is a shared pool with log-server store data path
                 "log-server-data",
                 || {
-                    Configuration::pinned()
+                    let config = Configuration::pinned();
+                    config
                         .log_server
-                        .rocksdb_data_memtables_budget()
+                        .data_service_memory_size(config.networking.message_size_limit)
                 },
             )
         });

--- a/crates/log-server/src/network.rs
+++ b/crates/log-server/src/network.rs
@@ -56,9 +56,10 @@ impl RequestPump {
         // rather than queuing which could cause unbounded memory growth.
         let data_pool = TaskCenter::with_current(|tc| {
             tc.memory_controller().create_pool("log-server-data", || {
-                Configuration::pinned()
+                let config = Configuration::pinned();
+                config
                     .log_server
-                    .rocksdb_data_memtables_budget()
+                    .data_service_memory_size(config.networking.message_size_limit)
             })
         });
 

--- a/crates/log-server/src/rocksdb_logstore/builder.rs
+++ b/crates/log-server/src/rocksdb_logstore/builder.rs
@@ -8,12 +8,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::num::NonZeroU32;
 use std::sync::Arc;
 
 use rocksdb::{BlockBasedOptions, Cache, SliceTransform};
 use tracing::{info, warn};
 
 use restate_core::ShutdownError;
+use restate_platform::prelude::ToReString;
+use restate_rocksdb::configuration::create_empty_db_options;
 use restate_rocksdb::{
     CfExactPattern, CfName, DbName, DbSpecBuilder, OpenMode, RocksDb, RocksDbManager,
 };
@@ -41,14 +44,15 @@ impl RocksDbLogStoreBuilder {
         let db_manager = RocksDbManager::get();
         let cfs = vec![CfName::new(DATA_CF), CfName::new(METADATA_CF)];
 
+        let opts = &Configuration::pinned().log_server;
         let db_spec = DbSpecBuilder::new(
             db_name,
             kind,
-            Configuration::pinned().log_server.data_dir(),
-            RocksConfigurator,
+            opts.data_dir(),
+            RocksDbConfigurator::new(opts)?,
         )
-        .add_cf_pattern(CfExactPattern::new(DATA_CF), RocksConfigurator)
-        .add_cf_pattern(CfExactPattern::new(METADATA_CF), RocksConfigurator)
+        .add_cf_pattern(CfExactPattern::new(DATA_CF), RocksCfConfigurator)
+        .add_cf_pattern(CfExactPattern::new(METADATA_CF), RocksCfConfigurator)
         // not very important but it's to reduce the number of merges by flushing.
         // it's also a small cf so it should be quick.
         .add_to_flush_on_shutdown(CfExactPattern::new(METADATA_CF))
@@ -78,9 +82,29 @@ impl RocksDbLogStoreBuilder {
     }
 }
 
-struct RocksConfigurator;
+struct RocksCfConfigurator;
 
-impl restate_rocksdb::configuration::DbConfigurator for RocksConfigurator {
+struct RocksDbConfigurator {
+    env: rocksdb::Env,
+}
+
+impl RocksDbConfigurator {
+    fn new(opts: &LogServerOptions) -> Result<Self, RocksDbLogStoreError> {
+        // dedicated env for log-server
+        let env = if opts.in_memory {
+            rocksdb::Env::mem_env()?
+        } else {
+            let mut env = rocksdb::Env::new()?;
+            env.set_high_priority_background_threads(1);
+            env.set_low_priority_background_threads(1);
+            env.set_bottom_priority_background_threads(1);
+            env
+        };
+        Ok(Self { env })
+    }
+}
+
+impl restate_rocksdb::configuration::DbConfigurator for RocksDbConfigurator {
     fn get_db_open_mode(&self) -> OpenMode {
         if Configuration::pinned().log_server.read_only {
             OpenMode::ReadOnly
@@ -92,35 +116,69 @@ impl restate_rocksdb::configuration::DbConfigurator for RocksConfigurator {
     fn get_db_options(
         &self,
         db_name: &DbName,
-        env: &rocksdb::Env,
+        _env: &rocksdb::Env,
         write_buffer_manager: &rocksdb::WriteBufferManager,
         limiter: &rocksdb::RateLimiter,
     ) -> rocksdb::Options {
-        let mut db_options = restate_rocksdb::configuration::create_default_db_options(
-            env,
-            db_name,
-            true, /* create_db_if_missing */
-            write_buffer_manager,
-            limiter,
-        );
         // load config from the input configuration
         let log_server_config = &Configuration::pinned().log_server;
+
+        let mut db_options = create_empty_db_options(db_name.clone());
         // amend default options from rocksdb_manager
         self.apply_db_opts_from_config(&mut db_options, &log_server_config.rocksdb);
 
+        db_options.set_wal_dir(log_server_config.wal_dir());
+        // dedicated environment for log-server to avoid queueing behind flush/compactions
+        // of partition store.
+        db_options.set_env(&self.env);
+        db_options.set_shared_ratelimiter(limiter);
+        db_options.create_if_missing(true);
+        db_options.create_missing_column_families(true);
+        // Avoid pushing back on compaction delays, sacrifice storage and do not hinder
+        // writes and flushes.
+        db_options.set_soft_pending_compaction_bytes_limit(512 * 1024 * 1024 * 1024);
+        // Do not push back on compaction delays, sacrifice storage and do not hinder
+        // writes and flushes.
+        db_options.set_hard_pending_compaction_bytes_limit(2 * 1024 * 1024 * 1024 * 1024);
+        // todo(asoli): Consider detaching from the write buffer manager since we have
+        // good grip over memory budgets for log-server but we are keeping it because it
+        // makes it easy to observe total rocksdb memory usage in metrics.
+        //
+        // write buffer is controlled by write buffer manager
+        db_options.set_write_buffer_manager(write_buffer_manager);
+        db_options.set_avoid_unnecessary_blocking_io(true);
+        // Let rocksdb decide for level sizes.
+        db_options.set_level_compaction_dynamic_level_bytes(true);
+        //
+        // [Not important setting, consider removing], allows to shard compressed
+        // block cache to up to 64 shards in memory.
+        db_options.set_table_cache_num_shard_bits(6);
+
+        // Speed up database open, useful for large databases and slow disk.
+        db_options.set_skip_stats_update_on_db_open(true);
+        // Log Server database is critical for correctness.
+        db_options.set_paranoid_checks(!log_server_config.rocksdb_disable_paranoid_checks);
+
+        // Disable WAL archiving.
+        // the following two options has to be both 0 to disable WAL log archive.
+        db_options.set_wal_size_limit_mb(0);
+        db_options.set_wal_ttl_seconds(0);
+
         restate_rocksdb::configuration::set_background_work_budget(
             &mut db_options,
-            log_server_config.rocksdb_max_background_flushes(),
+            // dedicated flush thread for log-server
+            NonZeroU32::new(2).unwrap(),
             log_server_config.rocksdb_max_background_compactions(),
         );
 
         if !log_server_config.rocksdb_disable_wal() {
             // RocksDB does not support recycling wal log files if wal is disabled when writing
-            db_options.set_recycle_log_file_num(4);
+            db_options
+                .set_recycle_log_file_num(log_server_config.max_write_buffer_number() as usize);
         }
 
         // log-server specific customizations
-
+        //
         // This is Rocksdb's default, it's added here for clarity.
         //
         // Rationale: If WAL tail is corrupted, it's likely that it has failed during write, that said,
@@ -135,7 +193,7 @@ impl restate_rocksdb::configuration::DbConfigurator for RocksConfigurator {
         // most reads are sequential
         db_options.set_advise_random_on_open(false);
 
-        db_options.set_max_total_wal_size(log_server_config.rocksdb_max_wal_size().as_u64());
+        db_options.set_max_total_wal_size(log_server_config.max_wal_total_size() as u64);
 
         // Flush both CFs atomically. This ensures the metadata CF (trim points, seals)
         // and the data CF are always consistent on disk without requiring WAL replay to
@@ -151,15 +209,11 @@ impl restate_rocksdb::configuration::DbConfigurator for RocksConfigurator {
     }
 
     fn note_config_update(&self, db: &restate_rocksdb::RocksAccess) {
-        let data_budget = {
-            let config = &Configuration::pinned().log_server;
-            config.rocksdb_data_memtables_budget()
-        };
-
-        update_data_cf_budget(db, data_budget.as_usize());
+        let config = &Configuration::pinned().log_server;
+        update_data_cf_budget(db, config);
         // Keep metadata CF write_buffer_size in sync so it never triggers a flush on
         // its own (atomic_flush means any CF triggering a flush drags all CFs along).
-        update_metadata_cf_write_buffer_size(db, data_budget.as_usize());
+        update_metadata_cf_write_buffer_size(db, config.write_buffer_size());
 
         // If current memtable usage exceeds the new budget, trigger a flush so that
         // memory is reclaimed promptly. With atomic_flush, flushing the data CF will
@@ -169,11 +223,11 @@ impl restate_rocksdb::configuration::DbConfigurator for RocksConfigurator {
             .unwrap()
             .unwrap_or_default() as usize;
 
-        let will_flush = total_data_usage > data_budget.as_usize();
+        let will_flush = total_data_usage > config.rocksdb_memory_budget().as_usize();
         info!(
             "Updating log-server data CF memory budget. usage:{}/{}, will_flush: {}",
             ByteCount::from(total_data_usage),
-            data_budget,
+            config.rocksdb_memory_budget(),
             will_flush
         );
         if will_flush {
@@ -188,25 +242,21 @@ impl restate_rocksdb::configuration::DbConfigurator for RocksConfigurator {
 }
 
 /// Dynamically updates the data CF sizing options to match the new memory budget.
-///
-/// Must stay in sync with the initial values set by [`cf_data_options`]:
-///   - `write_buffer_size = budget / 4`
-///   - `target_file_size_base = budget / 8`
-///   - `max_bytes_for_level_base = budget * 2` (= trigger × write_buffer_size = 8 × budget/4)
-///
-/// `level0_file_num_compaction_trigger` (8) is a constant that doesn't depend on the
-/// budget — the ratio `8 × (budget/4) = 2 × budget` holds for any budget value.
-fn update_data_cf_budget(db: &restate_rocksdb::RocksAccess, memory_budget: usize) {
-    let write_buffer_size = (memory_budget / 4).to_string();
-    let target_file_size_base = (memory_budget / 8).to_string();
-    let max_bytes_for_level_base = (memory_budget * 2).to_string();
+fn update_data_cf_budget(db: &restate_rocksdb::RocksAccess, opts: &LogServerOptions) {
+    let max_bytes_for_level_base_str = opts.max_bytes_for_level_base().to_restring();
+    let write_buffer_size_str = opts.write_buffer_size().to_restring();
+    let max_write_buffer_number_str = opts.max_write_buffer_number().to_restring();
+    let target_file_size_base_str = opts.target_file_size_base().to_restring();
+    let max_compaction_bytes = opts.max_compaction_bytes().to_restring();
 
     if let Err(err) = db.set_options_cf(
         DATA_CF,
         &[
-            ("write_buffer_size", &write_buffer_size),
-            ("target_file_size_base", &target_file_size_base),
-            ("max_bytes_for_level_base", &max_bytes_for_level_base),
+            ("write_buffer_size", &write_buffer_size_str),
+            ("target_file_size_base", &target_file_size_base_str),
+            ("max_write_buffer_number", &max_write_buffer_number_str),
+            ("max_bytes_for_level_base", &max_bytes_for_level_base_str),
+            ("max_compaction_bytes", &max_compaction_bytes),
         ],
     ) {
         warn!(
@@ -218,8 +268,11 @@ fn update_data_cf_budget(db: &restate_rocksdb::RocksAccess, memory_budget: usize
 
 /// Keeps the metadata CF write_buffer_size in sync with the data CF so that
 /// the metadata CF never independently triggers a flush under atomic_flush.
-fn update_metadata_cf_write_buffer_size(db: &restate_rocksdb::RocksAccess, data_budget: usize) {
-    let write_buffer_size = (data_budget / 4).to_string();
+fn update_metadata_cf_write_buffer_size(
+    db: &restate_rocksdb::RocksAccess,
+    write_buffer_size: usize,
+) {
+    let write_buffer_size = write_buffer_size.to_string();
     if let Err(err) = db.set_options_cf(METADATA_CF, &[("write_buffer_size", &write_buffer_size)]) {
         warn!(
             "Failed to update metadata CF write_buffer_size for {}/{METADATA_CF}: {err}",
@@ -228,7 +281,7 @@ fn update_metadata_cf_write_buffer_size(db: &restate_rocksdb::RocksAccess, data_
     }
 }
 
-impl restate_rocksdb::configuration::CfConfigurator for RocksConfigurator {
+impl restate_rocksdb::configuration::CfConfigurator for RocksCfConfigurator {
     fn get_cf_options(
         &self,
         _db_name: &DbName,
@@ -280,20 +333,28 @@ fn cf_data_options(
 ) {
     opts.set_block_based_table_factory(block_options);
 
-    let memtables_budget = log_server_config.rocksdb_data_memtables_budget().as_usize();
+    // Do not slow down on l0 number of files writes even if it hurts read
+    // amplification.
+    opts.set_level_zero_slowdown_writes_trigger(1 << 30);
+    opts.set_level_zero_stop_writes_trigger(1 << 30);
 
-    set_memory_related_opts(opts, memtables_budget);
     // With atomic_flush enabled, min_write_buffer_number_to_merge is forced to 1 by
-    // RocksDB. Each flush produces one L0 file of ~(budget / 4).
-    //
-    // We intentionally delay L0→L1 compaction (trigger=8) to give trimming a chance to
-    // reclaim data before compaction runs. Reads are rare thanks to the RecordCache, so
-    // higher L0 read amplification is acceptable. At trigger=8, L0 accumulates up to
-    // ~2×budget before compaction, with comfortable headroom to the default slowdown (20)
-    // and stop (36) triggers.
-    opts.set_level_zero_file_num_compaction_trigger(8);
-    // L1 target = trigger × write_buffer_size = 8 × (budget/4) = 2 × budget.
-    opts.set_max_bytes_for_level_base(memtables_budget as u64 * 2);
+    // RocksDB. Each flush produces one L0 file of ~(write_buffer_size). However, we
+    // set it here explicitly to unify where we define this value.
+    opts.set_min_write_buffer_number_to_merge(
+        log_server_config.min_write_buffer_number_to_merge() as i32
+    );
+
+    opts.set_write_buffer_size(log_server_config.write_buffer_size());
+    opts.set_max_write_buffer_number(log_server_config.max_write_buffer_number() as i32);
+    opts.set_target_file_size_base(log_server_config.target_file_size_base() as u64);
+    opts.set_max_compaction_bytes(log_server_config.max_compaction_bytes() as u64);
+    opts.set_max_bytes_for_level_base(log_server_config.max_bytes_for_level_base() as u64);
+
+    opts.set_level_zero_file_num_compaction_trigger(
+        log_server_config.level_zero_file_num_compaction_trigger() as i32,
+    );
+
     opts.set_compaction_style(rocksdb::DBCompactionStyle::Level);
     opts.set_num_levels(7);
 
@@ -303,7 +364,7 @@ fn cf_data_options(
     {
         rocksdb::DBCompressionType::None
     } else {
-        rocksdb::DBCompressionType::Zstd
+        rocksdb::DBCompressionType::Lz4
     };
     let levels = restate_rocksdb::configuration::build_compression_per_level(
         7,
@@ -332,10 +393,7 @@ fn cf_data_options(
 
         // Blob GC: relocate live blobs during compaction to reclaim space after trimming.
         opts.set_enable_blob_gc(true);
-        // All blob files are eligible for GC. Data is append-only so blob GC is purely
-        // about cleanup after DeleteRange trimming — there's no benefit to limiting
-        // eligibility to the oldest fraction.
-        opts.set_blob_gc_age_cutoff(1.0);
+        opts.set_blob_gc_age_cutoff(0.25);
         // Trigger forced compactions when >=50% of data in eligible blob files is garbage.
         // Without this (default 1.0 = disabled), SSTs referencing trimmed blob data may
         // not be picked for compaction naturally, delaying disk space reclamation.
@@ -352,18 +410,6 @@ fn cf_data_options(
     }
 }
 
-/// Sets common memtable and SST sizing for the data column family.
-///
-/// With 4 write buffers (1 mutable + 3 immutable), each memtable is `budget / 4`.
-/// The caller must separately set `level_zero_file_num_compaction_trigger` and
-/// `max_bytes_for_level_base` to satisfy the invariant:
-///   `trigger × write_buffer_size ≈ max_bytes_for_level_base`
-fn set_memory_related_opts(opts: &mut rocksdb::Options, memtables_budget: usize) {
-    opts.set_write_buffer_size(memtables_budget / 4);
-    opts.set_max_write_buffer_number(4);
-    opts.set_target_file_size_base(memtables_budget as u64 / 8);
-}
-
 fn cf_metadata_options(
     opts: &mut rocksdb::Options,
     block_options: &BlockBasedOptions,
@@ -374,16 +420,20 @@ fn cf_metadata_options(
     // The metadata CF uses the data CF's write_buffer_size so it never independently
     // triggers a flush (with atomic_flush, any CF triggering drags all CFs along).
     // Metadata writes are tiny (~20 bytes per op), so actual memory use is negligible.
-    let data_memtables_budget = log_server_config.rocksdb_data_memtables_budget().as_usize();
-    opts.set_write_buffer_size(data_memtables_budget / 4);
-    opts.set_max_write_buffer_number(4);
+    opts.set_write_buffer_size(log_server_config.write_buffer_size());
+    opts.set_max_write_buffer_number(log_server_config.max_write_buffer_number() as i32);
+
+    // Do not slow down on l0 number of files writes even if it hurts read
+    // amplification.
+    opts.set_level_zero_slowdown_writes_trigger(1 << 30);
+    opts.set_level_zero_stop_writes_trigger(1 << 30);
 
     // The metadata CF holds a handful of small keys per loglet (trim point, sequencer,
     // seal). Total data is typically a few hundred KB even with thousands of loglets —
     // SST files will never approach the default target_file_size_base or level limits,
     // so we leave those at RocksDB defaults. Compact eagerly to keep L0 clean for point
     // lookups (e.g. load_loglet_state).
-    opts.set_level_zero_file_num_compaction_trigger(2);
+    opts.set_level_zero_file_num_compaction_trigger(4);
     opts.set_num_levels(3);
     // The metadata CF is tiny — disable compression entirely to avoid unnecessary CPU
     // overhead on flushes and point lookups. The disk savings are negligible.

--- a/crates/log-server/src/rocksdb_logstore/writer.rs
+++ b/crates/log-server/src/rocksdb_logstore/writer.rs
@@ -211,8 +211,10 @@ impl LogStoreWriterBuilder {
                     }
 
                     let config = &config.live_load().log_server;
+                    let batch_bytes_limit = config.write_batch_commit_bytes();
+
                     // Opportunistically drain normal-pri commands.
-                    while batch.size_in_bytes() < config.write_batch_bytes().as_usize()
+                    while batch.size_in_bytes() < batch_bytes_limit
                         && config
                             .write_batch_commit_count
                             .is_none_or(|c| batch.len() < c.get())

--- a/crates/metadata-server/src/raft/storage/rocksdb_builder.rs
+++ b/crates/metadata-server/src/raft/storage/rocksdb_builder.rs
@@ -59,7 +59,6 @@ impl restate_rocksdb::configuration::DbConfigurator for RocksConfigurator {
         let mut db_options = restate_rocksdb::configuration::create_default_db_options(
             env,
             db_name,
-            true, /* create_db_if_missing */
             write_buffer_manager,
             limiter,
         );
@@ -214,7 +213,7 @@ fn cf_metadata_options(
     {
         rocksdb::DBCompressionType::None
     } else {
-        rocksdb::DBCompressionType::Zstd
+        rocksdb::DBCompressionType::Lz4
     };
     let levels = restate_rocksdb::configuration::build_compression_per_level(
         3,

--- a/crates/partition-store/src/memory.rs
+++ b/crates/partition-store/src/memory.rs
@@ -17,7 +17,7 @@ use metrics::{counter, gauge};
 use tracing::{info, trace, warn};
 
 use restate_core::{ShutdownError, TaskCenter, TaskKind, cancellation_watcher};
-use restate_types::config::Configuration;
+use restate_types::config::{Configuration, StorageOptions};
 use restate_types::identifiers::PartitionId;
 use restate_util_bytecount::ByteCount;
 
@@ -26,6 +26,68 @@ use crate::{PartitionDb, SharedState};
 
 const INITIAL_NUM_PARTITIONS: usize = 24;
 const DEBUG_MEMORY_REPORTING: bool = false;
+
+pub const MAX_WRITE_BUFFERS: u32 = 4;
+pub const NOMINAL_WRITE_BUFFERS: u32 = 4;
+// merge 2 memtables when flushing to L0
+pub const WRITE_BUFFERS_TO_MERGE: u32 = 2;
+pub const LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER: u32 = 2;
+/// Matches rocksdb default (target_file_size_base * 25)
+pub const COMPACTION_BYTES_MULTIPLIER: u32 = 25;
+/// Try to keep the table files above this size if partition write buffers are too small
+pub const MIN_FILE_SIZE: usize = 16 * 1024 * 1024;
+/// The absolute minimum write buffer size
+pub const MIN_WRITE_BUFFER_SIZE: usize = 1024 * 1024;
+
+pub struct PartitionDbMemoryConfig {
+    memory_budget: usize,
+    max_file_size: usize,
+}
+
+impl PartitionDbMemoryConfig {
+    pub fn calculate(memory_budget: usize, opts: &StorageOptions) -> Self {
+        Self {
+            memory_budget,
+            max_file_size: MIN_FILE_SIZE.max(opts.rocksdb_max_file_size.as_usize()),
+        }
+    }
+
+    pub fn memory_budget(&self) -> usize {
+        self.memory_budget
+    }
+
+    pub fn write_buffer_size(&self) -> usize {
+        MIN_WRITE_BUFFER_SIZE.max(self.memory_budget / NOMINAL_WRITE_BUFFERS as usize)
+    }
+
+    pub const fn min_write_buffer_number_to_merge(&self) -> u32 {
+        WRITE_BUFFERS_TO_MERGE
+    }
+
+    pub const fn max_write_buffer_number(&self) -> u32 {
+        MAX_WRITE_BUFFERS
+    }
+
+    pub const fn level_zero_file_num_compaction_trigger(&self) -> u32 {
+        LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER
+    }
+
+    pub fn max_bytes_for_level_base(&self) -> usize {
+        self.write_buffer_size()
+            * self.min_write_buffer_number_to_merge() as usize
+            * self.level_zero_file_num_compaction_trigger() as usize
+    }
+
+    pub fn target_file_size_base(&self) -> usize {
+        // Set the target file within the range of acceptable values
+        self.write_buffer_size()
+            .clamp(MIN_FILE_SIZE, self.max_file_size)
+    }
+
+    pub fn max_compaction_bytes(&self) -> usize {
+        self.target_file_size_base() * COMPACTION_BYTES_MULTIPLIER as usize
+    }
+}
 
 pub(crate) struct MemoryBudget {
     // manages memory budgets for rocksdb-based partition stores.
@@ -157,7 +219,7 @@ async fn collect_memory_usage(
     for db_state in dbs.iter() {
         assert!(db_state.maybe_open());
         let db = db_state.db().unwrap().clone();
-        let usage = MemoryUsage::create(db_state)?;
+        let usage = MemoryUsage::create(db_state).await?;
         // a partition will be considered open if it's Open or Closed for less than 30 seconds.
         if db_state
             .closed_since()
@@ -216,7 +278,6 @@ async fn rebalance_memory(
         report_memory_usage(&collected, total_budget);
     }
 
-    // possibly update memory budget
     if let Some(new_partition_budget) = total_budget.checked_div(collected.num_open_partitions) {
         // budget has changed since last time we checked
         if new_partition_budget != current_per_partition_budget {
@@ -245,7 +306,9 @@ async fn rebalance_memory(
                 // If/when it gets re-opened, we'll be monitoring its memory usage against the
                 // latest budget anyway and we'll be able to flush it prematurely if it exceeds the
                 // per-partition budget. This or WBM might hit it first.
-                partition_db.update_memory_budget(new_partition_budget);
+                partition_db
+                    .update_memory_budget(new_partition_budget)
+                    .await;
             }
         }
     }
@@ -256,10 +319,10 @@ async fn rebalance_memory(
     let mut reclaim_candidates: Vec<_> = Vec::with_capacity(collected.partitions.len());
     // did we exceed the total memory budget?
     for (usage, partition_db) in collected.partitions.values() {
-        // is this an offending partition? only if it exceeds its budget by 10%
+        // is this an offending partition? only if it exceeds its budget by 50%
         if !usage.is_flush_pending
             && usage.total_bytes
-                > (current_per_partition_budget + current_per_partition_budget.div_ceil(10))
+                > (current_per_partition_budget + current_per_partition_budget.div_ceil(2))
         {
             reclaim_candidates.push((usage, partition_db));
         }
@@ -345,13 +408,12 @@ impl MemoryUsage {
             .saturating_sub(self.total_bytes)
     }
 
-    fn create(partition_state: &crate::partition_db::State) -> anyhow::Result<Self> {
+    async fn create(partition_state: &crate::partition_db::State) -> anyhow::Result<Self> {
         assert!(partition_state.maybe_open());
         let partition_db = partition_state.db().unwrap();
 
         let cf_names = partition_db.cf_names();
-        let rocks_db = partition_db.rocksdb();
-        let raw_rocks_db = rocks_db.inner();
+        let rocks_db = partition_db.rocksdb().clone();
 
         let mut memory_usage = Self {
             closed_since: partition_state.closed_since(),
@@ -361,27 +423,32 @@ impl MemoryUsage {
             is_flush_pending: false,
         };
 
-        for cf in cf_names {
-            memory_usage.total_bytes += raw_rocks_db
-                .get_property_int_cf(&cf, "rocksdb.cur-size-all-mem-tables")?
-                .unwrap_or_default() as usize;
+        tokio::task::spawn_blocking(move || {
+            let raw_rocks_db = rocks_db.inner();
 
-            memory_usage.immutable_and_pinned_bytes += raw_rocks_db
-                .get_property_int_cf(&cf, "rocksdb.size-all-mem-tables")?
-                .unwrap_or_default()
-                as usize;
+            for cf in cf_names {
+                memory_usage.total_bytes += raw_rocks_db
+                    .get_property_int_cf(&cf, "rocksdb.cur-size-all-mem-tables")?
+                    .unwrap_or_default() as usize;
 
-            memory_usage.mutable_bytes += raw_rocks_db
-                .get_property_int_cf(&cf, "rocksdb.cur-size-active-mem-table")?
-                .unwrap_or_default() as usize;
+                memory_usage.immutable_and_pinned_bytes += raw_rocks_db
+                    .get_property_int_cf(&cf, "rocksdb.size-all-mem-tables")?
+                    .unwrap_or_default()
+                    as usize;
 
-            memory_usage.is_flush_pending |= raw_rocks_db
-                .get_property_int_cf(&cf, "rocksdb.mem-table-flush-pending")?
-                .unwrap_or_default()
-                == 1;
-        }
+                memory_usage.mutable_bytes += raw_rocks_db
+                    .get_property_int_cf(&cf, "rocksdb.cur-size-active-mem-table")?
+                    .unwrap_or_default() as usize;
 
-        Ok(memory_usage)
+                memory_usage.is_flush_pending |= raw_rocks_db
+                    .get_property_int_cf(&cf, "rocksdb.mem-table-flush-pending")?
+                    .unwrap_or_default()
+                    == 1;
+            }
+
+            Ok(memory_usage)
+        })
+        .await?
     }
 
     /// a partition will be considered open if it's Open or Closed for less than 30 seconds.

--- a/crates/partition-store/src/partition_db.rs
+++ b/crates/partition-store/src/partition_db.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use std::marker::PhantomData;
+use std::num::NonZeroU32;
 use std::ops::DerefMut;
 use std::sync::Arc;
 use std::time::Duration;
@@ -34,12 +35,12 @@ use restate_util_bytecount::ByteCount;
 
 use crate::durable_lsn_tracking::{AppliedLsnCollectorFactory, DurableLsnEventListener};
 use crate::keys::KeyKind;
-use crate::memory::MemoryBudget;
+use crate::memory::{MemoryBudget, PartitionDbMemoryConfig};
 use crate::scan::PhysicalScan;
 use crate::snapshots::LocalPartitionSnapshot;
 use crate::{DB_PREFIX_LENGTH, ScanMode, TableKind};
 
-use restate_util_string::ReString;
+use restate_util_string::{ReString, ToReString};
 
 #[derive(Clone)]
 pub struct PartitionDb {
@@ -129,22 +130,26 @@ impl PartitionDb {
         &self.durable_lsn
     }
 
-    pub(crate) fn update_memory_budget(&self, memory_budget: usize) {
+    pub(crate) async fn update_memory_budget(&self, memory_budget: usize) {
         // impacts only this partition's column-families
-        for cf in self.cf_names() {
-            let rocksdb = self.rocksdb.clone();
+        let cf_names = self.cf_names();
+        let rocksdb = self.rocksdb.clone();
 
-            // NOTE: Updating rocksdb's options is a blocking operations and may take a few
-            // tens of milliseconds on each column family. We need to perform this operation
-            // on non-blocking threads to avoid stalling the tokio runtime (starving failure
-            // detector, etc.).
-            tokio::task::spawn_blocking(move || {
-                let max_bytes_for_level_base = memory_budget;
-                let single_memtable_budget = memory_budget / 4;
-                let target_file_size_base = memory_budget / 8;
-                let max_bytes_for_level_base_str = max_bytes_for_level_base.to_string();
-                let single_memtable_budget_str = single_memtable_budget.to_string();
-                let target_file_size_base_str = target_file_size_base.to_string();
+        // NOTE: Updating rocksdb's options is a blocking operations and may take a few
+        // tens of milliseconds on each column family. We need to perform this operation
+        // on non-blocking threads to avoid stalling the tokio runtime (starving failure
+        // detector, etc.).
+        let _ = tokio::task::spawn_blocking(move || {
+            let opts = &Configuration::pinned().worker.storage;
+            let mem_config = PartitionDbMemoryConfig::calculate(memory_budget, opts);
+            for cf in cf_names {
+                let max_bytes_for_level_base_str =
+                    mem_config.max_bytes_for_level_base().to_restring();
+                let write_buffer_size_str = mem_config.write_buffer_size().to_restring();
+                let max_write_buffer_number_str =
+                    mem_config.max_write_buffer_number().to_restring();
+                let target_file_size_base_str = mem_config.target_file_size_base().to_restring();
+                let max_compaction_bytes = mem_config.max_compaction_bytes().to_restring();
 
                 debug!(
                     "Updating memory budget for {}/{} to {}",
@@ -156,9 +161,11 @@ impl PartitionDb {
                 if let Err(err) = rocksdb.inner().set_options_cf(
                     &cf,
                     &[
-                        ("write_buffer_size", &single_memtable_budget_str),
+                        ("write_buffer_size", &write_buffer_size_str),
                         ("target_file_size_base", &target_file_size_base_str),
+                        ("max_write_buffer_number", &max_write_buffer_number_str),
                         ("max_bytes_for_level_base", &max_bytes_for_level_base_str),
+                        ("max_compaction_bytes", &max_compaction_bytes),
                     ],
                 ) {
                     warn!(
@@ -166,8 +173,9 @@ impl PartitionDb {
                         rocksdb.name(),
                     );
                 }
-            });
-        }
+            }
+        })
+        .await;
     }
 
     #[track_caller]
@@ -550,6 +558,7 @@ impl State {
 pub struct RocksConfigurator<T> {
     memory_budget: Arc<MemoryBudget>,
     shared_state: Arc<crate::SharedState>,
+    use_multi_db_layout: bool,
     _marker: PhantomData<T>,
 }
 
@@ -558,16 +567,22 @@ impl<T> Clone for RocksConfigurator<T> {
         Self {
             memory_budget: self.memory_budget.clone(),
             shared_state: self.shared_state.clone(),
+            use_multi_db_layout: self.use_multi_db_layout,
             _marker: PhantomData,
         }
     }
 }
 
 impl<T> RocksConfigurator<T> {
-    pub fn new(memory_budget: Arc<MemoryBudget>, psm_state: Arc<crate::SharedState>) -> Self {
+    pub fn new(
+        memory_budget: Arc<MemoryBudget>,
+        psm_state: Arc<crate::SharedState>,
+        use_multi_db_layout: bool,
+    ) -> Self {
         Self {
             memory_budget,
             shared_state: psm_state,
+            use_multi_db_layout,
             _marker: PhantomData,
         }
     }
@@ -587,7 +602,6 @@ impl DbConfigurator for RocksConfigurator<AllDataCf> {
         let mut db_options = restate_rocksdb::configuration::create_default_db_options(
             env,
             db_name,
-            true, /* create_db_if_missing */
             write_buffer_manager,
             limiter,
         );
@@ -595,11 +609,20 @@ impl DbConfigurator for RocksConfigurator<AllDataCf> {
         let storage_config = &Configuration::pinned().worker.storage;
         self.apply_db_opts_from_config(&mut db_options, &storage_config.rocksdb);
 
-        restate_rocksdb::configuration::set_background_work_budget(
-            &mut db_options,
-            storage_config.rocksdb_max_background_flushes(),
-            storage_config.rocksdb_max_background_compactions(),
-        );
+        if self.use_multi_db_layout {
+            // In multi-db layout we don't want every database to grown the thread pool
+            restate_rocksdb::configuration::set_background_work_budget(
+                &mut db_options,
+                NonZeroU32::MIN,
+                NonZeroU32::MIN,
+            );
+        } else {
+            restate_rocksdb::configuration::set_background_work_budget(
+                &mut db_options,
+                storage_config.rocksdb_max_background_flushes(),
+                storage_config.rocksdb_max_background_compactions(),
+            );
+        }
 
         let event_listener = DurableLsnEventListener::new(&self.shared_state);
         db_options.add_event_listener(event_listener);
@@ -656,14 +679,11 @@ impl CfConfigurator for RocksConfigurator<AllDataCf> {
         ));
         cf_options.set_memtable_prefix_bloom_ratio(0.2);
         cf_options.set_memtable_whole_key_filtering(true);
-        // Most of the changes are highly temporal, we try to delay flushing
-        // As much as we can to increase the chances to observe a deletion.
-        //
         cf_options.set_num_levels(7);
         let l0_l1 = if config.rocksdb.rocksdb_disable_l0_l1_compression() {
             rocksdb::DBCompressionType::None
         } else {
-            rocksdb::DBCompressionType::Zstd
+            rocksdb::DBCompressionType::Lz4
         };
         let levels = restate_rocksdb::configuration::build_compression_per_level(
             7,
@@ -676,25 +696,31 @@ impl CfConfigurator for RocksConfigurator<AllDataCf> {
         cf_options.add_table_properties_collector_factory(AppliedLsnCollectorFactory);
 
         // -- Initial Memory Configuration --
-        let memtables_budget = self.memory_budget.current_per_partition_budget();
+        let mem_config = PartitionDbMemoryConfig::calculate(
+            self.memory_budget.current_per_partition_budget(),
+            config,
+        );
         tracing::debug!(
             "Configured {db_name}/{cf_name} with memtable budget={}",
-            ByteCount::from(memtables_budget)
+            ByteCount::from(mem_config.memory_budget())
         );
-        // We set the budget to allow 1 mutable + 3 immutable.
-        cf_options.set_write_buffer_size(memtables_budget / 4);
+        cf_options.set_write_buffer_size(mem_config.write_buffer_size());
 
-        // merge 2 memtables when flushing to L0
-        cf_options.set_min_write_buffer_number_to_merge(2);
-        cf_options.set_max_write_buffer_number(4);
-        // start flushing L0->L1 as soon as possible. each file on level0 is
-        // (memtable_memory_budget / 2). This will flush level 0 when it's bigger than
-        // memtable_memory_budget.
-        cf_options.set_level_zero_file_num_compaction_trigger(2);
-        // doesn't really matter much, but we don't want to create too many files
-        cf_options.set_target_file_size_base(memtables_budget as u64 / 8);
-        // make Level1 size equal to Level0 size, so that L0->L1 compactions are fast
-        cf_options.set_max_bytes_for_level_base(memtables_budget as u64);
+        // Do not slow down on l0 number of files writes even if it hurts read
+        // amplification.
+        cf_options.set_level_zero_slowdown_writes_trigger(1 << 30);
+        cf_options.set_level_zero_stop_writes_trigger(1 << 30);
+
+        cf_options.set_min_write_buffer_number_to_merge(
+            mem_config.min_write_buffer_number_to_merge() as i32,
+        );
+        cf_options.set_max_write_buffer_number(mem_config.max_write_buffer_number() as i32);
+        cf_options.set_level_zero_file_num_compaction_trigger(
+            mem_config.level_zero_file_num_compaction_trigger() as i32,
+        );
+        cf_options.set_target_file_size_base(mem_config.target_file_size_base() as u64);
+        cf_options.set_max_bytes_for_level_base(mem_config.max_bytes_for_level_base() as u64);
+        cf_options.set_max_compaction_bytes(mem_config.max_compaction_bytes() as u64);
 
         cf_options
     }

--- a/crates/partition-store/src/partition_store_manager.rs
+++ b/crates/partition-store/src/partition_store_manager.rs
@@ -163,6 +163,7 @@ impl PartitionStoreManager {
         let configurator = RocksConfigurator::<AllDataCf>::new(
             self.memory_controller.memory_budget.clone(),
             Arc::clone(&self.state),
+            self.use_multi_db_layout,
         );
 
         let db_spec = DbSpecBuilder::new(

--- a/crates/rocksdb/src/configuration.rs
+++ b/crates/rocksdb/src/configuration.rs
@@ -61,19 +61,22 @@ pub trait DbConfigurator {
     fn note_config_update(&self, _db: &RocksAccess) {}
 }
 
+pub fn create_empty_db_options(db_name: DbName) -> rocksdb::Options {
+    let mut db_options = rocksdb::Options::default();
+    db_options.add_event_listener(LoggingEventListener::new(db_name));
+    db_options
+}
+
 pub fn create_default_db_options(
     env: &rocksdb::Env,
     db_name: &DbName,
-    create_db_if_missing: bool,
     write_buffer_manager: &rocksdb::WriteBufferManager,
     limiter: &rocksdb::RateLimiter,
 ) -> rocksdb::Options {
     let mut db_options = rocksdb::Options::default();
     db_options.set_env(env);
     db_options.set_shared_ratelimiter(limiter);
-    if create_db_if_missing {
-        db_options.create_if_missing(true);
-    }
+    db_options.create_if_missing(true);
     db_options.create_missing_column_families(true);
     // write buffer is controlled by write buffer manager
     db_options.set_write_buffer_manager(write_buffer_manager);

--- a/crates/rocksdb/src/db_manager.rs
+++ b/crates/rocksdb/src/db_manager.rs
@@ -80,14 +80,12 @@ impl RocksDbManager {
             false,
             cache.clone(),
         );
-        // Setup the shared rocksdb environment
+        // Setup the default shared rocksdb environment. These are just the initial pool sizes;
+        // rocksdb grows them on demand at db-open to fit each database's max_background_flushes
+        // (high-priority) and max_background_compactions (low-priority), never shrinking below.
         let mut env = rocksdb::Env::new().expect("rocksdb env is created");
-        env.set_low_priority_background_threads(opts.rocksdb_low_priority_bg_threads().get() as i32);
-        env.set_high_priority_background_threads(
-            opts.rocksdb_high_priority_bg_threads().get() as i32
-        );
-        // Cap the bottom-most compaction to leave room for flushes/compactions that
-        // unblock write stalls.
+        env.set_high_priority_background_threads(2);
+        env.set_low_priority_background_threads(1);
         env.set_bottom_priority_background_threads(1);
 
         // Setup the global write rate limiter

--- a/crates/rocksdb/src/rock_access.rs
+++ b/crates/rocksdb/src/rock_access.rs
@@ -64,6 +64,8 @@ fn prepare_cf_options(
         // rocksdb will create a new cache, wasting ~32MB RSS per db.
         let mut cf_options = create_default_cf_options(Some(write_buffer_manager));
         cf_options.set_write_buffer_manager(write_buffer_manager);
+        cf_options.set_level_zero_slowdown_writes_trigger(1 << 30);
+        cf_options.set_level_zero_stop_writes_trigger(1 << 30);
 
         let mut block_opts = BlockBasedOptions::default();
         block_opts.set_block_cache(global_cache);

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -386,6 +386,14 @@ pub struct CommonOptions {
     /// device (use block size of 64k, direct IO, and iodepth of 32 across 4 jobs to get a
     /// reasonable estimate).
     ///
+    /// For instance, consider the output of the following command:
+    ///
+    /// ```text
+    /// fio --name=c --directory=/restate-data --rw=write --bs=1m --size=8g --numjobs=4 --direct=1 --group_reporting
+    /// ...
+    ///   WRITE: bw=601MiB/s (630MB/s), 601MiB/s-601MiB/s (630MB/s-630MB/s), io=32.0GiB (34.4GB), run=54560-54560msec
+    /// ```
+    ///
     /// The default value assumes a fast NVMe with bandwidth of 7GiB (per second).
     pub rocksdb_max_write_rate_per_second: NonZeroByteCount,
 
@@ -408,16 +416,23 @@ pub struct CommonOptions {
 
     /// # Rocksdb Low Priority Background Threads
     ///
-    /// The number of threads to reserve to lower priority Rocksdb background tasks. Defaults to the number of
-    /// cores on the machine.
+    /// The number of threads to reserve to lower priority Rocksdb background tasks.
+    ///
+    /// Defaults to the remaining CPU cores not used by high-priority rocksdb threads
+    ///
+    /// Since v1.7.0 (renamed from `rocksdb-bg-threads`)
     #[serde(skip_serializing_if = "Option::is_none")]
-    rocksdb_bg_threads: Option<NonZeroU32>,
+    rocksdb_low_priority_threads: Option<NonZeroU32>,
 
     /// # Rocksdb High Priority Background Threads
     ///
     /// The number of threads to reserve to high priority Rocksdb background tasks.
+    ///
+    /// Defaults to 1/4 of the number of CPU cores.
+    ///
+    /// Since v1.7.0 (renamed from `rocksdb-high-priority-bg-threads`)
     #[serde(skip_serializing_if = "Option::is_none")]
-    rocksdb_high_priority_bg_threads: Option<NonZeroU32>,
+    rocksdb_high_priority_threads: Option<NonZeroU32>,
 
     /// # Rocksdb performance statistics level
     ///
@@ -763,21 +778,21 @@ impl CommonOptions {
     }
 
     pub fn rocksdb_high_priority_bg_threads(&self) -> NonZeroU32 {
-        // This controls the number of concurrent flushes we can do to rocksdb. Since
-        // the background threads are shared across all databases, we want to make sure
-        // we have enough threads to perform flushes concurrently (in a modern nvme this
-        // is usually the best).
-        let user_specified_threads = self.rocksdb_high_priority_bg_threads.unwrap_or(*CPU_COUNT);
-
-        // The very least is that we we want to have a thread available per database + 1 thread for
-        // background purges.
-        user_specified_threads.max(NonZeroU32::new(4).unwrap())
+        // Give 1/4 of the CPUs to flushes unless the user specifies a value.
+        self.rocksdb_high_priority_threads
+            .unwrap_or_else(|| CPU_COUNT.div_ceil(NonZeroU32::new(4).unwrap()))
     }
 
     pub fn rocksdb_low_priority_bg_threads(&self) -> NonZeroU32 {
-        // Gives us 1/2 the core count unless the user wants to override it.
-        self.rocksdb_bg_threads
-            .unwrap_or_else(|| CPU_COUNT.div_ceil(NonZeroU32::new(2).unwrap()))
+        self.rocksdb_low_priority_threads.unwrap_or_else(|| {
+            // how many cpu threads are assigned for high-priority background tasks?
+            let remaining = CPU_COUNT
+                .get()
+                .saturating_sub(self.rocksdb_high_priority_bg_threads().get())
+                .max(1);
+            // Safe because of max(1) above.
+            NonZeroU32::new(remaining).unwrap()
+        })
     }
 
     /// set derived values if they are not configured to reduce verbose configurations
@@ -840,8 +855,8 @@ impl Default for CommonOptions {
                 .unwrap(),
             rocksdb_total_memory_size: NonZeroByteCount::try_from(2 * 1024 * 1024 * 1024).unwrap(), // 2GiB
             rocksdb_total_memtables_ratio: 0.85, // (85% of rocksdb-total-memory-size)
-            rocksdb_bg_threads: None,
-            rocksdb_high_priority_bg_threads: None,
+            rocksdb_low_priority_threads: None,
+            rocksdb_high_priority_threads: None,
             rocksdb_perf_level: PerfStatsLevel::EnableCount,
             rocksdb: Default::default(),
             metadata_update_interval: NonZeroFriendlyDuration::from_secs_unchecked(10),

--- a/crates/types/src/config/log_server.rs
+++ b/crates/types/src/config/log_server.rs
@@ -13,14 +13,25 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-
-use restate_util_bytecount::{ByteCount, NonZeroByteCount};
 use tracing::warn;
+
+use restate_util_bytecount::NonZeroByteCount;
 
 use super::{BackgroundWorkBudget, CommonOptions, RocksDbOptions};
 
 const MIN_ROCKSDB_MEMORY: NonZeroByteCount =
     NonZeroByteCount::new(NonZeroUsize::new(32 * 1024 * 1024).unwrap());
+// We'll use 50% extra memory in the worst case, but will reduce write stalls.
+const MAX_WRITE_BUFFERS: u32 = 12;
+const NOMINAL_WRITE_BUFFERS: u32 = 8;
+const WRITE_BUFFERS_TO_MERGE: u32 = 1;
+const LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER: u32 = 8;
+/// Matches rocksdb default (target_file_size_base * 25)
+const COMPACTION_BYTES_MULTIPLIER: u32 = 25;
+/// Try to keep the table files above this size if partition write buffers are too small
+const MIN_FILE_SIZE: usize = 16 * 1024 * 1024;
+/// The absolute minimum write buffer size
+const MIN_WRITE_BUFFER_SIZE: usize = 4 * 1024 * 1024;
 
 /// # Log server options
 ///
@@ -54,26 +65,10 @@ pub struct LogServerOptions {
 
     /// The maximum number of subcompactions to run in parallel.
     ///
-    /// Setting this to 1 means no sub-compactions are allowed (i.e. only 1 thread will do the compaction).
+    /// Setting this to 1 means no sub-compactions are allowed.
     ///
-    /// Default is 0 which maps to floor(number of CPU cores / 2)
+    /// Default is 1
     rocksdb_max_sub_compactions: u32,
-
-    /// The size limit of all WAL files
-    ///
-    /// Use this to limit the size of WAL files. If the size of all WAL files exceeds this limit,
-    /// the oldest WAL file will be deleted and if needed, memtable flush will be triggered.
-    ///
-    /// Note: RocksDB internally counts the uncompressed bytes to determine the WAL size, and since the
-    /// WAL may be compressed, the actual size on disk might be significantly smaller than this value (~1/4
-    /// depending on the compression ratio). For instance, if this is set to "1 MiB", then rocksdb
-    /// might decide to flush if the total WAL (on disk) reached ~260 KiB (compressed).
-    ///
-    /// Default is `0` which translates into 6 times the memory allocated for memtables for this
-    /// database.
-    #[serde(skip_serializing_if = "is_zero")]
-    #[serde(default)]
-    rocksdb_max_wal_size: ByteCount<true>,
 
     /// Whether to perform commits in background IO thread pools eagerly or not
     #[cfg_attr(feature = "schemars", schemars(skip))]
@@ -121,16 +116,6 @@ pub struct LogServerOptions {
     #[serde(skip_serializing_if = "std::ops::Not::not", default)]
     pub rocksdb_disable_blob_compression: bool,
 
-    /// # Max background flushes
-    ///
-    /// Maximum number of concurrent flush operations for this database. Flushes are
-    /// latency-critical (they unblock writes) and are allocated equally across databases.
-    ///
-    /// If unset, defaults are computed based on CPU count and active node roles.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "schemars", schemars(skip))]
-    rocksdb_max_background_flushes: Option<NonZeroU32>,
-
     /// # Max background compactions
     ///
     /// Maximum number of concurrent compaction operations for this database.
@@ -146,7 +131,8 @@ pub struct LogServerOptions {
     /// available for memtables of the log-server.
     ///
     /// If `write-batch-commit-count` is set, the write batch will be limited to whichever
-    /// of the two is reached first.
+    /// of the two is reached first. The value is clamped to the size of a single memtable
+    /// which is derived from rocksdb-memory-budget.
     #[serde(skip_serializing_if = "Option::is_none")]
     write_batch_commit_bytes: Option<NonZeroByteCount>,
 
@@ -160,6 +146,21 @@ pub struct LogServerOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub write_batch_commit_count: Option<NonZeroUsize>,
 
+    /// Custom Path for WAL files
+    ///
+    /// If unset, the default data directory is used for WAL files. If set, the path
+    /// must point to a directory that exists and is writable. The directory will be
+    /// used to store WAL files.
+    ///
+    /// The recommendation is to use low-latency NVMe SSD for the WAL directory with
+    /// sufficient IOPS capacity and bandwidth to your sustained workload. The `fdatasync`
+    /// latency of the storage device is a significant factor in the WAL performance if
+    /// `rocksdb-disable-wal-fsync` is set to `false`.
+    ///
+    /// Since v1.7.0
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    rocksdb_wal_dir: Option<PathBuf>,
+
     /// Disable WAL for the log-server
     ///
     /// [DANGEROUS] Not recommended for production use.
@@ -167,16 +168,39 @@ pub struct LogServerOptions {
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     rocksdb_disable_wal: bool,
 
+    /// # Clamps target size for sst files
+    ///
+    /// The target size for sst files. Restate uses this value to internally determine
+    /// the number of memtables to keep in memory and how much to merge before flushing.
+    ///
+    /// The value is automatically sanitized to 16 MiB if set to a smaller value.
+    ///
+    /// [default] is 128 MiB
+    ///
+    /// Since v1.7.0
+    pub rocksdb_max_file_size: NonZeroByteCount,
+
+    /// Disable RocksDB paranoid checks
+    ///
+    /// Since v1.7.0
+    #[cfg_attr(feature = "schemars", schemars(skip))]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub rocksdb_disable_paranoid_checks: bool,
+
     /// Starts in read-only mode
     ///
     /// This is useful for testing, debugging, and development.
     #[cfg_attr(feature = "schemars", schemars(skip))]
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub read_only: bool,
-}
 
-fn is_zero(value: &ByteCount<true>) -> bool {
-    *value == ByteCount::ZERO
+    /// [DANGEROUS] Starts in in-memory
+    /// This is useful for testing, and development.
+    ///
+    /// Since v1.7.0
+    #[cfg_attr(feature = "schemars", schemars(skip))]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub in_memory: bool,
 }
 
 impl LogServerOptions {
@@ -195,17 +219,12 @@ impl LogServerOptions {
     }
 
     pub fn apply_background_work_budget(&mut self, budget: &BackgroundWorkBudget) {
-        if self.rocksdb_max_background_flushes.is_none() {
-            self.rocksdb_max_background_flushes = Some(budget.max_background_flushes);
-        }
+        // for log-server, we only need the budget for compactions, not flushes
+        // since flushes are internally capped. This is due to the nature of
+        // this database (number of column families).
         if self.rocksdb_max_background_compactions.is_none() {
             self.rocksdb_max_background_compactions = Some(budget.max_background_compactions);
         }
-    }
-
-    pub fn rocksdb_max_background_flushes(&self) -> NonZeroU32 {
-        self.rocksdb_max_background_flushes
-            .unwrap_or(NonZeroU32::new(2).unwrap())
     }
 
     pub fn rocksdb_max_background_compactions(&self) -> NonZeroU32 {
@@ -221,42 +240,12 @@ impl LogServerOptions {
         self.rocksdb_disable_wal_fsync
     }
 
-    pub fn rocksdb_max_wal_size(&self) -> NonZeroByteCount {
-        NonZeroByteCount::try_from(if self.rocksdb_max_wal_size == ByteCount::ZERO {
-            6 * self.rocksdb_memory_budget().as_u64()
-        } else {
-            self.rocksdb_max_wal_size.as_u64()
-        })
-        .unwrap()
-    }
-
     pub fn rocksdb_max_sub_compactions(&self) -> u32 {
         if self.rocksdb_max_sub_compactions == 0 {
-            let parallelism: NonZeroU32 = std::thread::available_parallelism()
-                .unwrap_or(NonZeroUsize::new(2).unwrap())
-                .try_into()
-                .expect("number of cpu cores fits in u32");
-
-            // floor(number of CPU cores / 2)
-            parallelism.get() / 2
+            1
         } else {
             self.rocksdb_max_sub_compactions
         }
-    }
-
-    pub fn write_batch_bytes(&self) -> NonZeroByteCount {
-        // The assumption here is that most of the bytes will go into
-        // the data column family.
-        //
-        // todo(asoli): replace 4 with a shared const (or config). We divide by 4
-        // to cap the batch size to a single memtable's worth of data at most
-        // (as we allow total of 4 memtables for the data CF).
-        self.write_batch_commit_bytes.unwrap_or_else(|| {
-            // we divide by 4 to get the size of a single memtable, then by 4
-            // to put an upper bound over the ballooning per individual memtables to 25%
-            // over its budget.
-            self.rocksdb_data_memtables_budget().div_ceil(8)
-        })
     }
 
     pub fn rocksdb_memory_budget(&self) -> NonZeroByteCount {
@@ -276,14 +265,91 @@ impl LogServerOptions {
         self.rocksdb_memory_budget()
     }
 
-    /// Minimum value size for blob separation. Defaults to 4 KiB.
+    /// Minimum value size for blob separation. Defaults to 512 KiB.
     pub fn rocksdb_blob_min_size(&self) -> NonZeroByteCount {
-        self.rocksdb_blob_min_size
-            .unwrap_or(NonZeroByteCount::new(NonZeroUsize::new(4 * 1024).unwrap()))
+        self.rocksdb_blob_min_size.unwrap_or(NonZeroByteCount::new(
+            NonZeroUsize::new(512 * 1024).unwrap(),
+        ))
     }
 
     pub fn data_dir(&self) -> PathBuf {
         super::data_dir("log-store")
+    }
+
+    pub fn wal_dir(&self) -> PathBuf {
+        self.rocksdb_wal_dir
+            .clone()
+            .unwrap_or_else(|| self.data_dir())
+    }
+
+    pub fn write_batch_commit_bytes(&self) -> usize {
+        // let's decide on the absolute maximum batch size we'd like to accept
+        let upper_bound = self.write_buffer_size();
+
+        if let Some(user_limits) = self.write_batch_commit_bytes {
+            // sanitize the user-provided limit to the write buffer size
+            user_limits.as_usize().min(upper_bound)
+        } else {
+            // we come up with a reasonable default. That's 10% of the write buffer size
+            // to put an upper bound over the ballooning per individual memtables to 10%
+            // over its budget.
+            self.write_buffer_size().div_ceil(10)
+        }
+    }
+
+    /// Memory budget for the data service admission-control pool.
+    ///
+    /// Derived from a single write buffer, but clamped to at least `min_size` (the maximum
+    /// accepted record/message size). Otherwise a low-memory configuration could size the pool
+    /// below the largest valid append and reject it with `CapacityExceeded` before the writer
+    /// ever sees it (see `BackPressureMode::Lossy`).
+    pub fn data_service_memory_size(&self, min_size: NonZeroByteCount) -> NonZeroByteCount {
+        NonZeroByteCount::new(
+            NonZeroUsize::new(self.write_buffer_size()).expect("write buffer must be non-zero"),
+        )
+        .max(min_size)
+    }
+
+    pub fn write_buffer_size(&self) -> usize {
+        MIN_WRITE_BUFFER_SIZE
+            .max(self.rocksdb_memory_budget().as_usize() / NOMINAL_WRITE_BUFFERS as usize)
+    }
+
+    pub const fn min_write_buffer_number_to_merge(&self) -> u32 {
+        WRITE_BUFFERS_TO_MERGE
+    }
+
+    pub const fn max_write_buffer_number(&self) -> u32 {
+        MAX_WRITE_BUFFERS
+    }
+
+    pub const fn level_zero_file_num_compaction_trigger(&self) -> u32 {
+        LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER
+    }
+
+    pub fn max_bytes_for_level_base(&self) -> usize {
+        self.write_buffer_size()
+            * self.min_write_buffer_number_to_merge() as usize
+            * self.level_zero_file_num_compaction_trigger() as usize
+    }
+
+    pub fn target_file_size_base(&self) -> usize {
+        // Set the target file within the range of acceptable values
+        self.write_buffer_size()
+            .clamp(MIN_FILE_SIZE, self.max_file_size())
+    }
+
+    pub fn max_compaction_bytes(&self) -> usize {
+        self.target_file_size_base() * COMPACTION_BYTES_MULTIPLIER as usize
+    }
+
+    pub fn max_wal_total_size(&self) -> usize {
+        const SAFETY_MULTIPLIER: usize = 8;
+        self.write_buffer_size() * self.max_write_buffer_number() as usize * SAFETY_MULTIPLIER
+    }
+
+    pub fn max_file_size(&self) -> usize {
+        MIN_FILE_SIZE.max(self.rocksdb_max_file_size.as_usize())
     }
 }
 
@@ -292,23 +358,27 @@ impl Default for LogServerOptions {
         Self {
             read_only: false,
             rocksdb: RocksDbOptions::default(),
+            in_memory: false,
             // set by apply_common in runtime
             rocksdb_memory_budget: None,
             rocksdb_memory_ratio: 0.5,
-            rocksdb_max_sub_compactions: 0,
+            rocksdb_max_sub_compactions: 1,
+            rocksdb_wal_dir: None,
             rocksdb_disable_wal: false,
-            rocksdb_max_wal_size: ByteCount::ZERO,
             rocksdb_disable_wal_fsync: false,
+            rocksdb_disable_paranoid_checks: false,
             always_commit_in_background: false,
             #[allow(deprecated)]
             incoming_network_queue_length: None,
             rocksdb_enable_blob_separation: false,
             rocksdb_blob_min_size: None,
             rocksdb_disable_blob_compression: false,
-            rocksdb_max_background_flushes: None,
             rocksdb_max_background_compactions: None,
             write_batch_commit_bytes: None,
             write_batch_commit_count: None,
+            rocksdb_max_file_size: NonZeroByteCount::new(
+                NonZeroUsize::new(128 * 1024 * 1024).unwrap(),
+            ),
         }
     }
 }

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -88,43 +88,61 @@ pub struct BackgroundWorkBudget {
 /// (~65%) since it typically has many more column families generating compaction demand.
 ///
 /// Metadata-server and local-loglet always get a fixed small budget (1 flush, 1 compaction).
-pub fn compute_background_work_budgets(roles: &EnumSet<Role>) -> BackgroundWorkBudgets {
-    let cpu_count = CPU_COUNT.get();
-
-    // Fixed budgets for lightweight databases
-    let metadata_server = BackgroundWorkBudget {
-        max_background_flushes: NonZeroU32::new(1).unwrap(),
-        max_background_compactions: NonZeroU32::new(1).unwrap(),
-    };
+pub fn compute_background_work_budgets(
+    roles: &EnumSet<Role>,
+    rocksdb_high_priority_bg_threads: NonZeroU32,
+    rocksdb_low_priority_bg_threads: NonZeroU32,
+) -> BackgroundWorkBudgets {
+    // local-loglet never runs alongside log-server, so its slot is not counted against the
+    // shared pools below; it just gets a fixed minimal budget for the single-node case.
     let local_loglet = BackgroundWorkBudget {
         max_background_flushes: NonZeroU32::new(1).unwrap(),
         max_background_compactions: NonZeroU32::new(1).unwrap(),
     };
 
+    let has_metadata_server = roles.contains(Role::MetadataServer);
     let has_worker = roles.contains(Role::Worker);
     let has_log_server = roles.contains(Role::LogServer);
 
-    // Compute flush budget: split equally between active databases
-    // We reserve 2 flush slots for the fixed-budget databases (metadata-server + local-loglet),
-    // and split the rest equally between partition-store and log-server.
-    let total_flushes = cpu_count.div_ceil(4).max(4);
-    let available_flushes = total_flushes.saturating_sub(2).max(2);
+    // ---- Flush budget ----
+    //
+    // Flushes run on the shared high-priority env thread pool. `max_background_flushes` only
+    // bounds how many flushes a database *schedules* concurrently; all scheduled flushes
+    // compete for the same pool with no per-db reservation. To guarantee no database ever
+    // queues for a flush thread, we keep the sum of all per-db flush budgets within the pool,
+    // carving it into non-overlapping shares:
+    //
+    //   - metadata-server: 1 reserved slot, but only when its role is active on this node.
+    //   - log-server: a single reserved slot. Its data CF uses atomic_flush with one flushing
+    //     CF, so it can never have more than one flush in flight. One slot fully utilises it,
+    //     and because the slot is reserved, its latency-critical flushes never wait behind the
+    //     partition-store's many-CF flush bursts.
+    //   - partition-store (worker): the remainder. It has one CF per partition and benefits
+    //     from real flush parallelism.
+    //
+    // local-loglet is excluded from the accounting: it never co-runs with log-server.
+    //
+    // On very small pools the remainder may collapse to 1; raise
+    // `rocksdb-high-priority-threads` to give the partition-store more flush parallelism.
+    let high_pri_pool = rocksdb_high_priority_bg_threads.get();
+    let metadata_flush_reserve = if has_metadata_server { 1 } else { 0 };
+    // virtually a single CF + atomic_flush => at most 2 flush jobs in flight
+    let log_server_flush_reserve = if has_log_server { 2 } else { 0 };
 
-    let (worker_flushes, log_server_flushes) = match (has_worker, has_log_server) {
-        (true, true) => {
-            let half = available_flushes.div_ceil(2);
-            (half, available_flushes.saturating_sub(half).max(1))
-        }
-        (true, false) => (available_flushes, available_flushes),
-        (false, true) => (available_flushes, available_flushes),
-        (false, false) => (2, 2),
+    // partition-store gets the pool minus whatever reserves are actually active.
+    let worker_flushes = if has_worker {
+        high_pri_pool
+            .saturating_sub(metadata_flush_reserve + log_server_flush_reserve)
+            .max(1)
+    } else {
+        0
     };
 
     // Compute compaction budget: weighted split (worker ~65%, log-server ~35%)
     // Compactions are throughput-heavy; the partition-store with many CFs needs the lion's share.
-    let total_compactions = cpu_count.div_ceil(2).max(4);
-    let available_compactions = total_compactions.saturating_sub(2).max(2);
-
+    let total_compactions = rocksdb_low_priority_bg_threads.get();
+    // at least 2
+    let available_compactions = total_compactions.max(2);
     let (worker_compactions, log_server_compactions) = match (has_worker, has_log_server) {
         (true, true) => {
             let worker_share = ((available_compactions as f64 * 0.65).ceil() as u32).max(2);
@@ -138,14 +156,19 @@ pub fn compute_background_work_budgets(roles: &EnumSet<Role>) -> BackgroundWorkB
 
     BackgroundWorkBudgets {
         partition_store: BackgroundWorkBudget {
-            max_background_flushes: NonZeroU32::new(worker_flushes).unwrap(),
-            max_background_compactions: NonZeroU32::new(worker_compactions).unwrap(),
+            max_background_flushes: NonZeroU32::new(worker_flushes).unwrap_or(NonZeroU32::MIN),
+            max_background_compactions: NonZeroU32::new(worker_compactions)
+                .unwrap_or(NonZeroU32::MIN),
         },
         log_server: BackgroundWorkBudget {
-            max_background_flushes: NonZeroU32::new(log_server_flushes).unwrap(),
-            max_background_compactions: NonZeroU32::new(log_server_compactions).unwrap(),
+            max_background_flushes: NonZeroU32::MIN,
+            max_background_compactions: NonZeroU32::new(log_server_compactions)
+                .unwrap_or(NonZeroU32::MIN),
         },
-        metadata_server,
+        metadata_server: BackgroundWorkBudget {
+            max_background_flushes: NonZeroU32::MIN,
+            max_background_compactions: NonZeroU32::MIN,
+        },
         local_loglet,
     }
 }
@@ -279,6 +302,11 @@ pub struct Configuration {
 }
 
 impl Configuration {
+    /// The number of CPUs available to the current process.
+    pub fn num_cpus() -> NonZeroU32 {
+        *CPU_COUNT
+    }
+
     /// A default configuration that exclusively uses unix sockets.
     pub fn new_unix_sockets() -> Self {
         let mut config = Configuration::default();
@@ -368,7 +396,11 @@ impl Configuration {
         self.log_server.apply_common(&self.common);
 
         // Compute and apply role-aware background work budgets for all databases.
-        let budgets = compute_background_work_budgets(&self.common.roles);
+        let budgets = compute_background_work_budgets(
+            &self.common.roles,
+            self.common.rocksdb_high_priority_bg_threads(),
+            self.common.rocksdb_low_priority_bg_threads(),
+        );
         self.worker
             .storage
             .apply_background_work_budget(&budgets.partition_store);

--- a/crates/types/src/config/networking.rs
+++ b/crates/types/src/config/networking.rs
@@ -123,7 +123,7 @@ fn is_default_fabric_memory_limit(value: &NonZeroByteCount) -> bool {
 
 impl NetworkingOptions {
     pub fn stream_window_size(&self) -> u32 {
-        // santize to 500MiB if set higher
+        // sanitize to 500MiB if set higher
         let stream_window_size = self.data_stream_window_size.as_u64().min(500 * 1024 * 1024); // Sanitize to 500MiB if set higher.
 
         u32::try_from(stream_window_size).expect("window size too big")

--- a/crates/types/src/config/rocksdb.rs
+++ b/crates/types/src/config/rocksdb.rs
@@ -126,7 +126,7 @@ pub struct RocksDbOptions {
 
     /// # Disable L0/L1 SST compression
     ///
-    /// When false (the default), L0 and L1 SST files are compressed with Zstd.
+    /// When false (the default), L0 and L1 SST files are compressed with Lz4.
     /// Higher levels (L2+) always use Zstd regardless of this setting.
     /// Set to true to disable compression for L0/L1, which can improve write
     /// throughput at the cost of higher disk usage since these files are

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -802,6 +802,18 @@ pub struct StorageOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "schemars", schemars(skip))]
     rocksdb_max_background_compactions: Option<NonZeroU32>,
+
+    /// # Clamps target size for sst files
+    ///
+    /// The target size for sst files. Restate uses this value to internally determine
+    /// the number of memtables to keep in memory and how much to merge before flushing.
+    ///
+    /// The value is automatically sanitized to 16 MiB if set to a smaller value.
+    ///
+    /// [default] is 64 MiB
+    ///
+    /// Since v1.7.0
+    pub rocksdb_max_file_size: NonZeroByteCount,
 }
 
 impl StorageOptions {
@@ -830,12 +842,12 @@ impl StorageOptions {
 
     pub fn rocksdb_max_background_flushes(&self) -> NonZeroU32 {
         self.rocksdb_max_background_flushes
-            .unwrap_or(NonZeroU32::new(2).unwrap())
+            .unwrap_or(NonZeroU32::new(1).unwrap())
     }
 
     pub fn rocksdb_max_background_compactions(&self) -> NonZeroU32 {
         self.rocksdb_max_background_compactions
-            .unwrap_or(NonZeroU32::new(2).unwrap())
+            .unwrap_or(NonZeroU32::new(1).unwrap())
     }
 
     pub fn rocksdb_memory_budget(&self) -> NonZeroByteCount {
@@ -876,6 +888,9 @@ impl Default for StorageOptions {
             rocksdb_disable_auto_memory_reclaimer: false,
             rocksdb_max_background_flushes: None,
             rocksdb_max_background_compactions: None,
+            rocksdb_max_file_size: NonZeroByteCount::new(
+                NonZeroUsize::new(64 * 1024 * 1024).unwrap(),
+            ),
         }
     }
 }

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -698,7 +698,8 @@ where
                             &mut transaction,
                             &mut action_collector,
                             &mut vqueues,
-                        ).await?;
+                        )
+                        .await?;
 
                         if let Some(announce_leader) = maybe_announce_leader {
                             // update partition store with latest epoch metadata
@@ -748,7 +749,8 @@ where
                                 &self.state_machine.rule_book,
                                 &self.state_machine,
                                 &self.state_machine.min_restate_version,
-                            ).await?;
+                            )
+                            .await?;
 
                             Span::current().record("is_leader", is_leader);
 

--- a/release-notes/v1.7.0.md
+++ b/release-notes/v1.7.0.md
@@ -96,6 +96,44 @@ For snapshot export concurrency (previously derived from background jobs):
 export-concurrency-limit = 4
 ```
 
+#### Renamed Global RocksDB Thread-Pool Options
+
+Two `[common]` options that size the shared RocksDB background thread pools have been renamed:
+
+| Old key | New key |
+| --- | --- |
+| `rocksdb-bg-threads` | `rocksdb-low-priority-threads` |
+| `rocksdb-high-priority-bg-threads` | `rocksdb-high-priority-threads` |
+
+Their defaults also changed. `rocksdb-high-priority-threads` (flush pool) now defaults to `ceil(CPU / 4)`, and `rocksdb-low-priority-threads` (compaction pool) defaults to the CPU cores left over after the high-priority reservation. These two pools now also drive how the per-database flush and compaction budgets above are split between the partition-store, log-server, and metadata-server.
+
+```toml
+# Before
+[common]
+rocksdb-bg-threads = 8
+rocksdb-high-priority-bg-threads = 4
+
+# After
+[common]
+rocksdb-low-priority-threads = 8
+rocksdb-high-priority-threads = 4
+```
+
+#### Removed Log-Server RocksDB Options
+
+Two `[log-server]` options have been removed:
+
+- `rocksdb-max-wal-size` — the maximum total WAL size is now derived internally from the write-buffer size and the maximum number of write buffers.
+- `rocksdb-max-background-flushes` — the log-server now uses a fixed, dedicated flush budget. Its data column family flushes atomically with a single flushing CF, so it can never have more than one flush in flight.
+
+Remove these keys if present; they are no longer recognized:
+
+```toml
+[log-server]
+# rocksdb-max-wal-size = "..."          # remove
+# rocksdb-max-background-flushes = ...  # remove
+```
+
 ### Kafka and Shuffler Batch Ingestion Now Mandatory
 
 The batch ingestion path that was introduced as opt-in experimental in v1.6 is now the only implementation for both Kafka subscriptions ingestion (`restate-ingress-kafka`) and partition-to-partition shuffle (the partition processor's outbox shuffle). The two opt-in flags that previously gated this behavior are removed:
@@ -733,6 +771,23 @@ The shape of services tracing has changed:
 Ingress spans are unchanged. Dashboards, alerts, or queries keyed on the old long-running invocation span name or on per-command spans will need to be updated.
 
 _Related: #4530_
+
+#### RocksDB Storage Tuning Defaults and New Knobs
+
+Several RocksDB defaults were retuned for more predictable write throughput, and two new tuning knobs were added. Deployments using defaults need no action.
+
+Default changes:
+
+- `[log-server] rocksdb-blob-min-size`: raised from `4 KiB` to `512 KiB` (applies when blob separation is enabled).
+- `[log-server] rocksdb-max-sub-compactions`: now defaults to `1`. The previous default `0` — which mapped to `floor(CPU / 2)` — is no longer special-cased; set an explicit value to enable sub-compactions.
+- `[worker.storage] rocksdb-max-background-flushes`: default lowered from `2` to `1`.
+- `[worker.storage] rocksdb-max-background-compactions`: default lowered from `2` to `1`.
+
+New options:
+
+- `[log-server] rocksdb-wal-dir`: optional path to a dedicated directory for WAL files (defaults to the log-store data directory). Point it at a low-latency NVMe SSD with sufficient IOPS/bandwidth, especially when `rocksdb-disable-wal-fsync` is `false`.
+- `[log-server] rocksdb-max-file-size`: clamps the target SST file size (default `128 MiB`; sanitized up to a `16 MiB` minimum).
+- `[worker.storage] rocksdb-max-file-size`: clamps the target SST file size (default `64 MiB`; sanitized up to a `16 MiB` minimum).
 
 ### Observability
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -243,6 +243,7 @@ fn main() {
                 node_name = Configuration::pinned().node_name(),
                 config_source = %config_source,
                 base_dir = %restate_types::config::node_filepath("").display(),
+                cpus = % Configuration::num_cpus(),
                 "Starting Restate Server {}",
                 build_info::build_info()
             );


### PR DESCRIPTION

Revamps RocksDB memory and background work tuning across log-server, partition-store, metadata-server, and local loglet.

Adds explicit memtable, file-size, compaction, WAL, and write-batch sizing for log-server and partition-store, including a dedicated log-server RocksDB environment and WAL directory support.

Adjusts background work budget derivation, shared RocksDB defaults, and L0/L1 compression defaults to reduce write stalls and improve predictable resource usage.
