### PR TITLE
Add ErrorMessage.behavior to allow the SDK to customize behavior on error message.

### DIFF
--- a/crates/invoker-impl/src/error.rs
+++ b/crates/invoker-impl/src/error.rs
@@ -299,25 +299,20 @@ impl InvokerError {
         }
     }
 
-    pub(crate) fn next_retry_interval_override(&self) -> Option<Duration> {
+    pub(crate) fn requested_error_behavior(&self) -> RequestedErrorBehavior {
         match self {
+            InvokerError::SdkV2(SdkInvocationErrorV2 {
+                requested_error_behavior,
+                ..
+            }) => *requested_error_behavior,
             InvokerError::Sdk(SdkInvocationError {
                 next_retry_interval_override,
                 ..
-            }) => *next_retry_interval_override,
-            InvokerError::SdkV2(SdkInvocationErrorV2 {
-                next_retry_interval_override,
-                ..
-            }) => *next_retry_interval_override,
-            InvokerError::RateLimited { retry_after, .. } => *retry_after,
-            _ => None,
-        }
-    }
-
-    pub(crate) fn should_pause(&self) -> bool {
-        match self {
-            InvokerError::SdkV2(SdkInvocationErrorV2 { should_pause, .. }) => *should_pause,
-            _ => false,
+            }) => RequestedErrorBehavior::retry(*next_retry_interval_override),
+            InvokerError::RateLimited { retry_after, .. } => {
+                RequestedErrorBehavior::retry(*retry_after)
+            }
+            _ => RequestedErrorBehavior::Retry,
         }
     }
 
@@ -501,21 +496,46 @@ impl fmt::Display for InvocationErrorRelatedEntry {
     }
 }
 
