### PR TITLE
[VQueues] Rename next_run_at to next_at to expand usage

### DIFF
--- a/crates/partition-store/src/vqueue_table/entry.rs
+++ b/crates/partition-store/src/vqueue_table/entry.rs
@@ -15,8 +15,8 @@ use rocksdb::DBPinnableSlice;
 use restate_clock::RoughTimestamp;
 use restate_storage_api::vqueue_table::Status;
 use restate_storage_api::vqueue_table::{
-    EntryKey, EntryMetadata, EntryMetadataRef, EntryStatusHeader, LazyEntryStatus, Stage,
-    stats::EntryStatistics,
+    EntryKey, EntryMetadata, EntryMetadataRef, EntryStatusHeader, LazyEntryStatus,
+    OwnedEntryStatusHeader, Stage, stats::EntryStatistics,
 };
 use restate_types::identifiers::{InvocationId, PartitionKey, WithPartitionKey};
 use restate_types::vqueues::{EntryId, EntryKind, Seq, VQueueId, VQueueIdRef};
@@ -98,89 +98,18 @@ pub struct StatusHeaderRaw {
     status: Status,
 }
 
-#[derive(Debug)]
-pub struct OwnedEntryStatusHeader {
-    qid: VQueueId,
-    stage: Stage,
-    entry_key: EntryKey,
-    metadata: EntryMetadata,
-    status: Status,
-    stats: EntryStatistics,
-}
-
-impl OwnedEntryStatusHeader {
-    pub(crate) fn new(entry_id: EntryId, header: StatusHeaderRaw) -> Self {
-        Self {
-            qid: header.qid,
-            stage: header.stage,
-            entry_key: EntryKey::new(header.has_lock, header.next_run_at, header.seq, entry_id),
-            metadata: header.metadata,
-            status: header.status,
-            stats: header.stats,
-        }
-    }
-}
-
-impl EntryStatusHeader for OwnedEntryStatusHeader {
-    #[inline]
-    fn vqueue_id(&self) -> &VQueueId {
-        &self.qid
-    }
-
-    #[inline]
-    fn entry_id(&self) -> &EntryId {
-        self.entry_key.entry_id()
-    }
-
-    #[inline]
-    fn entry_key(&self) -> &EntryKey {
-        &self.entry_key
-    }
-
-    #[inline]
-    fn kind(&self) -> EntryKind {
-        self.entry_key.kind()
-    }
-
-    #[inline]
-    fn stage(&self) -> Stage {
-        self.stage
-    }
-
-    #[inline]
-    fn seq(&self) -> Seq {
-        self.entry_key.seq()
-    }
-
-    #[inline]
-    fn has_lock(&self) -> bool {
-        self.entry_key.has_lock()
-    }
-
-    #[inline]
-    fn next_run_at(&self) -> RoughTimestamp {
-        self.entry_key.run_at()
-    }
-
-    #[inline]
-    fn stats(&self) -> &EntryStatistics {
-        &self.stats
-    }
-
-    #[inline]
-    fn metadata(&self) -> &EntryMetadata {
-        &self.metadata
-    }
-
-    #[inline]
-    fn display_entry_id(&self) -> impl std::fmt::Display + '_ {
-        self.entry_id().display(self.qid.partition_key())
-    }
-
-    #[inline]
-    fn status(&self) -> Status {
-        self.status
-    }
+pub(super) fn entry_status_header_from_raw(
+    entry_id: EntryId,
+    header: StatusHeaderRaw,
+) -> OwnedEntryStatusHeader {
+    OwnedEntryStatusHeader::new(
+        header.qid,
+        header.stage,
+        EntryKey::new(header.has_lock, header.next_run_at, header.seq, entry_id),
+        header.metadata,
+        header.stats,
+        header.status,
+    )
 }
 
 #[derive(derive_more::Debug)]
@@ -197,7 +126,7 @@ impl<'a> LazyEntryStatusHolder<'a> {
         state_bytes: Cursor<DBPinnableSlice<'a>>,
     ) -> Self {
         Self {
-            header: OwnedEntryStatusHeader::new(entry_id, header),
+            header: entry_status_header_from_raw(entry_id, header),
             state_bytes,
         }
     }
@@ -261,7 +190,7 @@ impl<'a> EntryStatusHeader for LazyEntryStatusHolder<'a> {
 
     #[inline]
     fn display_entry_id(&self) -> impl std::fmt::Display + '_ {
-        self.entry_id().display(self.header.qid.partition_key())
+        self.header.display_entry_id()
     }
 }
 

--- a/crates/partition-store/src/vqueue_table/mod.rs
+++ b/crates/partition-store/src/vqueue_table/mod.rs
@@ -39,11 +39,13 @@ use restate_storage_api::vqueue_table::{
     EntryKey, EntryMetadata, EntryStatusHeader, EntryValue, LazyEntryStatus, ReadVQueueTable,
     ScanVQueueTable, Stage, Status, WriteVQueueTable, stats::EntryStatistics,
 };
-use restate_storage_api::vqueue_table::{ScanVQueueEntries, ScanVQueueMetaTable};
+use restate_storage_api::vqueue_table::{
+    OwnedEntryStatusHeader, ScanVQueueEntries, ScanVQueueEntryStatusTable, ScanVQueueMetaTable,
+};
 use restate_types::sharding::{KeyRange, PartitionKey};
 use restate_types::vqueues::{EntryId, Seq, VQueueId};
 
-use self::entry::{LazyEntryStatusHolder, OwnedEntryStatusHeader, StatusHeaderRawRef};
+use self::entry::{LazyEntryStatusHolder, StatusHeaderRawRef, entry_status_header_from_raw};
 use crate::keys::{DecodeTableKey, EncodeTableKey, EncodeTableKeyPrefix, KeyKind};
 use crate::scan::TableScan;
 use crate::vqueue_table::input::InputPayloadKeyRef;
