### PR TITLE
Allow pausing of invocations that are using vqueues

### DIFF
--- a/crates/invoker-impl/src/input_command.rs
+++ b/crates/invoker-impl/src/input_command.rs
@@ -13,7 +13,7 @@ use tokio::sync::mpsc;
 use restate_errors::NotRunningError;
 use restate_types::LimitKey;
 use restate_types::identifiers::{EntryIndex, InvocationId};
-use restate_types::invocation::InvocationTarget;
+use restate_types::invocation::{FencingToken, InvocationTarget};
 use restate_types::journal_v2::{CommandIndex, NotificationId};
 use restate_types::sharding::KeyRange;
 use restate_types::vqueues::VQueueId;
@@ -25,6 +25,7 @@ use restate_worker_api::resources::ReservedResources;
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct InvokeCommand {
     pub(super) invocation_id: InvocationId,
+    pub(super) fencing_token: FencingToken,
     pub(super) invocation_target: InvocationTarget,
 }
 
@@ -34,6 +35,7 @@ pub(crate) struct VQueueInvokeCommand {
     #[debug(skip)]
     pub(super) permit: ReservedResources,
     pub(super) invocation_id: InvocationId,
+    pub(super) fencing_token: FencingToken,
     pub(super) invocation_target: InvocationTarget,
     pub(super) limit_key: LimitKey<ReString>,
     pub(super) idempotency_key: Option<ReString>,
@@ -59,7 +61,7 @@ pub(crate) enum InputCommand {
         command_index: CommandIndex,
     },
 
-    /// Abort specific invocation id
+    /// Abort specific invocation id (the current attempt, unconditionally).
     Abort {
         invocation_id: InvocationId,
     },
@@ -89,11 +91,13 @@ impl restate_worker_api::invoker::InvokerHandle for InvokerHandle {
     fn invoke(
         &mut self,
         invocation_id: InvocationId,
+        fencing_token: FencingToken,
         invocation_target: InvocationTarget,
     ) -> Result<(), NotRunningError> {
         self.input
             .send(InputCommand::Invoke(Box::new(InvokeCommand {
                 invocation_id,
+                fencing_token,
                 invocation_target,
             })))
             .map_err(|_| NotRunningError)
@@ -104,6 +108,7 @@ impl restate_worker_api::invoker::InvokerHandle for InvokerHandle {
         qid: VQueueId,
         permit: ReservedResources,
         invocation_id: InvocationId,
+        fencing_token: FencingToken,
         invocation_target: InvocationTarget,
         limit_key: LimitKey<ReString>,
         idempotency_key: Option<ReString>,
@@ -113,6 +118,7 @@ impl restate_worker_api::invoker::InvokerHandle for InvokerHandle {
                 qid,
                 permit,
                 invocation_id,
+                fencing_token,
                 invocation_target,
                 limit_key,
                 idempotency_key,

--- a/crates/invoker-impl/src/invocation_state_machine.rs
+++ b/crates/invoker-impl/src/invocation_state_machine.rs
@@ -16,6 +16,7 @@ use tokio::task::AbortHandle;
 
 use restate_memory::LocalMemoryPool;
 use restate_types::identifiers::EntryIndex;
+use restate_types::invocation::FencingToken;
 use restate_types::retries;
 use restate_types::schema::invocation_target::OnMaxAttempts;
 use restate_types::service_protocol::ServiceProtocolVersion;
@@ -46,6 +47,10 @@ pub(super) struct InvocationStateMachine<K: TimerKey = tokio_util::time::delay_q
     #[allow(dead_code)]
     #[debug(skip)]
     pub(super) _permit: ReservedResources,
+    /// The invoker-task generation this state machine represents. Stamped onto
+    /// every effect this ISM emits so the partition processor can fence stale
+    /// effects from a previous attempt.
+    pub(super) fencing_token: FencingToken,
     pub(super) invocation_target: InvocationTarget,
     pub(super) limit_key: LimitKey<ReString>,
     pub(super) idempotency_key: Option<ReString>,
@@ -221,6 +226,7 @@ impl<K: TimerKey> InvocationStateMachine<K> {
     pub(super) fn create(
         qid: Option<VQueueId>,
         permit: ReservedResources,
+        fencing_token: FencingToken,
         invocation_target: InvocationTarget,
         limit_key: LimitKey<ReString>,
         idempotency_key: Option<ReString>,
@@ -234,6 +240,7 @@ impl<K: TimerKey> InvocationStateMachine<K> {
         Self {
             qid,
             _permit: permit,
+            fencing_token,
             invocation_target,
             limit_key,
             idempotency_key,
@@ -739,6 +746,7 @@ mod tests {
         InvocationStateMachine::create(
             None,
             ReservedResources::new_empty(),
+            0,
             InvocationTarget::mock_virtual_object(),
             LimitKey::None,
             None,

--- a/crates/invoker-impl/src/invocation_task/mod.rs
+++ b/crates/invoker-impl/src/invocation_task/mod.rs
@@ -37,7 +37,7 @@ use restate_service_client::{Request, ResponseBody, ServiceClient, ServiceClient
 use restate_types::LimitKey;
 use restate_types::deployment::PinnedDeployment;
 use restate_types::identifiers::InvocationId;
-use restate_types::invocation::InvocationTarget;
+use restate_types::invocation::{FencingToken, InvocationTarget};
 use restate_types::journal::EntryIndex;
 use restate_types::journal::enriched::EnrichedRawEntry;
 use restate_types::journal_v2::raw::RawNotification;
@@ -156,6 +156,7 @@ where
 
 pub(super) struct InvocationTaskOutput {
     pub(super) invocation_id: InvocationId,
+    pub(super) fencing_token: FencingToken,
     pub(super) inner: InvocationTaskOutputInner,
 }
 
@@ -260,6 +261,7 @@ pub(super) struct InvocationTask<EE, DMR> {
 
     // Connection params
     invocation_id: InvocationId,
+    fencing_token: FencingToken,
     invocation_target: InvocationTarget,
     limit_key: LimitKey<ReString>,
     idempotency_key: Option<ReString>,
@@ -344,6 +346,7 @@ where
     pub fn new(
         client: ServiceClient,
         invocation_id: InvocationId,
+        fencing_token: FencingToken,
         invocation_target: InvocationTarget,
         default_inactivity_timeout: Duration,
         default_abort_timeout: Duration,
@@ -363,6 +366,7 @@ where
         Self {
             client,
             invocation_id,
+            fencing_token,
             invocation_target,
             inactivity_timeout: default_inactivity_timeout,
             abort_timeout: default_abort_timeout,
@@ -613,6 +617,7 @@ impl<EE, Schemas> InvocationTask<EE, Schemas> {
     pub(crate) fn send_invoker_tx(&self, invocation_task_output_inner: InvocationTaskOutputInner) {
         let _ = self.invoker_tx.send(InvocationTaskOutput {
             invocation_id: self.invocation_id,
+            fencing_token: self.fencing_token,
             inner: invocation_task_output_inner,
         });
     }

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -1859,6 +1859,26 @@ where
         mut ism: InvocationStateMachine,
         budget: LocalMemoryPool,
     ) {
+        // If an in-flight state machine for this invocation already exists, abort it before
+        // starting the new task. This happens when a fresh Invoke/VQInvoke races a previous
+        // attempt that hasn't been removed yet (e.g. its abort is still in flight). Without this,
+        // `register_invocation` would silently overwrite the old ISM, leaking its task — which
+        // would keep running and could still emit now-stale effects. (No-op on the retry path,
+        // which removes the ISM before re-starting it.)
+        if let Some((_, _, mut old_ism)) = self
+            .invocation_state_machine_manager
+            .remove_invocation(&invocation_id)
+        {
+            if let Some(timer_key) = old_ism.take_retry_timer_key() {
+                self.retry_timers.try_remove(&timer_key);
+            }
+            trace!(
+                restate.invocation.id = %invocation_id,
+                "Aborting previous in-flight state machine before starting a new attempt"
+            );
+            old_ism.abort();
+        }
+
         // Start the InvocationTask
         let (completions_tx, completions_rx) = mpsc::unbounded_channel();
         let abort_handle = self.invocation_task_runner.start_invocation_task(

--- a/crates/invoker-impl/src/lib.rs
+++ b/crates/invoker-impl/src/lib.rs
@@ -47,7 +47,7 @@ use restate_types::config::{Configuration, InvokerOptions, ServiceClientOptions}
 use restate_types::deployment::PinnedDeployment;
 use restate_types::identifiers::PartitionId;
 use restate_types::identifiers::{DeploymentId, InvocationId, WithPartitionKey};
-use restate_types::invocation::InvocationTarget;
+use restate_types::invocation::{FencingToken, InvocationTarget};
 use restate_types::journal::EntryIndex;
 use restate_types::journal::enriched::EnrichedRawEntry;
 use restate_types::journal_events::raw::RawEvent;
@@ -65,7 +65,7 @@ use restate_util_time::DurationExt;
 use restate_worker_api::invoker::capacity::TokenBucket;
 use restate_worker_api::invoker::invocation_reader::InvocationReader;
 use restate_worker_api::invoker::{
-    Effect, EffectKind, EntryEnricher, InvocationStatusReport, YieldReason,
+    Effect, EffectKind, EntryEnricher, FencedEffect, InvocationStatusReport, YieldReason,
 };
 use restate_worker_api::resources::ReservedResources;
 
@@ -90,6 +90,17 @@ pub use input_command::InvokerHandle;
 use restate_types::LimitKey;
 use restate_util_string::ReString;
 
+/// Tags an [`Effect`] with the fencing token of the attempt that produced it (`ism.fencing_token`).
+///
+/// The partition processor checks the token against its in-memory `fencing_tokens` map before
+/// self-proposing the effect and then strips it, so the token never reaches Bifrost.
+fn fence(token: FencingToken, effect: Effect) -> FencedEffect {
+    FencedEffect {
+        fencing_token: token,
+        effect: Box::new(effect),
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Notification {
     /// V1 completion signal: just the entry index (data read from RocksDB on demand).
@@ -110,6 +121,7 @@ trait InvocationTaskRunner<SR> {
         &self,
         options: &InvokerOptions,
         invocation_id: InvocationId,
+        fencing_token: FencingToken,
         invocation_target: InvocationTarget,
         limit_key: LimitKey<ReString>,
         idempotency_key: Option<ReString>,
@@ -140,6 +152,7 @@ where
         &self,
         opts: &InvokerOptions,
         invocation_id: InvocationId,
+        fencing_token: FencingToken,
         invocation_target: InvocationTarget,
         limit_key: LimitKey<ReString>,
         idempotency_key: Option<ReString>,
@@ -157,6 +170,7 @@ where
                 InvocationTask::new(
                     self.client.clone(),
                     invocation_id,
+                    fencing_token,
                     invocation_target,
                     opts.inactivity_timeout.into(),
                     opts.abort_timeout.into(),
@@ -233,7 +247,7 @@ impl<StorageReader, TEntryEnricher, Schemas> Service<StorageReader, TEntryEnrich
         invoker_id: impl Into<InvokerId>,
         key_range: KeyRange,
         storage_reader: StorageReader,
-        sender: mpsc::Sender<Box<Effect>>,
+        sender: mpsc::Sender<FencedEffect>,
         options: &InvokerOptions,
         schemas: Live<Schemas>,
         client: ServiceClient,
@@ -300,7 +314,7 @@ impl<StorageReader, TEntryEnricher, Schemas> Service<StorageReader, TEntryEnrich
         invoker_id: impl Into<InvokerId>,
         key_range: KeyRange,
         storage_reader: StorageReader,
-        sender: mpsc::Sender<Box<Effect>>,
+        sender: mpsc::Sender<FencedEffect>,
         service_client_options: &ServiceClientOptions,
         invoker_options: &InvokerOptions,
         entry_enricher: TEntryEnricher,
@@ -531,7 +545,7 @@ where
             Some(invoke_input_command) = segmented_input_queue.next(), if !segmented_input_queue.inner().is_empty() && self.quota.is_slot_available() && self.pending_memory_lease.is_some() => {
                 let initial_memory_lease = self.pending_memory_lease.take().unwrap();
                 let budget = self.create_outbound_budget(options, initial_memory_lease);
-                self.handle_invoke(options, invoke_input_command.invocation_id, invoke_input_command.invocation_target, budget);
+                self.handle_invoke(options, invoke_input_command.invocation_id, invoke_input_command.fencing_token, invoke_input_command.invocation_target, budget);
             },
             memory_lease = self.memory_pool.reserve(initial_invocation_memory), if !segmented_input_queue.inner().is_empty() && self.pending_memory_lease.is_none() => {
                 self.pending_memory_lease = Some(memory_lease);
@@ -539,8 +553,16 @@ where
             Some(invocation_task_msg) = self.invocation_tasks_rx.recv() => {
                 let InvocationTaskOutput {
                     invocation_id,
+                    fencing_token,
                     inner
                 } = invocation_task_msg;
+                // Fence stale task output: if the invocation was aborted and restarted, the
+                // in-flight state machine has moved to a newer epoch. Output from the old task
+                // still draining out of the channel must be dropped so it neither mutates the new
+                // attempt's state machine nor gets emitted as an effect stamped with the new epoch.
+                if self.invocation_state_machine_manager.is_stale_fencing_token(&invocation_id, fencing_token) {
+                    trace!(restate.invocation.id = %invocation_id, "Dropping stale invoker task output from a previous attempt");
+                } else {
                 match inner {
                     InvocationTaskOutputInner::PinnedDeployment(deployment_metadata, has_changed) => {
                         self.handle_pinned_deployment(
@@ -603,6 +625,7 @@ where
                         self.handle_invocation_task_should_yield(invocation_id, oom, budget).await
                     }
                 };
+                }
             },
             Some(expired) = self.retry_timers.next() => {
                 let timer_key = expired.key();
@@ -669,6 +692,7 @@ where
             InvocationStateMachine::create(
                 Some(command.qid),
                 command.permit,
+                command.fencing_token,
                 command.invocation_target,
                 command.limit_key,
                 command.idempotency_key,
@@ -694,6 +718,7 @@ where
         &mut self,
         options: &InvokerOptions,
         invocation_id: InvocationId,
+        fencing_token: FencingToken,
         invocation_target: InvocationTarget,
         budget: LocalMemoryPool,
     ) {
@@ -714,6 +739,7 @@ where
             InvocationStateMachine::create(
                 None,
                 fake_permit,
+                fencing_token,
                 invocation_target,
                 LimitKey::None,
                 None,
@@ -857,17 +883,23 @@ where
             self.status_store.on_progress_made(&invocation_id);
             if let Some(pinned_deployment) = ism.pinned_deployment_to_notify() {
                 let _ = output_tx
-                    .send(Box::new(Effect {
-                        invocation_id,
-                        kind: EffectKind::PinnedDeployment(pinned_deployment),
-                    }))
+                    .send(fence(
+                        ism.fencing_token,
+                        Effect {
+                            invocation_id,
+                            kind: EffectKind::PinnedDeployment(pinned_deployment),
+                        },
+                    ))
                     .await;
             }
             let _ = output_tx
-                .send(Box::new(Effect {
-                    invocation_id,
-                    kind: EffectKind::JournalEntry { entry_index, entry },
-                }))
+                .send(fence(
+                    ism.fencing_token,
+                    Effect {
+                        invocation_id,
+                        kind: EffectKind::JournalEntry { entry_index, entry },
+                    },
+                ))
                 .await;
         } else {
             // If no state machine, this might be an entry for an aborted invocation.
@@ -907,17 +939,23 @@ where
             self.status_store.on_progress_made(&invocation_id);
             if let Some(pinned_deployment) = ism.pinned_deployment_to_notify() {
                 let _ = output_tx
-                    .send(Box::new(Effect {
-                        invocation_id,
-                        kind: EffectKind::PinnedDeployment(pinned_deployment),
-                    }))
+                    .send(fence(
+                        ism.fencing_token,
+                        Effect {
+                            invocation_id,
+                            kind: EffectKind::PinnedDeployment(pinned_deployment),
+                        },
+                    ))
                     .await;
             }
             let _ = output_tx
-                .send(Box::new(Effect {
-                    invocation_id,
-                    kind: EffectKind::journal_entry(notification, None),
-                }))
+                .send(fence(
+                    ism.fencing_token,
+                    Effect {
+                        invocation_id,
+                        kind: EffectKind::journal_entry(notification, None),
+                    },
+                ))
                 .await;
         } else {
             // If no state machine, this might be an entry for an aborted invocation.
@@ -954,17 +992,23 @@ where
             self.status_store.on_progress_made(&invocation_id);
             if let Some(pinned_deployment) = ism.pinned_deployment_to_notify() {
                 let _ = output_tx
-                    .send(Box::new(Effect {
-                        invocation_id,
-                        kind: EffectKind::PinnedDeployment(pinned_deployment),
-                    }))
+                    .send(fence(
+                        ism.fencing_token,
+                        Effect {
+                            invocation_id,
+                            kind: EffectKind::PinnedDeployment(pinned_deployment),
+                        },
+                    ))
                     .await;
             }
             let _ = output_tx
-                .send(Box::new(Effect {
-                    invocation_id,
-                    kind: EffectKind::journal_entry(command, Some(command_index)),
-                }))
+                .send(fence(
+                    ism.fencing_token,
+                    Effect {
+                        invocation_id,
+                        kind: EffectKind::journal_entry(command, Some(command_index)),
+                    },
+                ))
                 .await;
         } else {
             // If no state machine, this might be an entry for an aborted invocation.
@@ -1066,10 +1110,13 @@ where
 
             self.status_store.on_end(&invocation_id);
             let _ = sender
-                .send(Box::new(Effect {
-                    invocation_id,
-                    kind: EffectKind::End,
-                }))
+                .send(fence(
+                    ism.fencing_token,
+                    Effect {
+                        invocation_id,
+                        kind: EffectKind::End,
+                    },
+                ))
                 .await;
         } else {
             // If no state machine, this might be a result for an aborted invocation.
@@ -1109,14 +1156,17 @@ where
                 );
 
                 let _ = sender
-                    .send(Box::new(Effect {
-                        invocation_id,
-                        kind: EffectKind::Paused {
-                            paused_event: RawEvent::from(Event::Paused(PausedEvent {
-                                last_failure: None,
-                            })),
+                    .send(fence(
+                        ism.fencing_token,
+                        Effect {
+                            invocation_id,
+                            kind: EffectKind::Paused {
+                                paused_event: RawEvent::from(Event::Paused(PausedEvent {
+                                    last_failure: None,
+                                })),
+                            },
                         },
-                    }))
+                    ))
                     .await;
             } else {
                 trace!(
@@ -1125,12 +1175,15 @@ where
                 );
 
                 let _ = sender
-                    .send(Box::new(Effect {
-                        invocation_id,
-                        kind: EffectKind::Suspended {
-                            waiting_for_completed_entries: entry_indexes,
+                    .send(fence(
+                        ism.fencing_token,
+                        Effect {
+                            invocation_id,
+                            kind: EffectKind::Suspended {
+                                waiting_for_completed_entries: entry_indexes,
+                            },
                         },
-                    }))
+                    ))
                     .await;
             }
         } else {
@@ -1171,14 +1224,17 @@ where
                 );
 
                 let _ = sender
-                    .send(Box::new(Effect {
-                        invocation_id,
-                        kind: EffectKind::Paused {
-                            paused_event: RawEvent::from(Event::Paused(PausedEvent {
-                                last_failure: None,
-                            })),
+                    .send(fence(
+                        ism.fencing_token,
+                        Effect {
+                            invocation_id,
+                            kind: EffectKind::Paused {
+                                paused_event: RawEvent::from(Event::Paused(PausedEvent {
+                                    last_failure: None,
+                                })),
+                            },
                         },
-                    }))
+                    ))
                     .await;
             } else {
                 trace!(
@@ -1187,12 +1243,15 @@ where
                 );
 
                 let _ = sender
-                    .send(Box::new(Effect {
-                        invocation_id,
-                        kind: EffectKind::SuspendedV2 {
-                            waiting_for_notifications,
+                    .send(fence(
+                        ism.fencing_token,
+                        Effect {
+                            invocation_id,
+                            kind: EffectKind::SuspendedV2 {
+                                waiting_for_notifications,
+                            },
                         },
-                    }))
+                    ))
                     .await;
             }
         } else {
@@ -1233,14 +1292,17 @@ where
                 );
 
                 let _ = sender
-                    .send(Box::new(Effect {
-                        invocation_id,
-                        kind: EffectKind::Paused {
-                            paused_event: RawEvent::from(Event::Paused(PausedEvent {
-                                last_failure: None,
-                            })),
+                    .send(fence(
+                        ism.fencing_token,
+                        Effect {
+                            invocation_id,
+                            kind: EffectKind::Paused {
+                                paused_event: RawEvent::from(Event::Paused(PausedEvent {
+                                    last_failure: None,
+                                })),
+                            },
                         },
-                    }))
+                    ))
                     .await;
             } else {
                 trace!(
@@ -1249,12 +1311,15 @@ where
                 );
 
                 let _ = sender
-                    .send(Box::new(Effect {
-                        invocation_id,
-                        kind: EffectKind::SuspendedV3 {
-                            awaiting_on: future,
+                    .send(fence(
+                        ism.fencing_token,
+                        Effect {
+                            invocation_id,
+                            kind: EffectKind::SuspendedV3 {
+                                awaiting_on: future,
+                            },
                         },
-                    }))
+                    ))
                     .await;
             }
         } else {
@@ -1336,16 +1401,19 @@ where
                         ism.abort();
                         self.status_store.on_end(&invocation_id);
                         let _ = sender
-                            .send(Box::new(Effect {
-                                invocation_id,
-                                kind: EffectKind::Yield {
-                                    reason: YieldReason::ExhaustedMemoryBudget {
-                                        needed_memory: oom.needed,
+                            .send(fence(
+                                ism.fencing_token,
+                                Effect {
+                                    invocation_id,
+                                    kind: EffectKind::Yield {
+                                        reason: YieldReason::ExhaustedMemoryBudget {
+                                            needed_memory: oom.needed,
+                                        },
+                                        error_event: None,
+                                        resume_at: None,
                                     },
-                                    error_event: None,
-                                    resume_at: None,
                                 },
-                            }))
+                            ))
                             .await;
                     } else {
                         // Yield flag disabled: fall back to retry.
@@ -1378,7 +1446,6 @@ where
                 self.retry_timers.try_remove(&timer_key);
             }
 
-            // We abort only if the requested abort invocation epoch is same.
             trace!(
                 restate.invocation.target = %ism.invocation_target,
                 "Aborting invocation"
@@ -1386,9 +1453,7 @@ where
             ism.abort();
             self.status_store.on_end(invocation_id);
         } else {
-            trace!(
-                "Ignoring Abort command because there is no matching partition/invocation/invocation epoch"
-            );
+            trace!("Ignoring Abort command because there is no matching invocation");
         }
     }
 
@@ -1439,14 +1504,17 @@ where
             if ism.notify_pause() {
                 // If returns true, we need to pause now
                 let _ = sender
-                    .send(Box::new(Effect {
-                        invocation_id,
-                        kind: EffectKind::Paused {
-                            paused_event: RawEvent::from(Event::Paused(PausedEvent {
-                                last_failure: ism.last_transient_error_event,
-                            })),
+                    .send(fence(
+                        ism.fencing_token,
+                        Effect {
+                            invocation_id,
+                            kind: EffectKind::Paused {
+                                paused_event: RawEvent::from(Event::Paused(PausedEvent {
+                                    last_failure: ism.last_transient_error_event,
+                                })),
+                            },
                         },
-                    }))
+                    ))
                     .await;
             } else {
                 // Invocation still in flight, pause will happen later on
@@ -1571,12 +1639,15 @@ where
                     let _ = self
                         .invocation_state_machine_manager
                         .partition_sender()
-                        .send(Box::new(Effect {
-                            invocation_id,
-                            kind: EffectKind::JournalEvent {
-                                event: RawEvent::from(Event::TransientError(event)),
+                        .send(fence(
+                            ism.fencing_token,
+                            Effect {
+                                invocation_id,
+                                kind: EffectKind::JournalEvent {
+                                    event: RawEvent::from(Event::TransientError(event)),
+                                },
                             },
-                        }))
+                        ))
                         .await;
                 }
 
@@ -1649,17 +1720,20 @@ where
                 let _ = self
                     .invocation_state_machine_manager
                     .partition_sender()
-                    .send(Box::new(Effect {
-                        invocation_id,
-                        kind: EffectKind::Yield {
-                            reason: YieldReason::TransientError {
-                                retry_attempts,
-                                retry_count_since_last_stored_command,
+                    .send(fence(
+                        ism.fencing_token,
+                        Effect {
+                            invocation_id,
+                            kind: EffectKind::Yield {
+                                reason: YieldReason::TransientError {
+                                    retry_attempts,
+                                    retry_count_since_last_stored_command,
+                                },
+                                error_event,
+                                resume_at: Some(RoughTimestamp::now() + retry_after),
                             },
-                            error_event,
-                            resume_at: Some(RoughTimestamp::now() + retry_after),
                         },
-                    }))
+                    ))
                     .await;
             }
             OnTaskError::Pause => {
@@ -1714,12 +1788,15 @@ where
                 let _ = self
                     .invocation_state_machine_manager
                     .partition_sender()
-                    .send(Box::new(Effect {
-                        invocation_id,
-                        kind: EffectKind::Paused {
-                            paused_event: RawEvent::from(Event::Paused(paused_event)),
+                    .send(fence(
+                        ism.fencing_token,
+                        Effect {
+                            invocation_id,
+                            kind: EffectKind::Paused {
+                                paused_event: RawEvent::from(Event::Paused(paused_event)),
+                            },
                         },
-                    }))
+                    ))
                     .await;
             }
             OnTaskError::Fail => {
@@ -1740,10 +1817,13 @@ where
                 let _ = self
                     .invocation_state_machine_manager
                     .partition_sender()
-                    .send(Box::new(Effect {
-                        invocation_id,
-                        kind: EffectKind::Failed(error.into_invocation_error()),
-                    }))
+                    .send(fence(
+                        ism.fencing_token,
+                        Effect {
+                            invocation_id,
+                            kind: EffectKind::Failed(error.into_invocation_error()),
+                        },
+                    ))
                     .await;
             }
         }
@@ -1784,6 +1864,7 @@ where
         let abort_handle = self.invocation_task_runner.start_invocation_task(
             options,
             invocation_id,
+            ism.fencing_token,
             ism.invocation_target.clone(),
             ism.limit_key.clone(),
             ism.idempotency_key.clone(),
@@ -1925,7 +2006,7 @@ mod tests {
             mpsc::UnboundedSender<
                 restate_futures_util::command::Command<KeyRange, Vec<InvocationStatusReport>>,
             >,
-            mpsc::Receiver<Box<Effect>>,
+            mpsc::Receiver<FencedEffect>,
             Self,
         ) {
             let (input_tx, input_rx) = mpsc::unbounded_channel();
@@ -2008,6 +2089,7 @@ mod tests {
             &self,
             _options: &InvokerOptions,
             invocation_id: InvocationId,
+            _fencing_token: FencingToken,
             invocation_target: InvocationTarget,
             _limit_key: LimitKey<ReString>,
             _idempotency_key: Option<ReString>,
@@ -2041,6 +2123,7 @@ mod tests {
             &self,
             _options: &InvokerOptions,
             _invocation_id: InvocationId,
+            _fencing_token: FencingToken,
             _invocation_target: InvocationTarget,
             _limit_key: LimitKey<ReString>,
             _idempotency_key: Option<ReString>,
@@ -2063,6 +2146,7 @@ mod tests {
             &self,
             _options: &InvokerOptions,
             _invocation_id: InvocationId,
+            _fencing_token: FencingToken,
             _invocation_target: InvocationTarget,
             _limit_key: LimitKey<ReString>,
             _idempotency_key: Option<ReString>,
@@ -2199,7 +2283,7 @@ mod tests {
         let invocation_target = InvocationTarget::mock_service();
         let invocation_id = InvocationId::mock_generate(&invocation_target);
 
-        handle.invoke(invocation_id, invocation_target).unwrap();
+        handle.invoke(invocation_id, 0, invocation_target).unwrap();
 
         // Make sure invocation inputs are processed in order and produce an output effect.
         check!(let Some(_) = output_rx.recv().await);
@@ -2241,6 +2325,7 @@ mod tests {
             .inner_pin_mut()
             .enqueue(Box::new(InvokeCommand {
                 invocation_id: invocation_id_1,
+                fencing_token: 0,
                 invocation_target: InvocationTarget::mock_virtual_object(),
             }))
             .await;
@@ -2249,6 +2334,7 @@ mod tests {
             .inner_pin_mut()
             .enqueue(Box::new(InvokeCommand {
                 invocation_id: invocation_id_2,
+                fencing_token: 0,
                 invocation_target: InvocationTarget::mock_virtual_object(),
             }))
             .await;
@@ -2330,6 +2416,7 @@ mod tests {
              _| {
                 let _ = invoker_tx.send(InvocationTaskOutput {
                     invocation_id,
+                    fencing_token: 0,
                     inner: InvocationTaskOutputInner::NewEntry {
                         entry_index: 1,
                         entry: RawEntry::new(EnrichedEntryHeader::SetState {}, Bytes::default())
@@ -2353,6 +2440,7 @@ mod tests {
         service_inner.handle_invoke(
             &invoker_options,
             invocation_id,
+            0,
             InvocationTarget::mock_virtual_object(),
             budget,
         );
@@ -2428,6 +2516,7 @@ mod tests {
                 invocation_id.to_string(),
             )),
             ReservedResources::new_empty(),
+            0,
             invocation_target.clone(),
             LimitKey::None,
             None,
@@ -2486,6 +2575,7 @@ mod tests {
         service_inner.handle_invoke(
             &InvokerOptions::default(),
             invocation_id,
+            0,
             InvocationTarget::mock_virtual_object(),
             budget,
         );
@@ -2570,6 +2660,7 @@ mod tests {
         service_inner.handle_invoke(
             &invoker_options,
             invocation_id,
+            0,
             InvocationTarget::mock_virtual_object(),
             budget,
         );
@@ -2595,7 +2686,8 @@ mod tests {
         assert_that!(
             *effects_rx
                 .try_recv()
-                .expect("expected a proposed transient error event"),
+                .expect("expected a proposed transient error event")
+                .effect,
             pat!(Effect {
                 invocation_id: eq(invocation_id),
                 kind: pat!(EffectKind::JournalEvent {
@@ -2640,7 +2732,8 @@ mod tests {
         assert_that!(
             *effects_rx
                 .try_recv()
-                .expect("expected a newly proposed transient error event for different content"),
+                .expect("expected a newly proposed transient error event for different content")
+                .effect,
             pat!(Effect {
                 invocation_id: eq(invocation_id),
                 kind: pat!(EffectKind::JournalEvent {
@@ -2679,6 +2772,7 @@ mod tests {
         service_inner.handle_invoke(
             &invoker_options,
             invocation_id,
+            0,
             InvocationTarget::mock_virtual_object(),
             budget,
         );
@@ -2702,7 +2796,8 @@ mod tests {
         assert_that!(
             *effects_rx
                 .try_recv()
-                .expect("expected a proposed transient error event"),
+                .expect("expected a proposed transient error event")
+                .effect,
             pat!(Effect {
                 invocation_id: eq(invocation_id),
                 kind: pat!(EffectKind::Paused {
@@ -2741,6 +2836,7 @@ mod tests {
         service_inner.handle_invoke(
             &invoker_options,
             invocation_id,
+            FencingToken::default(),
             InvocationTarget::mock_virtual_object(),
             budget,
         );
@@ -2762,12 +2858,14 @@ mod tests {
             .handle_invocation_task_failed(invocation_id, error, service_inner.test_budget())
             .await;
         assert_that!(
-            *effects_rx.try_recv().expect("expected a Failed effect"),
-            pat!(Effect {
-                invocation_id: eq(invocation_id),
-                kind: pat!(EffectKind::Failed(predicate(|e: &InvocationError| e
-                    .code()
-                    == codes::INTERNAL)))
+            effects_rx.try_recv().expect("expected a Failed effect"),
+            pat!(FencedEffect {
+                effect: pat!(Effect {
+                    invocation_id: eq(invocation_id),
+                    kind: pat!(EffectKind::Failed(predicate(|e: &InvocationError| e
+                        .code()
+                        == codes::INTERNAL)))
+                })
             })
         );
     }
@@ -2786,6 +2884,7 @@ mod tests {
         service_inner.handle_invoke(
             &InvokerOptions::default(),
             invocation_id,
+            0,
             InvocationTarget::mock_virtual_object(),
             budget,
         );
@@ -2838,6 +2937,7 @@ mod tests {
         service_inner.handle_invoke(
             &invoker_options,
             invocation_id,
+            0,
             InvocationTarget::mock_virtual_object(),
             budget,
         );
@@ -2863,7 +2963,7 @@ mod tests {
             .try_recv()
             .expect("expected an effect to be emitted after pause");
         assert_that!(
-            *effect,
+            *effect.effect,
             pat!(Effect {
                 invocation_id: eq(invocation_id),
                 kind: pat!(EffectKind::Paused {
@@ -2933,6 +3033,7 @@ mod tests {
         service_inner.handle_invoke(
             &invoker_options,
             invocation_id,
+            0,
             InvocationTarget::mock_virtual_object(),
             budget,
         );
@@ -2972,7 +3073,7 @@ mod tests {
             .try_recv()
             .expect("expected an effect to be emitted after kill");
         assert_that!(
-            *effect,
+            *effect.effect,
             pat!(Effect {
                 invocation_id: eq(invocation_id),
                 kind: pat!(EffectKind::Failed(_))
@@ -3003,6 +3104,7 @@ mod tests {
         service_inner.handle_invoke(
             &invoker_options,
             invocation_id,
+            0,
             InvocationTarget::mock_virtual_object(),
             budget,
         );
@@ -3027,7 +3129,7 @@ mod tests {
             .try_recv()
             .expect("expected Paused effect to be emitted");
         assert_that!(
-            *effect,
+            *effect.effect,
             pat!(Effect {
                 invocation_id: eq(invocation_id),
                 kind: pat!(EffectKind::Paused {
@@ -3066,6 +3168,7 @@ mod tests {
         service_inner.handle_invoke(
             &invoker_options,
             invocation_id,
+            0,
             InvocationTarget::mock_virtual_object(),
             budget,
         );
@@ -3093,7 +3196,7 @@ mod tests {
             .try_recv()
             .expect("expected Paused effect to be emitted");
         assert_that!(
-            *effect,
+            *effect.effect,
             pat!(Effect {
                 invocation_id: eq(invocation_id),
                 kind: pat!(EffectKind::Paused {
@@ -3126,6 +3229,7 @@ mod tests {
         service_inner.handle_invoke(
             &invoker_options,
             invocation_id,
+            0,
             InvocationTarget::mock_virtual_object(),
             budget,
         );
@@ -3151,7 +3255,7 @@ mod tests {
             .try_recv()
             .expect("expected Paused effect to be emitted");
         assert_that!(
-            *effect,
+            *effect.effect,
             pat!(Effect {
                 invocation_id: eq(invocation_id),
                 kind: pat!(EffectKind::Paused {
@@ -3188,6 +3292,7 @@ mod tests {
         service_inner.handle_invoke(
             &invoker_options,
             invocation_id,
+            0,
             InvocationTarget::mock_virtual_object(),
             budget,
         );
@@ -3211,7 +3316,7 @@ mod tests {
             .try_recv()
             .expect("expected Paused effect to be emitted");
         assert_that!(
-            *effect,
+            *effect.effect,
             pat!(Effect {
                 invocation_id: eq(invocation_id),
                 kind: pat!(EffectKind::Paused {
@@ -3253,6 +3358,7 @@ mod tests {
         service_inner.handle_invoke(
             &invoker_options,
             invocation_id,
+            0,
             InvocationTarget::mock_virtual_object(),
             budget,
         );
@@ -3279,7 +3385,7 @@ mod tests {
             .try_recv()
             .expect("expected a transient error event");
         assert_that!(
-            *effect,
+            *effect.effect,
             pat!(Effect {
                 invocation_id: eq(invocation_id),
                 kind: pat!(EffectKind::JournalEvent {
@@ -3322,6 +3428,7 @@ mod tests {
         service_inner.handle_invoke(
             &invoker_options,
             invocation_id,
+            0,
             InvocationTarget::mock_virtual_object(),
             budget,
         );
@@ -3344,7 +3451,7 @@ mod tests {
             .try_recv()
             .expect("expected Yield effect to be emitted");
         assert_that!(
-            *effect,
+            *effect.effect,
             pat!(Effect {
                 invocation_id: eq(invocation_id),
                 kind: pat!(EffectKind::Yield {

--- a/crates/invoker-impl/src/state_machine_manager.rs
+++ b/crates/invoker-impl/src/state_machine_manager.rs
@@ -14,14 +14,14 @@ use tracing::trace;
 use restate_platform::hash::HashMap;
 use restate_types::identifiers::InvocationId;
 use restate_types::sharding::KeyRange;
-use restate_worker_api::invoker::{Effect, invocation_reader::InvocationReader};
+use restate_worker_api::invoker::{FencedEffect, invocation_reader::InvocationReader};
 
 use crate::InvocationStateMachine;
 
 /// Tree of [InvocationStateMachine] held by the [Service].
 #[derive(Debug)]
 pub(super) struct InvocationStateMachineManager<SR> {
-    output_tx: mpsc::Sender<Box<Effect>>,
+    output_tx: mpsc::Sender<FencedEffect>,
     invocation_state_machines: HashMap<InvocationId, InvocationStateMachine>,
     _partition_key_range: KeyRange,
     storage_reader: SR,
@@ -35,7 +35,7 @@ where
     pub(super) fn new(
         partition_key_range: KeyRange,
         storage_reader: SR,
-        sender: mpsc::Sender<Box<Effect>>,
+        sender: mpsc::Sender<FencedEffect>,
     ) -> Self {
         Self {
             output_tx: sender,
@@ -51,7 +51,7 @@ where
     }
 
     #[inline]
-    pub(super) fn partition_sender(&self) -> &mpsc::Sender<Box<Effect>> {
+    pub(super) fn partition_sender(&self) -> &mpsc::Sender<FencedEffect> {
         &self.output_tx
     }
 
@@ -59,17 +59,35 @@ where
     pub(super) fn resolve_invocation(
         &mut self,
         invocation_id: &InvocationId,
-    ) -> Option<(&mpsc::Sender<Box<Effect>>, &mut InvocationStateMachine)> {
+    ) -> Option<(&mpsc::Sender<FencedEffect>, &mut InvocationStateMachine)> {
         self.invocation_state_machines
             .get_mut(invocation_id)
             .map(|ism| (&self.output_tx, ism))
+    }
+
+    /// Returns `true` if the in-flight state machine for `invocation_id` exists
+    /// but represents a *different* (newer) attempt than `fencing_token`.
+    ///
+    /// This fences output from an aborted task that is still draining out of the
+    /// task→invoker channel after the invocation has already been restarted: such
+    /// output must neither mutate the new attempt's state machine nor be emitted
+    /// as an effect stamped with the new attempt's epoch.
+    #[inline]
+    pub(super) fn is_stale_fencing_token(
+        &self,
+        invocation_id: &InvocationId,
+        fencing_token: restate_types::invocation::FencingToken,
+    ) -> bool {
+        self.invocation_state_machines
+            .get(invocation_id)
+            .is_some_and(|ism| ism.fencing_token != fencing_token)
     }
 
     #[inline]
     pub(super) fn handle_for_invocation<R>(
         &mut self,
         invocation_id: &InvocationId,
-        f: impl FnOnce(&mpsc::Sender<Box<Effect>>, &mut InvocationStateMachine) -> R,
+        f: impl FnOnce(&mpsc::Sender<FencedEffect>, &mut InvocationStateMachine) -> R,
     ) -> Option<R> {
         if let Some((tx, ism)) = self.resolve_invocation(invocation_id) {
             Some(f(tx, ism))
@@ -83,7 +101,7 @@ where
     pub(super) fn remove_invocation(
         &mut self,
         invocation_id: &InvocationId,
-    ) -> Option<(&mpsc::Sender<Box<Effect>>, &SR, InvocationStateMachine)> {
+    ) -> Option<(&mpsc::Sender<FencedEffect>, &SR, InvocationStateMachine)> {
         self.invocation_state_machines
             .remove(invocation_id)
             .map(|ism| (&self.output_tx, &self.storage_reader, ism))

--- a/crates/invoker-impl/src/test_util.rs
+++ b/crates/invoker-impl/src/test_util.rs
@@ -17,7 +17,7 @@ use restate_memory::{IgnorePinnableMemoryStream, LocalMemoryLease, LocalMemoryPo
 use restate_types::LimitKey;
 use restate_types::errors::InvocationError;
 use restate_types::identifiers::{EntryIndex, InvocationId, InvocationUuid, ServiceId};
-use restate_types::invocation::{InvocationTarget, ServiceInvocationSpanContext};
+use restate_types::invocation::{FencingToken, InvocationTarget, ServiceInvocationSpanContext};
 use restate_types::journal::enriched::{
     AwakeableEnrichmentResult, CallEnrichmentResult, EnrichedEntryHeader, EnrichedRawEntry,
 };
@@ -133,6 +133,7 @@ impl InvokerHandle for MockInvokerHandle {
     fn invoke(
         &mut self,
         _invocation_id: InvocationId,
+        _fencing_token: FencingToken,
         _invocation_target: InvocationTarget,
     ) -> Result<(), NotRunningError> {
         Ok(())
@@ -143,6 +144,7 @@ impl InvokerHandle for MockInvokerHandle {
         _qid: VQueueId,
         _permit: ReservedResources,
         _invocation_id: InvocationId,
+        _fencing_token: FencingToken,
         _invocation_target: InvocationTarget,
         _limit_key: LimitKey<ReString>,
         _idempotency_key: Option<ReString>,

--- a/crates/types/src/invocation/mod.rs
+++ b/crates/types/src/invocation/mod.rs
@@ -1487,8 +1487,15 @@ impl WithInvocationId for NotifySignalRequest {
     }
 }
 
-/// The invocation epoch represents the restarts count of the invocation, as seen from the Partition processor.
-pub type InvocationEpoch = u32;
+/// Identifies an invoker-task generation, used to fence stale invoker effects.
+///
+/// This is a leader-local, in-memory value: the partition processor's leader keeps a
+/// `fencing_tokens` map, hands the current token to the invoker on (re)invoke, and the invoker
+/// echoes it on every effect. The leader drops effects whose token no longer matches *before*
+/// self-proposing them. It is intentionally **not** persisted and not written to Bifrost -- it is
+/// not part of the invocation lifecycle. Wraps around (a stale straggler never survives 2^32
+/// intervening invokes).
+pub type FencingToken = u32;
 
 mod serde_hacks {
     //! Module where we hide all the hacks to make back-compat working!

--- a/crates/wal-protocol/src/invocation.rs
+++ b/crates/wal-protocol/src/invocation.rs
@@ -1,0 +1,47 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use bytes::{Buf, BufMut, Bytes};
+
+use restate_types::bilrost_storage_encode_decode;
+use restate_types::identifiers::{InvocationId, PartitionProcessorRpcRequestId};
+
+/// Pause an invocation, proposed to the log from the pause RPC.
+///
+/// Bilrost-encoded so the v2 WAL command payload is already on the target encoding (the v1
+/// envelope carries it as opaque bytes; see [`crate::v1::Command::PauseInvocation`]).
+#[derive(Debug, Clone, bilrost::Message)]
+pub struct PauseInvocationCommand {
+    #[bilrost(tag(1))]
+    pub invocation_id: InvocationId,
+    /// The ingress RPC request awaiting the pause response if required.
+    #[bilrost(tag(2))]
+    pub request_id: Option<PartitionProcessorRpcRequestId>,
+}
+
+bilrost_storage_encode_decode!(PauseInvocationCommand);
+
+impl PauseInvocationCommand {
+    pub fn bilrost_encode<B: BufMut>(&self, b: &mut B) -> Result<(), bilrost::EncodeError> {
+        bilrost::Message::encode(self, b)
+    }
+
+    pub fn encoded_len(&self) -> usize {
+        bilrost::Message::encoded_len(self)
+    }
+
+    pub fn bilrost_encode_to_bytes(&self) -> Bytes {
+        bilrost::Message::encode_to_bytes(self)
+    }
+
+    pub fn bilrost_decode<B: Buf>(buf: B) -> Result<Self, bilrost::DecodeError> {
+        bilrost::OwnedMessage::decode(buf)
+    }
+}

--- a/crates/wal-protocol/src/lib.rs
+++ b/crates/wal-protocol/src/lib.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 pub mod control;
+pub mod invocation;
 pub mod timer;
 pub mod v1;
 pub mod v2;

--- a/crates/wal-protocol/src/v1.rs
+++ b/crates/wal-protocol/src/v1.rs
@@ -165,6 +165,11 @@ pub enum Command {
     AttachInvocation(AttachInvocationRequest),
     /// Resume an invocation
     ResumeInvocation(ResumeInvocationRequest),
+    /// Pause an invocation
+    /// payload is bilrost encoded [`invocation::PauseInvocationCommand`]
+    ///
+    /// Introduced in v1.7.0 to support pausing invocations regardless of invoker ISM presence.
+    PauseInvocation(#[debug(skip)] Bytes),
     /// Restart as new invocation from prefix
     RestartAsNewInvocation(RestartAsNewInvocationRequest),
 
@@ -252,6 +257,7 @@ impl HasRecordKeys for Envelope {
             Command::ProxyThrough(_) => Keys::Single(self.partition_key()),
             Command::AttachInvocation(_) => Keys::Single(self.partition_key()),
             Command::ResumeInvocation(req) => Keys::Single(req.invocation_id.partition_key()),
+            Command::PauseInvocation(_) => Keys::Single(self.partition_key()),
             Command::RestartAsNewInvocation(req) => Keys::Single(req.invocation_id.partition_key()),
             // todo: Handle journal entries that request cross-partition invocations
             Command::InvokerEffect(effect) => Keys::Single(effect.invocation_id.partition_key()),

--- a/crates/wal-protocol/src/v2.rs
+++ b/crates/wal-protocol/src/v2.rs
@@ -309,6 +309,11 @@ pub enum CommandKind {
     /// payload is bilrost encoded [`vqueues::VQueuesResume`]
     /// *Since v1.7.0
     VQueuesResume = 24,
+
+    /// Pause an invocation (manual pause RPC).
+    /// payload is bilrost encoded [`invocation::PauseInvocationCommand`]
+    /// *Since v1.7.0
+    PauseInvocation = 25,
 }
 
 mod bilrost_encoding {

--- a/crates/wal-protocol/src/v2/commands.rs
+++ b/crates/wal-protocol/src/v2/commands.rs
@@ -25,6 +25,7 @@ use super::{Command, CommandKind};
 pub use crate::control::UpsertRuleBookCommand;
 use crate::timer;
 // Re-epxort vqueues commands
+pub use crate::invocation::PauseInvocationCommand;
 pub use crate::vqueues::{VQueuesPauseCommand, VQueuesResumeCommand};
 
 pub use crate::control::{
@@ -406,6 +407,11 @@ command! {
 command! {
     @kind=CommandKind::ResumeInvocation,
     @command=ResumeInvocationCommand
+}
+
+command! {
+    @kind=CommandKind::PauseInvocation,
+    @command=PauseInvocationCommand
 }
 
 command! {

--- a/crates/wal-protocol/src/v2/compatibility.rs
+++ b/crates/wal-protocol/src/v2/compatibility.rs
@@ -106,6 +106,12 @@ impl TryFrom<v1::Envelope> for v2::Envelope<Raw> {
             v1::Command::ResumeInvocation(payload) => {
                 Envelope::new(dedup, commands::ResumeInvocationCommand::from(payload)).into_raw()
             }
+            v1::Command::PauseInvocation(payload) => Envelope::from_bytes_unchecked(
+                v2::CommandKind::PauseInvocation,
+                StorageCodecKind::Bilrost,
+                dedup,
+                payload,
+            ),
             v1::Command::ScheduleTimer(payload) => {
                 Envelope::new(dedup, commands::ScheduleTimerCommand::from(payload)).into_raw()
             }

--- a/crates/worker-api/src/invoker/effects.rs
+++ b/crates/worker-api/src/invoker/effects.rs
@@ -15,6 +15,7 @@ use restate_storage_api::vqueue_table::scheduler::YieldReason;
 use restate_types::deployment::PinnedDeployment;
 use restate_types::errors::InvocationError;
 use restate_types::identifiers::InvocationId;
+use restate_types::invocation::FencingToken;
 use restate_types::journal::EntryIndex;
 use restate_types::journal::enriched::EnrichedRawEntry;
 use restate_types::journal_events::raw::RawEvent;
@@ -27,13 +28,19 @@ use restate_types::storage::StoredRawEntry;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Effect {
     pub invocation_id: InvocationId,
-    // removed in v1.6
-    // #[cfg_attr(
-    //     feature = "serde",
-    //     serde(default, skip_serializing_if = "num_traits::Zero::is_zero")
-    // )]
-    // pub invocation_epoch: InvocationEpoch,
     pub kind: EffectKind,
+}
+
+/// An [`Effect`] tagged with the fencing token of the invoker-task generation that produced it.
+///
+/// The fencing token is a leader-local, in-memory fence: the partition processor checks it
+/// against its in-memory `fencing_tokens` map *before self-proposing* the wrapped effect, then
+/// strips it. Only the inner [`Effect`] is ever written to Bifrost, so the token never reaches
+/// the log -- it is deliberately kept out of the invocation lifecycle / storage format.
+#[derive(Debug)]
+pub struct FencedEffect {
+    pub fencing_token: FencingToken,
+    pub effect: Box<Effect>,
 }
 
 #[derive(Debug, Clone)]
@@ -106,6 +113,28 @@ impl EffectKind {
         Self::JournalEntryV2RawEntry {
             command_index_to_ack,
             raw_entry: raw_entry.into(),
+        }
+    }
+
+    /// Returns `true` if this effect ends the current invoker-task generation, i.e. after emitting
+    /// it the task will not produce any further effects for this attempt (it suspended, paused,
+    /// yielded, completed, or failed). The partition processor uses this to release the attempt's
+    /// fencing token. Non-terminal effects (deployment pin, journal entries/events) keep the
+    /// attempt running.
+    pub fn is_terminal(&self) -> bool {
+        match self {
+            Self::Suspended { .. }
+            | Self::SuspendedV2 { .. }
+            | Self::SuspendedV3 { .. }
+            | Self::Paused { .. }
+            | Self::Yield { .. }
+            | Self::End
+            | Self::Failed(_) => true,
+            Self::PinnedDeployment(_)
+            | Self::JournalEntry { .. }
+            | Self::JournalEntryV2 { .. }
+            | Self::JournalEvent { .. }
+            | Self::JournalEntryV2RawEntry { .. } => false,
         }
     }
 }

--- a/crates/worker-api/src/invoker/handle.rs
+++ b/crates/worker-api/src/invoker/handle.rs
@@ -12,7 +12,7 @@ use crate::resources::ReservedResources;
 use restate_errors::NotRunningError;
 use restate_types::LimitKey;
 use restate_types::identifiers::{EntryIndex, InvocationId};
-use restate_types::invocation::InvocationTarget;
+use restate_types::invocation::{FencingToken, InvocationTarget};
 use restate_types::journal_v2::{CommandIndex, NotificationId};
 use restate_types::vqueues::VQueueId;
 use restate_util_string::ReString;
@@ -21,19 +21,24 @@ pub trait InvokerHandle {
     fn invoke(
         &mut self,
         invocation_id: InvocationId,
+        fencing_token: FencingToken,
         invocation_target: InvocationTarget,
     ) -> Result<(), NotRunningError>;
 
+    #[allow(clippy::too_many_arguments)]
     fn vqueue_invoke(
         &mut self,
         qid: VQueueId,
         permit: ReservedResources,
         invocation_id: InvocationId,
+        fencing_token: FencingToken,
         invocation_target: InvocationTarget,
         limit_key: LimitKey<ReString>,
         idempotency_key: Option<ReString>,
     ) -> Result<(), NotRunningError>;
 
+    // The `notify_*` forwards below don't carry a `fencing_token` as the invoke calls establish
+    // the current fencing token which is used to stamp all outgoing invoker effects.
     fn notify_completion(
         &mut self,
         invocation_id: InvocationId,
@@ -59,6 +64,10 @@ pub trait InvokerHandle {
 
     fn abort_all(&mut self) -> Result<(), NotRunningError>;
 
-    /// *Note*: When aborting an invocation, and restarting it, the `invocation_epoch` MUST be bumped.
+    /// Aborts the running task for `invocation_id`.
+    ///
+    /// Stale effects from a previous attempt are fenced at write time by the leader's in-memory
+    /// fencing-token map: it is used to terminate an invocation, pause it, or clean up an orphaned
+    /// task.
     fn abort_invocation(&mut self, invocation_id: InvocationId) -> Result<(), NotRunningError>;
 }

--- a/crates/worker/src/partition/leadership/leader_state.rs
+++ b/crates/worker/src/partition/leadership/leader_state.rs
@@ -769,6 +769,16 @@ impl LeaderState {
                     )));
                 }
             }
+            Action::ForwardPauseInvocationResponse {
+                request_id,
+                response,
+            } => {
+                if let Some(response_tx) = self.awaiting_rpc_actions.remove(&request_id) {
+                    response_tx.send(Ok(PartitionProcessorRpcResponse::PauseInvocation(
+                        response.into(),
+                    )));
+                }
+            }
             Action::ForwardRestartAsNewInvocationResponse {
                 request_id,
                 response,

--- a/crates/worker/src/partition/leadership/leader_state.rs
+++ b/crates/worker/src/partition/leadership/leader_state.rs
@@ -545,6 +545,53 @@ impl LeaderState {
         }
     }
 
+    /// Like [`Self::handle_rpc_proposal_command`], but for the PauseInvocation command: after the
+    /// pause command is appended it clears `invocation_id`'s in-memory fencing token so a
+    /// straggler effect from the attempt being paused is dropped at write time.
+    ///
+    /// BRITTLE: the `fencing_tokens.remove` is a pre-apply, in-memory state mutation, and it must
+    /// run **only on the `Ok` arm, strictly after the append succeeds**. A failed `self_propose`
+    /// only replies an error -- the leader keeps running, it does not step down -- so clearing
+    /// before the append (or on failure) would strand the invocation: its effects would be
+    /// dropped at write time with no pause in the committed log. After a successful append the
+    /// pause's LSN is fixed, and because the leader self-proposes from a single task, every later
+    /// invoker-effect self-propose observes the cleared map and is fenced.
+    pub async fn propose_pause_and_fence(
+        &mut self,
+        request_id: PartitionProcessorRpcRequestId,
+        reciprocal: Reciprocal<
+            Oneshot<Result<PartitionProcessorRpcResponse, PartitionProcessorRpcError>>,
+        >,
+        invocation_id: InvocationId,
+        cmd: Command,
+    ) {
+        match self.awaiting_rpc_actions.entry(request_id) {
+            Entry::Occupied(mut o) => {
+                // Retry of an already-proposed pause: replace the reciprocal and fail the old one.
+                // The original successful propose already cleared the token; don't disturb a newer
+                // attempt's token from here.
+                let old_reciprocal = o.insert(reciprocal);
+                trace!(%request_id, "Replacing rpc with newer request");
+                old_reciprocal.send(Err(PartitionProcessorRpcError::Internal(
+                    "retried".to_string(),
+                )));
+            }
+            Entry::Vacant(v) => {
+                if let Err(e) = self
+                    .self_proposer
+                    .self_propose(invocation_id.partition_key(), cmd)
+                    .await
+                {
+                    reciprocal.send(Err(PartitionProcessorRpcError::Internal(e.to_string())));
+                } else {
+                    v.insert(reciprocal);
+                    // Clear ONLY here -- after the append succeeded. See the method doc.
+                    self.fencing_tokens.remove(&invocation_id);
+                }
+            }
+        }
+    }
+
     /// Append a command to Bifrost **without** dedup information and respond on Bifrost commit.
     ///
     /// Records appended this way are never filtered by the dedup mechanism during leadership

--- a/crates/worker/src/partition/leadership/leader_state.rs
+++ b/crates/worker/src/partition/leadership/leader_state.rs
@@ -33,10 +33,11 @@ use restate_limiter::RuleBook;
 use restate_partition_store::PartitionDb;
 use restate_storage_api::vqueue_table::scheduler::SchedulerDecisionsCommand;
 use restate_types::identifiers::{
-    LeaderEpoch, PartitionId, PartitionKey, PartitionProcessorRpcRequestId, WithPartitionKey,
+    InvocationId, LeaderEpoch, PartitionId, PartitionKey, PartitionProcessorRpcRequestId,
+    WithPartitionKey,
 };
-use restate_types::invocation::PurgeInvocationRequest;
 use restate_types::invocation::client::{InvocationOutput, SubmittedInvocationNotification};
+use restate_types::invocation::{FencingToken, PurgeInvocationRequest};
 use restate_types::logs::Keys;
 use restate_types::net::ingest::IngestRecord;
 use restate_types::net::partition_processor::{
@@ -90,6 +91,17 @@ pub struct LeaderState {
     awaiting_rpc_actions: HashMap<PartitionProcessorRpcRequestId, RpcReciprocal>,
     awaiting_rpc_self_propose: FuturesUnordered<SelfAppendFuture>,
 
+    /// Leader-local fencing tokens for in-flight invoker attempts (see [`FencingToken`]).
+    ///
+    /// Maps an in-flight invocation to the token handed to its current invoker task. Invoker
+    /// effects whose token does not match (or is absent) are dropped *before* being self-proposed,
+    /// fencing stragglers from a previous attempt. Entries are added on (re)invoke, removed when
+    /// the attempt ends (abort / terminal effect) or is fenced (pause / scheduler re-drive
+    /// propose), and the whole map is discarded on leadership loss (rebuilt on the next term).
+    fencing_tokens: restate_platform::hash::HashMap<InvocationId, FencingToken>,
+    /// Monotonic source of fresh fencing tokens; wraps (see [`FencingToken`]).
+    next_fencing_token: FencingToken,
+
     invoker_stream: InvokerStream,
     shuffle_stream: ReceiverStream<shuffle::OutboxTruncation>,
     schema_stream: WatchStream<Version>,
@@ -118,6 +130,10 @@ impl LeaderState {
         invoker_task_handle: TaskHandle<()>,
         self_proposer: SelfProposer,
         invoker_rx: InvokerStream,
+        // Fencing tokens seeded for the invocations resumed on becoming leader, and the next
+        // token to mint. See `fencing_tokens` / `mint_fencing_token`.
+        fencing_tokens: restate_platform::hash::HashMap<InvocationId, FencingToken>,
+        next_fencing_token: FencingToken,
         shuffle_rx: tokio::sync::mpsc::Receiver<shuffle::OutboxTruncation>,
         durability_tracker: DurabilityTracker,
         leader_query_guard: LeaderQueryGuard,
@@ -142,6 +158,8 @@ impl LeaderState {
             self_proposer,
             awaiting_rpc_actions: Default::default(),
             awaiting_rpc_self_propose: Default::default(),
+            fencing_tokens,
+            next_fencing_token,
             invoker_stream: invoker_rx,
             shuffle_stream: ReceiverStream::new(shuffle_rx),
             durability_tracker,
@@ -392,13 +410,31 @@ impl LeaderState {
                         )
                         .await?;
                 }
-                ActionEffect::Invoker(invoker_effect) => {
-                    self.self_proposer
-                        .self_propose(
-                            invoker_effect.invocation_id.partition_key(),
-                            Command::InvokerEffect(invoker_effect),
-                        )
-                        .await?;
+                ActionEffect::Invoker(fenced) => {
+                    let invocation_id = fenced.effect.invocation_id;
+                    // Fence stale effects at write time: only self-propose if the effect carries
+                    // the token of the invocation's *current* attempt. A mismatch (or a missing
+                    // entry) means the effect is a straggler from a previous attempt that has
+                    // since been re-invoked / paused / aborted, so it must not be written -- this
+                    // is what stops it from being applied to a newer attempt.
+                    if self.fencing_tokens.get(&invocation_id) == Some(&fenced.fencing_token) {
+                        // A terminal effect ends this attempt: stop accepting its token (GC). A
+                        // later re-invoke mints a fresh one.
+                        if fenced.effect.kind.is_terminal() {
+                            self.fencing_tokens.remove(&invocation_id);
+                        }
+                        self.self_proposer
+                            .self_propose(
+                                invocation_id.partition_key(),
+                                Command::InvokerEffect(fenced.effect),
+                            )
+                            .await?;
+                    } else {
+                        debug!(
+                            restate.invocation.id = %invocation_id,
+                            "Dropping stale invoker effect at write time (fencing token mismatch)"
+                        );
+                    }
                 }
                 ActionEffect::Shuffle(outbox_truncation) => {
                     // todo: Until we support partition splits we need to get rid of outboxes or introduce partition
@@ -582,15 +618,27 @@ impl LeaderState {
         Ok(())
     }
 
+    /// Mints a fresh fencing token for a (re)invoke and records it as the accepted token for
+    /// `invocation_id`, overwriting any previous one. Once recorded, straggler effects from the
+    /// previous attempt (carrying the old token) are dropped by [`Self::fence_invoker_effect`].
+    fn mint_fencing_token(&mut self, invocation_id: InvocationId) -> FencingToken {
+        let token = self.next_fencing_token;
+        self.next_fencing_token = self.next_fencing_token.wrapping_add(1);
+        self.fencing_tokens.insert(invocation_id, token);
+        token
+    }
+
     fn handle_action(&mut self, metas: VQueuesMeta<'_>, action: Action) -> Result<(), Error> {
         match action {
             Action::Invoke {
                 invocation_id,
                 invocation_target,
-            } => self
-                .invoker_handle
-                .invoke(invocation_id, invocation_target)
-                .map_err(Error::Invoker)?,
+            } => {
+                let fencing_token = self.mint_fencing_token(invocation_id);
+                self.invoker_handle
+                    .invoke(invocation_id, fencing_token, invocation_target)
+                    .map_err(Error::Invoker)?;
+            }
             Action::NewOutboxMessage {
                 seq_number,
                 message,
@@ -618,10 +666,14 @@ impl LeaderState {
                 .invoker_handle
                 .notify_completion(invocation_id, entry_index)
                 .map_err(Error::Invoker)?,
-            Action::AbortInvocation { invocation_id } => self
-                .invoker_handle
-                .abort_invocation(invocation_id)
-                .map_err(Error::Invoker)?,
+            Action::AbortInvocation { invocation_id } => {
+                // The attempt is ending; drop its fencing token so any straggler effect is dropped
+                // at write time (a later re-invoke mints a fresh token).
+                self.fencing_tokens.remove(&invocation_id);
+                self.invoker_handle
+                    .abort_invocation(invocation_id)
+                    .map_err(Error::Invoker)?;
+            }
             Action::IngressResponse {
                 request_id,
                 invocation_id,
@@ -752,11 +804,13 @@ impl LeaderState {
                     );
                     ReservedResources::new_empty()
                 });
+                let fencing_token = self.mint_fencing_token(invocation_id);
                 self.invoker_handle
                     .vqueue_invoke(
                         slot.vqueue_id().clone(),
                         run_permit,
                         invocation_id,
+                        fencing_token,
                         invocation_target,
                         slot.meta().limit_key().clone(),
                         idempotency_key,

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -827,6 +827,30 @@ impl<T> LeadershipState<T> {
         }
     }
 
+    pub async fn propose_pause_and_fence(
+        &mut self,
+        request_id: PartitionProcessorRpcRequestId,
+        reciprocal: Reciprocal<
+            Oneshot<Result<PartitionProcessorRpcResponse, PartitionProcessorRpcError>>,
+        >,
+        invocation_id: InvocationId,
+        cmd: Command,
+    ) {
+        match &mut self.state {
+            State::Follower | State::Candidate { .. } => {
+                // Just fail the rpc
+                reciprocal.send(Err(PartitionProcessorRpcError::NotLeader(
+                    self.partition.partition_id,
+                )))
+            }
+            State::Leader(leader_state) => {
+                leader_state
+                    .propose_pause_and_fence(request_id, reciprocal, invocation_id, cmd)
+                    .await;
+            }
+        }
+    }
+
     /// Append a command to Bifrost without dedup information, responding on Bifrost commit.
     pub async fn append_and_respond_asynchronously(
         &mut self,

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -35,6 +35,7 @@ use restate_invoker_impl::{
 };
 use restate_limiter::RuleBook;
 use restate_partition_store::PartitionStore;
+use restate_platform::hash::HashMap;
 use restate_service_protocol::codec::ProtobufRawEntryCodec;
 use restate_storage_api::StorageError;
 use restate_storage_api::deduplication_table::EpochSequenceNumber;
@@ -48,8 +49,9 @@ use restate_timer::TokioClock;
 use restate_types::cluster::cluster_state::RunMode;
 use restate_types::config::Configuration;
 use restate_types::errors::GenericError;
-use restate_types::identifiers::{LeaderEpoch, PartitionId};
+use restate_types::identifiers::{InvocationId, LeaderEpoch, PartitionId};
 use restate_types::identifiers::{PartitionKey, PartitionProcessorRpcRequestId};
+use restate_types::invocation::FencingToken;
 use restate_types::live::LiveLoadExt;
 use restate_types::logs::Keys;
 use restate_types::message::MessageIndex;
@@ -70,8 +72,8 @@ use restate_wal_protocol::control::{
 };
 use restate_wal_protocol::timer::TimerKeyValue;
 use restate_wal_protocol::{Command, Envelope};
+use restate_worker_api::invoker::InvokerHandle;
 use restate_worker_api::invoker::capacity::InvokerCapacity;
-use restate_worker_api::invoker::{Effect, InvokerHandle};
 use restate_worker_api::{
     LeaderQueryCommand, LeaderQueryRequest, LeaderQueryResponse, LeaderQuerySender,
 };
@@ -146,7 +148,7 @@ pub(crate) enum TaskTermination {
 #[derive(Debug)]
 pub(crate) enum ActionEffect {
     Scheduler(scheduler::Decisions),
-    Invoker(Box<Effect>),
+    Invoker(InvokerEffect),
     Shuffle(shuffle::OutboxTruncation),
     Timer(TimerKeyValue),
     Cleaner(cleaner::CleanerEffect),
@@ -494,7 +496,8 @@ where
                 scheduler_service.on_rules_updated(initial_diff);
             }
 
-            Self::resume_invoked_invocations(&mut invoker_handle, partition_store).await?;
+            let (fencing_tokens, next_fencing_token) =
+                Self::resume_invoked_invocations(&mut invoker_handle, partition_store).await?;
 
             let timer_service = TimerService::new(
                 TokioClock,
@@ -634,6 +637,8 @@ where
                 invoker_task_guard.into_handle(),
                 self_proposer,
                 invoker_rx,
+                fencing_tokens,
+                next_fencing_token,
                 shuffle_rx,
                 durability_tracker,
                 leader_query_guard,
@@ -649,7 +654,7 @@ where
     async fn resume_invoked_invocations(
         invoker_handle: &mut InvokerChannelServiceHandle,
         partition_store: &mut PartitionStore,
-    ) -> Result<(), Error> {
+    ) -> Result<(HashMap<InvocationId, FencingToken>, FencingToken), Error> {
         // todo(asoli): If we are asked to migrate to vqueues (or vqueues are enabled).
         // we must migrate all invoked invocations here (through a wal command).
         // (blocker to v1.7.0)
@@ -661,24 +666,32 @@ where
         );
 
         let start = tokio::time::Instant::now();
-        let mut count = 0;
+        // Seed a fresh fencing token per resumed invocation so the leader accepts its effects and
+        // can later fence stragglers from a re-invoke. On a fresh term there are no in-flight
+        // stragglers yet, so the starting tokens only need to be distinct from the ones
+        // `LeaderState::mint_fencing_token` will mint later, which continues from
+        // `next_fencing_token`.
+        let mut fencing_tokens = HashMap::default();
+        let mut next_fencing_token: FencingToken = 0;
         while let Some(invoked_invocation) = invoked_invocations.next().await {
             let InvokedInvocationStatusLite {
                 invocation_id,
                 invocation_target,
             } = invoked_invocation?;
+            let fencing_token = next_fencing_token;
+            next_fencing_token = next_fencing_token.wrapping_add(1);
+            fencing_tokens.insert(invocation_id, fencing_token);
             invoker_handle
-                .invoke(invocation_id, invocation_target)
+                .invoke(invocation_id, fencing_token, invocation_target)
                 .map_err(Error::Invoker)?;
-            count += 1;
         }
         debug!(
             "Leader partition resumed {} invocations in {:?}",
-            count,
+            fencing_tokens.len(),
             start.elapsed(),
         );
 
-        Ok(())
+        Ok((fencing_tokens, next_fencing_token))
     }
 
     async fn become_follower(&mut self) {

--- a/crates/worker/src/partition/rpc/mod.rs
+++ b/crates/worker/src/partition/rpc/mod.rs
@@ -51,6 +51,17 @@ pub(super) trait Actuator {
         replier: Replier<O>,
     ) -> impl Future<Output = ()>;
 
+    /// Like [`Self::handle_rpc_proposal_command`], but for the PauseInvocation command: once the
+    /// command is appended, it clears `invocation_id`'s in-memory fencing token so a straggler
+    /// effect from the attempt being paused is dropped at write time.
+    fn propose_pause_and_fence<O: 'static>(
+        &mut self,
+        invocation_id: InvocationId,
+        cmd: Command,
+        request_id: PartitionProcessorRpcRequestId,
+        replier: Replier<O>,
+    ) -> impl Future<Output = ()>;
+
     /// Appends a command to Bifrost **without** dedup information, responding on Bifrost commit.
     ///
     /// Records appended this way are never filtered by the dedup mechanism during leadership
@@ -111,6 +122,17 @@ where
             cmd,
         )
         .await
+    }
+
+    async fn propose_pause_and_fence<O>(
+        &mut self,
+        invocation_id: InvocationId,
+        cmd: Command,
+        request_id: PartitionProcessorRpcRequestId,
+        replier: Replier<O>,
+    ) {
+        LeadershipState::propose_pause_and_fence(self, request_id, replier.0, invocation_id, cmd)
+            .await
     }
 
     fn notify_invoker_to_retry_now(&mut self, invocation_id: InvocationId) {
@@ -332,8 +354,14 @@ where
                 .await
             }
             PartitionProcessorRpcRequestInner::PauseInvocation { invocation_id } => {
-                self.handle(pause_invocation::Request { invocation_id }, replier.map())
-                    .await
+                self.handle(
+                    pause_invocation::PauseRequest {
+                        request_id,
+                        invocation_id,
+                    },
+                    replier.map(),
+                )
+                .await
             }
         }
     }

--- a/crates/worker/src/partition/rpc/pause_invocation.rs
+++ b/crates/worker/src/partition/rpc/pause_invocation.rs
@@ -12,12 +12,14 @@ use super::*;
 use restate_storage_api::invocation_status_table::InvocationStatus;
 use restate_types::identifiers::InvocationId;
 use restate_types::net::partition_processor::PauseInvocationRpcResponse;
+use restate_wal_protocol::invocation::PauseInvocationCommand;
 
-pub(super) struct Request {
+pub(super) struct PauseRequest {
+    pub(super) request_id: PartitionProcessorRpcRequestId,
     pub(super) invocation_id: InvocationId,
 }
 
-impl<'a, TActuator: Actuator, TSchemas, TStorage> RpcHandler<Request>
+impl<'a, TActuator: Actuator, TSchemas, TStorage> RpcHandler<PauseRequest>
     for RpcContext<'a, TActuator, TSchemas, TStorage>
 where
     TStorage: ReadInvocationStatusTable,
@@ -27,7 +29,10 @@ where
 
     async fn handle(
         self,
-        Request { invocation_id }: Request,
+        PauseRequest {
+            request_id,
+            invocation_id,
+        }: PauseRequest,
         replier: Replier<Self::Output>,
     ) -> Result<(), Self::Error> {
         // Reading from a non-leader partition processor can return stale results
@@ -40,30 +45,64 @@ where
             return Ok(());
         }
 
-        // -- Figure out the invocation status
-        match self.storage.get_invocation_status(&invocation_id).await {
-            Ok(InvocationStatus::Invoked(_)) => {
-                // Let's poke the invoker to retry now, if possible
-                self.proposer.notify_invoker_to_pause(invocation_id);
-                replier.send(PauseInvocationRpcResponse::Accepted);
-            }
-            Ok(
-                InvocationStatus::Completed(_)
-                | InvocationStatus::Scheduled(_)
-                | InvocationStatus::Inboxed(_),
-            ) => {
-                replier.send(PauseInvocationRpcResponse::NotRunning);
-            }
-            Ok(InvocationStatus::Paused(_) | InvocationStatus::Suspended { .. }) => {
-                replier.send(PauseInvocationRpcResponse::AlreadyPaused);
-            }
-            Ok(InvocationStatus::Free) => {
-                replier.send(PauseInvocationRpcResponse::NotFound);
-            }
+        let status = match self.storage.get_invocation_status(&invocation_id).await {
+            Ok(status) => status,
             Err(storage_error) => {
                 replier.send_result(Err(PartitionProcessorRpcError::Internal(
                     storage_error.to_string(),
                 )));
+                return Ok(());
+            }
+        };
+
+        // The persisted PauseInvocation WAL command (kind 25) is only emitted for invocations that
+        // are on VQueues: a `vqueue_id` implies the partition enabled VQueues (gated by a version
+        // barrier), so every replica is new enough to decode the command. It is also exactly where
+        // the persisted pause is needed -- VQueues lets the partition processor drive the lifecycle,
+        // so the invoker no longer solely owns the invocation. Non-VQueue invocations remain
+        // invoker-owned, so the legacy best-effort invoker-poke path below is correct for them.
+        let on_vqueues = status
+            .get_invocation_metadata()
+            .is_some_and(|metadata| metadata.vqueue_id.is_some());
+
+        if on_vqueues {
+            // The apply path (OnManualPauseCommand) classifies the (possibly changed) status and
+            // replies via Action::ForwardPauseInvocationResponse. propose_pause_and_fence clears
+            // the leader's in-memory fencing token (after appending the command) so that any
+            // straggler effect from the attempt we are pausing is dropped at write time.
+            self.proposer
+                .propose_pause_and_fence(
+                    invocation_id,
+                    Command::PauseInvocation(
+                        PauseInvocationCommand {
+                            invocation_id,
+                            request_id: Some(request_id),
+                        }
+                        .bilrost_encode_to_bytes(),
+                    ),
+                    request_id,
+                    replier,
+                )
+                .await;
+            return Ok(());
+        }
+
+        // -- Legacy path for invoker-owned (non-VQueue) invocations: best-effort invoker poke.
+        match status {
+            InvocationStatus::Invoked(_) => {
+                self.proposer.notify_invoker_to_pause(invocation_id);
+                replier.send(PauseInvocationRpcResponse::Accepted);
+            }
+            InvocationStatus::Completed(_)
+            | InvocationStatus::Scheduled(_)
+            | InvocationStatus::Inboxed(_) => {
+                replier.send(PauseInvocationRpcResponse::NotRunning);
+            }
+            InvocationStatus::Paused(_) | InvocationStatus::Suspended { .. } => {
+                replier.send(PauseInvocationRpcResponse::AlreadyPaused);
+            }
+            InvocationStatus::Free => {
+                replier.send(PauseInvocationRpcResponse::NotFound);
             }
         };
 
@@ -76,8 +115,32 @@ mod tests {
     use super::*;
 
     use crate::partition::rpc::MockActuator;
+    use futures::FutureExt;
     use restate_core::network::Reciprocal;
+    use restate_storage_api::invocation_status_table::InFlightInvocationMetadata;
+    use restate_types::identifiers::WithPartitionKey;
+    use std::future::ready;
     use test_log::test;
+
+    struct MockStorage {
+        status: InvocationStatus,
+    }
+
+    impl ReadInvocationStatusTable for MockStorage {
+        fn get_invocation_status(
+            &mut self,
+            _: &InvocationId,
+        ) -> impl Future<Output = restate_storage_api::Result<InvocationStatus>> + Send {
+            ready(Ok(self.status.clone()))
+        }
+
+        fn any_non_completed_invocation_in_range(
+            &mut self,
+            _: restate_types::sharding::KeyRange,
+        ) -> impl Future<Output = restate_storage_api::Result<bool>> + Send {
+            ready(Ok(false))
+        }
+    }
 
     #[test(restate_core::test)]
     async fn reply_not_leader_when_not_leader() {
@@ -116,7 +179,10 @@ mod tests {
         let (tx, rx) = Reciprocal::mock();
         RpcHandler::handle(
             RpcContext::new(&mut proposer, &(), &mut storage),
-            Request { invocation_id },
+            PauseRequest {
+                request_id: Default::default(),
+                invocation_id,
+            },
             Replier::new(tx),
         )
         .await
@@ -126,5 +192,87 @@ mod tests {
             rx.recv().await,
             Err(PartitionProcessorRpcError::NotLeader(_))
         ));
+    }
+
+    /// A non-VQueue (invoker-owned) invocation uses the legacy invoker-poke path and is not
+    /// proposed as a WAL command.
+    #[test(restate_core::test)]
+    async fn non_vqueue_invocation_uses_legacy_invoker_poke() {
+        let invocation_id = InvocationId::mock_random();
+
+        let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
+        proposer
+            .expect_notify_invoker_to_pause()
+            .return_once_st(move |got_invocation_id| {
+                assert_eq!(got_invocation_id, invocation_id);
+            });
+
+        let mut storage = MockStorage {
+            // mock() has no vqueue_id.
+            status: InvocationStatus::Invoked(InFlightInvocationMetadata::mock()),
+        };
+
+        let (tx, rx) = Reciprocal::mock();
+        RpcHandler::handle(
+            RpcContext::new(&mut proposer, &(), &mut storage),
+            PauseRequest {
+                request_id: Default::default(),
+                invocation_id,
+            },
+            Replier::new(tx),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            rx.recv().await.unwrap(),
+            PartitionProcessorRpcResponse::PauseInvocation(PauseInvocationRpcResponse::Accepted)
+        );
+    }
+
+    /// A VQueue invocation is paused by proposing the persisted PauseInvocation command.
+    #[test(restate_core::test)]
+    async fn vqueue_invocation_proposes_pause_command() {
+        let invocation_id = InvocationId::mock_random();
+
+        let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
+        proposer
+            .expect_propose_pause_and_fence::<PauseInvocationRpcResponse>()
+            .return_once_st(move |got_invocation_id, cmd, request_id, replier| {
+                assert_eq!(got_invocation_id, invocation_id);
+                let Command::PauseInvocation(bytes) = cmd else {
+                    panic!("expected a PauseInvocation command");
+                };
+                let pause = PauseInvocationCommand::bilrost_decode(bytes).unwrap();
+                assert_eq!(pause.invocation_id, invocation_id);
+                assert_eq!(pause.request_id, Some(request_id));
+                replier.send(PauseInvocationRpcResponse::Accepted);
+                ready(()).boxed()
+            });
+
+        let mut storage = MockStorage {
+            status: InvocationStatus::Invoked(InFlightInvocationMetadata::mock_with_vqueue(
+                invocation_id.partition_key(),
+            )),
+        };
+
+        let (tx, rx) = Reciprocal::mock();
+        RpcHandler::handle(
+            RpcContext::new(&mut proposer, &(), &mut storage),
+            PauseRequest {
+                request_id: Default::default(),
+                invocation_id,
+            },
+            Replier::new(tx),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            rx.recv().await.unwrap(),
+            PartitionProcessorRpcResponse::PauseInvocation(PauseInvocationRpcResponse::Accepted)
+        );
     }
 }

--- a/crates/worker/src/partition/state_machine/actions.rs
+++ b/crates/worker/src/partition/state_machine/actions.rs
@@ -16,7 +16,8 @@ use restate_types::identifiers::{EntryIndex, InvocationId, PartitionProcessorRpc
 use restate_types::invocation::InvocationTarget;
 use restate_types::invocation::client::{
     CancelInvocationResponse, InvocationOutputResponse, KillInvocationResponse,
-    PurgeInvocationResponse, RestartAsNewInvocationResponse, ResumeInvocationResponse,
+    PauseInvocationResponse, PurgeInvocationResponse, RestartAsNewInvocationResponse,
+    ResumeInvocationResponse,
 };
 use restate_types::journal_v2::{CommandIndex, NotificationId};
 use restate_types::message::MessageIndex;
@@ -100,6 +101,10 @@ pub enum Action {
     ForwardResumeInvocationResponse {
         request_id: PartitionProcessorRpcRequestId,
         response: ResumeInvocationResponse,
+    },
+    ForwardPauseInvocationResponse {
+        request_id: PartitionProcessorRpcRequestId,
+        response: PauseInvocationResponse,
     },
     ForwardRestartAsNewInvocationResponse {
         request_id: PartitionProcessorRpcRequestId,

--- a/crates/worker/src/partition/state_machine/lifecycle/manual_pause.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/manual_pause.rs
@@ -1,0 +1,163 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use restate_storage_api::invocation_status_table::{
+    InvocationStatus, ReadInvocationStatusTable, WriteInvocationStatusTable,
+};
+use restate_storage_api::journal_events::WriteJournalEventsTable;
+use restate_storage_api::lock_table::WriteLockTable;
+use restate_storage_api::vqueue_table::{ReadVQueueTable, WriteVQueueTable};
+use restate_types::identifiers::InvocationId;
+use restate_types::invocation::InvocationMutationResponseSink;
+use restate_types::invocation::client::PauseInvocationResponse;
+use restate_types::journal_events::raw::RawEvent;
+use restate_types::journal_events::{Event, PausedEvent};
+
+use crate::partition::state_machine::lifecycle::OnPausedCommand;
+use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
+
+/// Applies a user-requested pause that was proposed to the log as a
+/// [`commands::PauseInvocationCommand`](restate_wal_protocol::v2::commands::PauseInvocationCommand).
+///
+/// Unlike the invoker-initiated [`OnPausedCommand`] (auto/error pause), this is driven by the
+/// partition processor itself, so it works regardless of whether the invoker currently holds an
+/// in-flight state machine. It classifies the current status, performs the pause for the cases it
+/// supports, and replies to the originating RPC.
+pub struct OnManualPauseCommand {
+    pub invocation_id: InvocationId,
+    pub response_sink: Option<InvocationMutationResponseSink>,
+}
+
+impl<'ctx, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>>
+    for OnManualPauseCommand
+where
+    S: ReadInvocationStatusTable
+        + WriteInvocationStatusTable
+        + WriteJournalEventsTable
+        + WriteVQueueTable
+        + ReadVQueueTable
+        + WriteLockTable,
+{
+    async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
+        let OnManualPauseCommand {
+            invocation_id,
+            response_sink,
+        } = self;
+
+        let response = match ctx.get_invocation_status(&invocation_id).await? {
+            InvocationStatus::Invoked(_) => {
+                // A user-requested pause carries no failure, so synthesize an empty PausedEvent.
+                OnPausedCommand {
+                    invocation_id: &invocation_id,
+                    paused_event: RawEvent::from(Event::Paused(PausedEvent { last_failure: None })),
+                }
+                .apply(ctx)
+                .await?;
+
+                // Unlike the invoker-initiated pause, the invoker may still be running this
+                // attempt (it didn't drive the pause), so tell it to abort. Any straggler effect
+                // from that attempt is fenced by the leader's write-time fencing-token check.
+                ctx.send_abort_invocation_to_invoker(invocation_id);
+
+                PauseInvocationResponse::Accepted
+            }
+            // TODO(Step 4): actually pause Suspended invocations instead of reporting AlreadyPaused.
+            InvocationStatus::Suspended { .. } | InvocationStatus::Paused(_) => {
+                PauseInvocationResponse::AlreadyPaused
+            }
+            InvocationStatus::Scheduled(_)
+            | InvocationStatus::Inboxed(_)
+            | InvocationStatus::Completed(_) => PauseInvocationResponse::NotRunning,
+            InvocationStatus::Free => PauseInvocationResponse::NotFound,
+        };
+
+        ctx.reply_to_pause_invocation(response_sink, response);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::partition::state_machine::Action;
+    use crate::partition::state_machine::tests::{TestEnv, fixtures, matchers};
+    use googletest::prelude::{all, assert_that, contains, eq, pat};
+    use restate_storage_api::invocation_status_table::{
+        InvocationStatusDiscriminants, ReadInvocationStatusTable,
+    };
+    use restate_types::identifiers::PartitionProcessorRpcRequestId;
+    use restate_wal_protocol::v2::{Command, commands};
+
+    fn pause_command(
+        invocation_id: InvocationId,
+        request_id: PartitionProcessorRpcRequestId,
+    ) -> restate_wal_protocol::v2::Envelope<restate_wal_protocol::v2::Raw> {
+        commands::PauseInvocationCommand::test_envelope(commands::PauseInvocationCommand {
+            invocation_id,
+            request_id: Some(request_id),
+        })
+    }
+
+    #[restate_core::test]
+    async fn pause_invoked_invocation() {
+        let mut test_env = TestEnv::create().await;
+        let invocation_id = fixtures::mock_start_invocation(&mut test_env).await;
+
+        let request_id = PartitionProcessorRpcRequestId::new();
+        let actions = test_env
+            .apply(pause_command(invocation_id, request_id))
+            .await;
+
+        assert_that!(
+            actions,
+            all!(
+                contains(pat!(Action::ForwardPauseInvocationResponse {
+                    request_id: eq(request_id),
+                    response: eq(PauseInvocationResponse::Accepted)
+                })),
+                // The invoker must be told to abort the still-running attempt.
+                contains(matchers::actions::abort_for_id(invocation_id)),
+            )
+        );
+        assert_that!(
+            test_env
+                .storage
+                .get_invocation_status(&invocation_id)
+                .await
+                .unwrap(),
+            matchers::storage::is_variant(InvocationStatusDiscriminants::Paused)
+        );
+
+        test_env.shutdown().await;
+    }
+
+    #[restate_core::test]
+    async fn pause_unknown_invocation_replies_not_found() {
+        let mut test_env = TestEnv::create().await;
+        let invocation_id = InvocationId::mock_random();
+
+        let request_id = PartitionProcessorRpcRequestId::new();
+        let actions = test_env
+            .apply(pause_command(invocation_id, request_id))
+            .await;
+
+        assert_that!(
+            actions,
+            contains(pat!(Action::ForwardPauseInvocationResponse {
+                request_id: eq(request_id),
+                response: eq(PauseInvocationResponse::NotFound)
+            }))
+        );
+
+        test_env.shutdown().await;
+    }
+}

--- a/crates/worker/src/partition/state_machine/lifecycle/manual_pause.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/manual_pause.rs
@@ -69,10 +69,21 @@ where
 
                 PauseInvocationResponse::Accepted
             }
-            // TODO(Step 4): actually pause Suspended invocations instead of reporting AlreadyPaused.
-            InvocationStatus::Suspended { .. } | InvocationStatus::Paused(_) => {
-                PauseInvocationResponse::AlreadyPaused
+            InvocationStatus::Suspended { metadata, .. } => {
+                // A suspended invocation has no live invoker task, so there is nothing to abort.
+                // `awaiting_on` is intentionally dropped: resuming a paused invocation re-invokes
+                // it, replaying the journal so the SDK re-derives what it is waiting on.
+                pause_invocation(
+                    ctx,
+                    &invocation_id,
+                    metadata,
+                    RawEvent::from(Event::Paused(PausedEvent { last_failure: None })),
+                )
+                .await?;
+
+                PauseInvocationResponse::Accepted
             }
+            InvocationStatus::Paused(_) => PauseInvocationResponse::AlreadyPaused,
             InvocationStatus::Scheduled(_)
             | InvocationStatus::Inboxed(_)
             | InvocationStatus::Completed(_) => PauseInvocationResponse::NotRunning,
@@ -90,13 +101,18 @@ mod tests {
     use super::*;
 
     use crate::partition::state_machine::Action;
+    use crate::partition::state_machine::tests::fixtures::{
+        invoker_entry_effect, invoker_suspended,
+    };
     use crate::partition::state_machine::tests::{TestEnv, fixtures, matchers};
-    use googletest::prelude::{all, assert_that, contains, eq, pat};
+    use googletest::prelude::{all, assert_that, contains, eq, not, pat};
     use restate_storage_api::invocation_status_table::{
         InvocationStatusDiscriminants, ReadInvocationStatusTable,
     };
     use restate_types::identifiers::PartitionProcessorRpcRequestId;
+    use restate_types::journal_v2::{NotificationId, SleepCommand};
     use restate_wal_protocol::v2::{Command, commands};
+    use std::time::{Duration, SystemTime};
 
     fn pause_command(
         invocation_id: InvocationId,
@@ -127,6 +143,64 @@ mod tests {
                 })),
                 // The invoker must be told to abort the still-running attempt.
                 contains(matchers::actions::abort_for_id(invocation_id)),
+            )
+        );
+        assert_that!(
+            test_env
+                .storage
+                .get_invocation_status(&invocation_id)
+                .await
+                .unwrap(),
+            matchers::storage::is_variant(InvocationStatusDiscriminants::Paused)
+        );
+
+        test_env.shutdown().await;
+    }
+
+    #[restate_core::test]
+    async fn pause_suspended_invocation() {
+        let mut test_env = TestEnv::create().await;
+        let invocation_id = fixtures::mock_start_invocation(&mut test_env).await;
+        fixtures::mock_pinned_deployment_v5(&mut test_env, invocation_id).await;
+
+        // Suspend the invocation on a sleep.
+        let completion_id = 1;
+        let _ = test_env
+            .apply_multiple([
+                invoker_entry_effect(
+                    invocation_id,
+                    SleepCommand {
+                        wake_up_time: (SystemTime::now() + Duration::from_secs(60)).into(),
+                        name: Default::default(),
+                        completion_id,
+                    },
+                ),
+                invoker_suspended(invocation_id, NotificationId::for_completion(completion_id)),
+            ])
+            .await;
+        assert_that!(
+            test_env
+                .storage
+                .get_invocation_status(&invocation_id)
+                .await
+                .unwrap(),
+            matchers::storage::is_variant(InvocationStatusDiscriminants::Suspended)
+        );
+
+        // Pausing a suspended invocation transitions it to Paused without aborting the invoker
+        // (there is no live task to abort).
+        let request_id = PartitionProcessorRpcRequestId::new();
+        let actions = test_env
+            .apply(pause_command(invocation_id, request_id))
+            .await;
+        assert_that!(
+            actions,
+            all!(
+                contains(pat!(Action::ForwardPauseInvocationResponse {
+                    request_id: eq(request_id),
+                    response: eq(PauseInvocationResponse::Accepted)
+                })),
+                not(contains(matchers::actions::abort_for_id(invocation_id))),
             )
         );
         assert_that!(

--- a/crates/worker/src/partition/state_machine/lifecycle/manual_pause.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/manual_pause.rs
@@ -20,7 +20,7 @@ use restate_types::invocation::client::PauseInvocationResponse;
 use restate_types::journal_events::raw::RawEvent;
 use restate_types::journal_events::{Event, PausedEvent};
 
-use crate::partition::state_machine::lifecycle::OnPausedCommand;
+use crate::partition::state_machine::lifecycle::pause_invocation;
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
 
 /// Applies a user-requested pause that was proposed to the log as a
@@ -52,13 +52,14 @@ where
         } = self;
 
         let response = match ctx.get_invocation_status(&invocation_id).await? {
-            InvocationStatus::Invoked(_) => {
+            InvocationStatus::Invoked(metadata) => {
                 // A user-requested pause carries no failure, so synthesize an empty PausedEvent.
-                OnPausedCommand {
-                    invocation_id: &invocation_id,
-                    paused_event: RawEvent::from(Event::Paused(PausedEvent { last_failure: None })),
-                }
-                .apply(ctx)
+                pause_invocation(
+                    ctx,
+                    &invocation_id,
+                    metadata,
+                    RawEvent::from(Event::Paused(PausedEvent { last_failure: None })),
+                )
                 .await?;
 
                 // Unlike the invoker-initiated pause, the invoker may still be running this

--- a/crates/worker/src/partition/state_machine/lifecycle/mod.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/mod.rs
@@ -36,7 +36,7 @@ pub(super) use notify_get_invocation_output_response::OnNotifyGetInvocationOutpu
 pub(super) use notify_invocation_response::OnNotifyInvocationResponse;
 pub(super) use notify_signal::OnNotifySignalCommand;
 pub(super) use notify_sleep_completion::OnNotifySleepCompletionCommand;
-pub(super) use paused::OnPausedCommand;
+pub(super) use paused::{OnPausedCommand, pause_invocation};
 pub(super) use pinned_deployment::OnPinnedDeploymentCommand;
 pub(super) use purge::OnPurgeCommand;
 pub(super) use purge_journal::OnPurgeJournalCommand;

--- a/crates/worker/src/partition/state_machine/lifecycle/mod.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/mod.rs
@@ -10,6 +10,7 @@
 
 mod cancel;
 mod event;
+mod manual_pause;
 mod manual_resume;
 mod migrate_journal_table;
 mod notify_get_invocation_output_response;
@@ -28,6 +29,7 @@ mod yield_invocation;
 
 pub(super) use cancel::OnCancelCommand;
 pub(super) use event::ApplyEventCommand;
+pub(super) use manual_pause::OnManualPauseCommand;
 pub(super) use manual_resume::OnManualResumeCommand;
 pub(super) use migrate_journal_table::VerifyOrMigrateJournalTableToV2Command;
 pub(super) use notify_get_invocation_output_response::OnNotifyGetInvocationOutputResponse;

--- a/crates/worker/src/partition/state_machine/lifecycle/paused.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/paused.rs
@@ -12,7 +12,8 @@ use tracing::debug;
 
 use restate_clock::UniqueTimestamp;
 use restate_storage_api::invocation_status_table::{
-    InvocationStatus, ReadInvocationStatusTable, WriteInvocationStatusTable,
+    InFlightInvocationMetadata, InvocationStatus, ReadInvocationStatusTable,
+    WriteInvocationStatusTable,
 };
 use restate_storage_api::journal_events::WriteJournalEventsTable;
 use restate_storage_api::lock_table::WriteLockTable;
@@ -42,8 +43,6 @@ where
         + ReadVQueueTable,
 {
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
-        // todo(asoli): This is overly conservative. With vqueues, it should be possible to pause a
-        // scheduled or suspended invocations.
         let OnPausedCommand {
             invocation_id,
             paused_event,
@@ -56,61 +55,84 @@ where
             | InvocationStatus::Inboxed(_)
             | InvocationStatus::Completed(_)
             | InvocationStatus::Free => {
-                // Nothing to do in these cases, pause gets processed only if the invocation was Invoked.
+                // Nothing to do in these cases, the invoker-driven pause is only processed if the
+                // invocation was Invoked.
                 return Ok(());
             }
         };
 
-        // Invoker paused the invocation, let's record the event, then set the status to paused
-        debug_if_leader!(ctx.is_leader, "Paused the invocation");
-
-        if invoked_meta.vqueue_id.is_some() {
-            // todo: use the new status
-            let entry_id = EntryId::from(invocation_id);
-            let Some(header) = ctx
-                .storage
-                .get_vqueue_entry_status(invocation_id.partition_key(), &entry_id)
-                .await?
-            else {
-                // This is equivalent to InvocationStatus::Free.
-                debug!(
-                    "Trying to pause invocation {invocation_id} which does not exist as a vqueue entry, will ignore."
-                );
-                return Ok(());
-            };
-
-            let at = UniqueTimestamp::from_unix_millis_unchecked(ctx.record_created_at);
-            VQueue::get(
-                header.vqueue_id(),
-                ctx.storage,
-                ctx.vqueues_cache,
-                ctx.is_leader.then_some(ctx.action_collector),
-            )
-            .await?
-            .expect("pausing in a non-existent vqueue")
-            .pause_entry(at, &header);
-        }
-
-        let mut invocation_status = InvocationStatus::Paused(invoked_meta);
-
-        ApplyEventCommand {
-            invocation_id,
-            invocation_status: &invocation_status,
-            event: paused_event,
-        }
-        .apply(ctx)
-        .await?;
-
-        // Update timestamps
-        if let Some(timestamps) = invocation_status.get_timestamps_mut() {
-            timestamps.update(ctx.record_created_at);
-        }
-
-        ctx.storage
-            .put_invocation_status(self.invocation_id, &invocation_status)?;
-
-        Ok(())
+        // The invoker drove this pause, so it has already stopped working on the invocation; no
+        // abort is needed (unlike the manual/persisted pause, see `OnManualPauseCommand`).
+        pause_invocation(ctx, invocation_id, invoked_meta, paused_event).await
     }
+}
+
+/// Performs the pause transition for an in-flight invocation: parks the VQueue entry (if any),
+/// records the paused event in the journal, and stores [`InvocationStatus::Paused`].
+///
+/// Shared by the invoker-initiated pause ([`OnPausedCommand`]) and the manual/persisted pause
+/// ([`super::OnManualPauseCommand`]). It does **not** abort the invoker — callers that drive the
+/// pause externally (the manual path) are responsible for that.
+pub(crate) async fn pause_invocation<'ctx, 's: 'ctx, S>(
+    ctx: &'ctx mut StateMachineApplyContext<'s, S>,
+    invocation_id: &InvocationId,
+    metadata: InFlightInvocationMetadata,
+    paused_event: RawEvent,
+) -> Result<(), Error>
+where
+    S: WriteInvocationStatusTable
+        + WriteJournalEventsTable
+        + WriteVQueueTable
+        + WriteLockTable
+        + ReadVQueueTable,
+{
+    debug_if_leader!(ctx.is_leader, "Paused the invocation");
+
+    if metadata.vqueue_id.is_some() {
+        let entry_id = EntryId::from(invocation_id);
+        let Some(header) = ctx
+            .storage
+            .get_vqueue_entry_status(invocation_id.partition_key(), &entry_id)
+            .await?
+        else {
+            // This is equivalent to InvocationStatus::Free.
+            debug!(
+                "Trying to pause invocation {invocation_id} which does not exist as a vqueue entry, will ignore."
+            );
+            return Ok(());
+        };
+
+        let at = UniqueTimestamp::from_unix_millis_unchecked(ctx.record_created_at);
+        VQueue::get(
+            header.vqueue_id(),
+            ctx.storage,
+            ctx.vqueues_cache,
+            ctx.is_leader.then_some(ctx.action_collector),
+        )
+        .await?
+        .expect("pausing in a non-existent vqueue")
+        .pause_entry(at, &header);
+    }
+
+    let mut invocation_status = InvocationStatus::Paused(metadata);
+
+    ApplyEventCommand {
+        invocation_id,
+        invocation_status: &invocation_status,
+        event: paused_event,
+    }
+    .apply(ctx)
+    .await?;
+
+    // Update timestamps
+    if let Some(timestamps) = invocation_status.get_timestamps_mut() {
+        timestamps.update(ctx.record_created_at);
+    }
+
+    ctx.storage
+        .put_invocation_status(invocation_id, &invocation_status)?;
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -78,7 +78,7 @@ use restate_types::identifiers::{
 };
 use restate_types::invocation::client::{
     CancelInvocationResponse, InvocationOutputResponse, KillInvocationResponse,
-    PurgeInvocationResponse, ResumeInvocationResponse,
+    PauseInvocationResponse, PurgeInvocationResponse, ResumeInvocationResponse,
 };
 use restate_types::invocation::{
     AttachInvocationRequest, IngressInvocationResponseSink, InvocationInput,
@@ -777,6 +777,22 @@ impl<S> StateMachineApplyContext<'_, S> {
                     update_pinned_deployment_id: resume_invocation_request
                         .update_pinned_deployment_id,
                     response_sink: resume_invocation_request.response_sink,
+                }
+                .apply(self)
+                .await?;
+                Ok(())
+            }
+            CommandKind::PauseInvocation => {
+                let pause = envelope
+                    .into_typed::<commands::PauseInvocationCommand>()
+                    .into_inner()?;
+
+                lifecycle::OnManualPauseCommand {
+                    invocation_id: pause.invocation_id,
+                    response_sink: pause
+                        .request_id
+                        .map(|request_id| IngressInvocationResponseSink { request_id })
+                        .map(InvocationMutationResponseSink::Ingress),
                 }
                 .apply(self)
                 .await?;
@@ -4699,6 +4715,30 @@ impl<S> StateMachineApplyContext<'_, S> {
 
         self.action_collector
             .push(Action::ForwardResumeInvocationResponse {
+                request_id,
+                response,
+            });
+    }
+
+    fn reply_to_pause_invocation(
+        &mut self,
+        response_sink: Option<InvocationMutationResponseSink>,
+        response: PauseInvocationResponse,
+    ) {
+        if response_sink.is_none() {
+            return;
+        }
+        let InvocationMutationResponseSink::Ingress(IngressInvocationResponseSink { request_id }) =
+            response_sink.unwrap();
+        debug_if_leader!(
+            self.is_leader,
+            "Send pause response to request id '{:?}': {:?}",
+            request_id,
+            response
+        );
+
+        self.action_collector
+            .push(Action::ForwardPauseInvocationResponse {
                 request_id,
                 response,
             });

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -4280,6 +4280,10 @@ impl<S> StateMachineApplyContext<'_, S> {
         )
     }
 
+    /// Legacy journal-v1 completion handling. It deliberately has no `Paused` arm (a completion
+    /// for a paused invocation falls into the catch-all "no longer running" branch): pausing is a
+    /// journal-v2 feature, and the v2 path (`ApplyNotificationCommand`) is authoritative for
+    /// store-don't-resume-while-paused. This whole v1 path is dead code to be removed with v1.8.
     async fn handle_completion(
         &mut self,
         invocation_id: InvocationId,

--- a/crates/worker/src/partition/state_machine/tests/matchers.rs
+++ b/crates/worker/src/partition/state_machine/tests/matchers.rs
@@ -120,6 +120,12 @@ pub mod actions {
         })
     }
 
+    pub fn abort_for_id(invocation_id: InvocationId) -> impl Matcher<ActualT = Action> {
+        pat!(Action::AbortInvocation {
+            invocation_id: eq(invocation_id)
+        })
+    }
+
     pub fn invoke_for_id_and_target(
         invocation_id: InvocationId,
         invocation_target: InvocationTarget,

--- a/crates/worker/src/partition/types.rs
+++ b/crates/worker/src/partition/types.rs
@@ -13,7 +13,7 @@ use restate_types::identifiers::{EntryIndex, InvocationId};
 use restate_types::invocation::{InvocationResponse, JournalCompletionTarget, ResponseResult};
 use restate_wal_protocol::Command;
 
-pub(crate) type InvokerEffect = Box<restate_worker_api::invoker::Effect>;
+pub(crate) type InvokerEffect = restate_worker_api::invoker::FencedEffect;
 pub(crate) type InvokerEffectKind = restate_worker_api::invoker::EffectKind;
 
 // Extension methods to the OutboxMessage type

--- a/release-notes/v1.7.0.md
+++ b/release-notes/v1.7.0.md
@@ -436,6 +436,16 @@ Five new SQL system tables let you inspect vqueues, the scheduler, and concurren
 
 These tables are populated only when vqueues is enabled.
 
+#### Pausing invocations
+
+When vqueues is enabled, the pause command behaves slightly differently:
+
+- **It is persisted and applied by the partition processor**, so a pause is honored deterministically regardless of whether the invoker is currently running the invocation (previously a pause could be silently dropped if the invoker was not actively processing it).
+- **Suspended invocations can now be paused** (in addition to running ones). Resuming re-invokes the invocation and replays its journal.
+- **Graceful drains are no longer supported.** Pausing a running invocation immediately transitions it to `Paused` and aborts the in-progress execution attempt, instead of waiting for the invoker to reach a safe point. Journaled progress is preserved and replayed on resume; any in-flight, not-yet-journaled work of the aborted attempt is re-executed on resume, following the usual durable-execution replay semantics.
+
+Invocations that are not on vqueues keep the previous best-effort pause behavior.
+
 ### Service Protocol v7 (Preview)
 
 Restate v1.7 introduces **service protocol v7**, an opt-in iteration of the runtime↔SDK wire protocol that is negotiated with deployments advertising support for it. Older deployments continue to run on v6 or earlier with no change.


### PR DESCRIPTION
Disclaimer: I hate to drop such a large change just before the release on you but I couldn't find a simpler way to add support for pause commands when using vqueues. I tried to keep the change limited to as few parts as possible to reduce the blast radius and to invalidate as little testing as possible.

The motivation for this PR is to make pausing invocations work with vqueues. With vqueues we no longer uphold the invariant that an `InvocationStatus::Invoked` invocation is owned by the invoker. Instead, retries can now also be driven by the partition processor. Hence, it is no longer sufficient to let pause commands go through the invoker to transition an invocation into the `InvocationStatus::Paused` state.

With vqueues, the partition processor owns the invocation and all invocation state changing operations first go through the partition processor. As all replicas need to stay in sync, the command first needs to be written to Bifrost and then applied. Since the invoker might concurrently produce invoker effects that are no longer valid (e.g. if the invocation was paused in between), we need to fence those effects off. The way fencing was solved is to introduce a write-time filter (an in-memory map of fencing tokens) which filters stale invoker effects before they are written to Bifrost. The fencing token map is cleared whenever an invocation is handed over from the invoker to the partition processor (on a terminal `EffectKind`), if the invocation is aborted or if the user pauses and invocation. In the last case, we are clearing the fencing token at propose-time and not apply time. This bit is crucial for correctness because we need to ensure that any invoker effect that is proposed after the pause command is proposed will be rejected.

As a nice side-effect, pause commands with vqueues become now durable and cannot be lost as it is the case with pause commands when using the non-vqueues mode. Moreover, the system now supports pausing suspended invocations.

One thing we lose with this change is the graceful drain of a paused invocation. Instead, the system is aborting a paused invocation right away and thereby is potentially throwing progress away. The reason why there is no graceful drain is that it would have complicated the partition processor state machine.

What is still missing and is probably needed for vqueues as well is `InputCommand::RetryNow` as this also needs to go through Bifrost to be applied by all partition processor replicas. This is something that I will add as a follow-up PR.