### PR TITLE
Rename action_concurrency to concurrency

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -71,7 +71,7 @@ pub enum Command {
     /// Manage active invocations
     #[clap(subcommand)]
     Invocations(invocations::Invocations),
-    /// Manage action concurrency-limit rules
+    /// Manage concurrency-limit rules
     #[clap(subcommand)]
     Rules(rules::Rules),
     /// Runs SQL queries against the data fusion service

--- a/cli/src/commands/rules/delete.rs
+++ b/cli/src/commands/rules/delete.rs
@@ -41,10 +41,7 @@ pub async fn run_delete(State(env): State<CliEnv>, opts: &Delete) -> Result<()> 
 
     let mut table = Table::new_styled();
     table.add_kv_row("Pattern:", &canonical);
-    table.add_kv_row(
-        "Concurrency:",
-        render_concurrency(current.action_concurrency),
-    );
+    table.add_kv_row("Concurrency:", render_concurrency(current.concurrency));
     if let Some(description) = &current.description {
         table.add_kv_row("Description:", description);
     }

--- a/cli/src/commands/rules/list.rs
+++ b/cli/src/commands/rules/list.rs
@@ -41,7 +41,7 @@ async fn list(env: &CliEnv, opts: &List) -> Result<()> {
     let client = DataFusionHttpClient::new(env).await?;
     let rows: Vec<RuleRow> = client
         .run_json_query(
-            "SELECT pattern, action_concurrency, description, disabled, version, last_modified \
+            "SELECT pattern, concurrency, description, disabled, version, last_modified \
              FROM sys_rules ORDER BY pattern"
                 .to_string(),
         )
@@ -72,7 +72,7 @@ async fn list(env: &CliEnv, opts: &List) -> Result<()> {
             let last_modified = row.last_modified.map(|dt| dt.display()).unwrap_or_default();
             table.add_row(vec![
                 Cell::new(row.pattern),
-                Cell::new(render_concurrency(row.action_concurrency)),
+                Cell::new(render_concurrency(row.concurrency)),
                 Cell::new(disabled),
                 Cell::new(row.description.unwrap_or_default()),
                 Cell::new(row.version),
@@ -81,7 +81,7 @@ async fn list(env: &CliEnv, opts: &List) -> Result<()> {
         } else {
             table.add_row(vec![
                 Cell::new(row.pattern),
-                Cell::new(render_concurrency(row.action_concurrency)),
+                Cell::new(render_concurrency(row.concurrency)),
                 Cell::new(disabled),
             ]);
         }

--- a/cli/src/commands/rules/mod.rs
+++ b/cli/src/commands/rules/mod.rs
@@ -51,7 +51,7 @@ pub enum Rules {
 pub(crate) struct RuleRow {
     pub pattern: String,
     #[serde(default)]
-    pub action_concurrency: Option<u32>,
+    pub concurrency: Option<u32>,
     #[serde(default)]
     pub description: Option<String>,
     pub disabled: bool,
@@ -61,9 +61,9 @@ pub(crate) struct RuleRow {
 }
 
 impl RuleRow {
-    /// The action concurrency limit as a `NonZeroU32` (the runtime shape).
+    /// The concurrency limit as a `NonZeroU32` (the runtime shape).
     fn concurrency(&self) -> Option<NonZeroU32> {
-        self.action_concurrency.and_then(NonZeroU32::new)
+        self.concurrency.and_then(NonZeroU32::new)
     }
 }
 
@@ -88,7 +88,7 @@ pub(crate) async fn fetch_rule(
     canonical_pattern: &str,
 ) -> Result<Option<RuleRow>> {
     let query = format!(
-        "SELECT pattern, action_concurrency, description, disabled, version, last_modified \
+        "SELECT pattern, concurrency, description, disabled, version, last_modified \
          FROM sys_rules WHERE pattern = '{}'",
         escape_sql(canonical_pattern)
     );

--- a/cli/src/commands/rules/set.rs
+++ b/cli/src/commands/rules/set.rs
@@ -28,7 +28,7 @@ pub struct Set {
     /// Rule pattern, e.g. `*`, `scope1/*`, `scope1/foo/bar`
     pattern: String,
 
-    /// Maximum concurrent actions (>= 1). On a new rule, omitting this means
+    /// Maximum concurrent running invocations (>= 1). On a new rule, omitting this means
     /// unlimited; on an existing rule it leaves the current limit unchanged.
     #[clap(long, conflicts_with = "unlimited")]
     concurrency: Option<NonZeroU32>,

--- a/crates/limiter/src/rule_book.rs
+++ b/crates/limiter/src/rule_book.rs
@@ -482,7 +482,7 @@ mod tests {
     fn upsert(concurrency: u32) -> RuleUpsert {
         RuleUpsert {
             limits: UserLimits {
-                action_concurrency: NonZeroU32::new(concurrency),
+                concurrency: NonZeroU32::new(concurrency),
             },
             description: None,
             disabled: false,
@@ -515,7 +515,7 @@ mod tests {
             pat("*"),
             PersistedRule {
                 limits: UserLimits {
-                    action_concurrency: NonZeroU32::new(1000),
+                    concurrency: NonZeroU32::new(1000),
                 },
                 description: Some("global default".to_owned()),
                 disabled: false,
@@ -527,7 +527,7 @@ mod tests {
             pat("scope1/*/tenant1"),
             PersistedRule {
                 limits: UserLimits {
-                    action_concurrency: NonZeroU32::new(10),
+                    concurrency: NonZeroU32::new(10),
                 },
                 description: None,
                 disabled: true,
@@ -553,7 +553,7 @@ mod tests {
         let r = book.get(&pat("*")).unwrap();
         assert_eq!(r.version, Version::from(1));
         assert!(!r.disabled);
-        assert_eq!(r.limits.action_concurrency, NonZeroU32::new(1000));
+        assert_eq!(r.limits.concurrency, NonZeroU32::new(1000));
     }
 
     #[test]
@@ -567,7 +567,7 @@ mod tests {
         book.apply_change(pat("*"), RuleChange::Upsert(upsert(500)))
             .unwrap();
         let r = book.get(&pat("*")).unwrap();
-        assert_eq!(r.limits.action_concurrency, NonZeroU32::new(500));
+        assert_eq!(r.limits.concurrency, NonZeroU32::new(500));
         assert_eq!(r.version, v_before_rule.next());
         assert_eq!(book.version(), v_before_book.next());
     }
@@ -690,7 +690,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            book.get(&pat("*")).unwrap().limits.action_concurrency,
+            book.get(&pat("*")).unwrap().limits.concurrency,
             NonZeroU32::new(500)
         );
     }
@@ -951,7 +951,7 @@ mod tests {
         let updates = book.diff(&prev);
         assert_eq!(updates_summary(&updates), vec![("*".to_owned(), "upsert")]);
         if let RuleUpdate::Upsert { limit, .. } = &updates[0] {
-            assert_eq!(limit.action_concurrency, NonZeroU32::new(500));
+            assert_eq!(limit.concurrency, NonZeroU32::new(500));
         }
     }
 

--- a/crates/limiter/src/user_limits.rs
+++ b/crates/limiter/src/user_limits.rs
@@ -37,19 +37,19 @@ use crate::RulePattern;
 #[cfg_attr(feature = "schema", derive(utoipa::ToSchema))]
 #[non_exhaustive]
 pub struct UserLimits {
-    /// Maximum concurrent invocations. `None` means unlimited.
+    /// Maximum concurrent running invocations. `None` means unlimited.
     #[cfg_attr(feature = "bilrost", bilrost(tag(1)))]
     #[cfg_attr(
         feature = "serde",
         serde(default, skip_serializing_if = "Option::is_none")
     )]
     #[cfg_attr(feature = "schema", schema(value_type = Option<u32>, minimum = 1))]
-    pub action_concurrency: Option<NonZeroU32>,
+    pub concurrency: Option<NonZeroU32>,
 }
 
 impl UserLimits {
-    pub fn new(action_concurrency: Option<NonZeroU32>) -> Self {
-        Self { action_concurrency }
+    pub fn new(concurrency: Option<NonZeroU32>) -> Self {
+        Self { concurrency }
     }
 }
 

--- a/crates/storage-query-datafusion/src/rules/row.rs
+++ b/crates/storage-query-datafusion/src/rules/row.rs
@@ -20,8 +20,8 @@ pub(crate) fn append_rule_row(
 ) {
     let mut row = builder.row();
     row.fmt_pattern(pattern);
-    if let Some(concurrency) = rule.limits.action_concurrency {
-        row.action_concurrency(concurrency.get());
+    if let Some(concurrency) = rule.limits.concurrency {
+        row.concurrency(concurrency.get());
     }
     if let Some(description) = rule.description.as_deref() {
         row.description(description);

--- a/crates/storage-query-datafusion/src/rules/schema.rs
+++ b/crates/storage-query-datafusion/src/rules/schema.rs
@@ -16,9 +16,9 @@ define_table!(sys_rules(
     /// Rule pattern in canonical display form (e.g. `scope/*/tenant`).
     pattern: DataType::Utf8,
 
-    /// Concurrent-action limit imposed by this rule. Null means the
-    /// rule does not constrain action concurrency.
-    action_concurrency: DataType::UInt32,
+    /// Concurrency limit imposed by this rule. Null means the
+    /// rule does not constrain concurrency.
+    concurrency: DataType::UInt32,
 
     /// Free-form description set by the operator.
     description: DataType::Utf8,

--- a/crates/vqueues/src/scheduler/resource_manager.rs
+++ b/crates/vqueues/src/scheduler/resource_manager.rs
@@ -169,9 +169,7 @@ impl ResourceManager {
         for resource in permit.resources {
             match resource {
                 UserPermitKind::LimitKeyConcurrency(scope, limit_key) => {
-                    let woken = self
-                        .user_limiter
-                        .release_action_concurrency(&scope, &limit_key);
+                    let woken = self.user_limiter.release_concurrency(&scope, &limit_key);
                     eligible.wake_up_queues(woken);
                 }
             }
@@ -302,9 +300,8 @@ impl ResourceManager {
                     for resource in resources {
                         match resource {
                             UserPermitKind::LimitKeyConcurrency(scope, limit_key) => {
-                                let woken = self
-                                    .user_limiter
-                                    .release_action_concurrency(&scope, &limit_key);
+                                let woken =
+                                    self.user_limiter.release_concurrency(&scope, &limit_key);
                                 eligible.wake_up_queues(woken);
                             }
                         }

--- a/crates/vqueues/src/scheduler/resource_manager/user_limiter.rs
+++ b/crates/vqueues/src/scheduler/resource_manager/user_limiter.rs
@@ -246,7 +246,7 @@ impl UserLimiter {
     /// Decrements usage counters and wakes up to 1 vqueue per affected counter level.
     ///
     /// Returns up to 3 vqueue handles that should be woken via `EligibilityTracker`.
-    pub(super) fn release_action_concurrency(
+    pub(super) fn release_concurrency(
         &mut self,
         scope: &Scope,
         limit_key: &LimitKey<ReString>,
@@ -394,7 +394,7 @@ fn limit_and_pattern(
     match limit {
         Limit::Undefined => (None, None),
         Limit::Defined(handle, user_limits) => {
-            let value = user_limits.action_concurrency.map(NonZeroU32::get);
+            let value = user_limits.concurrency.map(NonZeroU32::get);
             let pattern = rules.get_pattern(*handle).map(ToString::to_string);
             (value, pattern)
         }
@@ -972,7 +972,7 @@ fn make_level_status(
         Limit::Undefined => (None, None),
         Limit::Defined(handle, user_limits) => {
             let value = match limit_kind {
-                LimitKind::Concurrency => user_limits.action_concurrency,
+                LimitKind::Concurrency => user_limits.concurrency,
             };
             (value, Some(*handle))
         }
@@ -1111,7 +1111,7 @@ mod tests {
         assert_eq!(limiter.state.scopes[&s].l1[l1].l2[l2].value.concurrency, 2);
 
         // Decrement via release (also pops waiters, but there are none)
-        let woken = limiter.release_action_concurrency(&s, &lk);
+        let woken = limiter.release_concurrency(&s, &lk);
         assert!(woken.is_empty());
         assert_eq!(limiter.state.scopes[&s].value.concurrency, 1);
         assert_eq!(limiter.state.scopes[&s].l1[l1].value.concurrency, 1);
@@ -1128,7 +1128,7 @@ mod tests {
         assert!(limiter.state.scopes.contains_key(&s));
 
         // Release the single permit — all counters go to zero, nodes should be pruned
-        limiter.release_action_concurrency(&s, &lk);
+        limiter.release_concurrency(&s, &lk);
         assert!(
             !limiter.state.scopes.contains_key(&s),
             "scope node should be pruned when fully empty"
@@ -1139,7 +1139,7 @@ mod tests {
         limiter.increment_all(&s, &LimitKey::None, LimitKind::Concurrency);
 
         // Release the L2 path — L2 and L1 should be pruned, but scope stays (has usage=1)
-        limiter.release_action_concurrency(&s, &lk);
+        limiter.release_concurrency(&s, &lk);
         assert!(limiter.state.scopes.contains_key(&s));
         let l1 = lk.level1().unwrap();
         assert!(
@@ -1195,7 +1195,7 @@ mod tests {
         limiter.add_to_waiters(handles[5], &s, &lk, Level::Level2);
 
         // Release 1 permit for the full L2 path
-        let woken = limiter.release_action_concurrency(&s, &lk);
+        let woken = limiter.release_concurrency(&s, &lk);
         // Should wake exactly 1 from each level, deepest first
         assert_eq!(woken.len(), 3);
         assert_eq!(woken[0], handles[4]); // l2 head (deepest, highest priority)

--- a/release-notes/v1.7.0.md
+++ b/release-notes/v1.7.0.md
@@ -384,7 +384,7 @@ The old unversioned paths (`/{service}/{handler}`, `/restate/invocation/...`, `/
 
 #### Configuring concurrency limits (the rule book)
 
-Concurrency limits are defined in a cluster-wide **rule book**. A rule pairs a *pattern* — which selects the `scope`s it applies to — with a set of *limits*. The only limit available in v1.7 is `action_concurrency`: the maximum number of invocations that may run concurrently for a matching scope. More limit kinds will follow in later releases.
+Concurrency limits are defined in a cluster-wide **rule book**. A rule pairs a *pattern* — which selects the `scope`s it applies to — with a set of *limits*. The only limit available in v1.7 is `concurrency`: the maximum number of invocations that may run concurrently for a matching scope. More limit kinds will follow in later releases.
 
 A pattern is either an exact scope or the wildcard `*`:
 
@@ -415,7 +415,7 @@ restate rules delete "checkout"
 
 Run `restate rules --help` for the full surface.
 
-Send requests through the scoped ingress endpoints so they carry a `scope`; matching invocations are then throttled to the configured `action_concurrency` and held in their vqueue until a slot frees up. The applied rule book version per partition is visible as `applied_rule_book_version` in `partition_state` (and the `RULE-BOOK` column in `restatectl partition list`); the live rule set and per-counter usage are queryable via the `sys_rules` and `sys_user_limits` tables described below.
+Send requests through the scoped ingress endpoints so they carry a `scope`; matching invocations are then throttled to the configured `concurrency` and held in their vqueue until a slot frees up. The applied rule book version per partition is visible as `applied_rule_book_version` in `partition_state` (and the `RULE-BOOK` column in `restatectl partition list`); the live rule set and per-counter usage are queryable via the `sys_rules` and `sys_user_limits` tables described below.
 
 #### Limitation: enable vqueues only on fresh clusters
 
@@ -429,7 +429,7 @@ Until migration support lands, enable `experimental_enable_vqueues` only on fres
 
 Five new SQL system tables let you inspect vqueues, the scheduler, and concurrency limits directly via the storage query interface:
 
-- **`sys_rules`** — the configured rule book: one row per rule with its `pattern`, `action_concurrency` limit, `description`, `disabled` flag, `version`, and `last_modified` time.
+- **`sys_rules`** — the configured rule book: one row per rule with its `pattern`, `concurrency` limit, `description`, `disabled` flag, `version`, and `last_modified` time.
 - **`sys_vqueues`** — one row per entry across all vqueue stages (`inbox`, `running`, `paused`, `suspended`, `finished`), with the entry's `status`, `entry_kind` (`invocation` / `state-mutation`), attempt/suspension/yield counters, lifecycle timestamps, whether it holds a lock, and (for inbox entries) when it becomes runnable.
 - **`sys_vqueue_meta`** — aggregate metadata and statistics per vqueue: its `scope`, `service_name`, active/paused flags, per-stage entry counts, and exponential moving averages of queue/run/suspension/end-to-end durations and time spent blocked on concurrency rules or invoker throttling.
 - **`sys_scheduler`** — real-time scheduler state for each vqueue's head entry: queue depth, scheduler `status` (e.g. `Dormant`, `Ready`, `BlockedOn`, `Scheduled`), the `head_entry_id`, the `blocked_on` resource, and a per-resource breakdown of how long the head has been blocked (invoker concurrency, throttling rules, invoker throttling, invoker memory, concurrency rules, lock, deployment concurrency).


### PR DESCRIPTION
The flow-control rule-book limit was named `action_concurrency`, which is
too close to "actions", the billable unit in the Cloud products. Rename it
to plain `concurrency`, aligning with the existing internal naming
(`LimitKind::Concurrency`, `Usage.concurrency`).

This renames the `UserLimits::concurrency` field, the
`release_concurrency` scheduler method, the `sys_rules.concurrency` SQL
column, and the CLI `RuleRow::concurrency` field. The bilrost tag is
unchanged so persisted rules are unaffected; the serde/admin-REST JSON
field and SQL column name change, which is safe since v1.7 is still RC.