@@ -361,10 +363,9 @@ impl ReadVQueueTable for PartitionStoreTransaction<'_> {
             return Ok(None);
         };
 
-        Ok(Some(OwnedEntryStatusHeader::new(
-            *id,
-            StatusHeaderRaw::decode_length_delimited(&mut raw_value.as_ref())?,
-        )))
+        let header = StatusHeaderRaw::decode_length_delimited(&mut raw_value.as_ref())?;
+
+        Ok(Some(entry_status_header_from_raw(*id, header)))
     }
 
     // Currently unused but left for future use
@@ -466,6 +467,38 @@ impl ScanVQueueMetaTable for PartitionStore {
 
                 let (vqueue_id,) = meta_key.split();
                 f((&vqueue_id, &meta)).map_break(Ok)
+            },
+        )
+        .map_err(|_| StorageError::OperationalError)
+    }
+}
+
+impl ScanVQueueEntryStatusTable for PartitionStore {
+    fn for_each_vqueue_entry_status<F>(
+        &self,
+        range: KeyRange,
+        mut f: F,
+    ) -> Result<impl Future<Output = Result<()>> + Send>
+    where
+        F: for<'a> FnMut(&'a OwnedEntryStatusHeader) -> std::ops::ControlFlow<()>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.iterator_for_each(
+            "df-vqueue-entry-status",
+            Priority::Low,
+            TableScan::FullScanPartitionKeyRange::<EntryStatusKey>(range),
+            move |(mut key, mut value)| {
+                let status_key = break_on_err(EntryStatusKey::deserialize_from(&mut key))?;
+                let (_, entry_id) = status_key.split();
+                let header = break_on_err(
+                    StatusHeaderRaw::decode_length_delimited(&mut value)
+                        .map_err(StorageError::BilrostDecode),
+                )?;
+                let header = entry_status_header_from_raw(entry_id, header);
+
+                f(&header).map_break(Ok)
             },
         )
         .map_err(|_| StorageError::OperationalError)

--- a/crates/storage-api/src/vqueue_table/entry_status.rs
+++ b/crates/storage-api/src/vqueue_table/entry_status.rs
@@ -49,6 +49,99 @@ pub enum Status {
     Succeeded,
 }
 
+/// Owned vqueue entry status header.
+#[derive(Debug, Clone)]
+pub struct OwnedEntryStatusHeader {
+    qid: VQueueId,
+    stage: Stage,
+    entry_key: EntryKey,
+    metadata: EntryMetadata,
+    status: Status,
+    stats: EntryStatistics,
+}
+
+impl OwnedEntryStatusHeader {
+    pub fn new(
+        qid: VQueueId,
+        stage: Stage,
+        entry_key: EntryKey,
+        metadata: EntryMetadata,
+        stats: EntryStatistics,
+        status: Status,
+    ) -> Self {
+        Self {
+            qid,
+            stage,
+            entry_key,
+            metadata,
+            status,
+            stats,
+        }
+    }
+}
+
+impl EntryStatusHeader for OwnedEntryStatusHeader {
+    #[inline]
+    fn vqueue_id(&self) -> &VQueueId {
+        &self.qid
+    }
+
+    #[inline]
+    fn entry_id(&self) -> &EntryId {
+        self.entry_key.entry_id()
+    }
+
+    #[inline]
+    fn entry_key(&self) -> &EntryKey {
+        &self.entry_key
+    }
+
+    #[inline]
+    fn kind(&self) -> EntryKind {
+        self.entry_key.kind()
+    }
+
+    #[inline]
+    fn stage(&self) -> Stage {
+        self.stage
+    }
+
+    #[inline]
+    fn seq(&self) -> Seq {
+        self.entry_key.seq()
+    }
+
+    #[inline]
+    fn has_lock(&self) -> bool {
+        self.entry_key.has_lock()
+    }
+
+    #[inline]
+    fn next_run_at(&self) -> RoughTimestamp {
+        self.entry_key.run_at()
+    }
+
+    #[inline]
+    fn stats(&self) -> &EntryStatistics {
+        &self.stats
+    }
+
+    #[inline]
+    fn metadata(&self) -> &EntryMetadata {
+        &self.metadata
+    }
+
+    #[inline]
+    fn display_entry_id(&self) -> impl std::fmt::Display + '_ {
+        self.entry_id().display(self.qid.partition_key())
+    }
+
+    #[inline]
+    fn status(&self) -> Status {
+        self.status
+    }
+}
+
 mod bilrost_encoding {
     use bilrost::encoding::{DistinguishedProxiable, Proxiable};
     use bilrost::{Canonicity, DecodeErrorKind, Enumeration};

--- a/crates/storage-api/src/vqueue_table/tables.rs
+++ b/crates/storage-api/src/vqueue_table/tables.rs
@@ -15,7 +15,7 @@ use super::Status;
 use super::metadata::{VQueueMeta, VQueueMetaRef};
 use super::{
     EntryId, EntryKey, EntryMetadata, EntryStatusHeader, EntryValue, LazyEntryStatus,
-    stats::EntryStatistics,
+    OwnedEntryStatusHeader, stats::EntryStatistics,
 };
 use crate::Result;
 
@@ -282,4 +282,20 @@ pub trait ScanVQueueEntries {
             + Sync
             + 'static,
         S: IntoIterator<Item = Stage>;
+}
+
+pub trait ScanVQueueEntryStatusTable {
+    /// Iterate vqueue entry status headers within a partition-key range.
+    ///
+    /// Used for data-fusion queries.
+    fn for_each_vqueue_entry_status<F>(
+        &self,
+        range: KeyRange,
+        f: F,
+    ) -> Result<impl Future<Output = Result<()>> + Send>
+    where
+        F: for<'a> FnMut(&'a OwnedEntryStatusHeader) -> std::ops::ControlFlow<()>
+            + Send
+            + Sync
+            + 'static;
 }

