### PR TITLE
[Pause] Allow the CLI to pause suspended invocations 

### DIFF
--- a/cli/src/commands/invocations/cancel.rs
+++ b/cli/src/commands/invocations/cancel.rs
@@ -39,6 +39,7 @@ pub struct Cancel {
     /// * `workflowName`
     /// * `workflowName/key`
     /// * `workflowName/key/handler`
+    #[clap(verbatim_doc_comment)]
     pub(super) query: String,
     /// Ungracefully kill the invocation and its children
     #[clap(long)]

--- a/cli/src/commands/invocations/kill.rs
+++ b/cli/src/commands/invocations/kill.rs
@@ -29,6 +29,7 @@ pub struct Kill {
     /// * `workflowName`
     /// * `workflowName/key`
     /// * `workflowName/key/handler`
+    #[clap(verbatim_doc_comment)]
     query: String,
     /// Limit the number of fetched invocations
     #[clap(long, default_value_t = DEFAULT_BATCH_INVOCATIONS_OPERATION_LIMIT)]

--- a/cli/src/commands/invocations/pause.rs
+++ b/cli/src/commands/invocations/pause.rs
@@ -15,6 +15,7 @@ use crate::ui::invocations::render_simple_invocation_list;
 
 use crate::commands::invocations::{
     DEFAULT_BATCH_INVOCATIONS_OPERATION_LIMIT, DEFAULT_BATCH_INVOCATIONS_OPERATION_PRINT_LIMIT,
+    create_query_filter,
 };
 use anyhow::{Result, anyhow, bail};
 use cling::prelude::*;
@@ -22,7 +23,6 @@ use comfy_table::{Cell, Color, Table};
 use restate_admin_rest_model::version::AdminApiVersion;
 use restate_cli_util::ui::console::{StyledTable, confirm_or_exit};
 use restate_cli_util::{c_indent_table, c_println, c_success, c_warn};
-use restate_types::identifiers::InvocationId;
 
 #[derive(Run, Parser, Collect, Clone)]
 #[cling(run = "run_pause")]
@@ -49,28 +49,17 @@ pub async fn run_pause(State(env): State<CliEnv>, opts: &Pause) -> Result<()> {
 
     let sql_client = clients::DataFusionHttpClient::from(client.clone());
 
-    let q = opts.query.trim();
-    let filter = if let Ok(id) = q.parse::<InvocationId>() {
-        format!("id = '{id}'")
-    } else {
-        match q.find('/').unwrap_or_default() {
-            0 => format!("target LIKE '{q}/%'"),
-            // If there's one slash, let's add the wildcard depending on the service type,
-            // so we discriminate correctly with serviceName/handlerName with workflowName/workflowKey
-            1 => format!(
-                "(target = '{q}' AND target_service_ty = 'service') OR (target LIKE '{q}/%' AND target_service_ty != 'service'))"
-            ),
-            // Can only be exact match here
-            _ => format!("target LIKE '{q}'"),
-        }
-    };
-    // Filter only by invoked/suspended/paused, this command has no effect on non-completed invocations
-    let filter = format!("{filter} AND status = 'invoked' LIMIT {}", opts.limit);
+    // Pause only applies to in-flight invocations (running, backing-off, or suspended).
+    let filter = format!(
+        "{} AND status IN ('invoked', 'suspended') LIMIT {}",
+        create_query_filter(&opts.query),
+        opts.limit
+    );
 
     let invocations = find_active_invocations_simple(&sql_client, &filter).await?;
     if invocations.is_empty() {
         bail!(
-            "No invocations found for query {}! Note that the pause command only works on invocations either 'running', 'backing-off'.",
+            "No invocations found for query {}! Note that the pause command only works on invocations either 'running', 'backing-off' or 'suspended'.",
             opts.query
         );
     };

--- a/cli/src/commands/invocations/pause.rs
+++ b/cli/src/commands/invocations/pause.rs
@@ -34,6 +34,7 @@ pub struct Pause {
     /// * `virtualObjectName`
     /// * `virtualObjectName/key`
     /// * `virtualObjectName/key/handler`
+    #[clap(verbatim_doc_comment)]
     query: String,
     /// Limit the number of fetched invocations
     #[clap(long, default_value_t = DEFAULT_BATCH_INVOCATIONS_OPERATION_LIMIT)]

--- a/cli/src/commands/invocations/purge.rs
+++ b/cli/src/commands/invocations/purge.rs
@@ -37,6 +37,7 @@ pub struct Purge {
     /// * `workflowName`
     /// * `workflowName/key`
     /// * `workflowName/key/handler`
+    #[clap(verbatim_doc_comment)]
     query: String,
     /// Limit the number of fetched invocations
     #[clap(long, default_value_t = DEFAULT_BATCH_INVOCATIONS_OPERATION_LIMIT)]

--- a/cli/src/commands/invocations/restart_as_new.rs
+++ b/cli/src/commands/invocations/restart_as_new.rs
@@ -34,6 +34,7 @@ pub struct RestartAsNew {
     /// * `virtualObjectName`
     /// * `virtualObjectName/key`
     /// * `virtualObjectName/key/handler`
+    #[clap(verbatim_doc_comment)]
     query: String,
     /// Limit the number of fetched invocations
     #[clap(long, default_value_t = DEFAULT_BATCH_INVOCATIONS_OPERATION_LIMIT)]

--- a/cli/src/commands/invocations/resume.rs
+++ b/cli/src/commands/invocations/resume.rs
@@ -33,6 +33,7 @@ pub struct Resume {
     /// * `virtualObjectName`
     /// * `virtualObjectName/key`
     /// * `virtualObjectName/key/handler`
+    #[clap(verbatim_doc_comment)]
     query: String,
 
     /// When resuming from paused/suspended, provide a deployment id to use to replace the currently pinned deployment id.

--- a/release-notes/v1.7.0.md
+++ b/release-notes/v1.7.0.md
@@ -442,10 +442,10 @@ These tables are populated only when vqueues is enabled.
 When vqueues is enabled, the pause command behaves slightly differently:
 
 - **It is persisted and applied by the partition processor**, so a pause is honored deterministically regardless of whether the invoker is currently running the invocation (previously a pause could be silently dropped if the invoker was not actively processing it).
-- **Suspended invocations can now be paused** (in addition to running ones). Resuming re-invokes the invocation and replays its journal.
+- **Suspended invocations can now be paused** (in addition to running ones). The `restate invocations pause` CLI command and `PATCH /invocations/{id}/pause` now include suspended invocations in their selection. Resuming re-invokes the invocation and replays its journal.
 - **Graceful drains are no longer supported.** Pausing a running invocation immediately transitions it to `Paused` and aborts the in-progress execution attempt, instead of waiting for the invoker to reach a safe point. Journaled progress is preserved and replayed on resume; any in-flight, not-yet-journaled work of the aborted attempt is re-executed on resume, following the usual durable-execution replay semantics.
 
-Invocations that are not on vqueues keep the previous best-effort pause behavior.
+Invocations that are not on vqueues keep the previous best-effort pause behavior; in particular, pausing a suspended non-vqueue invocation is a no-op (reported as already paused).
 
 ### Service Protocol v7
 

--- a/release-notes/v1.7.0.md
+++ b/release-notes/v1.7.0.md
@@ -441,10 +441,10 @@ These tables are populated only when vqueues is enabled.
 When vqueues is enabled, the pause command behaves slightly differently:
 
 - **It is persisted and applied by the partition processor**, so a pause is honored deterministically regardless of whether the invoker is currently running the invocation (previously a pause could be silently dropped if the invoker was not actively processing it).
-- **Suspended invocations can now be paused** (in addition to running ones). Resuming re-invokes the invocation and replays its journal.
+- **Suspended invocations can now be paused** (in addition to running ones). The `restate invocations pause` CLI command and `PATCH /invocations/{id}/pause` now include suspended invocations in their selection. Resuming re-invokes the invocation and replays its journal.
 - **Graceful drains are no longer supported.** Pausing a running invocation immediately transitions it to `Paused` and aborts the in-progress execution attempt, instead of waiting for the invoker to reach a safe point. Journaled progress is preserved and replayed on resume; any in-flight, not-yet-journaled work of the aborted attempt is re-executed on resume, following the usual durable-execution replay semantics.
 
-Invocations that are not on vqueues keep the previous best-effort pause behavior.
+Invocations that are not on vqueues keep the previous best-effort pause behavior; in particular, pausing a suspended non-vqueue invocation is a no-op (reported as already paused).
 
 ### Service Protocol v7 (Preview)
 


### PR DESCRIPTION
Expand the `restate invocations pause` query filter from
`status = 'invoked'` to `status IN ('invoked', 'suspended')` so suspended
invocations are also selected, mirroring the resume command. The server
already supports this: vqueue invocations are paused, while non-vqueue
suspended invocations are reported as already paused (a no-op, HTTP 200).

Also reuse the shared `create_query_filter` helper instead of the
duplicated inline block, and document the behavior in the v1.7.0 release
notes.