### PR TITLE
Extend restate doctor with a few additional commands and convenience options

### DIFF
--- a/crates/log-server/src/rocksdb_logstore/record_format.rs
+++ b/crates/log-server/src/rocksdb_logstore/record_format.rs
@@ -84,16 +84,14 @@ impl<'a> DataRecordDecoder<'a> {
         self.buffer.len()
     }
 
-    pub fn decode(mut self) -> Result<Record, RecordDecodeError> {
-        // record flags
-        let flags = RecordFlags::from_bits_retain(self.buffer.get_u16_le());
+    /// Reads the record's `created_at` timestamp without consuming the decoder.
+    pub fn created_at(&self) -> Result<NanosSinceEpoch, RecordDecodeError> {
+        let mut buf = self.buffer;
+        read_flags_and_created_at(&mut buf).map(|(_, created_at)| created_at)
+    }
 
-        let timestamp = self.buffer.get_u64_le();
-        let created_at = if flags.contains(RecordFlags::HlcTimestamp) {
-            NanosSinceEpoch::from(UniqueTimestamp::try_from(timestamp)?)
-        } else {
-            NanosSinceEpoch::from(timestamp)
-        };
+    pub fn decode(mut self) -> Result<Record, RecordDecodeError> {
+        let (flags, created_at) = read_flags_and_created_at(&mut self.buffer)?;
 
         if flags.contains(RecordFlags::ExtendedHeader) {
             let extra_header_bytes = self.buffer.get_u8();
@@ -187,6 +185,20 @@ impl DataRecordEncoder<'_> {
     }
 }
 
+// Reads the record flags and the `created_at` timestamp from the buffer
+fn read_flags_and_created_at<B: Buf>(
+    buf: &mut B,
+) -> Result<(RecordFlags, NanosSinceEpoch), RecordDecodeError> {
+    let flags = RecordFlags::from_bits_retain(buf.get_u16_le());
+    let timestamp = buf.get_u64_le();
+    let created_at = if flags.contains(RecordFlags::HlcTimestamp) {
+        NanosSinceEpoch::from(UniqueTimestamp::try_from(timestamp)?)
+    } else {
+        NanosSinceEpoch::from(timestamp)
+    };
+    Ok((flags, created_at))
+}
+
 // Reads KeyStyle and extract the keys from the buffer
 fn read_keys<B: Buf>(buf: &mut B) -> Result<Keys, RecordDecodeError> {
     let key_style = buf.get_u8();
@@ -246,6 +258,10 @@ mod tests {
             buf.put_slice(body);
 
             let decoder = DataRecordDecoder::new(&buf)?;
+            assert_that!(
+                decoder.created_at()?,
+                eq(NanosSinceEpoch::from(timestamp_nanos))
+            );
             let decoded = decoder.decode()?;
             assert_that!(decoded.keys(), eq(&Keys::Single(42)));
             assert_that!(
@@ -269,6 +285,10 @@ mod tests {
             buf.put_slice(body);
 
             let decoder = DataRecordDecoder::new(&buf)?;
+            assert_that!(
+                decoder.created_at()?,
+                eq(NanosSinceEpoch::from(hlc_timestamp))
+            );
             let decoded = decoder.decode()?;
             assert_that!(decoded.keys(), eq(&Keys::Single(42)));
             // HLC timestamp gets converted to NanosSinceEpoch (millisecond precision)

--- a/tools/restate-doctor/src/app.rs
+++ b/tools/restate-doctor/src/app.rs
@@ -18,6 +18,7 @@ use crate::commands::completions::Completions;
 use crate::commands::id;
 use crate::commands::log_server;
 use crate::commands::partition_store;
+use crate::commands::partition_table;
 
 /// Restate Doctor - Diagnostic tools Restate storage
 ///
@@ -54,6 +55,9 @@ pub enum Command {
     /// Analyze partition store (RocksDB)
     #[clap(subcommand)]
     PartitionStore(partition_store::PartitionStoreCommand),
+    /// Partition table calculations (partition key -> partition id)
+    #[clap(subcommand)]
+    PartitionTable(partition_table::PartitionTableCommand),
     /// Analyze log-server store (RocksDB)
     #[clap(subcommand)]
     LogServer(log_server::LogServerCommand),

--- a/tools/restate-doctor/src/commands/log_server/scan.rs
+++ b/tools/restate-doctor/src/commands/log_server/scan.rs
@@ -14,6 +14,7 @@ use anyhow::{Context, Result};
 use bytes::BytesMut;
 use cling::prelude::*;
 use comfy_table::Table;
+use strum::VariantNames;
 
 use restate_cli_util::ui::console::StyledTable;
 use restate_cli_util::{c_println, c_title};
@@ -23,7 +24,7 @@ use restate_log_server::rocksdb_logstore::record_format::DataRecordDecoder;
 use restate_types::logs::{LogId, LogletId, LogletOffset, Record, SequenceNumber};
 use restate_types::storage::StorageCodec;
 use restate_util_bytecount::ByteCount;
-use restate_wal_protocol::Envelope;
+use restate_wal_protocol::{Command, Envelope};
 
 use crate::app::GlobalOpts;
 use crate::util::hex_encode;
@@ -61,6 +62,12 @@ pub struct Scan {
     /// --loglet-id/--log-id to avoid full-store scans.
     #[arg(long)]
     pub from_time: Option<jiff::Timestamp>,
+
+    /// Only show records with these WAL command types (e.g. Invoke,InvokerEffect).
+    /// Case-insensitive; can be specified multiple times or comma-separated.
+    /// By default all command types are shown.
+    #[arg(long, value_delimiter = ',', num_args = 1..)]
+    pub command: Vec<String>,
 
     /// Maximum number of records to display
     #[arg(long, short = 'n', default_value = "20")]
@@ -100,6 +107,30 @@ pub async fn run_scan(global_opts: &GlobalOpts, cmd: &Scan) -> Result<()> {
 
     let from_offset = LogletOffset::new(cmd.from_offset);
     let from_time_nanos: Option<i128> = cmd.from_time.map(|ts| ts.as_nanosecond());
+
+    // Resolve --command values to canonical command names upfront
+    let command_filter: Option<Vec<&'static str>> = if cmd.command.is_empty() {
+        None
+    } else {
+        Some(
+            cmd.command
+                .iter()
+                .map(|c| {
+                    Command::VARIANTS
+                        .iter()
+                        .find(|v| v.eq_ignore_ascii_case(c))
+                        .copied()
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "unknown command type '{c}', valid command types: {}",
+                                Command::VARIANTS.join(", ")
+                            )
+                        })
+                })
+                .collect::<Result<Vec<_>>>()?,
+        )
+    };
+
     let mut records = Vec::new();
     let mut skipped = 0;
 
@@ -186,6 +217,18 @@ pub async fn run_scan(global_opts: &GlobalOpts, cmd: &Scan) -> Result<()> {
             continue;
         }
 
+        // Command filter: requires decoding the record body. Records whose
+        // envelope fails to decode have command_name "?" and never match.
+        let mut decoded = None;
+        if let Some(filter) = &command_filter {
+            let info = decode_record_info(loglet_id, offset, value_bytes, cmd);
+            if !filter.contains(&info.command_name.as_str()) {
+                iter.next();
+                continue;
+            }
+            decoded = Some(info);
+        }
+
         // Pagination: skip
         if skipped < cmd.skip {
             skipped += 1;
@@ -198,7 +241,8 @@ pub async fn run_scan(global_opts: &GlobalOpts, cmd: &Scan) -> Result<()> {
             break;
         }
 
-        let record_info = decode_record_info(loglet_id, offset, value_bytes, cmd);
+        let record_info =
+            decoded.unwrap_or_else(|| decode_record_info(loglet_id, offset, value_bytes, cmd));
         records.push(record_info);
         iter.next();
     }
@@ -223,6 +267,9 @@ pub async fn run_scan(global_opts: &GlobalOpts, cmd: &Scan) -> Result<()> {
     );
     if let Some(from_time) = cmd.from_time {
         summary.add_kv_row("From time:", from_time.to_string());
+    }
+    if let Some(filter) = &command_filter {
+        summary.add_kv_row("Commands:", filter.join(", "));
     }
     if truncated {
         summary.add_kv_row(

--- a/tools/restate-doctor/src/commands/log_server/scan.rs
+++ b/tools/restate-doctor/src/commands/log_server/scan.rs
@@ -56,6 +56,12 @@ pub struct Scan {
     #[arg(long, default_value = "0")]
     pub from_offset: u32,
 
+    /// Only show records created at or after this RFC3339 timestamp
+    /// (e.g. 2026-06-10T12:00:00Z). Applies while scanning, so combine with
+    /// --loglet-id/--log-id to avoid full-store scans.
+    #[arg(long)]
+    pub from_time: Option<jiff::Timestamp>,
+
     /// Maximum number of records to display
     #[arg(long, short = 'n', default_value = "20")]
     pub limit: usize,
@@ -93,6 +99,7 @@ pub async fn run_scan(global_opts: &GlobalOpts, cmd: &Scan) -> Result<()> {
     };
 
     let from_offset = LogletOffset::new(cmd.from_offset);
+    let from_time_nanos: Option<i128> = cmd.from_time.map(|ts| ts.as_nanosecond());
     let mut records = Vec::new();
     let mut skipped = 0;
 
@@ -168,6 +175,17 @@ pub async fn run_scan(global_opts: &GlobalOpts, cmd: &Scan) -> Result<()> {
             }
         }
 
+        // Time filter: skip records created before --from-time. Records whose
+        // header fails to decode are kept so the decode error is surfaced.
+        if let Some(threshold) = from_time_nanos
+            && let Ok(decoder) = DataRecordDecoder::new(value_bytes)
+            && let Ok(created_at) = decoder.created_at()
+            && (created_at.as_u64() as i128) < threshold
+        {
+            iter.next();
+            continue;
+        }
+
         // Pagination: skip
         if skipped < cmd.skip {
             skipped += 1;
@@ -203,6 +221,9 @@ pub async fn run_scan(global_opts: &GlobalOpts, cmd: &Scan) -> Result<()> {
             LogletFilter::All => "all loglets".to_string(),
         },
     );
+    if let Some(from_time) = cmd.from_time {
+        summary.add_kv_row("From time:", from_time.to_string());
+    }
     if truncated {
         summary.add_kv_row(
             "Records:",

--- a/tools/restate-doctor/src/commands/mod.rs
+++ b/tools/restate-doctor/src/commands/mod.rs
@@ -12,3 +12,4 @@ pub mod completions;
 pub mod id;
 pub mod log_server;
 pub mod partition_store;
+pub mod partition_table;

--- a/tools/restate-doctor/src/commands/partition_table.rs
+++ b/tools/restate-doctor/src/commands/partition_table.rs
@@ -1,0 +1,83 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Partition table calculations (partition key -> partition id)
+
+use anyhow::Context;
+use cling::prelude::*;
+use comfy_table::Table;
+
+use restate_cli_util::c_println;
+use restate_cli_util::ui::console::StyledTable;
+use restate_types::Version;
+use restate_types::partition_table::{FindPartition, PartitionTable};
+
+/// Partition table commands
+#[derive(Run, Subcommand, Clone)]
+pub enum PartitionTableCommand {
+    /// Find the partition that owns a partition key
+    Find(Find),
+}
+
+/// Translate partition keys to partition ids for a given sharding.
+///
+/// Restate shards the u64 partition key space into equally sized partitions,
+/// so the number of partitions fully determines the sharding.
+#[derive(Run, Parser, Collect, Clone)]
+#[cling(run = "run_find")]
+pub struct Find {
+    /// Number of partitions of the cluster
+    #[arg(long, short)]
+    pub num_partitions: u16,
+
+    /// Partition key(s) to translate (decimal or 0x-prefixed hex)
+    #[arg(required = true, value_parser = parse_partition_key)]
+    pub partition_keys: Vec<u64>,
+}
+
+fn parse_partition_key(s: &str) -> Result<u64, std::num::ParseIntError> {
+    if let Some(hex) = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")) {
+        u64::from_str_radix(hex, 16)
+    } else {
+        s.parse()
+    }
+}
+
+pub async fn run_find(cmd: &Find) -> anyhow::Result<()> {
+    let partition_table =
+        PartitionTable::with_equally_sized_partitions(Version::MIN, cmd.num_partitions);
+
+    let mut table = Table::new_styled();
+    table.set_styled_header(vec![
+        "PARTITION KEY",
+        "PARTITION ID",
+        "KEY RANGE",
+        "CF NAME",
+    ]);
+
+    for partition_key in &cmd.partition_keys {
+        let partition_id = partition_table
+            .find_partition_id(*partition_key)
+            .with_context(|| format!("could not resolve partition key {partition_key}"))?;
+        let partition = partition_table
+            .get(&partition_id)
+            .expect("resolved partition must exist");
+
+        table.add_row(vec![
+            partition_key.to_string(),
+            partition_id.to_string(),
+            partition.key_range.to_string(),
+            partition.cf_name().to_string(),
+        ]);
+    }
+
+    c_println!("{table}");
+    Ok(())
+}


### PR DESCRIPTION
[[doctor] Add partition-table find command](https://github.com/restatedev/restate/commit/20f68a6f361a3c0fe8e7ccab702f82679fdc000e) 

Translates partition keys to partition ids for a given sharding.
Since the partition table is stored in the metadata store and not in
the partition store, the sharding is provided via --num-partitions,
which fully determines today's equal-sized key space split.

[[doctor] Add --from-time filter to log-server scan](https://github.com/restatedev/restate/commit/ff825e1020ce9efff3b8c48c79f42714b001e2e3) 

The time-based analogue of --from-offset: only show records created at
or after the given RFC3339 timestamp. Since the created_at timestamp
lives in the record value rather than the key, the filter is applied
while scanning (before skip/limit accounting) via a new non-consuming
DataRecordDecoder::created_at() accessor that avoids copying the record
body for filtered-out records.

[[doctor] Add --command filter to log-server scan](https://github.com/restatedev/restate/commit/0f63c4837e08fab51ff9b77873980acab6e31f6c) 

Only show records with the given WAL command types, e.g.
--command Invoke,InvokerEffect. Values are validated case-insensitively
against Command::VARIANTS. The filter is applied before skip/limit
accounting; the decoded record is reused for display to avoid double
decoding.