### PR TITLE
Size log-server-data-service correction

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/sequencer/appender.rs
@@ -145,18 +145,19 @@ impl<T: TransportConnect> SequencerAppender<T> {
 
         // this loop retries forever or until the task is cancelled
         let final_state = loop {
-            let store_backoff = self
-                .configuration
-                .live_load()
-                .bifrost
-                .replicated_loglet
-                .rpc_timeout;
+            let (store_backoff, delay_config) = {
+                let opts = &self.configuration.live_load().bifrost.replicated_loglet;
 
-            let delay_config = AdaptiveTimeout::new(TimeoutConfig {
-                backoff: store_backoff,
-                quantile: 0.90,     // base timeout on P90
-                safety_factor: 1.0, // do not overshoot the delay between waves
-            });
+                (
+                    opts.store_timeout,
+                    AdaptiveTimeout::new(TimeoutConfig {
+                        backoff: opts.rpc_timeout,
+                        quantile: 0.90,     // base timeout on P90
+                        safety_factor: 1.0, // do not overshoot the delay between waves
+                    }),
+                )
+            };
+
             state = match state {
                 // termination conditions
                 State::Done | State::Cancelled | State::Sealed | State::WriteUnavailable => {

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -343,7 +343,8 @@ pub struct ReplicatedLogletOptions {
     /// Adaptive timeout for LogServer Store Messages
     ///
     /// This configures the adaptive timeout range for Store operations from this node to log servers.
-    /// The timeout range is also used to determine the appropriate retry delay between retry attempts.
+    ///
+    /// Since v1.7.0
     pub store_timeout: BackoffInterval,
 
     /// Sequencer inactivity timeout

--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -340,6 +340,12 @@ pub struct ReplicatedLogletOptions {
     /// The timeout range is also used to determine the appropriate retry delay between retry attempts.
     pub rpc_timeout: BackoffInterval,
 
+    /// Adaptive timeout for LogServer Store Messages
+    ///
+    /// This configures the adaptive timeout range for Store operations from this node to log servers.
+    /// The timeout range is also used to determine the appropriate retry delay between retry attempts.
+    pub store_timeout: BackoffInterval,
+
     /// Sequencer inactivity timeout
     ///
     /// The sequencer is allowed to consider itself quiescent if it did not commit records for this period of time.
@@ -426,6 +432,10 @@ impl Default for ReplicatedLogletOptions {
             sequencer_retry_policy: None,
             rpc_timeout: BackoffInterval {
                 min_ms: NonZeroU32::new(250).unwrap(),
+                max_ms: NonZeroU32::new(60_000).unwrap(),
+            },
+            store_timeout: BackoffInterval {
+                min_ms: NonZeroU32::new(2000).unwrap(),
                 max_ms: NonZeroU32::new(60_000).unwrap(),
             },
             sequencer_inactivity_timeout: NonZeroFriendlyDuration::from_secs_unchecked(15),

--- a/crates/types/src/config/log_server.rs
+++ b/crates/types/src/config/log_server.rs
@@ -258,13 +258,6 @@ impl LogServerOptions {
         })
     }
 
-    pub fn rocksdb_data_memtables_budget(&self) -> NonZeroByteCount {
-        // The entire memory budget goes to the data CF. The metadata CF's write_buffer_size
-        // matches the data CF to avoid independently triggering atomic flushes, but its
-        // actual memory consumption is negligible (a few KB of real data per flush).
-        self.rocksdb_memory_budget()
-    }
-
     /// Minimum value size for blob separation. Defaults to 512 KiB.
     pub fn rocksdb_blob_min_size(&self) -> NonZeroByteCount {
         self.rocksdb_blob_min_size.unwrap_or(NonZeroByteCount::new(
@@ -299,15 +292,12 @@ impl LogServerOptions {
 
     /// Memory budget for the data service admission-control pool.
     ///
-    /// Derived from a single write buffer, but clamped to at least `min_size` (the maximum
+    /// Derived from memory available for write buffers, but clamped to at least `min_size` (the maximum
     /// accepted record/message size). Otherwise a low-memory configuration could size the pool
     /// below the largest valid append and reject it with `CapacityExceeded` before the writer
     /// ever sees it (see `BackPressureMode::Lossy`).
     pub fn data_service_memory_size(&self, min_size: NonZeroByteCount) -> NonZeroByteCount {
-        NonZeroByteCount::new(
-            NonZeroUsize::new(self.write_buffer_size()).expect("write buffer must be non-zero"),
-        )
-        .max(min_size)
+        self.rocksdb_memory_budget().max(min_size)
     }
 
     pub fn write_buffer_size(&self) -> usize {


### PR DESCRIPTION

A log server needs to carry at least a batch from every background appender. Too small
and we'd be dropping too many messages which can cause starvation for appenders who constantly
fail to acquire the memory needed.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4955).
* __->__ #4955
* #4954