### PR TITLE
[Resume] Resume backing-off VQueue invocations via persisted command

### DIFF
--- a/crates/types/src/invocation/mod.rs
+++ b/crates/types/src/invocation/mod.rs
@@ -26,6 +26,7 @@ use opentelemetry::trace::{SpanContext, SpanId, TraceFlags, TraceState};
 pub use opentelemetry::trace::TraceId;
 use serde_with::{DisplayFromStr, FromInto, serde_as};
 
+use restate_clock::RoughTimestamp;
 use restate_memory::ByteCount;
 use restate_util_string::ReString;
 
@@ -35,6 +36,7 @@ use crate::identifiers::{
     DeploymentId, EntryIndex, IdempotencyId, InvocationId, PartitionKey,
     PartitionProcessorRpcRequestId, ServiceId, SubscriptionId, WithInvocationId, WithPartitionKey,
 };
+use crate::invocation::client::PatchDeploymentId;
 use crate::journal_v2::{CompletionId, GetInvocationOutputResult, Signal};
 use crate::limit_key::LimitKey;
 use crate::time::MillisSinceEpoch;
@@ -1112,8 +1114,30 @@ impl WithInvocationId for PurgeInvocationRequest {
 #[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ResumeInvocationRequest {
     pub invocation_id: InvocationId,
+    /// The unresolved deployment patch to apply on resume, resolved and validated by the apply path
+    /// (`OnManualResumeCommand`) against the invocation status as of the command's log position.
+    ///
+    /// Only written on the VQueue path, where vqueues being enabled implies a cluster
+    /// `min_restate_version >= 1.7.0` (so every node understands this field). The non-VQueue path
+    /// keeps writing the already-resolved [`Self::update_pinned_deployment_id`] for compatibility
+    /// with pre-1.7.0 nodes. `None` therefore means "use `update_pinned_deployment_id` instead".
+    ///
+    /// Since *v1.7.0*
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub update_deployment_id: Option<PatchDeploymentId>,
+    /// Already-resolved deployment id. Written by the non-VQueue path (and by pre-1.7.0 nodes); the
+    /// apply path honors it directly when present. New VQueue-path writes leave this `None` and use
+    /// [`Self::update_deployment_id`] instead.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub update_pinned_deployment_id: Option<DeploymentId>,
+    /// When the rescheduled VQueue entry should run. `None` defaults to the entry's `created_at`
+    /// (its original priority position). A value in the past raises priority; the future delays it.
+    /// Uses [`RoughTimestamp`] (second precision) to match the VQueue scheduler's `run_at` key; a
+    /// finer-grained timestamp would only be truncated.
+    ///
+    /// Since *v1.7.0*
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_at: Option<RoughTimestamp>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub response_sink: Option<InvocationMutationResponseSink>,
 }

--- a/crates/vqueues/src/lib.rs
+++ b/crates/vqueues/src/lib.rs
@@ -39,11 +39,11 @@ use restate_storage_api::vqueue_table::{
 use restate_storage_api::{StorageError, lock_table};
 use restate_types::ServiceName;
 use restate_types::clock::UniqueTimestamp;
-use restate_types::identifiers::PartitionKey;
+use restate_types::identifiers::{DeploymentId, PartitionKey};
 use restate_types::invocation::InvocationTarget;
 use restate_types::vqueues::{EntryId, Seq, VQueueId};
 use restate_types::{LockName, Scope};
-use restate_util_string::ReString;
+use restate_util_string::{ReString, ToReString};
 use restate_worker_api::invoker::YieldReason;
 
 // Token bucket used for throttling over all vqueues
@@ -511,6 +511,132 @@ where
                 key: modified_key,
                 value,
             });
+            collector.push(A::from(event));
+        }
+    }
+
+    /// Reschedules a waiting entry to a new `run_at`, leaving its stage, [`Status`] and statistics
+    /// untouched. Only the entry key (its `run_at`) changes.
+    ///
+    /// `run_at` may be set in the past (`< now`): the entry becomes immediately eligible *and*
+    /// jumps ahead of entries with a larger `run_at` (the [`EntryKey`] ordering is by `run_at`),
+    /// so this doubles as a priority signal.
+    ///
+    /// Rescheduling makes sense for an entry that is *waiting* with a `run_at`:
+    /// - `Inbox`: changes scheduling eligibility right away. Emits the inbox reconciliation pair
+    ///   (`RemovedFromInbox` + `EnqueuedToInbox`) so the scheduler drops the stale key and
+    ///   re-evaluates eligibility at the new `run_at`.
+    /// - `Suspended` / `Paused`: changes the `run_at` the entry will carry once it is woken back
+    ///   into the inbox (see [`Self::wake_up`]). The scheduler does not track parked entries, so no
+    ///   event is emitted.
+    ///
+    /// This is *not* a stage transition: the entry stays in its current stage, so (unlike
+    /// [`Self::yield_entry`]) the vqueue's aggregate metadata (stage counts, active flag, dwell-time
+    /// EMAs) and the entry's stats are left untouched.
+    ///
+    /// It is a no-op (with a debug log) for any other stage (`Running`, where the entry is
+    /// executing, and the terminal stages) and a no-op if `run_at` already equals the entry's
+    /// current `run_at`.
+    ///
+    /// One can optionally provide a deployment to which the entry is pinned (updating it's metadata
+    /// accordingly).
+    pub fn reschedule(
+        &mut self,
+        header: &impl EntryStatusHeader,
+        run_at: RoughTimestamp,
+        pinned_deployment: Option<DeploymentId>,
+    ) {
+        let stage = header.stage();
+        if !matches!(stage, Stage::Inbox | Stage::Suspended | Stage::Paused) {
+            // Running entries are executing and terminal entries are done: there is nothing to
+            // reschedule. Be lenient and ignore rather than crash the caller.
+            debug!(
+                entry = %header.display_entry_id(),
+                qid = %header.vqueue_id(),
+                "Skipping reschedule of entry in stage {stage}",
+            );
+            return;
+        }
+
+        let vqueue_id = header.vqueue_id();
+        assert_eq!(
+            vqueue_id,
+            self.cache.get_mut(self.handle).unwrap().vqueue_id()
+        );
+
+        // Nothing to do if the entry is already scheduled at the requested time.
+        if header.entry_key().run_at() == run_at {
+            return;
+        }
+
+        // Delete the entry at its old key, then re-insert it at the new key in the *same* stage.
+        self.storage
+            .delete_vqueue_inbox(vqueue_id, stage, header.entry_key());
+
+        let modified_key = header.entry_key().set_run_at(Some(run_at));
+        let mut metadata = header.metadata().clone();
+        let stats = header.stats().clone();
+
+        if let Some(deployment_id) = pinned_deployment {
+            metadata.deployment = Some(deployment_id.to_restring());
+        }
+
+        debug!(
+            entry = %header.display_entry_id(),
+            qid = %header.vqueue_id(),
+            "{0}->{0}, status: {1} (reschedule)",
+            stage,
+            header.status(),
+        );
+
+        // Update the entry state to track the new entry key
+        self.storage.put_vqueue_entry_status(
+            vqueue_id,
+            stage,
+            &modified_key,
+            &metadata,
+            stats.clone(),
+            header.status(),
+        );
+
+        let value = EntryValue {
+            stats,
+            status: header.status(),
+            metadata,
+        };
+
+        // Re-insert the entry into its stage at the new key
+        self.storage
+            .put_vqueue_inbox(vqueue_id, stage, &modified_key, &value);
+
+        // Only inbox entries live in the scheduler's ring, so only they need reconciliation events;
+        // parked (Suspended/Paused) entries are not tracked by the scheduler.
+        if matches!(stage, Stage::Inbox)
+            && let Some(collector) = self.action_collector.as_deref_mut()
+        {
+            let mut event = VQueueEvent::new(self.handle);
+
+            // Confirm the removal of the stale key so the scheduler drops the old (future) wake-up,
+            // then enqueue the re-keyed entry.
+            //
+            // Important: Rescheduling an inbox entry can lead to a race with a decision that was
+            // proposed but not yet applied. Delaying the inbox entry might invalidate a run
+            // decision as the entry is not yet eligible for running. We need to be careful about
+            // applying the SchedulerActions and filter actions out that no longer apply. Currently,
+            // we do this by comparing the EntryKey and assume that a change constitutes an
+            // invalidation of the action.
+            //
+            // TODO(perf): the scheduler processes `RemovedFromInbox` before `EnqueuedToInbox`, so if
+            //  this entry is the vqueue's only inbox entry the queue momentarily looks dormant
+            //  between the two and may be evicted from / re-added to the scheduler's ring. A dedicated
+            //  re-key event (carrying both keys) would let the scheduler update the key in place and
+            //  avoid that transient flip.
+            event.push(EventDetails::RemovedFromInbox(*header.entry_key()));
+            event.push(EventDetails::EnqueuedToInbox {
+                key: modified_key,
+                value,
+            });
+
             collector.push(A::from(event));
         }
     }

