### PR TITLE
Drop unnecessary spawn

### DIFF
--- a/crates/invoker-impl/src/error.rs
+++ b/crates/invoker-impl/src/error.rs
@@ -15,7 +15,6 @@ use std::ops::RangeInclusive;
 use std::time::Duration;
 
 use http::{HeaderName, HeaderValue};
-use tokio::task::JoinError;
 
 use restate_memory::OutOfMemoryKind;
 use restate_service_client::ServiceClientError;
@@ -129,9 +128,6 @@ pub(crate) enum InvokerError {
     #[error("unexpected error while reading the response body: {0}")]
     #[code(restate_errors::RT0010)]
     ClientBody(Box<dyn std::error::Error + Send + Sync>),
-    #[error("unexpected join error, looks like hyper panicked: {0}")]
-    #[code(restate_errors::RT0010)]
-    UnexpectedJoinError(#[from] JoinError),
     #[error("unexpected closed request stream while trying to write a message")]
     #[code(restate_errors::RT0010)]
     UnexpectedClosedRequestStream,

--- a/crates/invoker-impl/src/invocation_task/mod.rs
+++ b/crates/invoker-impl/src/invocation_task/mod.rs
@@ -29,11 +29,10 @@ use http_body_util::StreamBody;
 use metrics::{counter, histogram};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tokio_util::task::AbortOnDropHandle;
 use tracing::{debug, instrument};
 
 use restate_memory::{LocalMemoryLease, LocalMemoryPool, PinnableMemoryStream};
-use restate_service_client::{Request, ResponseBody, ServiceClient, ServiceClientError};
+use restate_service_client::{ResponseBody, ServiceClient, ServiceClientError};
 use restate_types::LimitKey;
 use restate_types::deployment::PinnedDeployment;
 use restate_types::identifiers::InvocationId;
@@ -654,9 +653,10 @@ enum ResponseChunk {
 
 pin_project_lite::pin_project! {
     #[project = ResponseStreamProj]
-    enum ResponseStream {
+    enum ResponseStream<F>{
         WaitingHeaders {
-            join_handle: AbortOnDropHandle<Result<Response<ResponseBody>, ServiceClientError>>,
+            #[pin]
+            fut: F
         },
         ReadingBody {
             #[pin]
@@ -666,36 +666,30 @@ pin_project_lite::pin_project! {
     }
 }
 
-impl ResponseStream {
-    fn initialize(client: &ServiceClient, req: Request<InvokerBodyType>) -> Self {
-        // Because the body sender blocks on waiting for the request body buffer to be available,
-        // we need to spawn the request initiation separately, otherwise the loop below
-        // will deadlock on the journal entry write.
-        // This task::spawn won't be required by hyper 1.0, as the connection will be driven by a task
-        // spawned somewhere else (perhaps in the connection pool).
-        // See: https://github.com/restatedev/restate/issues/96 and https://github.com/restatedev/restate/issues/76
-        Self::WaitingHeaders {
-            join_handle: AbortOnDropHandle::new(tokio::task::spawn(client.call(req))),
-        }
+impl<F> ResponseStream<F>
+where
+    F: Future<Output = Result<Response<ResponseBody>, ServiceClientError>>,
+{
+    fn new(fut: F) -> Self {
+        Self::WaitingHeaders { fut }
     }
 }
 
-impl Stream for ResponseStream {
+impl<F> Stream for ResponseStream<F>
+where
+    F: Future<Output = Result<Response<ResponseBody>, ServiceClientError>>,
+{
     type Item = Result<ResponseChunk, InvokerError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.as_mut().project();
         match this {
-            ResponseStreamProj::WaitingHeaders { join_handle } => {
-                let http_response = match ready!(join_handle.poll_unpin(cx)) {
-                    Ok(Ok(res)) => res,
-                    Ok(Err(hyper_err)) => {
-                        *self = ResponseStream::Terminated;
+            ResponseStreamProj::WaitingHeaders { mut fut } => {
+                let http_response = match ready!(fut.poll_unpin(cx)) {
+                    Ok(res) => res,
+                    Err(hyper_err) => {
+                        self.as_mut().set(ResponseStream::Terminated);
                         return Poll::Ready(Some(Err(InvokerError::Client(Box::new(hyper_err)))));
-                    }
-                    Err(join_err) => {
-                        *self = ResponseStream::Terminated;
-                        return Poll::Ready(Some(Err(InvokerError::UnexpectedJoinError(join_err))));
                     }
                 };
 
@@ -703,7 +697,7 @@ impl Stream for ResponseStream {
                 let (http_response_header, body) = http_response.into_parts();
 
                 // Transition to reading body
-                *self = ResponseStream::ReadingBody { body };
+                self.as_mut().set(ResponseStream::ReadingBody { body });
                 Poll::Ready(Some(Ok(ResponseChunk::Parts(http_response_header))))
             }
             ResponseStreamProj::ReadingBody { body } => {
@@ -713,11 +707,11 @@ impl Stream for ResponseStream {
                         Poll::Ready(Some(Ok(ResponseChunk::Data(frame.into_data().unwrap()))))
                     }
                     Ok(_) => {
-                        *self = ResponseStream::Terminated;
+                        self.as_mut().set(ResponseStream::Terminated);
                         Poll::Ready(None)
                     }
                     Err(err) => {
-                        *self = ResponseStream::Terminated;
+                        self.as_mut().set(ResponseStream::Terminated);
                         Poll::Ready(Some(Err(InvokerError::ClientBody(err))))
                     }
                 }

--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner.rs
@@ -168,7 +168,9 @@ where
         );
 
         // Initialize the response stream state
-        let mut http_stream_rx = ResponseStream::initialize(&self.invocation_task.client, request);
+        let mut http_stream_rx = std::pin::pin!(ResponseStream::new(
+            self.invocation_task.client.call(request)
+        ));
 
         // === Replay phase (transaction alive) ===
         {
@@ -329,14 +331,15 @@ where
     // --- Loops
 
     /// This loop concurrently pushes journal entries and waits for the response headers and end of replay.
-    async fn replay_loop<JournalStream, E>(
+    async fn replay_loop<JournalStream, S, E>(
         &mut self,
         http_stream_tx: &mut InvokerBodySender,
-        http_stream_rx: &mut ResponseStream,
+        http_stream_rx: &mut S,
         journal_stream: JournalStream,
     ) -> TerminalLoopState<()>
     where
         JournalStream: Stream<Item = Result<(JournalEntry, LocalMemoryLease), E>> + Unpin,
+        S: Stream<Item = Result<ResponseChunk, InvokerError>> + Unpin,
         E: InvocationReaderError,
     {
         let mut journal_stream = journal_stream.fuse();
@@ -405,15 +408,16 @@ where
     }
 
     /// This loop concurrently reads the http response stream and journal completions from the invoker.
-    async fn bidi_stream_loop<IR>(
+    async fn bidi_stream_loop<S, IR>(
         &mut self,
         parent_span_context: &ServiceInvocationSpanContext,
         mut http_stream_tx: InvokerBodySender,
-        http_stream_rx: &mut ResponseStream,
+        http_stream_rx: &mut S,
         mut invocation_reader: IR,
         outbound_budget: &mut LocalMemoryPool,
     ) -> TerminalLoopState<()>
     where
+        S: Stream<Item = Result<ResponseChunk, InvokerError>> + Unpin,
         IR: InvocationReader,
     {
         let mut release_interval = tokio::time::interval(Self::BUDGET_RELEASE_INTERVAL);
@@ -472,11 +476,14 @@ where
         }
     }
 
-    async fn response_stream_loop(
+    async fn response_stream_loop<S>(
         &mut self,
         parent_span_context: &ServiceInvocationSpanContext,
-        http_stream_rx: &mut ResponseStream,
-    ) -> TerminalLoopState<()> {
+        http_stream_rx: &mut S,
+    ) -> TerminalLoopState<()>
+    where
+        S: Stream<Item = Result<ResponseChunk, InvokerError>> + Unpin,
+    {
         loop {
             tokio::select! {
                 chunk = http_stream_rx.next() => {

--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
@@ -199,7 +199,7 @@ where
         );
 
         // Initialize the response stream state
-        let http_stream_rx = ResponseStream::initialize(&self.invocation_task.client, request);
+        let http_stream_rx = ResponseStream::new(self.invocation_task.client.call(request));
 
         let mut decoder_stream = std::pin::pin!(
             DecoderStream::new(
@@ -241,7 +241,7 @@ where
             }
         }
 
-        let inner_stream = &mut decoder_stream.inner_pin_mut().inner;
+        let mut inner_stream = decoder_stream.inner_pin_mut().project().inner;
 
         if tokio::time::timeout(Duration::from_secs(5), async {
             loop {
@@ -1734,7 +1734,7 @@ impl<S> DecoderStream<S> {
 
 impl<S> Stream for DecoderStream<S>
 where
-    S: Stream<Item = Result<ResponseChunk, InvokerError>> + Unpin,
+    S: Stream<Item = Result<ResponseChunk, InvokerError>>,
 {
     type Item = Result<DecoderStreamItem, InvokerError>;
 


### PR DESCRIPTION

Summary:
After moving to h2 connection pool, it's now
safe to drop this spawn.

I tested both lambda and http/1.1 deployments
with no issues

Fixes #4829