--- a/crates/storage-query-datafusion/src/context.rs
+++ b/crates/storage-query-datafusion/src/context.rs
@@ -299,6 +299,12 @@ where
             self.partition_store_manager.clone(),
             &self.remote_scanner_manager,
         )?;
+        crate::vqueue_entry_status::register_self(
+            ctx,
+            self.partition_selector.clone(),
+            self.partition_store_manager.clone(),
+            &self.remote_scanner_manager,
+        )?;
         crate::vqueues::register_self(
             ctx,
             self.partition_selector.clone(),

--- a/crates/storage-query-datafusion/src/lib.rs
+++ b/crates/storage-query-datafusion/src/lib.rs
@@ -41,6 +41,7 @@ pub mod table_docs;
 mod table_macro;
 mod table_providers;
 mod user_limits;
+mod vqueue_entry_status;
 mod vqueue_meta;
 mod vqueues;
 pub use table_providers::Scan;

--- a/crates/storage-query-datafusion/src/table_docs.rs
+++ b/crates/storage-query-datafusion/src/table_docs.rs
@@ -10,7 +10,8 @@
 
 use crate::{
     deployment, inbox, invocation_state, invocation_status, journal, journal_events,
-    keyed_service_status, promise, scheduler_status, service, state, vqueue_meta, vqueues,
+    keyed_service_status, promise, scheduler_status, service, state, vqueue_entry_status,
+    vqueue_meta, vqueues,
 };
 use std::borrow::Cow;
 
@@ -27,6 +28,7 @@ pub const ALL_TABLE_DOCS: &[StaticTableDocs] = &[
     scheduler_status::schema::TABLE_DOCS,
     service::schema::TABLE_DOCS,
     state::schema::TABLE_DOCS,
+    vqueue_entry_status::schema::TABLE_DOCS,
     vqueue_meta::schema::TABLE_DOCS,
     vqueues::schema::TABLE_DOCS,
 ];

--- a/crates/storage-query-datafusion/src/vqueue_entry_status/mod.rs
+++ b/crates/storage-query-datafusion/src/vqueue_entry_status/mod.rs
@@ -1,0 +1,18 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod row;
+pub(crate) mod schema;
+mod table;
+
+pub(crate) use table::register_self;
+
+#[cfg(test)]
+mod tests;

--- a/crates/storage-query-datafusion/src/vqueue_entry_status/row.rs
+++ b/crates/storage-query-datafusion/src/vqueue_entry_status/row.rs
@@ -1,0 +1,184 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use restate_storage_api::vqueue_table::EntryStatusHeader;
+
+use super::schema::SysVqueueEntryStatusBuilder;
+
+#[inline]
+pub(crate) fn append_vqueue_entry_status_row(
+    builder: &mut SysVqueueEntryStatusBuilder,
+    header: &impl EntryStatusHeader,
+) {
+    let mut row = builder.row();
+
+    let qid = header.vqueue_id();
+    let stats = header.stats();
+    let metadata = header.metadata();
+
+    row.partition_key(qid.partition_key());
+    if row.is_entry_id_defined() {
+        row.fmt_entry_id(header.display_entry_id());
+    }
+    if row.is_vqueue_id_defined() {
+        row.fmt_vqueue_id(qid);
+    }
+    if row.is_stage_defined() {
+        row.fmt_stage(header.stage());
+    }
+    if row.is_status_defined() {
+        row.fmt_status(header.status());
+    }
+    if row.is_has_lock_defined() {
+        row.has_lock(header.has_lock());
+    }
+    if row.is_next_at_defined() {
+        row.next_at(header.next_run_at().as_unix_millis().as_u64() as i64);
+    }
+    if row.is_sequence_number_defined() {
+        row.sequence_number(header.seq().as_u64());
+    }
+
+    if row.is_entry_kind_defined() {
+        row.fmt_entry_kind(header.kind());
+    }
+
+    if row.is_created_at_defined() {
+        row.created_at(stats.created_at.to_unix_millis().as_u64() as i64);
+    }
+
+    if row.is_transitioned_at_defined() {
+        row.transitioned_at(stats.transitioned_at.to_unix_millis().as_u64() as i64);
+    }
+
+    if row.is_num_attempts_defined() {
+        row.num_attempts(stats.num_attempts);
+    }
+
+    if row.is_num_errors_defined() {
+        row.num_errors(stats.num_errors);
+    }
+
+    if row.is_num_pauses_defined() {
+        row.num_pauses(stats.num_paused);
+    }
+
+    if row.is_num_suspensions_defined() {
+        row.num_suspensions(stats.num_suspensions);
+    }
+
+    if row.is_num_yields_defined() {
+        row.num_yields(stats.num_yields);
+    }
+
+    if row.is_first_attempt_at_defined()
+        && let Some(first_attempt_at) = stats.first_attempt_at
+    {
+        row.first_attempt_at(first_attempt_at.to_unix_millis().as_u64() as i64);
+    }
+
+    if row.is_latest_attempt_at_defined()
+        && let Some(latest_attempt_at) = stats.latest_attempt_at
+    {
+        row.latest_attempt_at(latest_attempt_at.to_unix_millis().as_u64() as i64);
+    }
+
+    if row.is_first_runnable_at_defined() {
+        row.first_runnable_at(stats.first_runnable_at.as_u64() as i64);
+    }
+
+    if row.is_deployment_defined()
+        && let Some(deployment) = &metadata.deployment
+    {
+        row.fmt_deployment(deployment);
+    }
+
+    if row.is_needed_memory_defined()
+        && let Some(needed_memory) = metadata.needed_memory
+    {
+        row.needed_memory(needed_memory.as_u64());
+    }
+
+    if row.is_retry_attempts_defined() {
+        row.retry_attempts(metadata.retry_attempts);
+    }
+
+    if row.is_retry_count_since_last_stored_command_defined() {
+        row.retry_count_since_last_stored_command(metadata.retry_count_since_last_stored_command);
+    }
+
+    let latest_wait_stats = stats.latest_attempt_wait_stats;
+    if row.is_latest_attempt_blocked_on_invoker_concurrency_defined() {
+        row.latest_attempt_blocked_on_invoker_concurrency(
+            latest_wait_stats.blocked_on_invoker_concurrency_ms as i64,
+        );
+    }
+    if row.is_latest_attempt_blocked_on_throttling_rules_defined() {
+        row.latest_attempt_blocked_on_throttling_rules(
+            latest_wait_stats.blocked_on_throttling_rules_ms as i64,
+        );
+    }
+    if row.is_latest_attempt_blocked_on_invoker_throttling_defined() {
+        row.latest_attempt_blocked_on_invoker_throttling(
+            latest_wait_stats.blocked_on_invoker_throttling_ms as i64,
+        );
+    }
+    if row.is_latest_attempt_blocked_on_invoker_memory_defined() {
+        row.latest_attempt_blocked_on_invoker_memory(
+            latest_wait_stats.blocked_on_invoker_memory_ms as i64,
+        );
+    }
+    if row.is_latest_attempt_blocked_on_concurrency_rules_defined() {
+        row.latest_attempt_blocked_on_concurrency_rules(
+            latest_wait_stats.blocked_on_concurrency_rules_ms as i64,
+        );
+    }
+    if row.is_latest_attempt_blocked_on_lock_defined() {
+        row.latest_attempt_blocked_on_lock(latest_wait_stats.blocked_on_lock_ms as i64);
+    }
+    if row.is_latest_attempt_blocked_on_deployment_concurrency_defined() {
+        row.latest_attempt_blocked_on_deployment_concurrency(
+            latest_wait_stats.blocked_on_deployment_concurrency_ms as i64,
+        );
+    }
+
+    let total_wait_stats = stats.total_wait_stats;
+    if row.is_total_blocked_on_invoker_concurrency_defined() {
+        row.total_blocked_on_invoker_concurrency(
+            total_wait_stats.blocked_on_invoker_concurrency_ms as i64,
+        );
+    }
+    if row.is_total_blocked_on_throttling_rules_defined() {
+        row.total_blocked_on_throttling_rules(
+            total_wait_stats.blocked_on_throttling_rules_ms as i64,
+        );
+    }
+    if row.is_total_blocked_on_invoker_throttling_defined() {
+        row.total_blocked_on_invoker_throttling(
+            total_wait_stats.blocked_on_invoker_throttling_ms as i64,
+        );
+    }
+    if row.is_total_blocked_on_invoker_memory_defined() {
+        row.total_blocked_on_invoker_memory(total_wait_stats.blocked_on_invoker_memory_ms as i64);
+    }
+    if row.is_total_blocked_on_concurrency_rules_defined() {
+        row.total_blocked_on_concurrency_rules(
+            total_wait_stats.blocked_on_concurrency_rules_ms as i64,
+        );
+    }
+    if row.is_total_blocked_on_lock_defined() {
+        row.total_blocked_on_lock(total_wait_stats.blocked_on_lock_ms as i64);
+    }
+    if row.is_total_blocked_on_deployment_concurrency_defined() {
+        row.total_blocked_on_deployment_concurrency(
+            total_wait_stats.blocked_on_deployment_concurrency_ms as i64,
+        );
+    }
+}

--- a/crates/storage-query-datafusion/src/vqueue_entry_status/schema.rs
+++ b/crates/storage-query-datafusion/src/vqueue_entry_status/schema.rs
@@ -1,0 +1,130 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::table_macro::*;
+
+use datafusion::arrow::datatypes::DataType;
+
+define_sort_order!(sys_vqueue_entry_status(partition_key));
+
+define_table!(sys_vqueue_entry_status(
+    /// Internal column that is used for partitioning. Can be ignored.
+    partition_key: DataType::UInt64,
+
+    /// Identifier of the entry.
+    entry_id: DataType::Utf8,
+
+    /// The VQueue Identifier (vq_...).
+    vqueue_id: DataType::Utf8,
+
+    /// The stage this entry currently belongs to. Choices are 'inbox', 'running', 'paused',
+    /// 'suspended', and 'finished'.
+    stage: DataType::Utf8,
+
+    /// The entry processing status. Examples are `new`, `scheduled`, `started`,
+    /// `backing-off`, `yielded`, `killed`, `cancelled`, `failed`, and `succeeded`.
+    status: DataType::Utf8,
+
+    /// Whether this entry currently holds a lock.
+    has_lock: DataType::Boolean,
+
+    /// The next timestamp at which this entry is scheduled for the next transition.
+    next_at: TimestampMillisecond,
+
+    /// Sequence number encoded in the entry ordering key.
+    sequence_number: DataType::UInt64,
+
+    /// Entry kind (`invocation` or `state-mutation`).
+    entry_kind: DataType::Utf8,
+
+    /// Creation timestamp of the entry.
+    created_at: TimestampMillisecond,
+
+    /// Timestamp of the latest stage transition.
+    transitioned_at: TimestampMillisecond,
+
+    /// Number of times this entry has been moved to the run queue.
+    num_attempts: DataType::UInt32,
+
+    /// Number of times this entry has yielded execution due to transient errors.
+    num_errors: DataType::UInt32,
+
+    /// Number of times this entry has been moved to the paused stage.
+    num_pauses: DataType::UInt32,
+
+    /// Number of times this entry has been moved to the suspended stage.
+    num_suspensions: DataType::UInt32,
+
+    /// Number of times this entry has yielded execution.
+    num_yields: DataType::UInt32,
+
+    /// Timestamp of the first attempt to run this entry.
+    first_attempt_at: TimestampMillisecond,
+
+    /// Timestamp of the latest attempt to run this entry.
+    latest_attempt_at: TimestampMillisecond,
+
+    /// The realistic earliest time at which this entry can run its first attempt.
+    first_runnable_at: TimestampMillisecond,
+
+    /// If set, the entry's pinned deployment identifier.
+    deployment: DataType::Utf8,
+
+    /// If set, the amount of memory in bytes the invocation seems to require on the invoker side.
+    needed_memory: DataType::UInt64,
+
+    /// Number of retry attempts recorded in the entry metadata.
+    retry_attempts: DataType::UInt32,
+
+    /// Number of retries since the latest stored command.
+    retry_count_since_last_stored_command: DataType::UInt32,
+
+    /// Time the latest attempt spent waiting on global invoker capacity.
+    latest_attempt_blocked_on_invoker_concurrency: DataType::Duration,
+
+    /// Time the latest attempt spent blocked on user-defined per-vqueue throttling rules.
+    latest_attempt_blocked_on_throttling_rules: DataType::Duration,
+
+    /// Time the latest attempt spent blocked on node-level invoker throttling.
+    latest_attempt_blocked_on_invoker_throttling: DataType::Duration,
+
+    /// Time the latest attempt spent waiting on the invoker memory pool.
+    latest_attempt_blocked_on_invoker_memory: DataType::Duration,
+
+    /// Time the latest attempt spent waiting on user-defined concurrency limits.
+    latest_attempt_blocked_on_concurrency_rules: DataType::Duration,
+
+    /// Time the latest attempt spent waiting to acquire a virtual object lock.
+    latest_attempt_blocked_on_lock: DataType::Duration,
+
+    /// Time the latest attempt spent blocked on deployment concurrency capacity.
+    latest_attempt_blocked_on_deployment_concurrency: DataType::Duration,
+
+    /// Total time spent waiting on global invoker capacity across all attempts.
+    total_blocked_on_invoker_concurrency: DataType::Duration,
+
+    /// Total time spent blocked on user-defined per-vqueue throttling rules across all attempts.
+    total_blocked_on_throttling_rules: DataType::Duration,
+
+    /// Total time spent blocked on node-level invoker throttling across all attempts.
+    total_blocked_on_invoker_throttling: DataType::Duration,
+
+    /// Total time spent waiting on the invoker memory pool across all attempts.
+    total_blocked_on_invoker_memory: DataType::Duration,
+
+    /// Total time spent waiting on user-defined concurrency limits across all attempts.
+    total_blocked_on_concurrency_rules: DataType::Duration,
+
+    /// Total time spent waiting to acquire a virtual object lock across all attempts.
+    total_blocked_on_lock: DataType::Duration,
+
+    /// Total time spent blocked on deployment concurrency capacity across all attempts.
+    total_blocked_on_deployment_concurrency: DataType::Duration,
+));

--- a/crates/storage-query-datafusion/src/vqueue_entry_status/table.rs
+++ b/crates/storage-query-datafusion/src/vqueue_entry_status/table.rs
@@ -1,0 +1,87 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt::Debug;
+use std::ops::ControlFlow;
+use std::sync::Arc;
+
+use restate_partition_store::{PartitionStore, PartitionStoreManager};
+use restate_sharding::KeyRange;
+use restate_storage_api::StorageError;
+use restate_storage_api::vqueue_table::{OwnedEntryStatusHeader, ScanVQueueEntryStatusTable};
+use restate_types::vqueues::VQueueId;
+
+use crate::context::{QueryContext, SelectPartitions};
+use crate::filter::FirstMatchingPartitionKeyExtractor;
+use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
+use crate::remote_query_scanner_manager::RemoteScannerManager;
+use crate::table_providers::{PartitionedTableProvider, ScanPartition};
+use crate::vqueue_entry_status::row::append_vqueue_entry_status_row;
+use crate::vqueue_entry_status::schema::{
+    SysVqueueEntryStatusBuilder, sys_vqueue_entry_status_sort_order,
+};
+
+const NAME: &str = "sys_vqueue_entry_status";
+
+pub(crate) fn register_self(
+    ctx: &QueryContext,
+    partition_selector: impl SelectPartitions,
+    partition_store_manager: Arc<PartitionStoreManager>,
+    remote_scanner_manager: &RemoteScannerManager,
+) -> datafusion::common::Result<()> {
+    let local_scanner = Arc::new(LocalPartitionsScanner::new(
+        partition_store_manager,
+        VQueueEntryStatusScanner,
+    )) as Arc<dyn ScanPartition>;
+
+    let table = PartitionedTableProvider::new(
+        partition_selector,
+        SysVqueueEntryStatusBuilder::schema(),
+        sys_vqueue_entry_status_sort_order(),
+        remote_scanner_manager.create_distributed_scanner(NAME, local_scanner),
+        FirstMatchingPartitionKeyExtractor::default()
+            .with_vqueue_entry_id("entry_id")
+            .with_partitioned_resource_id::<VQueueId>("vqueue_id"),
+    );
+
+    ctx.register_partitioned_table(NAME, Arc::new(table))
+}
+
+#[derive(Debug, Clone)]
+struct VQueueEntryStatusScanner;
+
+impl ScanLocalPartition for VQueueEntryStatusScanner {
+    type Builder = SysVqueueEntryStatusBuilder;
+    type Item<'a> = &'a OwnedEntryStatusHeader;
+    type ConversionError = std::convert::Infallible;
+    type Filter = KeyRange;
+
+    fn for_each_row<
+        F: for<'a> FnMut(Self::Item<'a>) -> ControlFlow<Result<(), Self::ConversionError>>
+            + Send
+            + Sync
+            + 'static,
+    >(
+        partition_store: &PartitionStore,
+        range: KeyRange,
+        mut f: F,
+    ) -> Result<impl Future<Output = restate_storage_api::Result<()>> + Send, StorageError> {
+        partition_store
+            .for_each_vqueue_entry_status(range, move |item| f(item).map_break(Result::unwrap))
+    }
+
+    fn append_row<'a>(
+        row_builder: &mut Self::Builder,
+        header: Self::Item<'a>,
+    ) -> Result<(), Self::ConversionError> {
+        append_vqueue_entry_status_row(row_builder, header);
+        Ok(())
+    }
+}

