### PR TITLE
[ClusterController] Proactively refresh epoch metadata when detecting a stale metadata from gossip

### DIFF
--- a/crates/admin/src/cluster_controller/service/cluster_controller_state.rs
+++ b/crates/admin/src/cluster_controller/service/cluster_controller_state.rs
@@ -106,6 +106,7 @@ impl Leader {
             SchedulerTask::new(
                 service.cluster_state_refresher.cluster_state_watcher(),
                 scheduler,
+                service.replica_set_states.clone(),
                 service.metadata_writer.raw_metadata_store_client().clone(),
                 sync_epoch_metadata_rx,
             )

--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -897,8 +897,8 @@ impl<T: TransportConnect> Scheduler<T> {
                 (None, None) => false,
                 // We have recorded a next replica set, but the observed state doesn't have one. Did someone abort our next version?
                 (Some(_our_next), None) => true,
-                // There's a next version observed, that we're not aware of it yet. Let's report the epoch metadata as stale.
-                (None, Some(_their_next)) => true,
+                // There's a next version observed, only consider it stale if it's newer than out current version.
+                (None, Some(their_next)) => their_next > partition_state.current.version(),
                 (Some(our_next), Some(their_next)) => our_next.version() < their_next,
             }
         }

--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -879,6 +879,42 @@ impl<T: TransportConnect> Scheduler<T> {
 
         Ok(())
     }
+
+    /// Compares the stored epoch metadata for each partitions with the values we observed elsewhere in the system (or through gossip).
+    /// Returns the partition ids for which we think the epoch metadata might be stale.
+    pub(crate) fn detect_stale_partition_epoch_metadata(&self) -> Vec<PartitionId> {
+        self.replica_set_states
+            .partition_versions()
+            .into_iter()
+            .filter_map(|observed_version| {
+                let partition_id = observed_version.id;
+                self.partitions
+                    .get(&partition_id)
+                    .map(|partition_state| {
+                        if partition_state.current.version() < observed_version.current {
+                            Some(partition_id)
+                        } else {
+                            match (partition_state.next.as_ref(), observed_version.next) {
+                                (None, None) => None,
+                                // We have recorded a next replica set, but the observed state doesn't have one. Did someone abort our next version?
+                                (Some(_our_next), None) => Some(partition_id),
+                                // There's a next version observed, that we're not aware of it yet. Let's report the epoch metadata as stale.
+                                (None, Some(_their_next)) => Some(partition_id),
+                                (Some(our_next), Some(their_next)) => {
+                                    if our_next.version() < their_next {
+                                        Some(partition_id)
+                                    } else {
+                                        None
+                                    }
+                                }
+                            }
+                        }
+                    })
+                    // We haven't observed this partition before, so consider it stale.
+                    .unwrap_or(Some(partition_id))
+            })
+            .collect()
+    }
 }
 
 /// Returns `true` if the given node matches the leader affinity expression.