+/// What the SDK requested the invoker to do when an invocation fails.
+///
+/// Mirrors the protocol's `ErrorBehavior`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum RequestedErrorBehavior {
+    /// Retry the invocation using the configured retry policy.
+    #[default]
+    Retry,
+    /// Retry the invocation after the given delay, overriding the retry policy
+    /// for the next retry attempt only.
+    RetryWithIntervalOverride(Duration),
+    /// Pause the invocation instead of retrying.
+    Pause,
+    /// Fail the invocation, without retrying.
+    Fail,
+}
+
+impl RequestedErrorBehavior {
+    /// Build a retry behavior, optionally overriding the retry interval for the next attempt.
+    pub(crate) fn retry(next_retry_interval_override: Option<Duration>) -> Self {
+        match next_retry_interval_override {
+            Some(interval) => Self::RetryWithIntervalOverride(interval),
+            None => Self::Retry,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct SdkInvocationErrorV2 {
     pub(crate) related_command: Option<InvocationErrorRelatedCommandV2>,
-    pub(crate) next_retry_interval_override: Option<Duration>,
     pub(crate) error: Box<InvocationError>,
-    pub(crate) should_pause: bool,
+    pub(crate) requested_error_behavior: RequestedErrorBehavior,
 }
 
 impl SdkInvocationErrorV2 {
     pub(crate) fn unknown() -> Self {
         Self {
             related_command: None,
-            next_retry_interval_override: None,
             error: Default::default(),
-            should_pause: false,
+            requested_error_behavior: RequestedErrorBehavior::default(),
         }
     }
 }

--- a/crates/invoker-impl/src/invocation_state_machine.rs
+++ b/crates/invoker-impl/src/invocation_state_machine.rs
@@ -752,28 +752,36 @@ mod tests {
     fn handle_error_when_waiting_for_retry() {
         let mut invocation_state_machine = create_test_invocation_state_machine();
 
-        let_assert!(
-            OnTaskError::Retrying(_) = invocation_state_machine.handle_task_error(
+        assert_that!(
+            invocation_state_machine.handle_task_error(
                 true,
                 RequestedErrorBehavior::Retry,
                 true,
                 |_| 0
-            )
+            ),
+            pat!(OnTaskError::Retrying(_))
         );
-        check!(let AttemptState::WaitingRetry { .. } = invocation_state_machine.invocation_state);
+        assert_that!(
+            invocation_state_machine.invocation_state,
+            pat!(AttemptState::WaitingRetry { .. })
+        );
 
         invocation_state_machine.notify_retry_timer_fired(0);
 
         // We stay in `WaitingForRetry`
-        let_assert!(
-            OnTaskError::Retrying(_) = invocation_state_machine.handle_task_error(
+        assert_that!(
+            invocation_state_machine.handle_task_error(
                 true,
                 RequestedErrorBehavior::Retry,
                 true,
                 |_| 1
-            )
+            ),
+            pat!(OnTaskError::Retrying(_))
         );
-        check!(let AttemptState::WaitingRetry { .. } = invocation_state_machine.invocation_state);
+        assert_that!(
+            invocation_state_machine.invocation_state,
+            pat!(AttemptState::WaitingRetry { .. })
+        );
     }
 
     #[test]
@@ -782,13 +790,14 @@ mod tests {
 
         // Even though the error is transient and the retry policy allows more retries,
         // the SDK-requested Pause behavior takes precedence.
-        let_assert!(
-            OnTaskError::Pause = invocation_state_machine.handle_task_error(
+        assert_that!(
+            invocation_state_machine.handle_task_error(
                 true,
                 RequestedErrorBehavior::Pause,
                 true,
                 |_| 0
-            )
+            ),
+            pat!(OnTaskError::Pause)
         );
     }
 
@@ -798,13 +807,14 @@ mod tests {
 
         // Even though the error is transient and the retry policy allows more retries,
         // the SDK-requested Fail behavior takes precedence and fails without retrying.
-        let_assert!(
-            OnTaskError::Fail = invocation_state_machine.handle_task_error(
+        assert_that!(
+            invocation_state_machine.handle_task_error(
                 true,
                 RequestedErrorBehavior::Fail,
                 true,
                 |_| 0
-            )
+            ),
+            pat!(OnTaskError::Fail)
         );
     }
 

--- a/crates/invoker-impl/src/invocation_state_machine.rs
+++ b/crates/invoker-impl/src/invocation_state_machine.rs
@@ -22,6 +22,7 @@ use restate_types::service_protocol::ServiceProtocolVersion;
 use restate_types::vqueues::VQueueId;
 use restate_worker_api::resources::ReservedResources;
 
+use crate::error::RequestedErrorBehavior;
 use crate::quota::ConcurrencySlot;
 
 use super::*;
@@ -544,8 +545,7 @@ impl<K: TimerKey> InvocationStateMachine<K> {
     pub(super) fn handle_task_error(
         &mut self,
         error_is_transient: bool,
-        next_retry_interval_override: Option<Duration>,
-        should_pause: bool,
+        requested_error_behavior: RequestedErrorBehavior,
         should_bump_start_message_retry_count_since_last_stored_command: bool,
         register_timer: impl FnOnce(Duration) -> K,
     ) -> OnTaskError {
@@ -576,10 +576,13 @@ impl<K: TimerKey> InvocationStateMachine<K> {
             }
         };
 
-        if self.requested_pause || should_pause {
-            // Shortcircuit to pause, as this is what the user asked for
-            return OnTaskError::Pause;
-        }
+        // The SDK can request a specific behavior, which takes precedence over the retry policy.
+        let next_retry_interval_override = match requested_error_behavior {
+            RequestedErrorBehavior::Pause => return OnTaskError::Pause,
+            RequestedErrorBehavior::Fail => return OnTaskError::Fail,
+            RequestedErrorBehavior::Retry => None,
+            RequestedErrorBehavior::RetryWithIntervalOverride(interval) => Some(interval),
+        };
 
         if error_is_transient
             && let Some(next_timer) =
@@ -618,7 +621,7 @@ impl<K: TimerKey> InvocationStateMachine<K> {
         } else {
             match self.retry_policy_state.on_max_attempts {
                 OnMaxAttempts::Pause => OnTaskError::Pause,
-                OnMaxAttempts::Kill => OnTaskError::Kill,
+                OnMaxAttempts::Kill => OnTaskError::Fail,
             }
         }
     }
@@ -704,7 +707,7 @@ pub(super) enum OnTaskError {
     },
     Retrying(Duration),
     Pause,
-    Kill,
+    Fail,
 }
 
 pub(super) struct AttemptDeploymentId(Option<DeploymentId>);
@@ -750,8 +753,12 @@ mod tests {
         let mut invocation_state_machine = create_test_invocation_state_machine();
 
         let_assert!(
-            OnTaskError::Retrying(_) =
-                invocation_state_machine.handle_task_error(true, None, false, true, |_| 0)
+            OnTaskError::Retrying(_) = invocation_state_machine.handle_task_error(
+                true,
+                RequestedErrorBehavior::Retry,
+                true,
+                |_| 0
+            )
         );
         check!(let AttemptState::WaitingRetry { .. } = invocation_state_machine.invocation_state);
 
@@ -759,10 +766,46 @@ mod tests {
 
         // We stay in `WaitingForRetry`
         let_assert!(
-            OnTaskError::Retrying(_) =
-                invocation_state_machine.handle_task_error(true, None, false, true, |_| 1)
+            OnTaskError::Retrying(_) = invocation_state_machine.handle_task_error(
+                true,
+                RequestedErrorBehavior::Retry,
+                true,
+                |_| 1
+            )
         );
         check!(let AttemptState::WaitingRetry { .. } = invocation_state_machine.invocation_state);
+    }
+
+    #[test]
+    fn handle_error_with_pause_behavior_pauses() {
+        let mut invocation_state_machine = create_test_invocation_state_machine();
+
+        // Even though the error is transient and the retry policy allows more retries,
+        // the SDK-requested Pause behavior takes precedence.
+        let_assert!(
+            OnTaskError::Pause = invocation_state_machine.handle_task_error(
+                true,
+                RequestedErrorBehavior::Pause,
+                true,
+                |_| 0
+            )
+        );
+    }
+
+    #[test]
+    fn handle_error_with_fail_behavior_kills() {
+        let mut invocation_state_machine = create_test_invocation_state_machine();
+
+        // Even though the error is transient and the retry policy allows more retries,
+        // the SDK-requested Fail behavior takes precedence and fails without retrying.
+        let_assert!(
+            OnTaskError::Fail = invocation_state_machine.handle_task_error(
+                true,
+                RequestedErrorBehavior::Fail,
+                true,
+                |_| 0
+            )
+        );
     }
 
     #[test(tokio::test)]
@@ -895,8 +938,12 @@ mod tests {
 
         // Notify error
         let_assert!(
-            OnTaskError::Retrying(_) =
-                invocation_state_machine.handle_task_error(true, None, false, true, |_| 0)
+            OnTaskError::Retrying(_) = invocation_state_machine.handle_task_error(
+                true,
+                RequestedErrorBehavior::Retry,
+                true,
+                |_| 0
+            )
         );
         assert_eq!(
             invocation_state_machine.start_message_retry_count_since_last_stored_command,
@@ -911,8 +958,12 @@ mod tests {
 
         // Get error again
         let_assert!(
-            OnTaskError::Retrying(_) =
-                invocation_state_machine.handle_task_error(true, None, false, true, |_| 1)
+            OnTaskError::Retrying(_) = invocation_state_machine.handle_task_error(
+                true,
+                RequestedErrorBehavior::Retry,
+                true,
+                |_| 1
+            )
         );
         assert_eq!(
             invocation_state_machine.start_message_retry_count_since_last_stored_command,
@@ -949,8 +1000,12 @@ mod tests {
         // Invoker generates entry 1
         invocation_state_machine.notify_new_command(1, false);
         let_assert!(
-            OnTaskError::Retrying(_) =
-                invocation_state_machine.handle_task_error(true, None, false, true, |_| 0)
+            OnTaskError::Retrying(_) = invocation_state_machine.handle_task_error(
+                true,
+                RequestedErrorBehavior::Retry,
+                true,
+                |_| 0
+            )
         );
 
         // PP sends ack for command 1
@@ -987,8 +1042,12 @@ mod tests {
             false,
         );
         let_assert!(
-            OnTaskError::Retrying(_) =
-                invocation_state_machine.handle_task_error(true, None, false, true, |_| 0)
+            OnTaskError::Retrying(_) = invocation_state_machine.handle_task_error(
+                true,
+                RequestedErrorBehavior::Retry,
+                true,
+                |_| 0
+            )
         );
 
         // Waiting notifications acks and retry timer fired
@@ -1025,8 +1084,12 @@ mod tests {
 
         // Put the ISM in WaitingRetry state with timer key 0
         let_assert!(
-            OnTaskError::Retrying(_) =
-                invocation_state_machine.handle_task_error(true, None, false, true, |_| 0)
+            OnTaskError::Retrying(_) = invocation_state_machine.handle_task_error(
+                true,
+                RequestedErrorBehavior::Retry,
+                true,
+                |_| 0
+            )
         );
         check!(let AttemptState::WaitingRetry { .. } = invocation_state_machine.invocation_state);
 

--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
@@ -66,7 +66,8 @@ use restate_worker_api::invoker::invocation_reader::{
 };
 
 use crate::error::{
-    CommandPreconditionError, InvocationErrorRelatedCommandV2, InvokerError, SdkInvocationErrorV2,
+    CommandPreconditionError, InvocationErrorRelatedCommandV2, InvokerError,
+    RequestedErrorBehavior, SdkInvocationErrorV2,
 };
 use crate::invocation_task::{
     InvocationTask, InvocationTaskOutputInner, InvokerBodySender, InvokerBodyType, ResponseChunk,
@@ -1459,6 +1460,15 @@ where
     }
 
     fn handle_error_message(&mut self, error: proto::ErrorMessage) -> TerminalLoopState<()> {
+        let requested_error_behavior = match proto::ErrorBehavior::try_from(error.behavior)
+            .unwrap_or(proto::ErrorBehavior::Retry)
+        {
+            proto::ErrorBehavior::Retry => {
+                RequestedErrorBehavior::retry(error.next_retry_delay.map(Duration::from_millis))
+            }
+            proto::ErrorBehavior::Pause => RequestedErrorBehavior::Pause,
+            proto::ErrorBehavior::Fail => RequestedErrorBehavior::Fail,
+        };
         TerminalLoopState::Failed(InvokerError::SdkV2(SdkInvocationErrorV2 {
             related_command: Some(InvocationErrorRelatedCommandV2 {
                 related_command_index: error.related_command_index,
@@ -1472,8 +1482,7 @@ where
                     .related_command_index
                     .is_some_and(|entry_idx| entry_idx < self.command_index),
             }),
-            next_retry_interval_override: error.next_retry_delay.map(Duration::from_millis),
-            should_pause: error.should_pause,
+            requested_error_behavior,
             error: InvocationError::from(error).into(),
         }))
     }

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -2691,13 +2691,13 @@ mod tests {
         );
 
         // Transient error requesting a pause
-        let error_a = InvokerError::SdkV2(SdkInvocationErrorV2 {
+        let error = InvokerError::SdkV2(SdkInvocationErrorV2 {
             related_command: None,
             requested_error_behavior: RequestedErrorBehavior::Pause,
             error: InvocationError::new(codes::INTERNAL, "boom").into(),
         });
         service_inner
-            .handle_invocation_task_failed(invocation_id, error_a, service_inner.test_budget())
+            .handle_invocation_task_failed(invocation_id, error, service_inner.test_budget())
             .await;
         assert_that!(
             *effects_rx
@@ -2753,13 +2753,13 @@ mod tests {
         );
 
         // Transient error requesting to fail without retrying
-        let error_a = InvokerError::SdkV2(SdkInvocationErrorV2 {
+        let error = InvokerError::SdkV2(SdkInvocationErrorV2 {
             related_command: None,
             requested_error_behavior: RequestedErrorBehavior::Fail,
             error: InvocationError::new(codes::INTERNAL, "boom").into(),
         });
         service_inner
-            .handle_invocation_task_failed(invocation_id, error_a, service_inner.test_budget())
+            .handle_invocation_task_failed(invocation_id, error, service_inner.test_budget())
             .await;
         assert_that!(
             *effects_rx.try_recv().expect("expected a Failed effect"),

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -1498,8 +1498,7 @@ where
         // We need to capture the duration for logging and status updates.
         let result = ism.handle_task_error(
             error.is_transient(),
-            error.next_retry_interval_override(),
-            error.should_pause(),
+            error.requested_error_behavior(),
             error.should_bump_start_message_retry_count_since_last_stored_entry(),
             |duration| self.retry_timers.insert(invocation_id, duration),
         );
@@ -1723,7 +1722,7 @@ where
                     }))
                     .await;
             }
-            OnTaskError::Kill => {
+            OnTaskError::Fail => {
                 counter!(INVOKER_INVOCATION_TASKS,
                     "status" => TASK_OP_FAILED,
                     "transient" => "false",
@@ -1902,7 +1901,9 @@ mod tests {
     use restate_util_time::FriendlyDuration;
     use restate_worker_api::invoker::InvokerHandle;
 
-    use crate::error::{InvocationMemoryExhausted, InvokerError, SdkInvocationErrorV2};
+    use crate::error::{
+        InvocationMemoryExhausted, InvokerError, RequestedErrorBehavior, SdkInvocationErrorV2,
+    };
     use crate::quota::{ConcurrencySlot, InvokerConcurrencyQuota};
     use crate::test_util::EmptyStorageReader;
 
@@ -2583,8 +2584,9 @@ mod tests {
         // First transient error (A) -> should propose a TransientError event
         let error_a = InvokerError::SdkV2(SdkInvocationErrorV2 {
             related_command: None,
-            next_retry_interval_override: Some(Duration::from_millis(1)),
-            should_pause: false,
+            requested_error_behavior: RequestedErrorBehavior::RetryWithIntervalOverride(
+                Duration::from_millis(1),
+            ),
             error: InvocationError::new(codes::INTERNAL, "boom").into(),
         });
         service_inner
@@ -2608,8 +2610,9 @@ mod tests {
         // Same transient error (A again) -> should NOT propose a new event
         let error_a_same = InvokerError::SdkV2(SdkInvocationErrorV2 {
             related_command: None,
-            next_retry_interval_override: Some(Duration::from_millis(1)),
-            should_pause: false,
+            requested_error_behavior: RequestedErrorBehavior::RetryWithIntervalOverride(
+                Duration::from_millis(1),
+            ),
             error: InvocationError::new(codes::INTERNAL, "boom").into(),
         });
         service_inner
@@ -2626,8 +2629,9 @@ mod tests {
         // Different transient error (B: different message) -> should propose a new event
         let error_b = InvokerError::SdkV2(SdkInvocationErrorV2 {
             related_command: None,
-            next_retry_interval_override: Some(Duration::from_millis(1)),
-            should_pause: false,
+            requested_error_behavior: RequestedErrorBehavior::RetryWithIntervalOverride(
+                Duration::from_millis(1),
+            ),
             error: InvocationError::new(codes::INTERNAL, "boom-2").into(),
         });
         service_inner
@@ -2686,11 +2690,10 @@ mod tests {
             false, // has_changed = false -> directly selects protocol without emitting effect
         );
 
-        // Transient error with should_pause
+        // Transient error requesting a pause
         let error_a = InvokerError::SdkV2(SdkInvocationErrorV2 {
             related_command: None,
-            next_retry_interval_override: Some(Duration::from_millis(1)),
-            should_pause: true,
+            requested_error_behavior: RequestedErrorBehavior::Pause,
             error: InvocationError::new(codes::INTERNAL, "boom").into(),
         });
         service_inner
@@ -2705,6 +2708,66 @@ mod tests {
                 kind: pat!(EffectKind::Paused {
                     paused_event: predicate(|e: &RawEvent| e.ty() == EventType::Paused)
                 })
+            })
+        );
+    }
+
+    #[test(restate_core::test(start_paused = true))]
+    async fn error_message_should_fail() {
+        // Enable proposing events and keep timers short for the test
+        let invoker_options = InvokerOptionsBuilder::default()
+            .inactivity_timeout(FriendlyDuration::ZERO)
+            .abort_timeout(FriendlyDuration::ZERO)
+            .disable_eager_state(false)
+            .build()
+            .unwrap();
+
+        let invocation_id = InvocationId::mock_random();
+
+        // Mock service. The retry policy would allow retries and on-max-attempts would pause,
+        // but the SDK-requested Fail behavior takes precedence over both.
+        let (_, _status_tx, mut effects_rx, mut service_inner) = ServiceInner::mock(
+            (),
+            MockSchemas(
+                Some(RetryPolicy::fixed_delay(Duration::ZERO, Some(3))),
+                Some(OnMaxAttempts::Pause),
+            ),
+            None,
+            EmptyStorageReader,
+        );
+
+        // Start invocation epoch 0
+        let budget = service_inner.test_budget();
+        service_inner.handle_invoke(
+            &invoker_options,
+            invocation_id,
+            InvocationTarget::mock_virtual_object(),
+            budget,
+        );
+
+        // Select protocol V4 to allow proposing events
+        service_inner.handle_pinned_deployment(
+            invocation_id,
+            PinnedDeployment::new(DeploymentId::new(), ServiceProtocolVersion::V4),
+            false, // has_changed = false -> directly selects protocol without emitting effect
+        );
+
+        // Transient error requesting to fail without retrying
+        let error_a = InvokerError::SdkV2(SdkInvocationErrorV2 {
+            related_command: None,
+            requested_error_behavior: RequestedErrorBehavior::Fail,
+            error: InvocationError::new(codes::INTERNAL, "boom").into(),
+        });
+        service_inner
+            .handle_invocation_task_failed(invocation_id, error_a, service_inner.test_budget())
+            .await;
+        assert_that!(
+            *effects_rx.try_recv().expect("expected a Failed effect"),
+            pat!(Effect {
+                invocation_id: eq(invocation_id),
+                kind: pat!(EffectKind::Failed(predicate(|e: &InvocationError| e
+                    .code()
+                    == codes::INTERNAL)))
             })
         );
     }

--- a/service-protocol/dev/restate/service/protocol.proto
+++ b/service-protocol/dev/restate/service/protocol.proto
@@ -45,7 +45,7 @@ enum ServiceProtocolVersion {
   // * IdempotentRequestTarget.scope
   // * StartMessage.scope, StartMessage.limit_key and StartMessage.idempotency_key
   // * Semantic changes to Run proposal response, introduced ProposeRunCompletionAckMessage
-  // * ErrorMessage.should_pause
+  // * ErrorMessage.behavior
   V7 = 7;
 }
 

--- a/service-protocol/dev/restate/service/protocol.proto
+++ b/service-protocol/dev/restate/service/protocol.proto
@@ -185,10 +185,14 @@ message ErrorMessage {
   ErrorBehavior behavior = 9;
 }
 
-// What to do in case of an ErrorMessage
+// What to do in case of an ErrorMessage.
 enum ErrorBehavior {
   // Retry this invocation.
-  // In that case, next_retry_delay will be used if set, otherwise the runtime will follow the currently used retry policy.
+  //
+  // When retrying, next_retry_delay will be used if set, otherwise the runtime will follow the currently used retry policy.
+  //
+  // We use 0 for this so that unset `behavior` field is interpreter as RETRY,
+  // which matches the default behavior in previous service protocols.
   RETRY = 0;
   // Pause the invocation.
   PAUSE = 1;

--- a/service-protocol/dev/restate/service/protocol.proto
+++ b/service-protocol/dev/restate/service/protocol.proto
@@ -179,9 +179,19 @@ message ErrorMessage {
   // If provided, it will override the default retry policy used by Restate's invoker ONLY for the next retry attempt.
   optional uint64 next_retry_delay = 8;
 
-  // If true, Restate will pause instead of retrying.
-  // This field supersedes next_retry_delay.
-  bool should_pause = 9;
+  // What to do in case of an ErrorMessage
+  ErrorBehavior behavior = 9;
+}
+
+// What to do in case of an ErrorMessage
+enum ErrorBehavior {
+  // Retry this invocation.
+  // In that case, next_retry_delay will be used if set, otherwise the runtime will follow the currently used retry policy.
+  RETRY = 0;
+  // Pause the invocation.
+  PAUSE = 1;
+  // Fail this invocation, without retrying.
+  FAIL = 2;
 }
 
 // Type: 0x0000 + 3

--- a/service-protocol/dev/restate/service/protocol.proto
+++ b/service-protocol/dev/restate/service/protocol.proto
@@ -45,7 +45,7 @@ enum ServiceProtocolVersion {
   // * IdempotentRequestTarget.scope
   // * StartMessage.scope, StartMessage.limit_key and StartMessage.idempotency_key
   // * Semantic changes to Run proposal response, introduced ProposeRunCompletionAckMessage
-  // * ErrorMessage.behavior
+  // * ErrorMessage.behavior to customize retry behavior
   V7 = 7;
 }
 
@@ -177,6 +177,8 @@ message ErrorMessage {
 
   // Delay before executing the next retry, specified as duration in milliseconds.
   // If provided, it will override the default retry policy used by Restate's invoker ONLY for the next retry attempt.
+  //
+  // This field is relevant only if behavior = RETRY.
   optional uint64 next_retry_delay = 8;
 
   // What to do in case of an ErrorMessage


### PR DESCRIPTION
This replaces `ErrorMessage.should_pause` (was added in service protocol v7 not yet released).
The new behavior `Fail` allows the SDK to stop retrying on certain errors (such as journal mismatch).

We need this exactly to allow in the SDK to customize whether to fail/pause/retry on journal mismatch errors. Another idea was to reuse OutputCommandMessage for that, but it has few challanges:

* To commit a terminal failure, the sdk needs to commit both `OutputCommandMessage` and `EndMessage`. That commit is not atomic, and there is no mechanism at the moment to do so. This means that in an eventual failure between committing `OutputCommandMesage` and `EndMessage` would result in a retry, creating a hard to deal with situation in the SDK to know if the previous error was created by the sdk or not...
* It also makes sense to use ErrorMessage from an observability point of view, because it carries over info such as related journal command index, and because it creates and event, which will be correctly displyed in the UI.