--- a/crates/storage-query-datafusion/src/vqueue_entry_status/tests.rs
+++ b/crates/storage-query-datafusion/src/vqueue_entry_status/tests.rs
@@ -1,0 +1,173 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::num::NonZeroUsize;
+
+use datafusion::arrow::array::{
+    BooleanArray, DurationMillisecondArray, StringArray, TimestampMillisecondArray, UInt32Array,
+    UInt64Array,
+};
+use datafusion::arrow::record_batch::RecordBatch;
+use futures::StreamExt;
+use googletest::all;
+use googletest::prelude::{assert_that, eq};
+
+use restate_storage_api::Transaction;
+use restate_storage_api::vqueue_table::{
+    EntryId, EntryKey, EntryKind, EntryMetadata, Stage, Status, WriteVQueueTable,
+    stats::{EntryStatistics, WaitStats},
+};
+use restate_types::clock::UniqueTimestamp;
+use restate_types::time::MillisSinceEpoch;
+use restate_types::vqueues::VQueueId;
+use restate_util_string::ToReString;
+
+use crate::mocks::*;
+use crate::row;
+
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_vqueue_entry_status_header_fields() {
+    let mut engine = MockQueryEngine::create().await;
+
+    let qid = VQueueId::custom(3337, "df-vqueue-entry-status");
+    let entry_id = EntryId::new(EntryKind::Invocation, [9; 16]);
+    let key = EntryKey::new(true, MillisSinceEpoch::new(1_744_010_001_000), 42, entry_id);
+
+    let created_at =
+        UniqueTimestamp::try_from_unix_millis(MillisSinceEpoch::new(1_744_010_000_100)).unwrap();
+    let transitioned_at =
+        UniqueTimestamp::try_from_unix_millis(MillisSinceEpoch::new(1_744_010_000_300)).unwrap();
+    let first_attempt_at =
+        UniqueTimestamp::try_from_unix_millis(MillisSinceEpoch::new(1_744_010_000_400)).unwrap();
+    let latest_attempt_at =
+        UniqueTimestamp::try_from_unix_millis(MillisSinceEpoch::new(1_744_010_000_500)).unwrap();
+
+    let mut stats = EntryStatistics::new(created_at, key.run_at());
+    stats.transitioned_at = transitioned_at;
+    stats.num_attempts = 3;
+    stats.num_errors = 1;
+    stats.num_paused = 2;
+    stats.num_suspensions = 4;
+    stats.num_yields = 5;
+    stats.first_attempt_at = Some(first_attempt_at);
+    stats.latest_attempt_at = Some(latest_attempt_at);
+    stats.latest_attempt_wait_stats = WaitStats {
+        blocked_on_invoker_concurrency_ms: 10,
+        blocked_on_throttling_rules_ms: 20,
+        blocked_on_invoker_throttling_ms: 30,
+        blocked_on_invoker_memory_ms: 40,
+        blocked_on_concurrency_rules_ms: 50,
+        blocked_on_lock_ms: 60,
+        blocked_on_deployment_concurrency_ms: 70,
+    };
+    stats.total_wait_stats = WaitStats {
+        blocked_on_invoker_concurrency_ms: 100,
+        blocked_on_throttling_rules_ms: 200,
+        blocked_on_invoker_throttling_ms: 300,
+        blocked_on_invoker_memory_ms: 400,
+        blocked_on_concurrency_rules_ms: 500,
+        blocked_on_lock_ms: 600,
+        blocked_on_deployment_concurrency_ms: 700,
+    };
+
+    let needed_memory = NonZeroUsize::new(4096).unwrap();
+    let metadata = EntryMetadata {
+        deployment: Some("dp_status".to_restring()),
+        needed_memory: Some(needed_memory.into()),
+        retry_attempts: 7,
+        retry_count_since_last_stored_command: 2,
+    };
+
+    let mut tx = engine.partition_store().transaction();
+    let first_runnable_at = stats.first_runnable_at;
+    let latest_attempt_wait_stats = stats.latest_attempt_wait_stats;
+    let total_wait_stats = stats.total_wait_stats;
+    tx.put_vqueue_entry_status(
+        &qid,
+        Stage::Running,
+        &key,
+        &metadata,
+        stats,
+        Status::Started,
+    );
+    tx.commit().await.unwrap();
+    drop(tx);
+
+    let entry_id = key.entry_id().display(qid.partition_key()).to_string();
+    let records = engine
+        .execute(format!(
+            "SELECT entry_id, vqueue_id, stage, status, has_lock, next_at, sequence_number, \
+             entry_kind, created_at, transitioned_at, num_attempts, num_errors, num_pauses, \
+             num_suspensions, num_yields, first_attempt_at, latest_attempt_at, \
+             first_runnable_at, deployment, needed_memory, retry_attempts, \
+             retry_count_since_last_stored_command, latest_attempt_blocked_on_invoker_concurrency, \
+             latest_attempt_blocked_on_throttling_rules, latest_attempt_blocked_on_invoker_throttling, \
+             latest_attempt_blocked_on_invoker_memory, latest_attempt_blocked_on_concurrency_rules, \
+             latest_attempt_blocked_on_lock, latest_attempt_blocked_on_deployment_concurrency, \
+             total_blocked_on_invoker_concurrency, total_blocked_on_throttling_rules, \
+             total_blocked_on_invoker_throttling, total_blocked_on_invoker_memory, \
+             total_blocked_on_concurrency_rules, total_blocked_on_lock, \
+             total_blocked_on_deployment_concurrency FROM sys_vqueue_entry_status \
+             WHERE entry_id = '{entry_id}' ORDER BY sequence_number"
+        ))
+        .await
+        .unwrap()
+        .stream
+        .collect::<Vec<datafusion::common::Result<RecordBatch>>>()
+        .await
+        .remove(0)
+        .unwrap();
+
+    assert_eq!(records.num_rows(), 1);
+    assert_that!(
+        records,
+        all!(row!(
+            0,
+            {
+                "entry_id" => StringArray: eq(entry_id),
+                "vqueue_id" => StringArray: eq(qid.to_string()),
+                "stage" => StringArray: eq("running"),
+                "status" => StringArray: eq("started"),
+                "has_lock" => BooleanArray: eq(true),
+                "next_at" => TimestampMillisecondArray: eq(key.run_at().as_unix_millis().as_u64() as i64),
+                "sequence_number" => UInt64Array: eq(42),
+                "entry_kind" => StringArray: eq("invocation"),
+                "created_at" => TimestampMillisecondArray: eq(created_at.to_unix_millis().as_u64() as i64),
+                "transitioned_at" => TimestampMillisecondArray: eq(transitioned_at.to_unix_millis().as_u64() as i64),
+                "num_attempts" => UInt32Array: eq(3),
+                "num_errors" => UInt32Array: eq(1),
+                "num_pauses" => UInt32Array: eq(2),
+                "num_suspensions" => UInt32Array: eq(4),
+                "num_yields" => UInt32Array: eq(5),
+                "first_attempt_at" => TimestampMillisecondArray: eq(first_attempt_at.to_unix_millis().as_u64() as i64),
+                "latest_attempt_at" => TimestampMillisecondArray: eq(latest_attempt_at.to_unix_millis().as_u64() as i64),
+                "first_runnable_at" => TimestampMillisecondArray: eq(first_runnable_at.as_u64() as i64),
+                "deployment" => StringArray: eq("dp_status"),
+                "needed_memory" => UInt64Array: eq(needed_memory.get() as u64),
+                "retry_attempts" => UInt32Array: eq(7),
+                "retry_count_since_last_stored_command" => UInt32Array: eq(2),
+                "latest_attempt_blocked_on_invoker_concurrency" => DurationMillisecondArray: eq(latest_attempt_wait_stats.blocked_on_invoker_concurrency_ms as i64),
+                "latest_attempt_blocked_on_throttling_rules" => DurationMillisecondArray: eq(latest_attempt_wait_stats.blocked_on_throttling_rules_ms as i64),
+                "latest_attempt_blocked_on_invoker_throttling" => DurationMillisecondArray: eq(latest_attempt_wait_stats.blocked_on_invoker_throttling_ms as i64),
+                "latest_attempt_blocked_on_invoker_memory" => DurationMillisecondArray: eq(latest_attempt_wait_stats.blocked_on_invoker_memory_ms as i64),
+                "latest_attempt_blocked_on_concurrency_rules" => DurationMillisecondArray: eq(latest_attempt_wait_stats.blocked_on_concurrency_rules_ms as i64),
+                "latest_attempt_blocked_on_lock" => DurationMillisecondArray: eq(latest_attempt_wait_stats.blocked_on_lock_ms as i64),
+                "latest_attempt_blocked_on_deployment_concurrency" => DurationMillisecondArray: eq(latest_attempt_wait_stats.blocked_on_deployment_concurrency_ms as i64),
+                "total_blocked_on_invoker_concurrency" => DurationMillisecondArray: eq(total_wait_stats.blocked_on_invoker_concurrency_ms as i64),
+                "total_blocked_on_throttling_rules" => DurationMillisecondArray: eq(total_wait_stats.blocked_on_throttling_rules_ms as i64),
+                "total_blocked_on_invoker_throttling" => DurationMillisecondArray: eq(total_wait_stats.blocked_on_invoker_throttling_ms as i64),
+                "total_blocked_on_invoker_memory" => DurationMillisecondArray: eq(total_wait_stats.blocked_on_invoker_memory_ms as i64),
+                "total_blocked_on_concurrency_rules" => DurationMillisecondArray: eq(total_wait_stats.blocked_on_concurrency_rules_ms as i64),
+                "total_blocked_on_lock" => DurationMillisecondArray: eq(total_wait_stats.blocked_on_lock_ms as i64),
+                "total_blocked_on_deployment_concurrency" => DurationMillisecondArray: eq(total_wait_stats.blocked_on_deployment_concurrency_ms as i64),
+            }
+        ))
+    );
+}