--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -895,8 +895,10 @@ impl<T: TransportConnect> Scheduler<T> {
 
             match (partition_state.next.as_ref(), observed_version.next_version) {
                 (None, None) => false,
-                // We have recorded a next replica set, but the observed state doesn't have one. Did someone abort our next version?
-                (Some(_our_next), None) => true,
+                // The scheduler sticks with its proposed next version even if if it read None from the metadata store.
+                // So triggering a refetch wouldn't help. To avoid excessive metadata fetches, let's error on the
+                // side of reporting it as not stale.
+                (Some(_our_next), None) => false,
                 // There's a next version observed, only consider it stale if it's newer than our current version.
                 (None, Some(their_next)) => their_next > partition_state.current.version(),
                 (Some(our_next), Some(their_next)) => our_next.version() < their_next,

--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -897,7 +897,7 @@ impl<T: TransportConnect> Scheduler<T> {
                 (None, None) => false,
                 // We have recorded a next replica set, but the observed state doesn't have one. Did someone abort our next version?
                 (Some(_our_next), None) => true,
-                // There's a next version observed, only consider it stale if it's newer than out current version.
+                // There's a next version observed, only consider it stale if it's newer than our current version.
                 (None, Some(their_next)) => their_next > partition_state.current.version(),
                 (Some(our_next), Some(their_next)) => our_next.version() < their_next,
             }

--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -32,7 +32,9 @@ use restate_types::net::partition_processor_manager::{
 use restate_types::nodes_config::{NodeConfig, NodesConfiguration, WorkerState};
 use restate_types::partition_table::PartitionTable;
 use restate_types::partitions::leadership_policy::{LeaderAffinity, LeadershipPolicy};
-use restate_types::partitions::state::{PartitionReplicaSetStates, ReplicaSetState};
+use restate_types::partitions::state::{
+    ObservedPartitionReplicaSetVersion, PartitionReplicaSetStates, ReplicaSetState,
+};
 use restate_types::partitions::{PartitionConfiguration, worker_candidate_filter};
 use restate_types::replication::balanced_spread_selector::{
     BalancedSpreadSelector, SelectorOptions,
@@ -882,35 +884,40 @@ impl<T: TransportConnect> Scheduler<T> {
 
     /// Compares the stored epoch metadata for each partitions with the values we observed elsewhere in the system (or through gossip).
     /// Returns the partition ids for which we think the epoch metadata might be stale.
-    pub(crate) fn detect_stale_partition_epoch_metadata(&self) -> Vec<PartitionId> {
+    pub(crate) fn detect_stale_epoch_metadata(&self) -> Vec<PartitionId> {
+        fn is_stale(
+            partition_state: &PartitionState,
+            observed_version: &ObservedPartitionReplicaSetVersion,
+        ) -> bool {
+            if partition_state.current.version() < observed_version.current_version {
+                return true;
+            }
+
+            match (partition_state.next.as_ref(), observed_version.next_version) {
+                (None, None) => false,
+                // We have recorded a next replica set, but the observed state doesn't have one. Did someone abort our next version?
+                (Some(_our_next), None) => true,
+                // There's a next version observed, that we're not aware of it yet. Let's report the epoch metadata as stale.
+                (None, Some(_their_next)) => true,
+                (Some(our_next), Some(their_next)) => our_next.version() < their_next,
+            }
+        }
+
         self.replica_set_states
             .partition_versions()
             .into_iter()
             .filter_map(|observed_version| {
-                let partition_id = observed_version.id;
+                let partition_id = observed_version.partition_id;
                 self.partitions
                     .get(&partition_id)
                     .map(|partition_state| {
-                        if partition_state.current.version() < observed_version.current {
+                        if is_stale(partition_state, &observed_version) {
                             Some(partition_id)
                         } else {
-                            match (partition_state.next.as_ref(), observed_version.next) {
-                                (None, None) => None,
-                                // We have recorded a next replica set, but the observed state doesn't have one. Did someone abort our next version?
-                                (Some(_our_next), None) => Some(partition_id),
-                                // There's a next version observed, that we're not aware of it yet. Let's report the epoch metadata as stale.
-                                (None, Some(_their_next)) => Some(partition_id),
-                                (Some(our_next), Some(their_next)) => {
-                                    if our_next.version() < their_next {
-                                        Some(partition_id)
-                                    } else {
-                                        None
-                                    }
-                                }
-                            }
+                            None
                         }
                     })
-                    // We haven't observed this partition before, so consider it stale.
+                    // We haven't seen this partition before, so consider it stale.
                     .unwrap_or(Some(partition_id))
             })
             .collect()

--- a/crates/admin/src/cluster_controller/service/scheduler_task.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler_task.rs
@@ -12,8 +12,6 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use futures::future::OptionFuture;
-use restate_types::Versioned;
-use restate_types::partitions::state::PartitionReplicaSetStates;
 use tokio::sync::mpsc;
 use tracing::{debug, trace, warn};
 
@@ -31,10 +29,10 @@ use restate_types::metadata_store::keys::partition_processor_epoch_key;
 use restate_types::net::metadata::MetadataKind;
 use restate_types::nodes_config::NodesConfiguration;
 use restate_types::partitions::PartitionTable;
+use restate_types::partitions::state::PartitionReplicaSetStates;
 
 use crate::cluster_controller::cluster_state_refresher::ClusterStateWatcher;
 use crate::cluster_controller::service::scheduler::{self, Scheduler};
-use crate::cluster_controller::service::scheduler_task::version_tracker::PartitionConfigVersionTracker;
 
 pub struct SchedulerTask<T> {
     cluster_state_watcher: ClusterStateWatcher,
@@ -80,12 +78,15 @@ where
         let cs = TaskCenter::with_current(|tc| tc.cluster_state().clone());
         let mut cs_changed = std::pin::pin!(cs.changed());
 
-        let mut partition_config_version_tracker =
-            PartitionConfigVersionTracker::new(self.replica_set_states.clone());
+        let replica_set_states = self.replica_set_states.clone();
+        let mut observed_membersip_changed =
+            std::pin::pin!(replica_set_states.membership_changed());
 
         let mut fetch_epoch_metadata_task = Some(self.spawn_fetch_epoch_metadata_task(Vec::new())?);
 
         let mut next_fetch_interval = tokio::time::interval(Duration::from_secs(30));
+        // We've just scheduled a fetch, let's consume the initial tick from the interval (which ticks immediately).
+        next_fetch_interval.tick().await;
 
         loop {
             tokio::select! {
@@ -124,7 +125,6 @@ where
                         Ok(epoch_metadata) => {
                             for (partition_id, epoch_metadata) in epoch_metadata {
                                 let (_, _, current, next, leadership_policy) = epoch_metadata.into_inner();
-                                partition_config_version_tracker.note_observed_version(partition_id, current.version(), next.as_ref().map(|n| n.version()));
                                 self.scheduler.update_partition_configuration(partition_id, current, next, leadership_policy);
                             }
 
@@ -158,11 +158,12 @@ where
                     trace!("triggering an epoch metadata fetch as part of the periodic refreshes");
                     fetch_epoch_metadata_task = Some(self.spawn_fetch_epoch_metadata_task(Vec::new())?);
                 }
-                // If there's an ongoing epoch metadata refresh already ongoing, no need to poll the version tracker
-                // as it won't be able to schedule another refresh anyways.
-                _ = partition_config_version_tracker.changed(), if fetch_epoch_metadata_task.is_none() => {
-                    partition_config_version_tracker.ack();
-                    let stale_epoch_metadata = self.scheduler.detect_stale_partition_epoch_metadata();
+                _ = &mut observed_membersip_changed, if fetch_epoch_metadata_task.is_none() => {
+                    // we observed membership changed, but the scheduler might be already aware of it if, for
+                    // example, it's the one that triggered it. So let's notify it about the change and only
+                    // trigger a refresh if it reports back that it's not aware of it.
+                    observed_membersip_changed.set(replica_set_states.membership_changed());
+                    let stale_epoch_metadata = self.scheduler.detect_stale_epoch_metadata();
                     if !stale_epoch_metadata.is_empty() {
                         trace!("the scheduler detected some partitions ({:?}) with stale epoch metadata, triggering an epoch metadata fetch for those partitions", stale_epoch_metadata);
                         fetch_epoch_metadata_task = Some(self.spawn_fetch_epoch_metadata_task(stale_epoch_metadata)?);
@@ -265,251 +266,5 @@ impl FetchEpochMetadataTask {
         }
 
         latest_epoch_metadata
-    }
-}
-
-mod version_tracker {
-    use std::collections::HashMap;
-    use std::collections::hash_map::Entry;
-
-    use restate_types::identifiers::PartitionId;
-    use restate_types::{Version, partitions::state::PartitionReplicaSetStates};
-
-    /// Keeps tracks of the partition config version (current and next) observed in the replica set states struct
-    /// and the ones fetched already by the scheduler task. This allows the scheduler loop to detect whenever a
-    /// higher version that it hasn't yet fetched is available, reducing the staleness of the epoch metadata.
-    pub(super) struct PartitionConfigVersionTracker {
-        replica_set_states: PartitionReplicaSetStates,
-        observed_current_versions: HashMap<PartitionId, Version>,
-        observed_next_versions: HashMap<PartitionId, Version>,
-        acked: bool,
-    }
-
-    impl PartitionConfigVersionTracker {
-        pub(super) fn new(replica_set_states: PartitionReplicaSetStates) -> Self {
-            Self {
-                replica_set_states,
-                observed_current_versions: HashMap::default(),
-                observed_next_versions: HashMap::default(),
-                acked: true,
-            }
-        }
-
-        /// Returns a future that will resolve whenever a newer version than what we've previously seen is observed in the replica set states.
-        ///
-        /// Under the hood, this subscribes to all changes to replica set states and only fires whenever there's a version change, effectively
-        /// unsubscribing from durable lsn change notifications, etc
-        pub(super) async fn changed(&mut self) {
-            let replica_set_states = self.replica_set_states.clone();
-            // There's already a pending change that wasn't acked, let's fullfill the future immediately.
-            if !self.acked {
-                return;
-            }
-            loop {
-                let changed_future = replica_set_states.changed();
-                if self.update_if_changed() {
-                    self.acked = false;
-                    break;
-                }
-                changed_future.await;
-            }
-        }
-
-        pub(super) fn ack(&mut self) {
-            self.acked = true;
-        }
-
-        /// Updates the observed version of the given partition id.
-        pub(super) fn note_observed_version(
-            &mut self,
-            partition_id: PartitionId,
-            current_version: Version,
-            next_version: Option<Version>,
-        ) -> bool {
-            Self::update_version_if_newer(
-                &mut self.observed_current_versions,
-                partition_id,
-                current_version,
-            ) | Self::update_version_if_newer(
-                &mut self.observed_next_versions,
-                partition_id,
-                next_version.unwrap_or(Version::INVALID),
-            )
-        }
-
-        fn update_version_if_newer(
-            map: &mut HashMap<PartitionId, Version>,
-            partition_id: PartitionId,
-            version: Version,
-        ) -> bool {
-            match map.entry(partition_id) {
-                Entry::Occupied(mut occupied_entry) => {
-                    if occupied_entry.get() < &version {
-                        *occupied_entry.get_mut() = version;
-                        true
-                    } else {
-                        false
-                    }
-                }
-                Entry::Vacant(entry) => {
-                    entry.insert(version);
-                    true
-                }
-            }
-        }
-
-        fn update_if_changed(&mut self) -> bool {
-            let mut changed = false;
-            for p in self.replica_set_states.partition_versions() {
-                changed |= self.note_observed_version(p.id, p.current, p.next);
-            }
-            changed
-        }
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-        use futures::FutureExt;
-        use restate_types::{
-            GenerationalNodeId, PlainNodeId,
-            identifiers::LeaderEpoch,
-            logs::Lsn,
-            partitions::state::{LeadershipState, PartitionReplicaSetStates, ReplicaSetState},
-        };
-
-        #[test]
-        fn partition_version_tracker() {
-            let partition_replica_set_states: PartitionReplicaSetStates = Default::default();
-            let mut tracker =
-                PartitionConfigVersionTracker::new(partition_replica_set_states.clone());
-
-            // After init, tracker shouldn't have any changes pending.
-            assert!(tracker.changed().now_or_never().is_none());
-
-            // A new version observed for a partition should trigger a notification.
-            {
-                partition_replica_set_states.note_observed_membership(
-                    PartitionId::from(0),
-                    LeadershipState {
-                        current_leader_epoch: LeaderEpoch::from(0),
-                        current_leader: GenerationalNodeId::from(0),
-                    },
-                    &ReplicaSetState {
-                        version: Version::from(1),
-                        members: Default::default(),
-                    },
-                    &None,
-                );
-
-                assert!(tracker.changed().now_or_never().is_some());
-            }
-
-            // Without acknowledging the change, the tracker should fullfill the changed future with every poll.
-            assert!(tracker.changed().now_or_never().is_some());
-            assert!(tracker.changed().now_or_never().is_some());
-
-            // Acknowledge the change.
-            tracker.ack();
-            assert!(tracker.changed().now_or_never().is_none());
-
-            // Observing a "next" version for a partition should trigger a notification.
-            {
-                partition_replica_set_states.note_observed_membership(
-                    PartitionId::from(0),
-                    LeadershipState {
-                        current_leader_epoch: LeaderEpoch::from(0),
-                        current_leader: GenerationalNodeId::from(0),
-                    },
-                    &ReplicaSetState {
-                        version: Version::from(1),
-                        members: Default::default(),
-                    },
-                    &Some(ReplicaSetState {
-                        version: Version::from(2),
-                        members: Default::default(),
-                    }),
-                );
-
-                assert!(tracker.changed().now_or_never().is_some());
-                tracker.ack();
-            }
-
-            // Observing a higher version for a partition should trigger a notification.
-            {
-                partition_replica_set_states.note_observed_membership(
-                    PartitionId::from(0),
-                    LeadershipState {
-                        current_leader_epoch: LeaderEpoch::from(0),
-                        current_leader: GenerationalNodeId::from(0),
-                    },
-                    &ReplicaSetState {
-                        version: Version::from(3),
-                        members: Default::default(),
-                    },
-                    &None,
-                );
-
-                assert!(tracker.changed().now_or_never().is_some());
-                tracker.ack();
-                assert!(tracker.changed().now_or_never().is_none());
-            }
-
-            // Observing a new partition should trigger a notification.
-            {
-                partition_replica_set_states.note_observed_membership(
-                    PartitionId::from(5),
-                    LeadershipState {
-                        current_leader_epoch: LeaderEpoch::from(0),
-                        current_leader: GenerationalNodeId::from(0),
-                    },
-                    &ReplicaSetState {
-                        version: Version::from(1),
-                        members: Default::default(),
-                    },
-                    &None,
-                );
-
-                assert!(tracker.changed().now_or_never().is_some());
-                tracker.ack();
-                assert!(tracker.changed().now_or_never().is_none());
-            }
-
-            // Manually noting the change to the tracker after obsering a change shouldn't trigger a notification.
-            {
-                partition_replica_set_states.note_observed_membership(
-                    PartitionId::from(0),
-                    LeadershipState {
-                        current_leader_epoch: LeaderEpoch::from(0),
-                        current_leader: GenerationalNodeId::from(0),
-                    },
-                    &ReplicaSetState {
-                        version: Version::from(10),
-                        members: Default::default(),
-                    },
-                    &None,
-                );
-                tracker.note_observed_version(PartitionId::from(0), Version::from(10), None);
-
-                assert!(tracker.changed().now_or_never().is_none());
-            }
-
-            // Leadership changes & durable lsn changes shouldn't trigger a notification.
-            {
-                partition_replica_set_states.note_observed_leader(
-                    PartitionId::from(0),
-                    LeadershipState {
-                        current_leader_epoch: LeaderEpoch::from(10),
-                        current_leader: GenerationalNodeId::from(2),
-                    },
-                );
-                partition_replica_set_states.note_durable_lsn(
-                    PartitionId::from(0),
-                    PlainNodeId::from(2),
-                    Lsn::from(120),
-                );
-                assert!(tracker.changed().now_or_never().is_none());
-            }
-        }
     }
 }

--- a/crates/admin/src/cluster_controller/service/scheduler_task.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler_task.rs
@@ -79,7 +79,7 @@ where
         let mut cs_changed = std::pin::pin!(cs.changed());
 
         let replica_set_states = self.replica_set_states.clone();
-        let mut observed_membersip_changed =
+        let mut observed_membership_changed =
             std::pin::pin!(replica_set_states.membership_changed());
 
         let mut fetch_epoch_metadata_task = Some(self.spawn_fetch_epoch_metadata_task(Vec::new())?);
@@ -163,11 +163,11 @@ where
                     trace!("triggering an epoch metadata fetch as part of the periodic refreshes");
                     fetch_epoch_metadata_task = Some(self.spawn_fetch_epoch_metadata_task(Vec::new())?);
                 }
-                _ = &mut observed_membersip_changed, if fetch_epoch_metadata_task.is_none() => {
+                _ = &mut observed_membership_changed, if fetch_epoch_metadata_task.is_none() => {
+                    observed_membership_changed.set(replica_set_states.membership_changed());
                     // we observed membership changed, but the scheduler might be already aware of it if, for
                     // example, it's the one that triggered it. So let's notify it about the change and only
                     // trigger a refresh if it reports back that it's not aware of it.
-                    observed_membersip_changed.set(replica_set_states.membership_changed());
                     let stale_epoch_metadata = self.scheduler.detect_stale_epoch_metadata();
                     if !stale_epoch_metadata.is_empty() {
                         trace!("the scheduler detected some partitions ({:?}) with stale epoch metadata, triggering an epoch metadata fetch for those partitions", stale_epoch_metadata);

--- a/crates/admin/src/cluster_controller/service/scheduler_task.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler_task.rs
@@ -12,8 +12,10 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use futures::future::OptionFuture;
+use restate_types::Versioned;
+use restate_types::partitions::state::PartitionReplicaSetStates;
 use tokio::sync::mpsc;
-use tracing::{debug, warn};
+use tracing::{debug, trace, warn};
 
 use restate_core::network::TransportConnect;
 use restate_core::{
@@ -32,11 +34,13 @@ use restate_types::partitions::PartitionTable;
 
 use crate::cluster_controller::cluster_state_refresher::ClusterStateWatcher;
 use crate::cluster_controller::service::scheduler::{self, Scheduler};
+use crate::cluster_controller::service::scheduler_task::version_tracker::PartitionConfigVersionTracker;
 
 pub struct SchedulerTask<T> {
     cluster_state_watcher: ClusterStateWatcher,
     metadata_client: MetadataStoreClient,
     scheduler: Scheduler<T>,
+    replica_set_states: PartitionReplicaSetStates,
     sync_epoch_metadata_rx: mpsc::Receiver<Vec<PartitionId>>,
 }
 
@@ -47,12 +51,14 @@ where
     pub fn new(
         cluster_state_watcher: ClusterStateWatcher,
         scheduler: Scheduler<T>,
+        replica_set_states: PartitionReplicaSetStates,
         metadata_client: MetadataStoreClient,
         sync_epoch_metadata_rx: mpsc::Receiver<Vec<PartitionId>>,
     ) -> Self {
         Self {
             cluster_state_watcher,
             scheduler,
+            replica_set_states,
             metadata_client,
             sync_epoch_metadata_rx,
         }
@@ -73,6 +79,9 @@ where
 
         let cs = TaskCenter::with_current(|tc| tc.cluster_state().clone());
         let mut cs_changed = std::pin::pin!(cs.changed());
+
+        let mut partition_config_version_tracker =
+            PartitionConfigVersionTracker::new(self.replica_set_states.clone());
 
         let mut fetch_epoch_metadata_task = Some(self.spawn_fetch_epoch_metadata_task(Vec::new())?);
 
@@ -110,10 +119,12 @@ where
                     self.on_cluster_state_change(&cs, &legacy_cluster_state, nodes_config.live_load(), partition_table.live_load()).await
                 }
                 Some(epoch_metadata) = OptionFuture::from(fetch_epoch_metadata_task.as_mut()) => {
+                    trace!("applying new epoch metadata fetched from the metadata store");
                     match epoch_metadata {
                         Ok(epoch_metadata) => {
                             for (partition_id, epoch_metadata) in epoch_metadata {
                                 let (_, _, current, next, leadership_policy) = epoch_metadata.into_inner();
+                                partition_config_version_tracker.note_observed_version(partition_id, current.version(), next.as_ref().map(|n| n.version()));
                                 self.scheduler.update_partition_configuration(partition_id, current, next, leadership_policy);
                             }
 
@@ -143,6 +154,13 @@ where
                     }
                 }
                 _ = next_fetch_interval.tick() => {
+                    trace!("triggering an epoch metadata fetch as part of the periodic refreshes");
+                    if fetch_epoch_metadata_task.is_none() {
+                        fetch_epoch_metadata_task = Some(self.spawn_fetch_epoch_metadata_task(Vec::new())?);
+                    }
+                }
+                _ = partition_config_version_tracker.changed() => {
+                    trace!("epoch metadata version change detected, triggering an epoch metadata fetch");
                     if fetch_epoch_metadata_task.is_none() {
                         fetch_epoch_metadata_task = Some(self.spawn_fetch_epoch_metadata_task(Vec::new())?);
                     }
@@ -244,5 +262,94 @@ impl FetchEpochMetadataTask {
         }
 
         latest_epoch_metadata
+    }
+}
+
+mod version_tracker {
+    use std::collections::HashMap;
+    use std::collections::hash_map::Entry;
+
+    use restate_types::identifiers::PartitionId;
+    use restate_types::{Version, partitions::state::PartitionReplicaSetStates};
+
+    /// Keeps tracks of the partition config version (current and next) observed in the replica set states struct
+    /// and the ones fetched already by the scheduler task. This allows the scheduler loop to detect whenever a
+    /// higher version that it hasn't yet fetched is available, reducing the staleness of the epoch metadata.
+    pub(super) struct PartitionConfigVersionTracker {
+        replica_set_states: PartitionReplicaSetStates,
+        observed_current_versions: HashMap<PartitionId, Version>,
+        observed_next_versions: HashMap<PartitionId, Version>,
+    }
+
+    impl PartitionConfigVersionTracker {
+        pub(super) fn new(replica_set_states: PartitionReplicaSetStates) -> Self {
+            Self {
+                replica_set_states,
+                observed_current_versions: HashMap::default(),
+                observed_next_versions: HashMap::default(),
+            }
+        }
+
+        /// Returns a future that will resolve whenever a newer version than what we've previously seen is observed in the replica set states.
+        ///
+        /// Under the hood, this subscribes to all changes to replica set states and only fires whenever there's a version change, effectively
+        /// unsubscribing from durable lsn change notifications, etc
+        pub(super) async fn changed(&mut self) {
+            let replica_set_states = self.replica_set_states.clone();
+            loop {
+                let changed_future = replica_set_states.changed();
+                if self.update_if_changed() {
+                    break;
+                }
+                changed_future.await;
+            }
+        }
+
+        /// Updates the observed version of the given partition id.
+        pub(super) fn note_observed_version(
+            &mut self,
+            partition_id: PartitionId,
+            current_version: Version,
+            next_version: Option<Version>,
+        ) -> bool {
+            Self::update_version_if_newer(
+                &mut self.observed_current_versions,
+                partition_id,
+                current_version,
+            ) | Self::update_version_if_newer(
+                &mut self.observed_next_versions,
+                partition_id,
+                next_version.unwrap_or(Version::INVALID),
+            )
+        }
+
+        fn update_version_if_newer(
+            map: &mut HashMap<PartitionId, Version>,
+            partition_id: PartitionId,
+            version: Version,
+        ) -> bool {
+            match map.entry(partition_id) {
+                Entry::Occupied(mut occupied_entry) => {
+                    if occupied_entry.get() < &version {
+                        *occupied_entry.get_mut() = version;
+                        true
+                    } else {
+                        false
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(version);
+                    true
+                }
+            }
+        }
+
+        fn update_if_changed(&mut self) -> bool {
+            let mut changed = false;
+            for p in self.replica_set_states.partition_versions() {
+                changed |= self.note_observed_version(p.id, p.current, p.next);
+            }
+            changed
+        }
     }
 }

--- a/crates/admin/src/cluster_controller/service/scheduler_task.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler_task.rs
@@ -85,7 +85,12 @@ where
         let mut fetch_epoch_metadata_task = Some(self.spawn_fetch_epoch_metadata_task(Vec::new())?);
 
         let mut next_fetch_interval = tokio::time::interval(Duration::from_secs(30));
-        // We've just scheduled a fetch, let's consume the initial tick from the interval (which ticks immediately).
+        // If we don't drain the ticks for long (e.g. not polling it because of the guard), there's a risk that we
+        // might accumulate a lot of them. The default behavior will burst through them causing back-to-back fetches
+        // until the interval is drained, which might overwhelm the metadata store. Let's change the default behavior
+        // to schedule the next tick from the moment we've consumed the previous one.
+        next_fetch_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // We've just scheduled a fetch, let's consume the initial tick from the interval which ticks immediately.
         next_fetch_interval.tick().await;
 
         loop {
@@ -153,7 +158,7 @@ where
                         }
                     }
                 }
-                // Trigger the periodic full epoch metadata fetch if there's no epoch metadata fetch is already in flight.
+                // Trigger the periodic full epoch metadata fetch if there's no epoch metadata fetch that is already in flight.
                 _ = next_fetch_interval.tick(), if fetch_epoch_metadata_task.is_none() => {
                     trace!("triggering an epoch metadata fetch as part of the periodic refreshes");
                     fetch_epoch_metadata_task = Some(self.spawn_fetch_epoch_metadata_task(Vec::new())?);

--- a/crates/admin/src/cluster_controller/service/scheduler_task.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler_task.rs
@@ -153,16 +153,19 @@ where
                         }
                     }
                 }
-                _ = next_fetch_interval.tick() => {
+                // Trigger the periodic full epoch metadata fetch if there's no epoch metadata fetch is already in flight.
+                _ = next_fetch_interval.tick(), if fetch_epoch_metadata_task.is_none() => {
                     trace!("triggering an epoch metadata fetch as part of the periodic refreshes");
-                    if fetch_epoch_metadata_task.is_none() {
-                        fetch_epoch_metadata_task = Some(self.spawn_fetch_epoch_metadata_task(Vec::new())?);
-                    }
+                    fetch_epoch_metadata_task = Some(self.spawn_fetch_epoch_metadata_task(Vec::new())?);
                 }
-                _ = partition_config_version_tracker.changed() => {
-                    trace!("epoch metadata version change detected, triggering an epoch metadata fetch");
-                    if fetch_epoch_metadata_task.is_none() {
-                        fetch_epoch_metadata_task = Some(self.spawn_fetch_epoch_metadata_task(Vec::new())?);
+                // If there's an ongoing epoch metadata refresh already ongoing, no need to poll the version tracker
+                // as it won't be able to schedule another refresh anyways.
+                _ = partition_config_version_tracker.changed(), if fetch_epoch_metadata_task.is_none() => {
+                    partition_config_version_tracker.ack();
+                    let stale_epoch_metadata = self.scheduler.detect_stale_partition_epoch_metadata();
+                    if !stale_epoch_metadata.is_empty() {
+                        trace!("the scheduler detected some partitions ({:?}) with stale epoch metadata, triggering an epoch metadata fetch for those partitions", stale_epoch_metadata);
+                        fetch_epoch_metadata_task = Some(self.spawn_fetch_epoch_metadata_task(stale_epoch_metadata)?);
                     }
                 }
             }
@@ -279,6 +282,7 @@ mod version_tracker {
         replica_set_states: PartitionReplicaSetStates,
         observed_current_versions: HashMap<PartitionId, Version>,
         observed_next_versions: HashMap<PartitionId, Version>,
+        acked: bool,
     }
 
     impl PartitionConfigVersionTracker {
@@ -287,6 +291,7 @@ mod version_tracker {
                 replica_set_states,
                 observed_current_versions: HashMap::default(),
                 observed_next_versions: HashMap::default(),
+                acked: false,
             }
         }
 
@@ -296,13 +301,22 @@ mod version_tracker {
         /// unsubscribing from durable lsn change notifications, etc
         pub(super) async fn changed(&mut self) {
             let replica_set_states = self.replica_set_states.clone();
+            // There's already a pending change that wasn't acked, let's fullfill the future immediately.
+            if !self.acked {
+                return;
+            }
             loop {
                 let changed_future = replica_set_states.changed();
                 if self.update_if_changed() {
+                    self.acked = false;
                     break;
                 }
                 changed_future.await;
             }
+        }
+
+        pub(super) fn ack(&mut self) {
+            self.acked = true;
         }
 
         /// Updates the observed version of the given partition id.

--- a/crates/admin/src/cluster_controller/service/scheduler_task.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler_task.rs
@@ -291,7 +291,7 @@ mod version_tracker {
                 replica_set_states,
                 observed_current_versions: HashMap::default(),
                 observed_next_versions: HashMap::default(),
-                acked: false,
+                acked: true,
             }
         }
 
@@ -364,6 +364,152 @@ mod version_tracker {
                 changed |= self.note_observed_version(p.id, p.current, p.next);
             }
             changed
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use futures::FutureExt;
+        use restate_types::{
+            GenerationalNodeId, PlainNodeId,
+            identifiers::LeaderEpoch,
+            logs::Lsn,
+            partitions::state::{LeadershipState, PartitionReplicaSetStates, ReplicaSetState},
+        };
+
+        #[test]
+        fn partition_version_tracker() {
+            let partition_replica_set_states: PartitionReplicaSetStates = Default::default();
+            let mut tracker =
+                PartitionConfigVersionTracker::new(partition_replica_set_states.clone());
+
+            // After init, tracker shouldn't have any changes pending.
+            assert!(tracker.changed().now_or_never().is_none());
+
+            // A new version observed for a partition should trigger a notification.
+            {
+                partition_replica_set_states.note_observed_membership(
+                    PartitionId::from(0),
+                    LeadershipState {
+                        current_leader_epoch: LeaderEpoch::from(0),
+                        current_leader: GenerationalNodeId::from(0),
+                    },
+                    &ReplicaSetState {
+                        version: Version::from(1),
+                        members: Default::default(),
+                    },
+                    &None,
+                );
+
+                assert!(tracker.changed().now_or_never().is_some());
+            }
+
+            // Without acknowledging the change, the tracker should fullfill the changed future with every poll.
+            assert!(tracker.changed().now_or_never().is_some());
+            assert!(tracker.changed().now_or_never().is_some());
+
+            // Acknowledge the change.
+            tracker.ack();
+            assert!(tracker.changed().now_or_never().is_none());
+
+            // Observing a "next" version for a partition should trigger a notification.
+            {
+                partition_replica_set_states.note_observed_membership(
+                    PartitionId::from(0),
+                    LeadershipState {
+                        current_leader_epoch: LeaderEpoch::from(0),
+                        current_leader: GenerationalNodeId::from(0),
+                    },
+                    &ReplicaSetState {
+                        version: Version::from(1),
+                        members: Default::default(),
+                    },
+                    &Some(ReplicaSetState {
+                        version: Version::from(2),
+                        members: Default::default(),
+                    }),
+                );
+
+                assert!(tracker.changed().now_or_never().is_some());
+                tracker.ack();
+            }
+
+            // Observing a higher version for a partition should trigger a notification.
+            {
+                partition_replica_set_states.note_observed_membership(
+                    PartitionId::from(0),
+                    LeadershipState {
+                        current_leader_epoch: LeaderEpoch::from(0),
+                        current_leader: GenerationalNodeId::from(0),
+                    },
+                    &ReplicaSetState {
+                        version: Version::from(3),
+                        members: Default::default(),
+                    },
+                    &None,
+                );
+
+                assert!(tracker.changed().now_or_never().is_some());
+                tracker.ack();
+                assert!(tracker.changed().now_or_never().is_none());
+            }
+
+            // Observing a new partition should trigger a notification.
+            {
+                partition_replica_set_states.note_observed_membership(
+                    PartitionId::from(5),
+                    LeadershipState {
+                        current_leader_epoch: LeaderEpoch::from(0),
+                        current_leader: GenerationalNodeId::from(0),
+                    },
+                    &ReplicaSetState {
+                        version: Version::from(1),
+                        members: Default::default(),
+                    },
+                    &None,
+                );
+
+                assert!(tracker.changed().now_or_never().is_some());
+                tracker.ack();
+                assert!(tracker.changed().now_or_never().is_none());
+            }
+
+            // Manually noting the change to the tracker after obsering a change shouldn't trigger a notification.
+            {
+                partition_replica_set_states.note_observed_membership(
+                    PartitionId::from(0),
+                    LeadershipState {
+                        current_leader_epoch: LeaderEpoch::from(0),
+                        current_leader: GenerationalNodeId::from(0),
+                    },
+                    &ReplicaSetState {
+                        version: Version::from(10),
+                        members: Default::default(),
+                    },
+                    &None,
+                );
+                tracker.note_observed_version(PartitionId::from(0), Version::from(10), None);
+
+                assert!(tracker.changed().now_or_never().is_none());
+            }
+
+            // Leadership changes & durable lsn changes shouldn't trigger a notification.
+            {
+                partition_replica_set_states.note_observed_leader(
+                    PartitionId::from(0),
+                    LeadershipState {
+                        current_leader_epoch: LeaderEpoch::from(10),
+                        current_leader: GenerationalNodeId::from(2),
+                    },
+                );
+                partition_replica_set_states.note_durable_lsn(
+                    PartitionId::from(0),
+                    PlainNodeId::from(2),
+                    Lsn::from(120),
+                );
+                assert!(tracker.changed().now_or_never().is_none());
+            }
         }
     }
 }

--- a/crates/types/src/partitions/state.rs
+++ b/crates/types/src/partitions/state.rs
@@ -34,6 +34,8 @@ pub struct PartitionReplicaSetStates {
 struct Inner {
     partitions: DashMap<PartitionId, MembershipState>,
     global_notify: Notify,
+    // Fires only for partition membership changes
+    membership_notify: Notify,
 }
 
 impl PartitionReplicaSetStates {
@@ -97,6 +99,7 @@ impl PartitionReplicaSetStates {
 
         if modified {
             self.inner.global_notify.notify_waiters();
+            self.inner.membership_notify.notify_waiters();
         }
     }
 
@@ -231,16 +234,16 @@ impl PartitionReplicaSetStates {
     }
 
     /// A lightweight accessor to the partition versions to avoid the clone introduced by the `iter` method.
-    pub fn partition_versions(&self) -> Vec<PartitionReplicaSetVersion> {
+    pub fn partition_versions(&self) -> Vec<ObservedPartitionReplicaSetVersion> {
         self.inner
             .partitions
             .iter()
             .map(|entry| {
                 let (id, state) = (*entry.key(), entry.value());
-                PartitionReplicaSetVersion {
-                    id,
-                    current: state.observed_current_membership.version,
-                    next: state.observed_next_membership.as_ref().map(|s| s.version),
+                ObservedPartitionReplicaSetVersion {
+                    partition_id: id,
+                    current_version: state.observed_current_membership.version,
+                    next_version: state.observed_next_membership.as_ref().map(|s| s.version),
                 }
             })
             .collect()
@@ -252,6 +255,14 @@ impl PartitionReplicaSetStates {
     /// partition replica set states, then await this future for updates.
     pub fn changed(&self) -> Notified<'_> {
         self.inner.global_notify.notified()
+    }
+
+    /// Future to monitor changes to the partition membership changes only.
+    ///
+    /// If you don't want to miss any changes, it's advised to create this future first, read the
+    /// partition replica set states, then await this future for updates.
+    pub fn membership_changed(&self) -> Notified<'_> {
+        self.inner.membership_notify.notified()
     }
 }
 
@@ -484,8 +495,8 @@ pub struct MemberState {
 }
 
 #[derive(Debug, Clone)]
-pub struct PartitionReplicaSetVersion {
-    pub id: PartitionId,
-    pub current: Version,
-    pub next: Option<Version>,
+pub struct ObservedPartitionReplicaSetVersion {
+    pub partition_id: PartitionId,
+    pub current_version: Version,
+    pub next_version: Option<Version>,
 }

--- a/crates/types/src/partitions/state.rs
+++ b/crates/types/src/partitions/state.rs
@@ -372,7 +372,7 @@ impl MembershipState {
             }
             std::cmp::Ordering::Equal => {
                 // merge member's durable lsns
-                result.durable_lsn_changed = self
+                result.durable_lsn_changed |= self
                     .observed_current_membership
                     .merge(incoming_current_membership.clone());
             }
@@ -412,7 +412,7 @@ impl MembershipState {
             }
             std::cmp::Ordering::Equal => {
                 // merge member's durable lsns
-                result.durable_lsn_changed =
+                result.durable_lsn_changed |=
                     my_next_membership.merge(incoming_next_membership.clone());
             }
             std::cmp::Ordering::Less => { /* ignore it */ }
@@ -527,4 +527,126 @@ pub struct ObservedPartitionReplicaSetVersion {
     pub partition_id: PartitionId,
     pub current_version: Version,
     pub next_version: Option<Version>,
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::FutureExt;
+
+    use super::{LeadershipState, PartitionReplicaSetStates, ReplicaSetState};
+    use crate::identifiers::{LeaderEpoch, PartitionId};
+    use crate::partitions::state::MemberState;
+    use crate::{GenerationalNodeId, PlainNodeId, Version, logs::Lsn};
+
+    #[test]
+    fn changed_notifications() {
+        let states: PartitionReplicaSetStates = Default::default();
+
+        // After init, the change notifications shouldn't fire.
+        assert!(states.changed().now_or_never().is_none());
+        assert!(states.membership_changed().now_or_never().is_none());
+
+        // Observing a new partition should trigger both notification.
+        {
+            let changed = states.changed();
+            let membership_changed = states.membership_changed();
+            states.note_observed_membership(
+                PartitionId::from(0),
+                LeadershipState {
+                    current_leader_epoch: LeaderEpoch::from(0),
+                    current_leader: GenerationalNodeId::from(0),
+                },
+                &ReplicaSetState {
+                    version: Version::from(1),
+                    members: Default::default(),
+                },
+                &None,
+            );
+
+            assert!(changed.now_or_never().is_some());
+            assert!(membership_changed.now_or_never().is_some());
+        }
+
+        // Observing a "next" version for a partition should trigger both notifications.
+        {
+            let changed = states.changed();
+            let membership_changed = states.membership_changed();
+            states.note_observed_membership(
+                PartitionId::from(0),
+                LeadershipState {
+                    current_leader_epoch: LeaderEpoch::from(0),
+                    current_leader: GenerationalNodeId::from(0),
+                },
+                &ReplicaSetState {
+                    version: Version::from(1),
+                    members: Default::default(),
+                },
+                &Some(ReplicaSetState {
+                    version: Version::from(2),
+                    members: Default::default(),
+                }),
+            );
+
+            assert!(changed.now_or_never().is_some());
+            assert!(membership_changed.now_or_never().is_some());
+        }
+
+        // Observing a higher version for a partition should trigger a notification.
+        {
+            let changed = states.changed();
+            let membership_changed = states.membership_changed();
+            states.note_observed_membership(
+                PartitionId::from(0),
+                LeadershipState {
+                    current_leader_epoch: LeaderEpoch::from(0),
+                    current_leader: GenerationalNodeId::from(0),
+                },
+                &ReplicaSetState {
+                    version: Version::from(3),
+                    members: vec![MemberState {
+                        node_id: PlainNodeId::from(0),
+                        durable_lsn: Lsn::from(50),
+                    }],
+                },
+                &None,
+            );
+
+            assert!(changed.now_or_never().is_some());
+            assert!(membership_changed.now_or_never().is_some());
+        }
+
+        // Leadership changes should trigger a changed notification, but not a membership changed notification.
+        {
+            let changed = states.changed();
+            let membership_changed = states.membership_changed();
+            states.note_observed_leader(
+                PartitionId::from(0),
+                LeadershipState {
+                    current_leader_epoch: LeaderEpoch::from(10),
+                    current_leader: GenerationalNodeId::from(2),
+                },
+            );
+            assert!(changed.now_or_never().is_some());
+            assert!(membership_changed.now_or_never().is_none());
+        }
+
+        // Durable lsn changes should trigger a changed notification, but not a membership changed notification.
+        {
+            let changed = states.changed();
+            let membership_changed = states.membership_changed();
+            states.note_durable_lsn(PartitionId::from(0), PlainNodeId::from(0), Lsn::from(100));
+            assert!(changed.now_or_never().is_some());
+            assert!(membership_changed.now_or_never().is_none());
+        }
+
+        // Applying a change that doesn't mutate the state should not trigger a changed notification.
+        // In this case, it's applying a durable LSN change older than what we've observed before
+        {
+            let changed = states.changed();
+            let membership_changed = states.membership_changed();
+            states.note_durable_lsn(PartitionId::from(0), PlainNodeId::from(0), Lsn::from(70));
+            assert!(changed.now_or_never().is_none());
+            assert!(membership_changed.now_or_never().is_none());
+        }
+    }
 }

--- a/crates/types/src/partitions/state.rs
+++ b/crates/types/src/partitions/state.rs
@@ -93,12 +93,14 @@ impl PartitionReplicaSetStates {
                     observed_current_membership: current_membership.clone(),
                     observed_next_membership: next_membership.clone(),
                 });
-                true
+                MembershipMergeResult::all_changed()
             }
         };
 
-        if modified {
+        if modified.changed() {
             self.inner.global_notify.notify_waiters();
+        }
+        if modified.membership_changed {
             self.inner.membership_notify.notify_waiters();
         }
     }
@@ -319,14 +321,34 @@ impl Default for MembershipState {
     }
 }
 
+#[derive(Debug, Default)]
+struct MembershipMergeResult {
+    leadership_changed: bool,
+    membership_changed: bool,
+    durable_lsn_changed: bool,
+}
+
+impl MembershipMergeResult {
+    fn changed(&self) -> bool {
+        self.leadership_changed || self.membership_changed || self.durable_lsn_changed
+    }
+    fn all_changed() -> Self {
+        Self {
+            leadership_changed: true,
+            membership_changed: true,
+            durable_lsn_changed: true,
+        }
+    }
+}
+
 impl MembershipState {
     fn merge(
         &mut self,
         incoming_leadership_state: LeadershipState,
         incoming_current_membership: &ReplicaSetState,
         incoming_next_membership: &Option<ReplicaSetState>,
-    ) -> bool {
-        let mut modified = false;
+    ) -> MembershipMergeResult {
+        let mut result = MembershipMergeResult::default();
         match incoming_current_membership
             .version
             .cmp(&self.observed_current_membership.version)
@@ -335,7 +357,8 @@ impl MembershipState {
             std::cmp::Ordering::Greater => {
                 // todo: try to use previous durable lsns if the two replica-sets intersect
                 self.observed_current_membership = incoming_current_membership.clone();
-                modified = true;
+                result.membership_changed = true;
+                result.durable_lsn_changed = true;
                 if self
                     .observed_next_membership
                     .as_ref()
@@ -349,31 +372,33 @@ impl MembershipState {
             }
             std::cmp::Ordering::Equal => {
                 // merge member's durable lsns
-                modified = self
+                result.durable_lsn_changed = self
                     .observed_current_membership
                     .merge(incoming_current_membership.clone());
             }
             std::cmp::Ordering::Less => { /* ignore it */ }
         }
 
-        modified |= self
+        result.leadership_changed |= self
             .current_leader
             .send_if_modified(|l| l.merge(incoming_leadership_state));
 
         // dealing with next membership configuration
         let Some(incoming_next_membership) = incoming_next_membership else {
-            return modified;
+            return result;
         };
 
         // incoming has next but it older/equal to our own current
         if incoming_next_membership.version <= self.observed_current_membership.version {
             // ignore it, their next is lower that our current's
-            return modified;
+            return result;
         }
 
         let Some(my_next_membership) = &mut self.observed_next_membership else {
             self.observed_next_membership = Some(incoming_next_membership.clone());
-            return true;
+            result.membership_changed = true;
+            result.durable_lsn_changed = true;
+            return result;
         };
 
         match incoming_next_membership
@@ -382,15 +407,18 @@ impl MembershipState {
         {
             std::cmp::Ordering::Greater => {
                 *my_next_membership = incoming_next_membership.clone();
-                modified = true;
+                result.membership_changed = true;
+                result.durable_lsn_changed = true;
             }
             std::cmp::Ordering::Equal => {
-                modified = my_next_membership.merge(incoming_next_membership.clone());
+                // merge member's durable lsns
+                result.durable_lsn_changed =
+                    my_next_membership.merge(incoming_next_membership.clone());
             }
             std::cmp::Ordering::Less => { /* ignore it */ }
         }
 
-        modified
+        result
     }
 
     /// Returns true if the given node_id is part of the current or next membership.

--- a/crates/types/src/partitions/state.rs
+++ b/crates/types/src/partitions/state.rs
@@ -230,6 +230,22 @@ impl PartitionReplicaSetStates {
             .map(|entry| (*entry.key(), entry.value().clone()))
     }
 
+    /// A lightweight accessor to the partition versions to avoid the clone introduced by the `iter` method.
+    pub fn partition_versions(&self) -> Vec<PartitionReplicaSetVersion> {
+        self.inner
+            .partitions
+            .iter()
+            .map(|entry| {
+                let (id, state) = (*entry.key(), entry.value());
+                PartitionReplicaSetVersion {
+                    id,
+                    current: state.observed_current_membership.version,
+                    next: state.observed_next_membership.as_ref().map(|s| s.version),
+                }
+            })
+            .collect()
+    }
+
     /// Future to monitor changes to the partition replica set states.
     ///
     /// If you don't want to miss any changes, it's advised to create this future first, read the
@@ -465,4 +481,11 @@ impl Merge for ReplicaSetState {
 pub struct MemberState {
     pub node_id: PlainNodeId,
     pub durable_lsn: Lsn,
+}
+
+#[derive(Debug, Clone)]
+pub struct PartitionReplicaSetVersion {
+    pub id: PartitionId,
+    pub current: Version,
+    pub next: Option<Version>,
 }


### PR DESCRIPTION
Fixes https://github.com/restatedev/restate/issues/4937

Cluster controller now refreshes its own epoch metadata once every 30secs. This is usually fine as it's the one doing most of the epoch metadata changes anyways. And usually on leadership transitions, the cluster controller is reconstructed and fetches the latest epoch metadata on startup.

However, if the metadata was updated by another node (e.g. the CC was isolated), it'll take up to 30secs (the hardcoded refresh interval) for the CC to notice that change. During that time, all of its instructions are ignored by other nodes who have observed the higher replicaset version. In a situation where a partition doesn't have a leader, this can leave that partition write unavailable until the next epoch metadata refresh. This was the scenario caught by our jepsen tests in https://github.com/restatedev/restate/issues/4937.

Replicaset versions, however, get replicated to all nodes over gossip every second. So this PR allows the cluster controller to tap into this info, and use it as a notification for the CC to potentially detect if there's some stale epoch metadata that needs to be refreshed.

## Validation

Some validation on a local docker cluster.

On startup, first node does only a single fetch and then the next one is the scheduled one:

```

❯❯❯ just restate-logs
nodes="$(docker compose config --services | grep -E '^restate-[0-9]+$' || true)"; if [ -z "$nodes" ]; then echo "No Restate nodes found"; exit 0; fi; docker compose logs -f $nod
es
restate-1-1  | 2026-06-16T15:41:20.739050Z DEBUG restate_admin::cluster_controller::service::scheduler_task
restate-1-1  |   Running SchedulerTask
restate-1-1  | on rs:worker-16
restate-1-1  | 2026-06-16T15:41:21.023780Z TRACE restate_admin::cluster_controller::service::scheduler_task
restate-1-1  |   applying new epoch metadata fetched from the metadata store
restate-1-1  | on rs:worker-5
restate-1-1  | 2026-06-16T15:41:50.740854Z TRACE restate_admin::cluster_controller::service::scheduler_task
restate-1-1  |   triggering an epoch metadata fetch as part of the periodic refreshes
restate-1-1  | on rs:worker-17
restate-1-1  | 2026-06-16T15:41:51.637272Z TRACE restate_admin::cluster_controller::service::scheduler_task
restate-1-1  |   applying new epoch metadata fetched from the metadata store
restate-1-1  | on rs:worker-13
```

To simulate out of band notifications, I used `docker pause` to pause N1 (such that it doesn't relinquish its leadership), then unpaused it. When unpaused, it detected the changes done by N2, and refetched them. While re-fetching them, two partition reads failed, so the stale detection kicked again (during the application of the first fetch result) and refetched the only two stale partitions.

```
# Last periodic refresh on N1
restate-1-1  | 2026-06-16T15:51:06.036114Z TRACE restate_admin::cluster_controller::service::scheduler_task
restate-1-1  |   triggering an epoch metadata fetch as part of the periodic refreshes
restate-1-1  | on rs:worker-32
restate-1-1  | 2026-06-16T15:51:06.607184Z TRACE restate_admin::cluster_controller::service::scheduler_task
restate-1-1  |   applying new epoch metadata fetched from the metadata store
restate-1-1  | on rs:worker-36

# <--- Paused N1 here. N2 took over.
restate-2-1  | 2026-06-16T15:51:08.780875Z DEBUG restate_admin::cluster_controller::service::scheduler_task
restate-2-1  |   Running SchedulerTask
restate-2-1  | on rs:worker-144
restate-2-1  | 2026-06-16T15:51:10.192776Z TRACE restate_admin::cluster_controller::service::scheduler_task
restate-2-1  |   applying new epoch metadata fetched from the metadata store
restate-2-1  | on rs:worker-135

# <--- Unpaused N1. It detected the stale metadata.
restate-1-1  | 2026-06-16T15:51:13.818179Z TRACE restate_admin::cluster_controller::service::scheduler_task
restate-1-1  |   the scheduler detected some partitions ([23, 14, 21, 9, 4, 1, 0, 11, 8, 16, 3, 13, 22, 18, 20, 19, 12]) with stale epoch metadata, triggering an epoch metadata
fetch for those partitions
restate-1-1  | on rs:worker-20
restate-1-1  | 2026-06-16T15:51:13.819842Z DEBUG restate_admin::cluster_controller::service::scheduler_task

# Sporadic fetch failures
restate-1-1  |   Failed to fetch epoch metadata for partition 23
restate-1-1  |     err: other error: [retryable] [http://restate-3:5122/] The operation was cancelled: operation was canceled
restate-1-1  | on rs:worker-14
restate-1-1  | 2026-06-16T15:51:13.868946Z DEBUG restate_admin::cluster_controller::service::scheduler_task
restate-1-1  |   Failed to fetch epoch metadata for partition 21
restate-1-1  |     err: other error: [retryable] [http://restate-1:5122/] The service is currently unavailable: not leader
restate-1-1  | on rs:worker-47

# Applying the result of the fetch results. Each application triggers a change in the replicaset state changes, so a followup check is done in the next loop. This followup is what catches the fact that partition 21 and 23 failed.
restate-1-1  | 2026-06-16T15:51:14.284931Z TRACE restate_admin::cluster_controller::service::scheduler_task
restate-1-1  |   applying new epoch metadata fetched from the metadata store
restate-1-1  | on rs:worker-14

# N2 Stepping down (irrelevant)
restate-2-1  | 2026-06-16T15:51:20.230168Z DEBUG restate_admin::cluster_controller::service::scheduler_task
restate-2-1  |   Scheduler is shutting down, possibly due to a leader-to-follower transition
restate-2-1  | on rs:worker-62
restate-2-1  | 2026-06-16T15:51:20.230345Z DEBUG restate_admin::cluster_controller::service::scheduler_task
restate-2-1  |   Stopping SchedulerTask
restate-2-1  | on rs:worker-62

# Refetches for 23 and 21 are enqueued
restate-1-1  | 2026-06-16T15:51:20.329801Z TRACE restate_admin::cluster_controller::service::scheduler_task
restate-1-1  |   the scheduler detected some partitions ([23, 21]) with stale epoch metadata, triggering an epoch metadata fetch for those partitions
restate-1-1  | on rs:worker-47
restate-1-1  | 2026-06-16T15:51:20.393480Z TRACE restate_admin::cluster_controller::service::scheduler_task
restate-1-1  |   applying new epoch metadata fetched from the metadata store
restate-1-1  | on rs:worker-49

# 15 seconds later, the full periodic refresh kicks in again
restate-1-1  | 2026-06-16T15:51:36.035646Z TRACE restate_admin::cluster_controller::service::scheduler_task
restate-1-1  |   triggering an epoch metadata fetch as part of the periodic refreshes
restate-1-1  | on rs:worker-20
restate-1-1  | 2026-06-16T15:51:36.703058Z TRACE restate_admin::cluster_controller::service::scheduler_task
restate-1-1  |   applying new epoch metadata fetched from the metadata store
restate-1-1  | on rs:worker-29
```