### PR TITLE
Experimental automatic publishing of grafana dashboard

### DIFF
--- a/.github/workflows/grafana-dashboards.yml
+++ b/.github/workflows/grafana-dashboards.yml
@@ -1,0 +1,77 @@
+name: Publish Grafana dashboards
+
+# Publishes the in-repo Grafana dashboards (monitoring/grafana/*.json) as a new
+# revision of their grafana.com marketplace listings on every stable release, so
+# the published dashboards never drift from the code.
+#
+# Requires the `GRAFANA_COM_API_KEY` repository secret: a grafana.com API token
+# with permission to publish dashboard revisions for the restatedev org.
+#
+# NOTE: grafana.com's community-dashboards publish API is not officially
+# documented. The revision resource (.../revisions/{n}/download) is confirmed to
+# exist, so the publish endpoint is `POST /api/dashboards/{id}/revisions`. The
+# request body shape below ({"json": "<stringified dashboard>"}) and the required
+# token scope should be confirmed with a manual `workflow_dispatch` dry-run before
+# relying on this in a real release.
+
+on:
+  workflow_call:
+    inputs:
+      # comes from cargo-dist workflow call
+      plan:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "ref to publish from, eg v1.5.0 (defaults to the default branch)"
+        required: false
+        type: string
+      dry_run:
+        description: "print the endpoint and payload instead of publishing"
+        required: true
+        type: boolean
+        default: true
+
+jobs:
+  publish-grafana-dashboards:
+    runs-on: warp-ubuntu-latest-x64-2x
+    strategy:
+      fail-fast: false
+      matrix:
+        dashboard:
+          - id: 24747
+            file: monitoring/grafana/restate-overview.json
+          - id: 24748
+            file: monitoring/grafana/restate-internals.json
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Publish dashboard revision
+        # Non-blocking: a grafana.com failure must not fail the release.
+        continue-on-error: true
+        env:
+          GRAFANA_COM_API_KEY: ${{ secrets.GRAFANA_COM_API_KEY }}
+          ID: ${{ matrix.dashboard.id }}
+          FILE: ${{ matrix.dashboard.file }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          # The published JSON must have a null top-level "id".
+          payload="$(jq -c '{json: (.id = null | tostring)}' "$FILE")"
+          endpoint="https://grafana.com/api/dashboards/$ID/revisions"
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "DRY RUN — would POST $FILE to $endpoint"
+            printf '%s' "$payload" | jq -C '.json |= "<stringified dashboard, \(. | length) bytes>"'
+            exit 0
+          fi
+
+          echo "Publishing $FILE to $endpoint"
+          curl --fail-with-body -sS -X POST \
+            -H "Authorization: Bearer $GRAFANA_COM_API_KEY" \
+            -H "Content-Type: application/json" \
+            "$endpoint" \
+            -d "$payload"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -377,6 +377,16 @@ jobs:
       "id-token": "write"
       "packages": "write"
 
+  custom-grafana:
+    needs:
+      - plan
+      - host
+    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
+    uses: ./.github/workflows/grafana-dashboards.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
+
   custom-docker-push-release:
     needs:
       - plan
@@ -427,10 +437,11 @@ jobs:
       - custom-docker-push-release
       - custom-npm
       - custom-release-notes
+      - custom-grafana
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && (needs.custom-homebrew.result == 'skipped' || needs.custom-homebrew.result == 'success') && (needs.custom-docker-push-release.result == 'skipped' || needs.custom-docker-push-release.result == 'success') && (needs.custom-npm.result == 'skipped' || needs.custom-npm.result == 'success') && (needs.custom-release-notes.result == 'skipped' || needs.custom-release-notes.result == 'success') }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.custom-homebrew.result == 'skipped' || needs.custom-homebrew.result == 'success') && (needs.custom-docker-push-release.result == 'skipped' || needs.custom-docker-push-release.result == 'success') && (needs.custom-npm.result == 'skipped' || needs.custom-npm.result == 'success') && (needs.custom-release-notes.result == 'skipped' || needs.custom-release-notes.result == 'success') && (needs.custom-grafana.result == 'skipped' || needs.custom-grafana.result == 'success') }}
     runs-on: "warp-ubuntu-latest-arm64-2x"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/monitoring/grafana/README.md
+++ b/monitoring/grafana/README.md
@@ -4,12 +4,17 @@ This directory contains Grafana dashboards for monitoring Restate Server cluster
 
 ## Dashboards
 
-| Dashboard | File | Description |
-|-----------|------|-------------|
-| **Restate: Overview** | `restate-overview.json` | High-level cluster health, resources, and throughput |
-| **Restate: Internals** | `restate-internals.json` | Deep-dive into Bifrost, Invoker, RocksDB, and more |
+| Dashboard | File | grafana.com | Description |
+|-----------|------|-------------|-------------|
+| **Restate: Overview** | `restate-overview.json` | [24747](https://grafana.com/grafana/dashboards/24747) | High-level cluster health, resources, and throughput |
+| **Restate: Internals** | `restate-internals.json` | [24748](https://grafana.com/grafana/dashboards/24748) | Deep-dive into Bifrost, Invoker, RocksDB, and more |
 
 The dashboards are linked together - click "Internals" from the Overview to drill down, or "Overview" from Internals to go back.
+
+These JSON files are the source of truth. On every stable release the `Publish Grafana
+dashboards` workflow (`.github/workflows/grafana-dashboards.yml`) pushes them as a new
+revision of the grafana.com listings above. The workflow requires the `GRAFANA_COM_API_KEY`
+repository secret (a grafana.com API token allowed to publish revisions for the restatedev org).
 
 ### Overview Dashboard
 


### PR DESCRIPTION

Summary:
The work on this PR is not completed because of the following:
- There are no public documentation for market place API. I couldn't also
  reverse engineer it from the browser, somehow when uploading a new revision it
  doesn't show up in the debug console.
- My account does now allow creating API keys. I am not sure if the org owner
  can actually create API keys or not. This still can be AI hallucinations.