--- a/crates/storage-query-datafusion/src/vqueues/row.rs
+++ b/crates/storage-query-datafusion/src/vqueues/row.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use restate_storage_api::vqueue_table::{EntryKey, EntryKind, EntryValue, Stage};
+use restate_storage_api::vqueue_table::{EntryKey, EntryValue, Stage};
 use restate_types::vqueues::VQueueId;
 
 use super::schema::SysVqueuesBuilder;
@@ -49,11 +49,7 @@ pub(crate) fn append_vqueues_row<'a>(
     }
 
     if row.is_entry_kind_defined() {
-        row.entry_kind(match entry_key.kind() {
-            EntryKind::Invocation => "invocation",
-            EntryKind::StateMutation => "state-mutation",
-            EntryKind::Unknown => "unknown",
-        });
+        row.fmt_entry_kind(entry_key.kind());
     }
 
     if row.is_created_at_defined() {

--- a/crates/storage-query-datafusion/src/vqueues/row.rs
+++ b/crates/storage-query-datafusion/src/vqueues/row.rs
@@ -37,8 +37,8 @@ pub(crate) fn append_vqueues_row<'a>(
     if row.is_has_lock_defined() {
         row.has_lock(entry_key.has_lock());
     }
-    if matches!(stage, Stage::Inbox) && row.is_run_at_defined() {
-        row.run_at(entry_key.run_at().as_unix_millis().as_u64() as i64);
+    if matches!(stage, Stage::Inbox) && row.is_next_at_defined() {
+        row.next_at(entry_key.run_at().as_unix_millis().as_u64() as i64);
     }
     if row.is_sequence_number_defined() {
         row.sequence_number(entry_key.seq().as_u64());

--- a/crates/storage-query-datafusion/src/vqueues/schema.rs
+++ b/crates/storage-query-datafusion/src/vqueues/schema.rs
@@ -39,9 +39,9 @@ define_table!(sys_vqueues(
     /// Whether this entry currently holds a lock.
     has_lock: DataType::Boolean,
 
-    /// The entry will be eligible to run after this timestamp. Only present for entries
-    /// that are in the stage=inbox.
-    run_at: TimestampMillisecond,
+    /// The next timestamp at which this entry is scheduled for the next transition.
+    /// Only present for entries that are in the stage=inbox.
+    next_at: TimestampMillisecond,
 
     /// Sequence number encoded in the queue ordering key.
     sequence_number: DataType::UInt64,

--- a/crates/storage-query-datafusion/src/vqueues/tests.rs
+++ b/crates/storage-query-datafusion/src/vqueues/tests.rs
@@ -79,7 +79,7 @@ async fn get_vqueue_entry_value_fields() {
         .execute(
             "SELECT stage, status, num_attempts, num_pauses, num_suspensions, num_yields, \
             created_at, transitioned_at, first_attempt_at, latest_attempt_at, first_runnable_at, \
-            run_at, deployment FROM sys_vqueues WHERE stage = 'inbox' ORDER BY sequence_number",
+            next_at, deployment FROM sys_vqueues WHERE stage = 'inbox' ORDER BY sequence_number",
         )
         .await
         .unwrap()
@@ -107,7 +107,7 @@ async fn get_vqueue_entry_value_fields() {
                 "first_attempt_at" => TimestampMillisecondArray: eq(first_attempt_at.to_unix_millis().as_u64() as i64),
                 "latest_attempt_at" => TimestampMillisecondArray: eq(latest_attempt_at.to_unix_millis().as_u64() as i64),
                 "first_runnable_at" => TimestampMillisecondArray: eq(value.stats.first_runnable_at.as_u64() as i64),
-                "run_at" => TimestampMillisecondArray: eq(key.run_at().as_unix_millis().as_u64() as i64),
+                "next_at" => TimestampMillisecondArray: eq(key.run_at().as_unix_millis().as_u64() as i64),
                 "deployment" => StringArray: eq("dp_123"),
             }
         ))

--- a/crates/types/src/vqueues/entry_id.rs
+++ b/crates/types/src/vqueues/entry_id.rs
@@ -16,9 +16,20 @@ use super::ParseError;
 const REMAINDER_LEN: usize = 16;
 
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, strum::FromRepr, bilrost::Enumeration,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    strum::FromRepr,
+    bilrost::Enumeration,
+    strum::Display,
 )]
 #[repr(u8)]
+#[strum(serialize_all = "kebab-case")]
 pub enum EntryKind {
     /// Must not be used as input when encoding but it can be observed when decoding
     /// if the raw bytes did not form a known entry kind.

--- a/release-notes/unreleased/add-vqueue-entry-status-table.md
+++ b/release-notes/unreleased/add-vqueue-entry-status-table.md
@@ -1,0 +1,16 @@
+# Release Notes: Add `sys_vqueue_entry_status` Table
+
+## New Feature
+
+### What Changed
+Added a `sys_vqueue_entry_status` SQL table that exposes vqueue entry status-header fields from the partition store.
+
+### Why This Matters
+Operators can inspect the authoritative vqueue entry status header directly, including the entry id, vqueue id, stage, status, scheduling key fields, entry statistics, wait statistics, deployment, memory, and retry metadata.
+
+### Impact on Users
+- Existing deployments gain a new introspection table after upgrade.
+- No migration or configuration changes are required.
+
+### Migration Guidance
+No action required.


### PR DESCRIPTION

In the context of a finished invocation, next_at is the time at which we will perform the cleanup of completion or journal. Therefore, renaming to next_at aligns the fields's name to its semantics.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4967).
* __->__ #4967
* #4966