### PR TITLE
Split store timeout from rpc timeout

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
@@ -145,18 +145,19 @@ impl<T: TransportConnect> SequencerAppender<T> {
 
         // this loop retries forever or until the task is cancelled
         let final_state = loop {
-            let store_backoff = self
-                .configuration
-                .live_load()
-                .bifrost
-                .replicated_loglet
-                .rpc_timeout;
+            let (store_backoff, delay_config) = {
+                let opts = &self.configuration.live_load().bifrost.replicated_loglet;
 
-            let delay_config = AdaptiveTimeout::new(TimeoutConfig {
-                backoff: store_backoff,
-                quantile: 0.90,     // base timeout on P90
-                safety_factor: 1.0, // do not overshoot the delay between waves
-            });
+                (
+                    opts.store_timeout,
+                    AdaptiveTimeout::new(TimeoutConfig {
+                        backoff: opts.rpc_timeout,
+                        quantile: 0.90,     // base timeout on P90
+                        safety_factor: 1.0, // do not overshoot the delay between waves
+                    }),
+                )
+            };
+
             state = match state {
                 // termination conditions
                 State::Done | State::Cancelled | State::Sealed | State::WriteUnavailable => {

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -340,6 +340,12 @@ pub struct ReplicatedLogletOptions {
     /// The timeout range is also used to determine the appropriate retry delay between retry attempts.
     pub rpc_timeout: BackoffInterval,
 
+    /// Adaptive timeout for LogServer Store Messages
+    ///
+    /// This configures the adaptive timeout range for Store operations from this node to log servers.
+    /// The timeout range is also used to determine the appropriate retry delay between retry attempts.
+    pub store_timeout: BackoffInterval,
+
     /// Sequencer inactivity timeout
     ///
     /// The sequencer is allowed to consider itself quiescent if it did not commit records for this period of time.
@@ -426,6 +432,10 @@ impl Default for ReplicatedLogletOptions {
             sequencer_retry_policy: None,
             rpc_timeout: BackoffInterval {
                 min_ms: NonZeroU32::new(250).unwrap(),
+                max_ms: NonZeroU32::new(60_000).unwrap(),
+            },
+            store_timeout: BackoffInterval {
+                min_ms: NonZeroU32::new(2000).unwrap(),
                 max_ms: NonZeroU32::new(60_000).unwrap(),
             },
             sequencer_inactivity_timeout: NonZeroFriendlyDuration::from_secs_unchecked(15),


### PR DESCRIPTION

Allow store timeouts to have a much higher default bounds. This is suitable for the current spread selector. This ensures
that the sequencer is less aggressive in sending new waves when log-servers are slow. The delay between waves still uses
the rpc timeout.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4954).
* #4955
* __->__ #4954