### PR TITLE
[Pause] Test invoker-effect fencing across pause/resume

### DIFF
--- a/crates/worker/src/partition/leadership/fencing.rs
+++ b/crates/worker/src/partition/leadership/fencing.rs
@@ -1,0 +1,101 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Leader-local fencing tokens used to drop stale invoker effects at write time.
+
+use restate_platform::hash::HashMap;
+use restate_types::identifiers::InvocationId;
+use restate_types::invocation::FencingToken;
+
+/// Tracks, per in-flight invocation, the fencing token of the invoker attempt whose effects the
+/// leader currently accepts.
+///
+/// A fresh token is [`mint`](Self::mint)ed on every (re)invoke and handed to the invoker, which
+/// echoes it on every effect. Before self-proposing an invoker effect the leader checks
+/// [`accepts`](Self::accepts): an effect whose token is not the invocation's current token is a
+/// straggler from a previous attempt and is dropped. The token is [`clear`](Self::clear)ed when
+/// an attempt ends (abort / terminal effect) or is fenced (pause). The whole structure is
+/// leader-local and discarded on leadership loss (rebuilt on the next term).
+///
+/// The counter is global (per leader) and wraps: a straggler would have to survive 2^32
+/// intervening invokes to alias a live token, which cannot happen (effects drain in
+/// milliseconds).
+#[derive(Default)]
+pub(crate) struct FencingTokens {
+    tokens: HashMap<InvocationId, FencingToken>,
+    next: FencingToken,
+}
+
+impl FencingTokens {
+    /// Mint a fresh token for a (re)invoke of `invocation_id` and record it as the accepted
+    /// token, replacing any previous one.
+    pub(crate) fn mint(&mut self, invocation_id: InvocationId) -> FencingToken {
+        let token = self.next;
+        self.next = self.next.wrapping_add(1);
+        self.tokens.insert(invocation_id, token);
+        token
+    }
+
+    /// Whether an invoker effect carrying `token` should be accepted: `true` iff `token` is
+    /// `invocation_id`'s current (most recently minted, not since cleared) token.
+    pub(crate) fn accepts(&self, invocation_id: &InvocationId, token: FencingToken) -> bool {
+        self.tokens.get(invocation_id) == Some(&token)
+    }
+
+    /// Stop accepting `invocation_id`'s current token (the attempt ended or was fenced). A later
+    /// [`mint`](Self::mint) starts accepting a fresh attempt.
+    pub(crate) fn clear(&mut self, invocation_id: &InvocationId) {
+        self.tokens.remove(invocation_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_only_the_current_token() {
+        let mut ft = FencingTokens::default();
+        let id = InvocationId::mock_random();
+
+        let t1 = ft.mint(id); // invoke (attempt 1)
+        assert!(ft.accepts(&id, t1)); // attempt-1 effect accepted
+
+        ft.clear(&id); // pause
+        assert!(!ft.accepts(&id, t1)); // straggler dropped while paused
+
+        let t2 = ft.mint(id); // resume (attempt 2)
+        assert_ne!(t1, t2);
+        assert!(!ft.accepts(&id, t1)); // attempt-1 straggler still fenced
+        assert!(ft.accepts(&id, t2)); // attempt-2 effect accepted
+    }
+
+    #[test]
+    fn distinct_invocations_are_independent() {
+        let mut ft = FencingTokens::default();
+        let a = InvocationId::mock_random();
+        let b = InvocationId::mock_random();
+
+        let ta = ft.mint(a);
+        let tb = ft.mint(b);
+        assert!(ft.accepts(&a, ta));
+        assert!(ft.accepts(&b, tb));
+
+        ft.clear(&a);
+        assert!(!ft.accepts(&a, ta)); // a is fenced
+        assert!(ft.accepts(&b, tb)); // b is unaffected
+    }
+
+    #[test]
+    fn unknown_invocation_never_accepts() {
+        let ft = FencingTokens::default();
+        assert!(!ft.accepts(&InvocationId::mock_random(), 0));
+    }
+}

--- a/crates/worker/src/partition/leadership/leader_state.rs
+++ b/crates/worker/src/partition/leadership/leader_state.rs
@@ -36,8 +36,8 @@ use restate_types::identifiers::{
     InvocationId, LeaderEpoch, PartitionId, PartitionKey, PartitionProcessorRpcRequestId,
     WithPartitionKey,
 };
+use restate_types::invocation::PurgeInvocationRequest;
 use restate_types::invocation::client::{InvocationOutput, SubmittedInvocationNotification};
-use restate_types::invocation::{FencingToken, PurgeInvocationRequest};
 use restate_types::logs::Keys;
 use restate_types::net::ingest::IngestRecord;
 use restate_types::net::partition_processor::{
@@ -57,6 +57,7 @@ use restate_worker_api::{SchedulerStatusEntry, UserLimitCounterEntry};
 
 use crate::metric_definitions::{PARTITION_HANDLE_LEADER_ACTIONS, USAGE_LEADER_ACTION_COUNT};
 use crate::partition::cleaner::{CleanerEffect, CleanerHandle};
+use crate::partition::leadership::fencing::FencingTokens;
 use crate::partition::leadership::self_proposer::SelfProposer;
 use crate::partition::leadership::{ActionEffect, Error, InvokerStream, TimerService};
 use crate::partition::shuffle;
@@ -91,16 +92,10 @@ pub struct LeaderState {
     awaiting_rpc_actions: HashMap<PartitionProcessorRpcRequestId, RpcReciprocal>,
     awaiting_rpc_self_propose: FuturesUnordered<SelfAppendFuture>,
 
-    /// Leader-local fencing tokens for in-flight invoker attempts (see [`FencingToken`]).
-    ///
-    /// Maps an in-flight invocation to the token handed to its current invoker task. Invoker
-    /// effects whose token does not match (or is absent) are dropped *before* being self-proposed,
-    /// fencing stragglers from a previous attempt. Entries are added on (re)invoke, removed when
-    /// the attempt ends (abort / terminal effect) or is fenced (pause / scheduler re-drive
-    /// propose), and the whole map is discarded on leadership loss (rebuilt on the next term).
-    fencing_tokens: restate_platform::hash::HashMap<InvocationId, FencingToken>,
-    /// Monotonic source of fresh fencing tokens; wraps (see [`FencingToken`]).
-    next_fencing_token: FencingToken,
+    /// Leader-local fencing tokens for in-flight invoker attempts. Used to drop stale invoker
+    /// effects (from a previous attempt) before they are self-proposed. Discarded on leadership
+    /// loss and rebuilt on the next term. See [`FencingTokens`].
+    fencing_tokens: FencingTokens,
 
     invoker_stream: InvokerStream,
     shuffle_stream: ReceiverStream<shuffle::OutboxTruncation>,
@@ -130,10 +125,8 @@ impl LeaderState {
         invoker_task_handle: TaskHandle<()>,
         self_proposer: SelfProposer,
         invoker_rx: InvokerStream,
-        // Fencing tokens seeded for the invocations resumed on becoming leader, and the next
-        // token to mint. See `fencing_tokens` / `mint_fencing_token`.
-        fencing_tokens: restate_platform::hash::HashMap<InvocationId, FencingToken>,
-        next_fencing_token: FencingToken,
+        // Fencing tokens seeded for the invocations resumed on becoming leader. See `fencing_tokens`.
+        fencing_tokens: FencingTokens,
         shuffle_rx: tokio::sync::mpsc::Receiver<shuffle::OutboxTruncation>,
         durability_tracker: DurabilityTracker,
         leader_query_guard: LeaderQueryGuard,
@@ -159,12 +152,18 @@ impl LeaderState {
             awaiting_rpc_actions: Default::default(),
             awaiting_rpc_self_propose: Default::default(),
             fencing_tokens,
-            next_fencing_token,
             invoker_stream: invoker_rx,
             shuffle_stream: ReceiverStream::new(shuffle_rx),
             durability_tracker,
             _leader_query_guard: leader_query_guard,
         }
+    }
+
+    /// Test-only access to the fencing-token map, so tests in the parent module can mint/inspect
+    /// tokens while driving the real `handle_action_effects` / `propose_pause_and_fence` paths.
+    #[cfg(test)]
+    pub(crate) fn fencing_tokens_mut(&mut self) -> &mut FencingTokens {
+        &mut self.fencing_tokens
     }
 
     pub fn read_scheduler_status(
@@ -417,11 +416,14 @@ impl LeaderState {
                     // entry) means the effect is a straggler from a previous attempt that has
                     // since been re-invoked / paused / aborted, so it must not be written -- this
                     // is what stops it from being applied to a newer attempt.
-                    if self.fencing_tokens.get(&invocation_id) == Some(&fenced.fencing_token) {
+                    if self
+                        .fencing_tokens
+                        .accepts(&invocation_id, fenced.fencing_token)
+                    {
                         // A terminal effect ends this attempt: stop accepting its token (GC). A
                         // later re-invoke mints a fresh one.
                         if fenced.effect.kind.is_terminal() {
-                            self.fencing_tokens.remove(&invocation_id);
+                            self.fencing_tokens.clear(&invocation_id);
                         }
                         self.self_proposer
                             .self_propose(
@@ -586,7 +588,7 @@ impl LeaderState {
                 } else {
                     v.insert(reciprocal);
                     // Clear ONLY here -- after the append succeeded. See the method doc.
-                    self.fencing_tokens.remove(&invocation_id);
+                    self.fencing_tokens.clear(&invocation_id);
                 }
             }
         }
@@ -665,23 +667,13 @@ impl LeaderState {
         Ok(())
     }
 
-    /// Mints a fresh fencing token for a (re)invoke and records it as the accepted token for
-    /// `invocation_id`, overwriting any previous one. Once recorded, straggler effects from the
-    /// previous attempt (carrying the old token) are dropped by [`Self::fence_invoker_effect`].
-    fn mint_fencing_token(&mut self, invocation_id: InvocationId) -> FencingToken {
-        let token = self.next_fencing_token;
-        self.next_fencing_token = self.next_fencing_token.wrapping_add(1);
-        self.fencing_tokens.insert(invocation_id, token);
-        token
-    }
-
     fn handle_action(&mut self, metas: VQueuesMeta<'_>, action: Action) -> Result<(), Error> {
         match action {
             Action::Invoke {
                 invocation_id,
                 invocation_target,
             } => {
-                let fencing_token = self.mint_fencing_token(invocation_id);
+                let fencing_token = self.fencing_tokens.mint(invocation_id);
                 self.invoker_handle
                     .invoke(invocation_id, fencing_token, invocation_target)
                     .map_err(Error::Invoker)?;
@@ -716,7 +708,7 @@ impl LeaderState {
             Action::AbortInvocation { invocation_id } => {
                 // The attempt is ending; drop its fencing token so any straggler effect is dropped
                 // at write time (a later re-invoke mints a fresh token).
-                self.fencing_tokens.remove(&invocation_id);
+                self.fencing_tokens.clear(&invocation_id);
                 self.invoker_handle
                     .abort_invocation(invocation_id)
                     .map_err(Error::Invoker)?;
@@ -861,7 +853,7 @@ impl LeaderState {
                     );
                     ReservedResources::new_empty()
                 });
-                let fencing_token = self.mint_fencing_token(invocation_id);
+                let fencing_token = self.fencing_tokens.mint(invocation_id);
                 self.invoker_handle
                     .vqueue_invoke(
                         slot.vqueue_id().clone(),

--- a/crates/worker/src/partition/leadership/leader_state.rs
+++ b/crates/worker/src/partition/leadership/leader_state.rs
@@ -37,8 +37,8 @@ use restate_types::identifiers::{
     InvocationId, LeaderEpoch, PartitionId, PartitionKey, PartitionProcessorRpcRequestId,
     WithPartitionKey,
 };
+use restate_types::invocation::PurgeInvocationRequest;
 use restate_types::invocation::client::{InvocationOutput, SubmittedInvocationNotification};
-use restate_types::invocation::{FencingToken, PurgeInvocationRequest};
 use restate_types::logs::Keys;
 use restate_types::net::ingest::{IngestRecord, ResponseStatus};
 use restate_types::net::partition_processor::{
@@ -61,6 +61,7 @@ use restate_worker_api::{SchedulerStatusEntry, UserLimitCounterEntry};
 
 use crate::metric_definitions::{PARTITION_HANDLE_LEADER_ACTIONS, USAGE_LEADER_ACTION_COUNT};
 use crate::partition::cleaner::{CleanerEffect, CleanerHandle};
+use crate::partition::leadership::fencing::FencingTokens;
 use crate::partition::leadership::self_proposer::SelfProposer;
 use crate::partition::leadership::{
     Error, InvokerStream, LeaderEvent, NetworkServiceEvent, RpcReciprocal, TimerService,
@@ -99,16 +100,10 @@ pub struct LeaderState {
     awaiting_rpc_actions: HashMap<PartitionProcessorRpcRequestId, RpcReciprocal>,
     awaiting_rpc_self_propose: FuturesUnordered<SelfAppendFuture>,
 
-    /// Leader-local fencing tokens for in-flight invoker attempts (see [`FencingToken`]).
-    ///
-    /// Maps an in-flight invocation to the token handed to its current invoker task. Invoker
-    /// effects whose token does not match (or is absent) are dropped *before* being self-proposed,
-    /// fencing stragglers from a previous attempt. Entries are added on (re)invoke, removed when
-    /// the attempt ends (abort / terminal effect) or is fenced (pause / scheduler re-drive
-    /// propose), and the whole map is discarded on leadership loss (rebuilt on the next term).
-    fencing_tokens: restate_platform::hash::HashMap<InvocationId, FencingToken>,
-    /// Monotonic source of fresh fencing tokens; wraps (see [`FencingToken`]).
-    next_fencing_token: FencingToken,
+    /// Leader-local fencing tokens for in-flight invoker attempts. Used to drop stale invoker
+    /// effects (from a previous attempt) before they are self-proposed. Discarded on leadership
+    /// loss and rebuilt on the next term. See [`FencingTokens`].
+    fencing_tokens: FencingTokens,
 
     invoker_stream: InvokerStream,
     shuffle_stream: WatchStream<Option<shuffle::OutboxTruncation>>,
@@ -141,10 +136,8 @@ impl LeaderState {
         invoker_task_handle: TaskHandle<()>,
         self_proposer: SelfProposer,
         invoker_rx: InvokerStream,
-        // Fencing tokens seeded for the invocations resumed on becoming leader, and the next
-        // token to mint. See `fencing_tokens` / `mint_fencing_token`.
-        fencing_tokens: restate_platform::hash::HashMap<InvocationId, FencingToken>,
-        next_fencing_token: FencingToken,
+        // Fencing tokens seeded for the invocations resumed on becoming leader. See `fencing_tokens`.
+        fencing_tokens: FencingTokens,
         shuffle_rx: tokio::sync::watch::Receiver<Option<shuffle::OutboxTruncation>>,
         durability_tracker: DurabilityTracker,
         leader_query_guard: LeaderQueryGuard,
@@ -173,7 +166,6 @@ impl LeaderState {
             awaiting_rpc_actions: Default::default(),
             awaiting_rpc_self_propose: Default::default(),
             fencing_tokens,
-            next_fencing_token,
             invoker_stream: invoker_rx,
             shuffle_stream: WatchStream::new(shuffle_rx),
             durability_tracker,
@@ -182,6 +174,45 @@ impl LeaderState {
             _leader_query_guard: leader_query_guard,
             encoding_arena: BytesMut::with_capacity(128 * 1024),
         }
+    }
+
+    /// Test-only access to the fencing-token map, so tests in the parent module can mint/inspect
+    /// tokens while driving the real invoker-effect and pause-proposal paths.
+    #[cfg(test)]
+    pub(crate) fn fencing_tokens_mut(&mut self) -> &mut FencingTokens {
+        &mut self.fencing_tokens
+    }
+
+    #[cfg(test)]
+    pub(crate) fn handle_invoker_effect(&mut self, effect: InvokerEffect) -> Result<(), Error> {
+        let mut state = LeaderEventHandlerState {
+            partition_key_range: self.partition_key_range,
+            self_proposer: &mut self.self_proposer,
+            awaiting_rpc_actions: &mut self.awaiting_rpc_actions,
+            awaiting_rpc_self_propose: &mut self.awaiting_rpc_self_propose,
+            fencing_tokens: &mut self.fencing_tokens,
+            arena: &mut self.encoding_arena,
+        };
+        effect.handle(&mut state)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn propose_pause_and_fence(
+        &mut self,
+        request_id: PartitionProcessorRpcRequestId,
+        reciprocal: RpcReciprocal,
+        invocation_id: InvocationId,
+        cmd: Command,
+    ) {
+        let mut state = LeaderEventHandlerState {
+            partition_key_range: self.partition_key_range,
+            self_proposer: &mut self.self_proposer,
+            awaiting_rpc_actions: &mut self.awaiting_rpc_actions,
+            awaiting_rpc_self_propose: &mut self.awaiting_rpc_self_propose,
+            fencing_tokens: &mut self.fencing_tokens,
+            arena: &mut self.encoding_arena,
+        };
+        state.propose_pause_and_fence(request_id, reciprocal, invocation_id, cmd);
     }
 
     pub fn read_scheduler_status(
@@ -437,7 +468,7 @@ struct LeaderEventHandlerState<'a> {
     self_proposer: &'a mut SelfProposer,
     awaiting_rpc_actions: &'a mut HashMap<PartitionProcessorRpcRequestId, RpcReciprocal>,
     awaiting_rpc_self_propose: &'a mut FuturesUnordered<SelfAppendFuture>,
-    fencing_tokens: &'a mut restate_platform::hash::HashMap<InvocationId, FencingToken>,
+    fencing_tokens: &'a mut FencingTokens,
     arena: &'a mut BytesMut,
 }
 
@@ -497,7 +528,7 @@ impl LeaderEventHandlerState<'_> {
     /// pause command is appended it clears `invocation_id`'s in-memory fencing token so a
     /// straggler effect from the attempt being paused is dropped at write time.
     ///
-    /// BRITTLE: the `fencing_tokens.remove` is a pre-apply, in-memory state mutation, and it must
+    /// BRITTLE: clearing the fencing token is a pre-apply, in-memory state mutation, and it must
     /// run **only on the `Ok` arm, strictly after the append succeeds**. A failed `self_propose`
     /// only replies an error -- the leader keeps running, it does not step down -- so clearing
     /// before the append (or on failure) would strand the invocation: its effects would be
@@ -533,7 +564,7 @@ impl LeaderEventHandlerState<'_> {
                 } else {
                     v.insert(reciprocal);
                     // Clear ONLY here -- after the append succeeded. See the method doc.
-                    self.fencing_tokens.remove(&invocation_id);
+                    self.fencing_tokens.clear(&invocation_id);
                 }
             }
         }
@@ -665,11 +696,14 @@ impl LeaderEventHandler for InvokerEffect {
         // entry) means the effect is a straggler from a previous attempt that has
         // since been re-invoked / paused / aborted, so it must not be written -- this
         // is what stops it from being applied to a newer attempt.
-        if state.fencing_tokens.get(&invocation_id) == Some(&self.fencing_token) {
+        if state
+            .fencing_tokens
+            .accepts(&invocation_id, self.fencing_token)
+        {
             // A terminal effect ends this attempt: stop accepting its token (GC). A
             // later re-invoke mints a fresh one.
             if self.effect.kind.is_terminal() {
-                state.fencing_tokens.remove(&invocation_id);
+                state.fencing_tokens.clear(&invocation_id);
             }
             state.self_proposer.self_propose(
                 invocation_id.partition_key(),
@@ -823,16 +857,6 @@ impl LeaderState {
         Ok(())
     }
 
-    /// Mints a fresh fencing token for a (re)invoke and records it as the accepted token for
-    /// `invocation_id`, overwriting any previous one. Once recorded, straggler effects from the
-    /// previous attempt (carrying the old token) are dropped by [`Self::fence_invoker_effect`].
-    fn mint_fencing_token(&mut self, invocation_id: InvocationId) -> FencingToken {
-        let token = self.next_fencing_token;
-        self.next_fencing_token = self.next_fencing_token.wrapping_add(1);
-        self.fencing_tokens.insert(invocation_id, token);
-        token
-    }
-
     fn handle_action(
         &mut self,
         processor: &(impl Processor + HasVQueues),
@@ -843,7 +867,7 @@ impl LeaderState {
                 invocation_id,
                 invocation_target,
             } => {
-                let fencing_token = self.mint_fencing_token(invocation_id);
+                let fencing_token = self.fencing_tokens.mint(invocation_id);
                 self.invoker_handle
                     .invoke(invocation_id, fencing_token, invocation_target)
                     .map_err(Error::Invoker)?;
@@ -878,7 +902,7 @@ impl LeaderState {
             Action::AbortInvocation { invocation_id } => {
                 // The attempt is ending; drop its fencing token so any straggler effect is dropped
                 // at write time (a later re-invoke mints a fresh token).
-                self.fencing_tokens.remove(&invocation_id);
+                self.fencing_tokens.clear(&invocation_id);
                 self.invoker_handle
                     .abort_invocation(invocation_id)
                     .map_err(Error::Invoker)?;
@@ -1024,7 +1048,7 @@ impl LeaderState {
                     );
                     ReservedResources::new_empty()
                 });
-                let fencing_token = self.mint_fencing_token(invocation_id);
+                let fencing_token = self.fencing_tokens.mint(invocation_id);
                 self.invoker_handle
                     .vqueue_invoke(
                         slot.vqueue_id().clone(),

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 mod durability_tracker;
+mod fencing;
 mod leader_state;
 mod self_proposer;
 pub mod trim_queue;
@@ -35,7 +36,6 @@ use restate_invoker_impl::{
 };
 use restate_limiter::RuleBook;
 use restate_partition_store::PartitionStore;
-use restate_platform::hash::HashMap;
 use restate_service_protocol::codec::ProtobufRawEntryCodec;
 use restate_storage_api::StorageError;
 use restate_storage_api::deduplication_table::EpochSequenceNumber;
@@ -51,7 +51,6 @@ use restate_types::config::Configuration;
 use restate_types::errors::GenericError;
 use restate_types::identifiers::{InvocationId, LeaderEpoch, PartitionId};
 use restate_types::identifiers::{PartitionKey, PartitionProcessorRpcRequestId};
-use restate_types::invocation::FencingToken;
 use restate_types::live::LiveLoadExt;
 use restate_types::logs::Keys;
 use restate_types::message::MessageIndex;
@@ -79,6 +78,7 @@ use restate_worker_api::{
 };
 
 use self::durability_tracker::DurabilityTracker;
+use self::fencing::FencingTokens;
 use self::trim_queue::{LogTrimmer, TrimQueue};
 use crate::invoker_integration::EntryEnricher;
 use crate::partition::LeadershipInfo;
@@ -496,7 +496,7 @@ where
                 scheduler_service.on_rules_updated(initial_diff);
             }
 
-            let (fencing_tokens, next_fencing_token) =
+            let fencing_tokens =
                 Self::resume_invoked_invocations(&mut invoker_handle, partition_store).await?;
 
             let timer_service = TimerService::new(
@@ -638,7 +638,6 @@ where
                 self_proposer,
                 invoker_rx,
                 fencing_tokens,
-                next_fencing_token,
                 shuffle_rx,
                 durability_tracker,
                 leader_query_guard,
@@ -654,7 +653,7 @@ where
     async fn resume_invoked_invocations(
         invoker_handle: &mut InvokerChannelServiceHandle,
         partition_store: &mut PartitionStore,
-    ) -> Result<(HashMap<InvocationId, FencingToken>, FencingToken), Error> {
+    ) -> Result<FencingTokens, Error> {
         // todo(asoli): If we are asked to migrate to vqueues (or vqueues are enabled).
         // we must migrate all invoked invocations here (through a wal command).
         // (blocker to v1.7.0)
@@ -668,30 +667,28 @@ where
         let start = tokio::time::Instant::now();
         // Seed a fresh fencing token per resumed invocation so the leader accepts its effects and
         // can later fence stragglers from a re-invoke. On a fresh term there are no in-flight
-        // stragglers yet, so the starting tokens only need to be distinct from the ones
-        // `LeaderState::mint_fencing_token` will mint later, which continues from
-        // `next_fencing_token`.
-        let mut fencing_tokens = HashMap::default();
-        let mut next_fencing_token: FencingToken = 0;
+        // stragglers yet, so the starting tokens only need to be distinct from the ones minted
+        // later, which they are (the counter keeps advancing).
+        let mut fencing_tokens = FencingTokens::default();
+        let mut count = 0usize;
         while let Some(invoked_invocation) = invoked_invocations.next().await {
             let InvokedInvocationStatusLite {
                 invocation_id,
                 invocation_target,
             } = invoked_invocation?;
-            let fencing_token = next_fencing_token;
-            next_fencing_token = next_fencing_token.wrapping_add(1);
-            fencing_tokens.insert(invocation_id, fencing_token);
+            let fencing_token = fencing_tokens.mint(invocation_id);
             invoker_handle
                 .invoke(invocation_id, fencing_token, invocation_target)
                 .map_err(Error::Invoker)?;
+            count += 1;
         }
         debug!(
             "Leader partition resumed {} invocations in {:?}",
-            fencing_tokens.len(),
+            count,
             start.elapsed(),
         );
 
-        Ok((fencing_tokens, next_fencing_token))
+        Ok(fencing_tokens)
     }
 
     async fn become_follower(&mut self) {
@@ -973,6 +970,15 @@ mod tests {
     use test_log::test;
     use tokio_stream::StreamExt;
 
+    use super::ActionEffect;
+    use restate_core::network::Reciprocal;
+    use restate_types::deployment::PinnedDeployment;
+    use restate_types::identifiers::{DeploymentId, InvocationId, PartitionProcessorRpcRequestId};
+    use restate_types::invocation::FencingToken;
+    use restate_types::service_protocol::ServiceProtocolVersion;
+    use restate_wal_protocol::invocation::PauseInvocationCommand;
+    use restate_worker_api::invoker::{Effect, EffectKind, FencedEffect};
+
     const PARTITION_ID: PartitionId = PartitionId::MIN;
     const NODE_ID: GenerationalNodeId = GenerationalNodeId::new(0, 0);
     const PARTITION_KEY_RANGE: KeyRange = KeyRange::FULL;
@@ -1081,5 +1087,182 @@ mod tests {
             .await;
         RocksDbManager::get().shutdown().await;
         Ok(())
+    }
+
+    /// Pausing a (vqueue) invocation fences invoker activity: after the leader appends the pause
+    /// command and clears the fencing token, invoker effects carrying the paused attempt's token
+    /// are dropped at write time (never appended), while the resumed attempt's effects are
+    /// accepted. Exercises the real `propose_pause_and_fence` (append-then-clear) and
+    /// `handle_action_effects` (write-time fence) paths against an in-memory Bifrost.
+    #[test(restate_core::test)]
+    async fn pause_fences_stale_invoker_effects() -> googletest::Result<()> {
+        let env = TestCoreEnv::create_with_single_node(0, 0).await;
+
+        RocksDbManager::init();
+        let bifrost = Bifrost::init_in_memory(env.metadata_writer).await;
+        let replica_set_states = PartitionReplicaSetStates::default();
+        let partition_store_manager = PartitionStoreManager::create(true).await?;
+        let ingress = IngestionClient::new(
+            env.networking.clone(),
+            env.metadata.updateable_partition_table(),
+            PartitionRouting::new(replica_set_states.clone(), TaskCenter::current()),
+            NonZeroUsize::new(10 * 1024 * 1024).unwrap(),
+            SessionOptions::default(),
+        );
+        let (leader_query_tx, _leader_query_rx) = restate_worker_api::channel();
+        let mut state = LeadershipState::new(
+            Arc::new(PARTITION),
+            InvokerCapacity::new_unlimited(),
+            ingress,
+            bifrost.clone(),
+            None,
+            TrimQueue::default(),
+            leader_query_tx,
+            PartitionLeaderHandlesRegistry::default(),
+            RuleBookCacheHandle::detached(),
+        );
+
+        let leader_epoch = LeaderEpoch::from(1);
+        let leadership_info = LeadershipInfo {
+            version: Version::MIN,
+            leader_epoch,
+            current_config: PartitionConfiguration::default().into(),
+            next_config: None,
+        };
+        state.run_for_leader(Box::new(leadership_info)).await?;
+
+        // The first record is the AnnounceLeader the candidate proposed; decode it to drive
+        // on_announce_leader, then keep reading from the same stream to observe later appends.
+        let mut reader = bifrost
+            .create_reader(PARTITION_ID.into(), KeyFilter::Any, Lsn::OLDEST, Lsn::MAX)
+            .expect("valid reader");
+        let announce_leader = {
+            let record = reader.next().await.unwrap()?;
+            let_assert!(
+                Command::AnnounceLeader(announce_leader) =
+                    record.try_decode::<Envelope>().unwrap()?.command
+            );
+            announce_leader
+        };
+
+        let mut partition_store = partition_store_manager.open(&PARTITION, None).await?;
+        let rule_book = RuleBook::default();
+        state
+            .on_announce_leader(
+                &announce_leader,
+                &mut partition_store,
+                &replica_set_states,
+                &Configuration::pinned(),
+                &mut VQueuesMetaCache::new_empty(1024),
+                &rule_book,
+                MockStateMachineFeatures,
+                SemanticRestateVersion::current(),
+            )
+            .await?;
+
+        let State::Leader(leader_state) = &mut state.state else {
+            panic!("expected to be leader");
+        };
+
+        let invocation_id = InvocationId::mock_random();
+        // Four distinguishable effects so we can assert exactly which were appended.
+        let dep_attempt1 = DeploymentId::from_parts(1, 1);
+        let dep_paused = DeploymentId::from_parts(1, 2);
+        let dep_resume_stale = DeploymentId::from_parts(1, 3);
+        let dep_attempt2 = DeploymentId::from_parts(1, 4);
+
+        // Attempt 1: its effect carries the current token, so it is accepted and appended.
+        let t1 = leader_state.fencing_tokens_mut().mint(invocation_id);
+        leader_state
+            .handle_action_effects([pinned_deployment_effect(invocation_id, t1, dep_attempt1)])
+            .await?;
+
+        // Pause: append the PauseInvocation command and clear the token (after the append).
+        let request_id = PartitionProcessorRpcRequestId::new();
+        let (reciprocal, _rx) = Reciprocal::mock();
+        let pause_cmd = Command::PauseInvocation(
+            PauseInvocationCommand {
+                invocation_id,
+                request_id: Some(request_id),
+            }
+            .bilrost_encode_to_bytes(),
+        );
+        leader_state
+            .propose_pause_and_fence(request_id, reciprocal, invocation_id, pause_cmd)
+            .await;
+        // The pause cleared the token, so attempt 1's token is no longer accepted.
+        assert!(
+            !leader_state
+                .fencing_tokens_mut()
+                .accepts(&invocation_id, t1)
+        );
+
+        // A straggler from attempt 1 arriving after the pause is dropped (token cleared).
+        leader_state
+            .handle_action_effects([pinned_deployment_effect(invocation_id, t1, dep_paused)])
+            .await?;
+
+        // Attempt 2 (resume): attempt 1's token is still fenced; attempt 2's effect is accepted.
+        let t2 = leader_state.fencing_tokens_mut().mint(invocation_id);
+        assert_ne!(t1, t2);
+        leader_state
+            .handle_action_effects([pinned_deployment_effect(
+                invocation_id,
+                t1,
+                dep_resume_stale,
+            )])
+            .await?;
+        leader_state
+            .handle_action_effects([pinned_deployment_effect(invocation_id, t2, dep_attempt2)])
+            .await?;
+
+        // The committed log after AnnounceLeader must be exactly: InvokerEffect(attempt1),
+        // PauseInvocation, InvokerEffect(attempt2) -- the two stale stragglers were fenced.
+        let mut invoker_effect_deployments = Vec::new();
+        let mut saw_pause = false;
+        for _ in 0..3 {
+            let record = reader.next().await.unwrap()?;
+            match record.try_decode::<Envelope>().unwrap()?.command {
+                Command::InvokerEffect(effect) => {
+                    assert_eq!(effect.invocation_id, invocation_id);
+                    let EffectKind::PinnedDeployment(pinned) = effect.kind else {
+                        panic!("expected only PinnedDeployment effect kinds")
+                    };
+                    invoker_effect_deployments.push(pinned.deployment_id);
+                }
+                Command::PauseInvocation(_) => saw_pause = true,
+                other => panic!("unexpected command appended: {other:?}"),
+            }
+        }
+        assert!(saw_pause, "the pause command should have been appended");
+        assert_eq!(
+            invoker_effect_deployments,
+            vec![dep_attempt1, dep_attempt2],
+            "only the accepted attempts' effects should be appended; stale stragglers must be fenced",
+        );
+
+        state.step_down().await;
+        TaskCenter::current()
+            .shutdown_node("test_completed", 0)
+            .await;
+        RocksDbManager::get().shutdown().await;
+        Ok(())
+    }
+
+    fn pinned_deployment_effect(
+        invocation_id: InvocationId,
+        fencing_token: FencingToken,
+        deployment_id: DeploymentId,
+    ) -> ActionEffect {
+        ActionEffect::Invoker(FencedEffect {
+            fencing_token,
+            effect: Box::new(Effect {
+                invocation_id,
+                kind: EffectKind::PinnedDeployment(PinnedDeployment::new(
+                    deployment_id,
+                    ServiceProtocolVersion::V4,
+                )),
+            }),
+        })
     }
 }

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 mod durability_tracker;
+mod fencing;
 mod leader_state;
 mod self_proposer;
 pub mod trim_queue;
@@ -34,7 +35,6 @@ use restate_invoker_impl::{
     InvokerHandle as InvokerChannelServiceHandle, Service as InvokerService,
 };
 use restate_partition_store::PartitionStore;
-use restate_platform::hash::HashMap;
 use restate_service_protocol::codec::ProtobufRawEntryCodec;
 use restate_storage_api::StorageError;
 use restate_storage_api::deduplication_table::EpochSequenceNumber;
@@ -48,8 +48,7 @@ use restate_types::GenerationalNodeId;
 use restate_types::cluster::cluster_state::RunMode;
 use restate_types::config::Configuration;
 use restate_types::errors::GenericError;
-use restate_types::identifiers::{InvocationId, LeaderEpoch, PartitionId};
-use restate_types::invocation::FencingToken;
+use restate_types::identifiers::{LeaderEpoch, PartitionId};
 use restate_types::live::LiveLoadExt;
 use restate_types::logs::Keys;
 use restate_types::message::MessageIndex;
@@ -77,6 +76,7 @@ use restate_worker_api::{
 };
 
 use self::durability_tracker::DurabilityTracker;
+use self::fencing::FencingTokens;
 use self::trim_queue::{HasTrimQueue, LogTrimmer};
 use crate::invoker_integration::EntryEnricher;
 use crate::partition::LeadershipInfo;
@@ -692,16 +692,15 @@ where
                 scheduler_service.on_rules_updated(initial_diff);
             }
 
-            let (fencing_tokens, next_fencing_token) =
-                if processor.fsm().features().is_vqueues_enabled() {
-                    // VQueues migration is atomic. Either all invocations have a vqueue id, or none of them do.
-                    // As such, if the partition has the feature enabled, it means that we no longer have any "Invoked"
-                    // invocation without a vqueue id. So the `resume_invoked_invocations` scan below would have skipped all
-                    // invocations anyways.
-                    (HashMap::default(), 0)
-                } else {
-                    Self::resume_invoked_invocations(&mut invoker_handle, partition_store).await?
-                };
+            let fencing_tokens = if processor.fsm().features().is_vqueues_enabled() {
+                // VQueues migration is atomic. Either all invocations have a vqueue id, or none of them do.
+                // As such, if the partition has the feature enabled, it means that we no longer have any "Invoked"
+                // invocation without a vqueue id. So the `resume_invoked_invocations` scan below would have skipped all
+                // invocations anyways.
+                FencingTokens::default()
+            } else {
+                Self::resume_invoked_invocations(&mut invoker_handle, partition_store).await?
+            };
 
             let timer_service = TimerService::new(
                 TokioClock,
@@ -792,7 +791,6 @@ where
                 self_proposer,
                 invoker_rx,
                 fencing_tokens,
-                next_fencing_token,
                 shuffle_rx,
                 durability_tracker,
                 leader_query_guard,
@@ -811,7 +809,7 @@ where
     async fn resume_invoked_invocations(
         invoker_handle: &mut InvokerChannelServiceHandle,
         partition_store: &mut PartitionStore,
-    ) -> Result<(HashMap<InvocationId, FencingToken>, FencingToken), Error> {
+    ) -> Result<FencingTokens, Error> {
         let mut invoked_invocations = std::pin::pin!(
             partition_store
                 .scan_legacy_invoked_invocations()
@@ -821,30 +819,28 @@ where
         let start = tokio::time::Instant::now();
         // Seed a fresh fencing token per resumed invocation so the leader accepts its effects and
         // can later fence stragglers from a re-invoke. On a fresh term there are no in-flight
-        // stragglers yet, so the starting tokens only need to be distinct from the ones
-        // `LeaderState::mint_fencing_token` will mint later, which continues from
-        // `next_fencing_token`.
-        let mut fencing_tokens = HashMap::default();
-        let mut next_fencing_token: FencingToken = 0;
+        // stragglers yet, so the starting tokens only need to be distinct from the ones minted
+        // later, which they are (the counter keeps advancing).
+        let mut fencing_tokens = FencingTokens::default();
+        let mut count = 0usize;
         while let Some(invoked_invocation) = invoked_invocations.next().await {
             let InvokedInvocationStatusLite {
                 invocation_id,
                 invocation_target,
             } = invoked_invocation?;
-            let fencing_token = next_fencing_token;
-            next_fencing_token = next_fencing_token.wrapping_add(1);
-            fencing_tokens.insert(invocation_id, fencing_token);
+            let fencing_token = fencing_tokens.mint(invocation_id);
             invoker_handle
                 .invoke(invocation_id, fencing_token, invocation_target)
                 .map_err(Error::Invoker)?;
+            count += 1;
         }
         debug!(
             "Leader partition resumed {} invocations in {:?}",
-            fencing_tokens.len(),
+            count,
             start.elapsed(),
         );
 
-        Ok((fencing_tokens, next_fencing_token))
+        Ok(fencing_tokens)
     }
 
     async fn become_follower(&mut self) {
@@ -1050,6 +1046,16 @@ mod tests {
     use crate::partition_processor_manager::PartitionLeaderHandlesRegistry;
     use crate::rule_book_cache::RuleBookCacheHandle;
 
+    use restate_core::network::Reciprocal;
+    use restate_types::deployment::PinnedDeployment;
+    use restate_types::identifiers::{DeploymentId, InvocationId, PartitionProcessorRpcRequestId};
+    use restate_types::invocation::FencingToken;
+    use restate_types::service_protocol::ServiceProtocolVersion;
+    use restate_wal_protocol::invocation::PauseInvocationCommand;
+    use restate_worker_api::invoker::{Effect, EffectKind, FencedEffect};
+
+    use crate::partition::types::InvokerEffect;
+
     const PARTITION_ID: PartitionId = PartitionId::MIN;
     const NODE_ID: GenerationalNodeId = GenerationalNodeId::new(0, 0);
     const PARTITION_KEY_RANGE: KeyRange = KeyRange::FULL;
@@ -1168,5 +1174,187 @@ mod tests {
             .await;
         RocksDbManager::get().shutdown().await;
         Ok(())
+    }
+
+    /// Pausing a vqueue invocation fences invoker activity: after the leader appends the pause
+    /// command and clears the fencing token, effects carrying the paused attempt's token are
+    /// dropped at write time while the resumed attempt's effects are accepted.
+    #[test(restate_core::test)]
+    async fn pause_fences_stale_invoker_effects() -> googletest::Result<()> {
+        let env = TestCoreEnv::create_with_single_node(0, 0).await;
+
+        RocksDbManager::init();
+        let bifrost = Bifrost::init_in_memory(env.metadata_writer).await;
+        let replica_set_states = PartitionReplicaSetStates::default();
+        let partition_store_manager = PartitionStoreManager::create(true).await?;
+        let ingress = IngestionClient::new(
+            env.networking.clone(),
+            env.metadata.updateable_partition_table(),
+            PartitionRouting::new(replica_set_states.clone(), TaskCenter::current()),
+            NonZeroUsize::new(10 * 1024 * 1024).unwrap(),
+            SessionOptions::default(),
+        );
+        let mut node_ctx = NodeContext::new(
+            NODE_ID,
+            Configuration::live(),
+            replica_set_states,
+            RuleBookCacheHandle::detached(),
+            bifrost.clone(),
+            InvokerCapacity::new_unlimited(),
+            PartitionLeaderHandlesRegistry::default(),
+        );
+
+        let mut partition_store = partition_store_manager.open(&PARTITION, None).await?;
+        let mut ctx = ProcessorRawContext::new(
+            Arc::new(PARTITION),
+            PersistedFeatures {
+                journal_v2: true,
+                vqueues: true,
+                unique_random_seeds: true,
+            },
+        );
+        let (leader_query_tx, _leader_query_rx) = restate_worker_api::channel();
+        let mut state = LeadershipState::new(PARTITION_ID, ingress, leader_query_tx);
+
+        let leader_epoch = LeaderEpoch::from(1);
+        let leadership_info = LeadershipInfo {
+            version: Version::MIN,
+            leader_epoch,
+            current_config: PartitionConfiguration::default().into(),
+            next_config: None,
+        };
+        state
+            .run_for_leader(&mut ctx, &node_ctx, Box::new(leadership_info))
+            .await?;
+
+        // The first record is the AnnounceLeader the candidate proposed; decode it to drive
+        // on_announce_leader, then keep reading from the same stream to observe later appends.
+        let mut reader = bifrost
+            .create_reader(PARTITION_ID.into(), KeyFilter::Any, Lsn::OLDEST, Lsn::MAX)
+            .expect("valid reader");
+        let announce_leader = {
+            let record = reader.next().await.unwrap()?;
+            let_assert!(
+                Command::AnnounceLeader(announce_leader) =
+                    record.try_decode::<Envelope>().unwrap()?.command
+            );
+            announce_leader
+        };
+
+        state
+            .on_announce_leader(
+                &mut node_ctx,
+                &mut ctx,
+                &mut partition_store,
+                announce_leader.leader_epoch,
+            )
+            .await?;
+
+        let State::Leader(leader_state) = &mut state.state else {
+            panic!("expected to be leader");
+        };
+
+        let invocation_id = InvocationId::mock_random();
+        // Four distinguishable effects so we can assert exactly which were appended.
+        let dep_attempt1 = DeploymentId::from_parts(1, 1);
+        let dep_paused = DeploymentId::from_parts(1, 2);
+        let dep_resume_stale = DeploymentId::from_parts(1, 3);
+        let dep_attempt2 = DeploymentId::from_parts(1, 4);
+
+        // Attempt 1: its effect carries the current token, so it is accepted and appended.
+        let t1 = leader_state.fencing_tokens_mut().mint(invocation_id);
+        leader_state.handle_invoker_effect(pinned_deployment_effect(
+            invocation_id,
+            t1,
+            dep_attempt1,
+        ))?;
+
+        // Pause: append the PauseInvocation command and clear the token (after the append).
+        let request_id = PartitionProcessorRpcRequestId::new();
+        let (reciprocal, _rx) = Reciprocal::mock();
+        let pause_cmd = Command::PauseInvocation(
+            PauseInvocationCommand {
+                invocation_id,
+                request_id: Some(request_id),
+            }
+            .bilrost_encode_to_bytes(),
+        );
+        leader_state.propose_pause_and_fence(request_id, reciprocal, invocation_id, pause_cmd);
+        // The pause cleared the token, so attempt 1's token is no longer accepted.
+        assert!(
+            !leader_state
+                .fencing_tokens_mut()
+                .accepts(&invocation_id, t1)
+        );
+
+        // A straggler from attempt 1 arriving after the pause is dropped (token cleared).
+        leader_state.handle_invoker_effect(pinned_deployment_effect(
+            invocation_id,
+            t1,
+            dep_paused,
+        ))?;
+
+        // Attempt 2 (resume): attempt 1's token is still fenced; attempt 2's effect is accepted.
+        let t2 = leader_state.fencing_tokens_mut().mint(invocation_id);
+        assert_ne!(t1, t2);
+        leader_state.handle_invoker_effect(pinned_deployment_effect(
+            invocation_id,
+            t1,
+            dep_resume_stale,
+        ))?;
+        leader_state.handle_invoker_effect(pinned_deployment_effect(
+            invocation_id,
+            t2,
+            dep_attempt2,
+        ))?;
+
+        // The committed log after AnnounceLeader must be exactly: InvokerEffect(attempt1),
+        // PauseInvocation, InvokerEffect(attempt2) -- the two stale stragglers were fenced.
+        let mut invoker_effect_deployments = Vec::new();
+        let mut saw_pause = false;
+        for _ in 0..3 {
+            let record = reader.next().await.unwrap()?;
+            match record.try_decode::<Envelope>().unwrap()?.command {
+                Command::InvokerEffect(effect) => {
+                    assert_eq!(effect.invocation_id, invocation_id);
+                    let EffectKind::PinnedDeployment(pinned) = effect.kind else {
+                        panic!("expected only PinnedDeployment effect kinds")
+                    };
+                    invoker_effect_deployments.push(pinned.deployment_id);
+                }
+                Command::PauseInvocation(_) => saw_pause = true,
+                other => panic!("unexpected command appended: {other:?}"),
+            }
+        }
+        assert!(saw_pause, "the pause command should have been appended");
+        assert_eq!(
+            invoker_effect_deployments,
+            vec![dep_attempt1, dep_attempt2],
+            "only the accepted attempts' effects should be appended; stale stragglers must be fenced",
+        );
+
+        state.step_down().await;
+        TaskCenter::current()
+            .shutdown_node("test_completed", 0)
+            .await;
+        RocksDbManager::get().shutdown().await;
+        Ok(())
+    }
+
+    fn pinned_deployment_effect(
+        invocation_id: InvocationId,
+        fencing_token: FencingToken,
+        deployment_id: DeploymentId,
+    ) -> InvokerEffect {
+        FencedEffect {
+            fencing_token,
+            effect: Box::new(Effect {
+                invocation_id,
+                kind: EffectKind::PinnedDeployment(PinnedDeployment::new(
+                    deployment_id,
+                    ServiceProtocolVersion::V4,
+                )),
+            }),
+        }
     }
 }


### PR DESCRIPTION
Extract the leader's fencing-token state into a FencingTokens struct (mint/accepts/clear over a per-invocation map + a global wrapping counter) so the fence logic is testable in isolation, and cover it:

- FencingTokens unit tests: an effect is accepted iff it carries the invocation's current token; a paused (cleared) attempt's token is fenced; a resumed attempt mints a fresh token; distinct invocations are independent.
- A leadership integration test (pause_fences_stale_invoker_effects) drives the real handle_action_effects / propose_pause_and_fence paths against an in-memory Bifrost: after a pause clears the token, invoker effects from the paused attempt are dropped at write time (never appended), while the resumed attempt's effects are accepted.

No behavior change: LeaderState now delegates the four fencing sites (mint on invoke, accept + terminal-GC on effect, clear on abort/pause) to FencingTokens.