--- a/crates/vqueues/src/scheduler/drr.rs
+++ b/crates/vqueues/src/scheduler/drr.rs
@@ -438,7 +438,9 @@ mod tests {
     use restate_storage_api::Transaction;
     use restate_storage_api::vqueue_table::scheduler::SchedulerAction;
     use restate_storage_api::vqueue_table::stats::WaitStats;
-    use restate_storage_api::vqueue_table::{EntryKey, EntryMetadata, ReadVQueueTable};
+    use restate_storage_api::vqueue_table::{
+        EntryKey, EntryMetadata, EntryStatusHeader, ReadVQueueTable, Stage,
+    };
     use restate_types::ServiceName;
     use restate_types::clock::UniqueTimestamp;
     use restate_types::identifiers::{PartitionId, PartitionKey};
@@ -562,6 +564,80 @@ mod tests {
         .expect("vqueue should be created");
 
         vqueue.run_entry(at, &header, WaitStats::default())
+    }
+
+    async fn reschedule(
+        txn: &mut PartitionStoreTransaction<'_>,
+        cache: &mut VQueuesMetaCache,
+        qid: &VQueueId,
+        entry_id: &EntryId,
+        run_at: RoughTimestamp,
+        action_collector: Option<&mut Vec<VQueueEvent>>,
+    ) {
+        let at = UniqueTimestamp::try_from(1_300u64).unwrap();
+        let header = txn
+            .get_vqueue_entry_status(qid.partition_key(), entry_id)
+            .await
+            .expect("entry state header lookup should succeed")
+            .expect("entry state header should exist");
+
+        let mut vqueue = VQueue::get_or_create_vqueue(
+            at,
+            qid,
+            txn,
+            cache,
+            action_collector,
+            &ServiceName::new("test"),
+            &None,
+            &LimitKey::None,
+            &None,
+        )
+        .await
+        .expect("vqueue should be created");
+
+        vqueue.reschedule(&header, run_at, None);
+    }
+
+    /// Parks a running entry into the Suspended stage.
+    async fn suspend(
+        txn: &mut PartitionStoreTransaction<'_>,
+        cache: &mut VQueuesMetaCache,
+        qid: &VQueueId,
+        entry_id: &EntryId,
+    ) {
+        let at = UniqueTimestamp::try_from(1_250u64).unwrap();
+        let header = txn
+            .get_vqueue_entry_status(qid.partition_key(), entry_id)
+            .await
+            .expect("entry state header lookup should succeed")
+            .expect("entry state header should exist");
+
+        let mut vqueue = VQueue::get_or_create_vqueue(
+            at,
+            qid,
+            txn,
+            cache,
+            None::<&mut Vec<VQueueEvent>>,
+            &ServiceName::new("test"),
+            &None,
+            &LimitKey::None,
+            &None,
+        )
+        .await
+        .expect("vqueue should be created");
+
+        vqueue.suspend_entry(at, &header);
+    }
+
+    async fn read_header(
+        txn: &PartitionStoreTransaction<'_>,
+        qid: &VQueueId,
+        entry_id: &EntryId,
+    ) -> impl EntryStatusHeader + 'static {
+        txn.get_vqueue_entry_status(qid.partition_key(), entry_id)
+            .await
+            .expect("entry state header lookup should succeed")
+            .expect("entry state header should exist")
     }
 
     async fn create_resource_manager_with_throttling(
@@ -721,6 +797,122 @@ mod tests {
         assert_eq!(keys.len(), 1);
         assert_eq!(keys[0], overdue_key);
         assert_ne!(keys[0], future_key);
+    }
+
+    /// `reschedule` re-keys an entry's `run_at` for the waiting stages and is a no-op otherwise:
+    /// - Inbox: pulls the entry forward (and emits the reconciliation pair); no-op if unchanged.
+    /// - Suspended: re-keys in place without notifying the scheduler (parked entries aren't tracked).
+    /// - Running: nothing to reschedule.
+    /// In every case the entry's `Status` and stats are preserved.
+    #[restate_core::test]
+    async fn reschedule_moves_run_at_only_for_waiting_stages() {
+        let mut rocksdb = storage_test_environment().await;
+        let mut cache = VQueuesMetaCache::new_empty(TEST_VQUEUES_CAPACITY);
+        let qid = test_qid(2_200);
+        let now = MillisSinceEpoch::now().as_u64();
+        let now_rough = RoughTimestamp::from_unix_millis_clamped(MillisSinceEpoch::new(now));
+        // A distinct, far-future run_at so every reschedule is an actual move.
+        let future = MillisSinceEpoch::new(now.saturating_add(600_000));
+
+        let mut txn = rocksdb.transaction();
+        let mut events: Vec<VQueueEvent> = Vec::new();
+
+        // -- Inbox: a waiting entry is pulled forward to `now`, emitting the reconciliation pair
+        //    (`RemovedFromInbox` of the old key + `EnqueuedToInbox` at the new key).
+        let inbox = *enqueue_entry_with_run_at(&mut txn, &mut cache, &qid, 1, future, None)
+            .await
+            .entry_id();
+        let inbox_status = read_header(&txn, &qid, &inbox).await.status();
+
+        reschedule(
+            &mut txn,
+            &mut cache,
+            &qid,
+            &inbox,
+            now_rough,
+            Some(&mut events),
+        )
+        .await;
+        let header = read_header(&txn, &qid, &inbox).await;
+        assert_eq!(header.entry_key().run_at(), now_rough);
+        assert_eq!(header.stage(), Stage::Inbox);
+        assert_eq!(header.status(), inbox_status); // status untouched
+        assert_eq!(header.stats().num_yields, 0); // not counted as a yield
+        assert_eq!(events.len(), 1);
+        match &events[0].updates[..] {
+            [
+                EventDetails::RemovedFromInbox(old_key),
+                EventDetails::EnqueuedToInbox { key: new_key, .. },
+            ] => {
+                assert_ne!(old_key.run_at(), now_rough);
+                assert_eq!(new_key.run_at(), now_rough);
+            }
+            other => panic!("expected a RemovedFromInbox + EnqueuedToInbox pair, got {other:?}"),
+        }
+
+        // Re-keying to the same run_at is a no-op: nothing emitted, nothing changed.
+        events.clear();
+        reschedule(
+            &mut txn,
+            &mut cache,
+            &qid,
+            &inbox,
+            now_rough,
+            Some(&mut events),
+        )
+        .await;
+        assert!(events.is_empty());
+        assert_eq!(
+            read_header(&txn, &qid, &inbox).await.entry_key().run_at(),
+            now_rough
+        );
+
+        // -- Suspended: re-keyed in place, no scheduler event.
+        let suspended = *enqueue_entry_with_run_at(&mut txn, &mut cache, &qid, 2, future, None)
+            .await
+            .entry_id();
+        suspend(&mut txn, &mut cache, &qid, &suspended).await;
+        let suspended_status = read_header(&txn, &qid, &suspended).await.status();
+
+        events.clear();
+        reschedule(
+            &mut txn,
+            &mut cache,
+            &qid,
+            &suspended,
+            now_rough,
+            Some(&mut events),
+        )
+        .await;
+        let header = read_header(&txn, &qid, &suspended).await;
+        assert_eq!(header.entry_key().run_at(), now_rough);
+        assert_eq!(header.stage(), Stage::Suspended);
+        assert_eq!(header.status(), suspended_status);
+        assert!(events.is_empty());
+
+        // -- Running: nothing to reschedule, the entry is left untouched.
+        let running_key = {
+            let key = enqueue_entry_with_run_at(&mut txn, &mut cache, &qid, 3, future, None).await;
+            move_to_running(&mut txn, &mut cache, &qid, &key, None).await
+        };
+        let running = *running_key.entry_id();
+
+        events.clear();
+        reschedule(
+            &mut txn,
+            &mut cache,
+            &qid,
+            &running,
+            now_rough,
+            Some(&mut events),
+        )
+        .await;
+        let header = read_header(&txn, &qid, &running).await;
+        assert_eq!(header.stage(), Stage::Running);
+        assert_eq!(header.entry_key().run_at(), running_key.run_at());
+        assert!(events.is_empty());
+
+        txn.commit().await.expect("commit should succeed");
     }
 
     #[restate_core::test]

--- a/crates/worker/src/partition/rpc/resume_invocation.rs
+++ b/crates/worker/src/partition/rpc/resume_invocation.rs
@@ -9,9 +9,8 @@
 // by the Apache License, Version 2.0.
 
 use super::*;
-use restate_storage_api::invocation_status_table::{
-    InFlightInvocationMetadata, InvocationStatus, ReadInvocationStatusTable,
-};
+use crate::partition::state_machine::resolve_pinned_deployment;
+use restate_storage_api::invocation_status_table::{InvocationStatus, ReadInvocationStatusTable};
 use restate_types::identifiers::{InvocationId, WithPartitionKey};
 use restate_types::invocation::client::PatchDeploymentId;
 use restate_types::invocation::{
@@ -30,6 +29,7 @@ impl<'a, TActuator: Actuator, TSchemas, TStorage> RpcHandler<Request>
     for RpcContext<'a, TActuator, TSchemas, TStorage>
 where
     TActuator: Actuator,
+    // Needed for the non-VQueue path, which resolves the deployment here (see `handle`).
     TSchemas: DeploymentResolver,
     TStorage: ReadInvocationStatusTable,
 {
@@ -57,80 +57,92 @@ where
 
         // -- Figure out the invocation status
         match self.storage.get_invocation_status(&invocation_id).await {
-            Ok(InvocationStatus::Invoked(_)) => {
-                if !matches!(update_deployment_id, PatchDeploymentId::KeepPinned) {
-                    replier.send(ResumeInvocationRpcResponse::CannotPatchDeploymentId);
-                    return Ok(());
-                }
-
-                // Let's poke the invoker to retry now, if possible
-                self.proposer.notify_invoker_to_retry_now(invocation_id);
-                replier.send(ResumeInvocationRpcResponse::Ok);
-            }
-            Ok(InvocationStatus::Suspended {
-                metadata:
-                    InFlightInvocationMetadata {
-                        invocation_target,
-                        pinned_deployment,
-                        ..
-                    },
-                ..
-            })
-            | Ok(InvocationStatus::Paused(InFlightInvocationMetadata {
-                invocation_target,
-                pinned_deployment,
-                ..
-            })) => {
-                // Let's look at the deployment id here, and see if we need to do some changes
-                let update_pinned_deployment_id = match (update_deployment_id, pinned_deployment) {
-                    (PatchDeploymentId::KeepPinned, _) | (PatchDeploymentId::PinToLatest, None) => {
-                        // If the request is to keep pinned, no change will be applied.
-                        None
-                    }
-                    (_, None) => {
-                        // No deployment is even pinned, return back the error
+            Ok(InvocationStatus::Invoked(metadata)) => {
+                if metadata.vqueue_id.is_some() {
+                    // VQueue-owned: the invoker no longer solely drives the lifecycle. Propose the
+                    // persisted command, forwarding the *unresolved* deployment patch -- it is
+                    // resolved and validated (and the entry rescheduled) in the apply path
+                    // (`OnManualResumeCommand`), which classifies the possibly-changed status. There
+                    // is no running attempt to fence, so use the plain proposal path -- unlike
+                    // pause's `propose_pause_and_fence`. Writing the new `update_deployment_id` field
+                    // is safe here: vqueues being enabled implies a cluster min version >= 1.7.0.
+                    self.proposer
+                        .handle_rpc_proposal_command(
+                            invocation_id.partition_key(),
+                            Command::ResumeInvocation(ResumeInvocationRequest {
+                                invocation_id,
+                                update_deployment_id: Some(update_deployment_id),
+                                update_pinned_deployment_id: None,
+                                run_at: None,
+                                response_sink: Some(InvocationMutationResponseSink::Ingress(
+                                    IngressInvocationResponseSink { request_id },
+                                )),
+                            }),
+                            request_id,
+                            replier,
+                        )
+                        .await;
+                } else {
+                    // Legacy invoker-owned path: there is a live attempt, so the pinned deployment
+                    // cannot be patched. Poke the invoker to retry now, if possible.
+                    if !matches!(update_deployment_id, PatchDeploymentId::KeepPinned) {
                         replier.send(ResumeInvocationRpcResponse::CannotPatchDeploymentId);
                         return Ok(());
                     }
-                    (resume_invocation_deployment_id, Some(pinned_deployment)) => {
-                        let Some(deployment) = (match resume_invocation_deployment_id {
-                            PatchDeploymentId::PinToLatest => {
-                                self.schemas.resolve_latest_deployment_for_service(
-                                    invocation_target.service_name(),
-                                )
-                            }
-                            PatchDeploymentId::PinTo { id } => self.schemas.get_deployment(&id),
-                            PatchDeploymentId::KeepPinned => {
-                                unreachable!()
-                            }
-                        }) else {
-                            replier.send(ResumeInvocationRpcResponse::DeploymentNotFound);
-                            return Ok(());
-                        };
+                    self.proposer.notify_invoker_to_retry_now(invocation_id);
+                    replier.send(ResumeInvocationRpcResponse::Ok);
+                }
+            }
+            Ok(InvocationStatus::Suspended { metadata, .. })
+            | Ok(InvocationStatus::Paused(metadata)) => {
+                if metadata.vqueue_id.is_some() {
+                    // VQueue path: forward the unresolved patch; the apply path resolves it against
+                    // the status as of the command's log position. Safe to write the new
+                    // `update_deployment_id` field -- vqueues imply a cluster min version >= 1.7.0.
+                    self.proposer
+                        .handle_rpc_proposal_command(
+                            invocation_id.partition_key(),
+                            Command::ResumeInvocation(ResumeInvocationRequest {
+                                invocation_id,
+                                update_deployment_id: Some(update_deployment_id),
+                                update_pinned_deployment_id: None,
+                                run_at: None,
+                                response_sink: Some(InvocationMutationResponseSink::Ingress(
+                                    IngressInvocationResponseSink { request_id },
+                                )),
+                            }),
+                            request_id,
+                            replier,
+                        )
+                        .await;
+                    return Ok(());
+                }
 
-                        if !deployment
-                            .supported_protocol_versions
-                            .contains(&(pinned_deployment.service_protocol_version as i32))
-                        {
-                            replier.send(ResumeInvocationRpcResponse::IncompatibleDeploymentId {
-                                pinned_protocol_version: pinned_deployment.service_protocol_version
-                                    as i32,
-                                deployment_id: deployment.id,
-                                supported_protocol_versions: deployment.supported_protocol_versions,
-                            });
-                            return Ok(());
-                        }
-                        Some(deployment.id)
+                // Non-VQueue path: a pre-1.7.0 node may still apply this command and does not know
+                // `update_deployment_id`, so we resolve here -- reusing the apply path's resolver --
+                // and propose the already-resolved `update_pinned_deployment_id` (the field older
+                // nodes understand).
+                let update_pinned_deployment_id = match resolve_pinned_deployment(
+                    Some(&update_deployment_id),
+                    None,
+                    &metadata,
+                    Some(self.schemas),
+                ) {
+                    Ok(resolved) => resolved,
+                    Err(response) => {
+                        replier.send(response.into());
+                        return Ok(());
                     }
                 };
 
-                // We need to propose the message, PP will deal with invoking this back
                 self.proposer
                     .handle_rpc_proposal_command(
                         invocation_id.partition_key(),
                         Command::ResumeInvocation(ResumeInvocationRequest {
                             invocation_id,
+                            update_deployment_id: None,
                             update_pinned_deployment_id,
+                            run_at: None,
                             response_sink: Some(InvocationMutationResponseSink::Ingress(
                                 IngressInvocationResponseSink { request_id },
                             )),
@@ -220,6 +232,54 @@ mod tests {
         let mut storage = MockStorage {
             expected_invocation_id: invocation_id,
             status: InvocationStatus::Invoked(InFlightInvocationMetadata::mock()),
+        };
+
+        let (tx, rx) = Reciprocal::mock();
+        RpcHandler::handle(
+            RpcContext::new(&mut proposer, &(), &mut storage),
+            Request {
+                request_id: Default::default(),
+                invocation_id,
+                update_deployment_id: Default::default(),
+            },
+            Replier::new(tx),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            rx.recv().await.unwrap(),
+            PartitionProcessorRpcResponse::ResumeInvocation(ResumeInvocationRpcResponse::Ok)
+        );
+    }
+
+    /// A VQueue Invoked invocation is resumed by proposing the persisted ResumeInvocation command
+    /// (so the apply path can pull a backing-off attempt forward), not by poking the invoker.
+    #[test(restate_core::test)]
+    async fn vqueue_invoked_proposes_resume_command() {
+        let invocation_id = InvocationId::mock_random();
+
+        let mut proposer = MockActuator::new();
+        proposer.expect_is_leader().return_const(true);
+        // The invoker must NOT be poked for a VQueue invocation.
+        proposer.expect_notify_invoker_to_retry_now().never();
+        proposer
+            .expect_handle_rpc_proposal_command::<ResumeInvocationRpcResponse>()
+            .return_once_st(move |_, cmd, _request_id, replier| {
+                // The command shape (response_sink, deployment patching) is covered by
+                // `propose_resume_command_on_paused_and_suspended`; here we only care that the
+                // Invoked+VQueue path proposes ResumeInvocation rather than poking the invoker.
+                let_assert!(Command::ResumeInvocation(request) = cmd);
+                assert_eq!(request.invocation_id, invocation_id);
+                replier.send(ResumeInvocationRpcResponse::Ok);
+                ready(()).boxed()
+            });
+
+        let mut storage = MockStorage {
+            expected_invocation_id: invocation_id,
+            status: InvocationStatus::Invoked(InFlightInvocationMetadata::mock_with_vqueue(
+                invocation_id.partition_key(),
+            )),
         };
 
         let (tx, rx) = Reciprocal::mock();
@@ -481,89 +541,45 @@ mod tests {
         .await
         .unwrap();
 
-        assert_that!(
+        // Non-VQueue path resolves the deployment in the RPC and rejects the incompatible pin
+        // synchronously (no command proposed).
+        assert_eq!(
             rx.recv().await.unwrap(),
-            eq(PartitionProcessorRpcResponse::ResumeInvocation(
+            PartitionProcessorRpcResponse::ResumeInvocation(
                 ResumeInvocationRpcResponse::IncompatibleDeploymentId {
                     pinned_protocol_version: i32::from(pinned_version),
                     deployment_id: expected_deployment_id,
                     supported_protocol_versions: 1..=4,
                 }
-            ))
+            )
         );
     }
 
-    #[rstest]
-    #[restate_core::test]
-    async fn override_compatible_pinned_deployment_proposes_command(
-        #[values(true, false)] pin_to_specific: bool,
-        #[values(true, false)] suspended: bool,
-    ) {
+    /// A legacy invoker-owned (non-VQueue) Invoked invocation has a live attempt, so its pinned
+    /// deployment cannot be patched: the RPC rejects synchronously without poking the invoker.
+    #[test(restate_core::test)]
+    async fn legacy_invoked_rejects_deployment_patch() {
         let invocation_id = InvocationId::mock_random();
-        let invocation_target = InvocationTarget::mock_service();
-        let pinned_version = ServiceProtocolVersion::V4;
-
-        // Candidate deployment supports V4 -> Should be compatible
-        let mut dep = Deployment::mock();
-        dep.supported_protocol_versions = 1..=4;
-        let expected_deployment_id = dep.id;
-
-        let mut schemas = MockDeploymentMetadataRegistry::default();
-        schemas.mock_deployment(dep.clone());
-        if !pin_to_specific {
-            schemas.mock_latest_service(invocation_target.service_name(), dep.id);
-        }
 
         let mut proposer = MockActuator::new();
         proposer.expect_is_leader().return_const(true);
+        proposer.expect_notify_invoker_to_retry_now().never();
         proposer
             .expect_handle_rpc_proposal_command::<ResumeInvocationRpcResponse>()
-            .return_once_st(move |_, cmd, request_id, replier| {
-                assert_that!(
-                    cmd,
-                    pat!(Command::ResumeInvocation(pat!(ResumeInvocationRequest {
-                        invocation_id: eq(invocation_id),
-                        update_pinned_deployment_id: some(eq(expected_deployment_id)),
-                        response_sink: some(eq(InvocationMutationResponseSink::Ingress(
-                            IngressInvocationResponseSink { request_id }
-                        )))
-                    })))
-                );
-                replier.send(ResumeInvocationRpcResponse::Ok);
-                ready(()).boxed()
-            });
+            .never();
 
-        let metadata = InFlightInvocationMetadata {
-            invocation_target,
-            pinned_deployment: Some(PinnedDeployment::new(DeploymentId::new(), pinned_version)),
-            ..InFlightInvocationMetadata::mock()
-        };
         let mut storage = MockStorage {
             expected_invocation_id: invocation_id,
-            status: if suspended {
-                InvocationStatus::Suspended {
-                    metadata,
-                    awaiting_on: UnresolvedFuture::empty(),
-                }
-            } else {
-                InvocationStatus::Paused(metadata)
-            },
+            status: InvocationStatus::Invoked(InFlightInvocationMetadata::mock()),
         };
 
         let (tx, rx) = Reciprocal::mock();
-        let update_deployment_id = if pin_to_specific {
-            PatchDeploymentId::PinTo {
-                id: expected_deployment_id,
-            }
-        } else {
-            PatchDeploymentId::PinToLatest
-        };
         RpcHandler::handle(
-            RpcContext::new(&mut proposer, &schemas, &mut storage),
+            RpcContext::new(&mut proposer, &(), &mut storage),
             Request {
                 request_id: Default::default(),
                 invocation_id,
-                update_deployment_id,
+                update_deployment_id: PatchDeploymentId::PinToLatest,
             },
             Replier::new(tx),
         )
@@ -572,7 +588,9 @@ mod tests {
 
         assert_eq!(
             rx.recv().await.unwrap(),
-            PartitionProcessorRpcResponse::ResumeInvocation(ResumeInvocationRpcResponse::Ok)
+            PartitionProcessorRpcResponse::ResumeInvocation(
+                ResumeInvocationRpcResponse::CannotPatchDeploymentId
+            )
         );
     }
 

--- a/crates/worker/src/partition/state_machine/lifecycle/manual_resume.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/manual_resume.rs
@@ -8,22 +8,96 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::partition::state_machine::lifecycle::ResumeInvocationCommand;
-use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
+use restate_clock::RoughTimestamp;
 use restate_storage_api::invocation_status_table::{
-    InvocationStatus, ReadInvocationStatusTable, WriteInvocationStatusTable,
+    InFlightInvocationMetadata, InvocationStatus, ReadInvocationStatusTable,
+    WriteInvocationStatusTable,
 };
 use restate_storage_api::lock_table::WriteLockTable;
 use restate_storage_api::vqueue_table::{ReadVQueueTable, WriteVQueueTable};
 use restate_types::identifiers::{DeploymentId, InvocationId};
 use restate_types::invocation::InvocationMutationResponseSink;
-use restate_types::invocation::client::ResumeInvocationResponse;
+use restate_types::invocation::client::{PatchDeploymentId, ResumeInvocationResponse};
+use restate_types::schema::deployment::DeploymentResolver;
 use tracing::trace;
+
+use crate::partition::state_machine::lifecycle::ResumeInvocationCommand;
+use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
 
 pub struct OnManualResumeCommand {
     pub invocation_id: InvocationId,
+    /// The unresolved deployment patch (VQueue path only), resolved against `ctx.schema` here in
+    /// the apply path so the decision uses the invocation status as of this log position. `None`
+    /// means the non-VQueue path / a pre-1.7.0 node already resolved it into
+    /// `update_pinned_deployment_id`.
+    pub update_deployment_id: Option<PatchDeploymentId>,
+    /// Already-resolved deployment id from the non-VQueue path (or a pre-1.7.0 node). When present
+    /// we honor it directly instead of resolving `update_deployment_id`.
     pub update_pinned_deployment_id: Option<DeploymentId>,
+    /// When the rescheduled VQueue entry should run; `None` defaults to its `created_at`.
+    pub run_at: Option<RoughTimestamp>,
     pub response_sink: Option<InvocationMutationResponseSink>,
+}
+
+/// Resolves and validates the pinned-deployment patch to apply on resume. Shared by the VQueue
+/// apply path (here) and the non-VQueue resume RPC handler.
+///
+/// Returns `Ok(Some(id))` to repin, `Ok(None)` to leave the pinned deployment unchanged, or
+/// `Err(response)` with the client-facing error to forward when the patch cannot be applied.
+pub(crate) fn resolve_pinned_deployment<R: DeploymentResolver>(
+    update_deployment_id: Option<&PatchDeploymentId>,
+    already_resolved_deployment_id: Option<DeploymentId>,
+    metadata: &InFlightInvocationMetadata,
+    schema: Option<&R>,
+) -> Result<Option<DeploymentId>, ResumeInvocationResponse> {
+    // The non-VQueue path (or a pre-1.7.0 node) carries an already-resolved id; honor it directly.
+    if let Some(id) = already_resolved_deployment_id {
+        return Ok(Some(id));
+    }
+
+    // No unresolved patch to apply (or an explicit `KeepPinned`): leave the pinned deployment as is.
+    let Some(update_deployment_id) = update_deployment_id else {
+        return Ok(None);
+    };
+    if update_deployment_id == &PatchDeploymentId::KeepPinned {
+        return Ok(None);
+    }
+
+    let Some(schema) = schema else {
+        // Without a schema we cannot resolve a deployment.
+        return Err(ResumeInvocationResponse::DeploymentNotFound);
+    };
+
+    match metadata.pinned_deployment.as_ref() {
+        // Pinning to latest while nothing is pinned yet is a no-op (matches the old RPC behavior).
+        None if matches!(update_deployment_id, PatchDeploymentId::PinToLatest) => Ok(None),
+        None => Err(ResumeInvocationResponse::CannotChangeDeploymentId),
+        Some(pinned_deployment) => {
+            let resolved = match update_deployment_id {
+                PatchDeploymentId::PinToLatest => schema.resolve_latest_deployment_for_service(
+                    metadata.invocation_target.service_name(),
+                ),
+                PatchDeploymentId::PinTo { id } => schema.get_deployment(id),
+                PatchDeploymentId::KeepPinned => unreachable!("handled above"),
+            };
+
+            let Some(deployment) = resolved else {
+                return Err(ResumeInvocationResponse::DeploymentNotFound);
+            };
+
+            if !deployment
+                .supported_protocol_versions
+                .contains(&(pinned_deployment.service_protocol_version as i32))
+            {
+                return Err(ResumeInvocationResponse::IncompatibleDeploymentId {
+                    pinned_protocol_version: pinned_deployment.service_protocol_version as i32,
+                    deployment_id: deployment.id,
+                    supported_protocol_versions: deployment.supported_protocol_versions,
+                });
+            }
+            Ok(Some(deployment.id))
+        }
+    }
 }
 
 impl<'ctx, 's: 'ctx, S> CommandHandler<&'ctx mut StateMachineApplyContext<'s, S>>
@@ -38,27 +112,99 @@ where
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S>) -> Result<(), Error> {
         let OnManualResumeCommand {
             invocation_id,
+            update_deployment_id,
             update_pinned_deployment_id,
+            run_at,
             response_sink,
         } = self;
         match ctx.get_invocation_status(&invocation_id).await? {
-            InvocationStatus::Invoked(_) => {
-                // The RPC command handler already dealt with it
+            InvocationStatus::Invoked(mut metadata) => {
+                // For VQueue invocations the resume RPC proposes this command instead of poking the
+                // invoker. A backing-off attempt is parked in the VQueue inbox with a future
+                // run_at; reschedule it so the scheduler retries it immediately (the VQueue
+                // analogue of InputCommand::RetryNow).
+                //
+                // A non-VQueue invocation reaches this arm only if it was Suspended/Paused at RPC
+                // time (those propose the command) but has since become Invoked -- i.e. it is
+                // already resumed, so there is nothing left to do.
+                if metadata.vqueue_id.is_some() {
+                    // Resolve the (optional) deployment patch against the current status; a serial
+                    // pause+resume may land here as Invoked, so we honor the intent rather than
+                    // dropping it.
+                    let resolved = match resolve_pinned_deployment(
+                        update_deployment_id.as_ref(),
+                        update_pinned_deployment_id,
+                        &metadata,
+                        ctx.schema.as_ref(),
+                    ) {
+                        Ok(resolved) => resolved,
+                        Err(response) => {
+                            ctx.reply_to_resume_invocation(response_sink, response);
+                            return Ok(());
+                        }
+                    };
+
+                    // Pull a backing-off attempt forward. The returned flag tells us whether the
+                    // entry was actually waiting (Inbox/Suspended/Paused); a running attempt is a
+                    // no-op.
+                    let was_waiting = ctx
+                        .vqueue_reschedule_invocation(&invocation_id, run_at, resolved)
+                        .await?;
+
+                    if let Some(new_pinned_deployment_id) = resolved {
+                        // A repin only makes sense for a waiting (backing-off) entry. If the entry
+                        // is running its attempt, repinning would change the deployment mid-flight
+                        // -- which the API/legacy path rejects -- so reject it here too instead of
+                        // silently repinning.
+                        if !was_waiting {
+                            ctx.reply_to_resume_invocation(
+                                response_sink,
+                                ResumeInvocationResponse::CannotChangeDeploymentId,
+                            );
+                            return Ok(());
+                        }
+
+                        // Apply the repin so the next retry uses it, then persist.
+                        if let Some(pinned) = &mut metadata.pinned_deployment {
+                            trace!(
+                                "Updating pinned deployment from {} to {} when resuming",
+                                pinned.deployment_id, new_pinned_deployment_id
+                            );
+                            pinned.deployment_id = new_pinned_deployment_id;
+                            ctx.storage.put_invocation_status(
+                                &invocation_id,
+                                &InvocationStatus::Invoked(metadata),
+                            )?;
+                        }
+                    }
+                }
                 ctx.reply_to_resume_invocation(response_sink, ResumeInvocationResponse::Ok);
             }
             mut is @ InvocationStatus::Suspended { .. } | mut is @ InvocationStatus::Paused(_) => {
-                if let Some(new_pinned_deployment_id) = update_pinned_deployment_id {
-                    // Update pinned deployment only if set.
-                    // This was already previously checked by the RPC handler.
-                    if let Some(invocation_pinned_deploment) =
-                        &mut is.get_invocation_metadata_mut().unwrap().pinned_deployment
-                    {
-                        trace!(
-                            "Updating pinned deployment from {} to {} when resuming",
-                            invocation_pinned_deploment.deployment_id, new_pinned_deployment_id
-                        );
-                        invocation_pinned_deploment.deployment_id = new_pinned_deployment_id;
+                // Resolve + validate the deployment patch here (rather than at RPC time) so the
+                // decision uses the status as of this log position.
+                let resolved = match resolve_pinned_deployment(
+                    update_deployment_id.as_ref(),
+                    update_pinned_deployment_id,
+                    is.get_invocation_metadata().unwrap(),
+                    ctx.schema.as_ref(),
+                ) {
+                    Ok(resolved) => resolved,
+                    Err(response) => {
+                        ctx.reply_to_resume_invocation(response_sink, response);
+                        return Ok(());
                     }
+                };
+
+                if let Some(new_pinned_deployment_id) = resolved
+                    && let Some(invocation_pinned_deploment) =
+                        &mut is.get_invocation_metadata_mut().unwrap().pinned_deployment
+                {
+                    trace!(
+                        "Updating pinned deployment from {} to {} when resuming",
+                        invocation_pinned_deploment.deployment_id, new_pinned_deployment_id
+                    );
+                    invocation_pinned_deploment.deployment_id = new_pinned_deployment_id;
                 }
 
                 // Resume
@@ -105,12 +251,162 @@ mod tests {
     };
     use restate_types::deployment::PinnedDeployment;
     use restate_types::identifiers::PartitionProcessorRpcRequestId;
-    use restate_types::invocation::{IngressInvocationResponseSink, ResumeInvocationRequest};
+    use restate_types::invocation::{
+        IngressInvocationResponseSink, InvocationTarget, ResumeInvocationRequest,
+    };
     use restate_types::journal_v2::{NotificationId, SleepCommand};
+    use restate_types::schema::deployment::Deployment;
+    use restate_types::schema::deployment::test_util::MockDeploymentMetadataRegistry;
     use restate_types::service_protocol::ServiceProtocolVersion;
     use restate_wal_protocol::v2::{Command, commands};
     use restate_worker_api::invoker::Effect;
     use std::time::{Duration, SystemTime};
+
+    fn mock_metadata(
+        pinned: Option<ServiceProtocolVersion>,
+        invocation_target: InvocationTarget,
+    ) -> InFlightInvocationMetadata {
+        InFlightInvocationMetadata {
+            invocation_target,
+            pinned_deployment: pinned
+                .map(|version| PinnedDeployment::new(DeploymentId::new(), version)),
+            ..InFlightInvocationMetadata::mock()
+        }
+    }
+
+    #[test]
+    fn resolve_no_patch_keep_pinned_and_legacy_field() {
+        let meta = mock_metadata(
+            Some(ServiceProtocolVersion::V5),
+            InvocationTarget::mock_service(),
+        );
+
+        // No unresolved patch (VQueue path with nothing to change) is a no-op, even without a schema.
+        assert_eq!(
+            resolve_pinned_deployment(None, None, &meta, None::<&MockDeploymentMetadataRegistry>),
+            Ok(None)
+        );
+
+        // An explicit KeepPinned is likewise a no-op.
+        assert_eq!(
+            resolve_pinned_deployment(
+                Some(&PatchDeploymentId::KeepPinned),
+                None,
+                &meta,
+                None::<&MockDeploymentMetadataRegistry>,
+            ),
+            Ok(None)
+        );
+
+        // An already-resolved id (non-VQueue / pre-1.7.0 path) is honored directly without resolving.
+        let resolved = DeploymentId::new();
+        assert_eq!(
+            resolve_pinned_deployment(
+                Some(&PatchDeploymentId::PinToLatest),
+                Some(resolved),
+                &meta,
+                None::<&MockDeploymentMetadataRegistry>,
+            ),
+            Ok(Some(resolved))
+        );
+    }
+
+    #[test]
+    fn resolve_compatible_repins_via_pin_to_and_latest() {
+        let invocation_target = InvocationTarget::mock_service();
+        let mut dep = Deployment::mock();
+        dep.supported_protocol_versions = 1..=4;
+        let dep_id = dep.id;
+
+        let mut schemas = MockDeploymentMetadataRegistry::default();
+        schemas.mock_deployment(dep.clone());
+        schemas.mock_latest_service(invocation_target.service_name(), dep.id);
+
+        let meta = mock_metadata(Some(ServiceProtocolVersion::V4), invocation_target);
+
+        assert_eq!(
+            resolve_pinned_deployment(
+                Some(&PatchDeploymentId::PinTo { id: dep_id }),
+                None,
+                &meta,
+                Some(&schemas),
+            ),
+            Ok(Some(dep_id))
+        );
+        assert_eq!(
+            resolve_pinned_deployment(
+                Some(&PatchDeploymentId::PinToLatest),
+                None,
+                &meta,
+                Some(&schemas),
+            ),
+            Ok(Some(dep_id))
+        );
+    }
+
+    #[test]
+    fn resolve_incompatible_and_unknown_and_unpinned() {
+        let invocation_target = InvocationTarget::mock_service();
+        let mut dep = Deployment::mock();
+        dep.supported_protocol_versions = 1..=4; // incompatible with V5
+        let dep_id = dep.id;
+        let mut schemas = MockDeploymentMetadataRegistry::default();
+        schemas.mock_deployment(dep);
+
+        let pinned_version = ServiceProtocolVersion::V5;
+        let meta = mock_metadata(Some(pinned_version), invocation_target);
+
+        // Incompatible protocol version.
+        assert_eq!(
+            resolve_pinned_deployment(
+                Some(&PatchDeploymentId::PinTo { id: dep_id }),
+                None,
+                &meta,
+                Some(&schemas),
+            ),
+            Err(ResumeInvocationResponse::IncompatibleDeploymentId {
+                pinned_protocol_version: pinned_version as i32,
+                deployment_id: dep_id,
+                supported_protocol_versions: 1..=4,
+            })
+        );
+
+        // Unknown deployment id.
+        assert_eq!(
+            resolve_pinned_deployment(
+                Some(&PatchDeploymentId::PinTo {
+                    id: DeploymentId::new()
+                }),
+                None,
+                &meta,
+                Some(&schemas),
+            ),
+            Err(ResumeInvocationResponse::DeploymentNotFound)
+        );
+
+        // Nothing pinned: PinToLatest is a no-op, PinTo cannot change.
+        let unpinned = mock_metadata(None, InvocationTarget::mock_service());
+        assert_eq!(
+            resolve_pinned_deployment(
+                Some(&PatchDeploymentId::PinToLatest),
+                None,
+                &unpinned,
+                Some(&schemas),
+            ),
+            Ok(None)
+        );
+        assert_eq!(
+            resolve_pinned_deployment(
+                Some(&PatchDeploymentId::PinTo {
+                    id: DeploymentId::new()
+                }),
+                None,
+                &unpinned,
+                Some(&schemas),
+            ),
+            Err(ResumeInvocationResponse::CannotChangeDeploymentId)
+        );
+    }
 
     #[restate_core::test]
     async fn pause_then_resume() {
@@ -134,7 +430,9 @@ mod tests {
             .apply(commands::ResumeInvocationCommand::test_envelope(
                 ResumeInvocationRequest {
                     invocation_id,
+                    update_deployment_id: None,
                     update_pinned_deployment_id: None,
+                    run_at: None,
                     response_sink: Some(InvocationMutationResponseSink::Ingress(
                         IngressInvocationResponseSink { request_id },
                     )),
@@ -198,7 +496,11 @@ mod tests {
             .apply(commands::ResumeInvocationCommand::test_envelope(
                 ResumeInvocationRequest {
                     invocation_id,
+                    // Exercises the deprecated read-compat path: an already-resolved id is honored
+                    // directly (no schema resolution).
+                    update_deployment_id: None,
                     update_pinned_deployment_id: Some(new_deployment_id),
+                    run_at: None,
                     response_sink: Some(InvocationMutationResponseSink::Ingress(
                         IngressInvocationResponseSink { request_id },
                     )),
@@ -267,7 +569,9 @@ mod tests {
             .apply(commands::ResumeInvocationCommand::test_envelope(
                 ResumeInvocationRequest {
                     invocation_id,
+                    update_deployment_id: None,
                     update_pinned_deployment_id: None,
+                    run_at: None,
                     response_sink: Some(InvocationMutationResponseSink::Ingress(
                         IngressInvocationResponseSink { request_id },
                     )),

--- a/crates/worker/src/partition/state_machine/lifecycle/mod.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/mod.rs
@@ -31,6 +31,7 @@ pub(super) use cancel::OnCancelCommand;
 pub(super) use event::ApplyEventCommand;
 pub(super) use manual_pause::OnManualPauseCommand;
 pub(super) use manual_resume::OnManualResumeCommand;
+pub(crate) use manual_resume::resolve_pinned_deployment;
 pub(super) use migrate_journal_table::VerifyOrMigrateJournalTableToV2Command;
 pub(super) use notify_get_invocation_output_response::OnNotifyGetInvocationOutputResponse;
 pub(super) use notify_invocation_response::OnNotifyInvocationResponse;

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -14,6 +14,8 @@ mod lifecycle;
 mod utils;
 
 pub use actions::{Action, ActionCollector};
+// Re-exported so the resume RPC handler can resolve deployments the same way the apply path does.
+pub(crate) use lifecycle::resolve_pinned_deployment;
 
 use std::collections::HashSet;
 use std::fmt;
@@ -30,6 +32,7 @@ use futures::{StreamExt, TryStreamExt};
 use metrics::{counter, histogram};
 use tracing::{Instrument, debug, error, info, trace, warn};
 
+use restate_clock::RoughTimestamp;
 use restate_limiter::LimitKey;
 use restate_limiter::RuleBook;
 
@@ -71,11 +74,11 @@ use restate_types::errors::{
     KILLED_INVOCATION_ERROR, NOT_FOUND_INVOCATION_ERROR, NOT_READY_INVOCATION_ERROR,
     WORKFLOW_ALREADY_INVOKED_INVOCATION_ERROR,
 };
-use restate_types::identifiers::WithPartitionKey;
 use restate_types::identifiers::{
     AwakeableIdentifier, EntryIndex, ExternalSignalIdentifier, InvocationId,
     PartitionProcessorRpcRequestId, ServiceId, StateMutationId,
 };
+use restate_types::identifiers::{DeploymentId, WithPartitionKey};
 use restate_types::invocation::client::{
     CancelInvocationResponse, InvocationOutputResponse, KillInvocationResponse,
     PauseInvocationResponse, PurgeInvocationResponse, ResumeInvocationResponse,
@@ -774,8 +777,10 @@ impl<S> StateMachineApplyContext<'_, S> {
 
                 lifecycle::OnManualResumeCommand {
                     invocation_id: resume_invocation_request.invocation_id,
+                    update_deployment_id: resume_invocation_request.update_deployment_id,
                     update_pinned_deployment_id: resume_invocation_request
                         .update_pinned_deployment_id,
+                    run_at: resume_invocation_request.run_at,
                     response_sink: resume_invocation_request.response_sink,
                 }
                 .apply(self)
@@ -3257,6 +3262,19 @@ impl<S> StateMachineApplyContext<'_, S> {
                     return Ok(());
                 }
 
+                if entry_key != state_header.entry_key() {
+                    // Stale decision: the entry was rescheduled (re-keyed) after the scheduler
+                    // proposed this run. A fresh decision for the new key will run it. See the
+                    // matching guard in `run_invocation` for the full rationale.
+                    debug!(
+                        vqueue = %qid,
+                        "Ignoring a stale decision to run {mutation_id}: it was rescheduled (decision run_at {} != current {})",
+                        entry_key.run_at(),
+                        state_header.entry_key().run_at(),
+                    );
+                    return Ok(());
+                }
+
                 let Some(state_mutation) = self
                     .storage
                     .get_vqueue_input_payload::<ExternalStateMutation>(
@@ -3357,6 +3375,24 @@ impl<S> StateMachineApplyContext<'_, S> {
                 "Ignoring the scheduler's decision to run {invocation_id} because the entry has
                 already moved to {} stage!",
                 header.stage(),
+            );
+            return Ok(());
+        }
+
+        if entry_key != header.entry_key() {
+            // The decision can be stale: the entry may have been rescheduled (resume /
+            // pause+resume / explicit reschedule) after the scheduler proposed this decision,
+            // which re-keys it (a new run_at) while keeping it in `Inbox`, so the stage check
+            // above does not catch it. A reschedule emits a fresh decision for the new key, so we
+            // honor this one only if it still matches the stored key and let the fresh decision
+            // run the entry otherwise. This holds for both directions: a future reschedule must
+            // not run now, and an earlier reschedule runs via its fresh decision (avoiding a
+            // double dispatch). No state transition / stats update happens on skip.
+            debug!(
+                vqueue = %qid,
+                "Ignoring a stale decision to run {invocation_id}: it was rescheduled (decision run_at {} != current {})",
+                entry_key.run_at(),
+                header.entry_key().run_at(),
             );
             return Ok(());
         }
@@ -5512,6 +5548,67 @@ impl<S> StateMachineApplyContext<'_, S> {
         };
 
         Ok(())
+    }
+
+    /// Reschedules a waiting VQueue invocation to a new `run_at` so the scheduler re-evaluates its
+    /// eligibility (e.g. to pull a backing-off attempt forward past its retry backoff).
+    ///
+    /// `run_at` is decided by the command (`None` here): when absent we default to the entry's
+    /// `created_at`, which is always `<= now` (so the entry becomes immediately eligible) and
+    /// restores its original priority position rather than demoting it behind already-ready entries.
+    /// A caller may pass an explicit `run_at` in the past to raise priority or in the future to
+    /// delay.
+    ///
+    /// Optionally set a deployment id as the pinned deployment in the entry's metadata.
+    ///
+    /// Returns whether the entry was in a *waiting* stage (`Inbox`/`Suspended`/`Paused`) and thus
+    /// actually reschedulable. A running (or otherwise non-waiting) entry is left untouched by
+    /// [`VQueue::reschedule`] and returns `false`, so the caller can avoid changes that are unsafe
+    /// while an attempt is in flight (e.g. repinning the deployment).
+    // [vqueues only]
+    async fn vqueue_reschedule_invocation(
+        &mut self,
+        invocation_id: &InvocationId,
+        run_at: Option<RoughTimestamp>,
+        pinned_deployment: Option<DeploymentId>,
+    ) -> Result<bool, Error>
+    where
+        S: WriteVQueueTable + WriteLockTable + ReadVQueueTable,
+    {
+        let entry_id = EntryId::from(invocation_id);
+        let Some(header) = self
+            .storage
+            .get_vqueue_entry_status(invocation_id.partition_key(), &entry_id)
+            .await?
+        else {
+            // todo resolve once we decided on the actual migration strategy
+            panic!(
+                "Trying to reschedule invocation {invocation_id} which does not exist as a vqueue entry. Have you forgotten to migrate from the old inbox to vqueues?"
+            );
+        };
+
+        // Default to the entry's `created_at`: always eligible and at its original priority.
+        let run_at = run_at.unwrap_or_else(|| RoughTimestamp::from(header.stats().created_at));
+
+        // Only waiting entries can be rescheduled; a running/terminal entry is a no-op below.
+        let is_waiting = matches!(
+            header.stage(),
+            Stage::Inbox | Stage::Suspended | Stage::Paused
+        );
+
+        let qid = header.vqueue_id();
+        let mut vqueue = VQueue::get(
+            qid,
+            self.storage,
+            self.vqueues_cache,
+            self.is_leader.then_some(self.action_collector),
+        )
+        .await?
+        .expect("rescheduling in a non-existent vqueue");
+
+        vqueue.reschedule(&header, run_at, pinned_deployment);
+
+        Ok(is_waiting)
     }
 
     async fn vqueue_enqueue_state_mutation(


### PR DESCRIPTION
Resuming an Invoked invocation pokes the invoker (InputCommand::RetryNow) to
fire its pending retry timer. That is wrong for VQueue invocations: a failed
VQueue attempt backs off inside the VQueue (Stage::Inbox, Status::BackingOff)
with a future run_at, so the invoker has no timer to fire and the legacy poke
does nothing.

For VQueue invocations the resume RPC now proposes the existing
Command::ResumeInvocation instead of poking the invoker (gated on vqueue_id,
mirroring the pause RPC). When applied to a backing-off invocation, the entry
is re-keyed to the current record time so the scheduler runs it immediately --
the VQueue analogue of RetryNow.

- vqueues: add VQueue::reschedule, which re-keys an inbox entry to a new run_at,
  preserving Status/stats (mark_transition, not mark_yield) and emitting the
  Inbox->Inbox reconciliation event pair. No-op when run_at is unchanged.
- worker: add vqueue_reschedule_invocation_to_now (no-op while still running),
  call it from OnManualResumeCommand's Invoked arm for VQueue invocations, and
  gate the resume RPC's Invoked arm on vqueue_id. No fencing interaction is
  needed: the failed attempt already ended and the scheduler mints a fresh
  fencing token when it dispatches the rescheduled entry.