### PR TITLE
Add `snapshot` subcommand to restate-doctor: run SQL over partition snapshots offline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -158,7 +158,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1462,6 +1462,12 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -1659,6 +1665,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,7 +1731,7 @@ checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
  "crossterm",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1772,7 +1787,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
 
@@ -3049,7 +3064,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3146,6 +3161,12 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "enum-map"
@@ -3263,8 +3284,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "etcd-client"
@@ -3331,6 +3358,17 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "figment"
@@ -3993,6 +4031,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "hostname"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4369,7 +4416,7 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.2",
  "unit-prefix",
  "web-time",
 ]
@@ -4507,7 +4554,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4588,7 +4635,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5414,6 +5461,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5426,13 +5482,25 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -5444,7 +5512,7 @@ checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -5504,7 +5572,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5967,7 +6035,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6695,7 +6763,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -6736,12 +6804,12 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6770,6 +6838,16 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "raft"
@@ -7429,7 +7507,7 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -7545,27 +7623,42 @@ name = "restate-doctor"
 version = "1.7.1-dev"
 dependencies = [
  "anyhow",
+ "arrow",
+ "async-trait",
+ "axum",
  "bilrost",
  "bytes",
+ "bytestring",
  "clap",
  "clap_complete",
  "cling",
  "comfy-table",
  "crossterm",
  "ctrlc",
+ "datafusion",
+ "futures",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
  "jiff",
+ "object_store 0.13.2",
  "restate-cli-util",
+ "restate-core",
  "restate-limiter",
  "restate-log-server",
+ "restate-metadata-store",
+ "restate-object-store-util",
  "restate-partition-store",
  "restate-rocksdb",
  "restate-storage-api",
+ "restate-storage-query-datafusion",
  "restate-types",
  "restate-util-bytecount",
  "restate-wal-protocol",
  "restate-workspace-hack",
  "rlimit",
  "rust-rocksdb",
+ "rustyline",
  "serde",
  "serde_json",
  "strum",
@@ -7574,6 +7667,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ulid",
+ "url",
  "vergen",
 ]
 
@@ -9272,7 +9366,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9331,7 +9425,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9357,6 +9451,28 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustyline"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.28.0",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+ "utf8parse",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "ryu"
@@ -9965,7 +10081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10015,7 +10131,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10189,7 +10305,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10198,7 +10314,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10217,7 +10333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11044,6 +11160,12 @@ checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
@@ -11424,7 +11546,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ default-members = [
     "crates/codederror/derive",
     "server",
     "tools/restate-doctor",
-    "tools/restatectl",
+    "tools/restatectl"
 ]
 resolver = "2"
 
@@ -235,6 +235,7 @@ rocksdb = { version = "0.48.0", package = "rust-rocksdb", features = [
 ], git = "https://github.com/restatedev/rust-rocksdb", rev = "432ac4288a219dd70d4c71ccfcd0ad51d6bcc0d1" }
 rstest = "0.26.1"
 rustls = { version = "0.23.35", default-features = false, features = ["ring"] }
+rustyline = { version = "14.0.0" }
 schemars = { version = "1.2", features = ["bytes1"] }
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/partition-store/src/partition_store_manager.rs
+++ b/crates/partition-store/src/partition_store_manager.rs
@@ -387,7 +387,10 @@ impl PartitionStoreManager {
         self.state.drop_partition(partition_id).await
     }
 
-    #[cfg(test)]
+    /// Opens a partition store by importing an already-downloaded snapshot, discarding any
+    /// existing local state for the partition. Unlike [`Self::open`], this takes a snapshot the
+    /// caller has fetched itself (e.g. via [`crate::snapshots::SnapshotRepository::get_latest`]),
+    /// which lets the caller use the snapshot's own key range.
     pub async fn open_from_snapshot(
         &self,
         partition: &Partition,

--- a/crates/storage-query-datafusion/src/context.rs
+++ b/crates/storage-query-datafusion/src/context.rs
@@ -44,6 +44,7 @@ use restate_types::schema::service::ServiceMetadataResolver;
 use restate_worker_api::invoker::StatusHandle;
 use restate_worker_api::{SchedulerStatusEntry, UserLimitCounterEntry};
 
+use crate::empty_invoker_status_handle::EmptyInvokerStatusHandle;
 use crate::node_fan_out::NodeWarnings;
 use crate::remote_query_scanner_manager::RemoteScannerManager;
 
@@ -372,6 +373,114 @@ impl RegisterTable for ClusterTables {
         ctx.datafusion_context
             .sql(CLUSTER_LOGS_TAIL_SEGMENTS_VIEW)
             .await?;
+
+        Ok(())
+    }
+}
+
+/// A query context registerer that exposes only the partition-store-backed tables.
+///
+/// Unlike [`UserTables`], it needs neither a schema registry nor a metadata-store client, so it can
+/// run against partition data with no live cluster behind it — e.g. a snapshot restored by an
+/// offline debugging tool. The leader-owned tables (`sys_scheduler_status`, `sys_user_limits`) are
+/// intentionally omitted: that state is ephemeral and never present in a snapshot. The invoker
+/// columns of `sys_invocation_state` are likewise leader-owned and resolve to nulls here, which is
+/// the truthful answer for a snapshot; the table is still registered because the `sys_invocation`
+/// view joins against it.
+pub struct PartitionTables<P> {
+    partition_selector: P,
+    partition_store_manager: Arc<PartitionStoreManager>,
+    remote_scanner_manager: RemoteScannerManager,
+}
+
+impl<P> PartitionTables<P> {
+    pub fn new(
+        partition_selector: P,
+        partition_store_manager: Arc<PartitionStoreManager>,
+        remote_scanner_manager: RemoteScannerManager,
+    ) -> Self {
+        Self {
+            partition_selector,
+            partition_store_manager,
+            remote_scanner_manager,
+        }
+    }
+}
+
+impl<P> RegisterTable for PartitionTables<P>
+where
+    P: SelectPartitions + Clone,
+{
+    async fn register(&self, ctx: &QueryContext) -> Result<(), BuildError> {
+        crate::invocation_state::register_self(
+            ctx,
+            self.partition_selector.clone(),
+            Some(EmptyInvokerStatusHandle),
+            self.partition_store_manager.clone(),
+            &self.remote_scanner_manager,
+        )?;
+        crate::invocation_status::register_self(
+            ctx,
+            self.partition_selector.clone(),
+            self.partition_store_manager.clone(),
+            &self.remote_scanner_manager,
+        )?;
+        crate::keyed_service_status::register_self(
+            ctx,
+            self.partition_selector.clone(),
+            self.partition_store_manager.clone(),
+            &self.remote_scanner_manager,
+        )?;
+        crate::locks::register_self(
+            ctx,
+            self.partition_selector.clone(),
+            self.partition_store_manager.clone(),
+            &self.remote_scanner_manager,
+        )?;
+        crate::state::register_self(
+            ctx,
+            self.partition_selector.clone(),
+            self.partition_store_manager.clone(),
+            &self.remote_scanner_manager,
+        )?;
+        crate::journal::register_self(
+            ctx,
+            self.partition_selector.clone(),
+            self.partition_store_manager.clone(),
+            &self.remote_scanner_manager,
+        )?;
+        crate::journal_events::register_self(
+            ctx,
+            self.partition_selector.clone(),
+            self.partition_store_manager.clone(),
+            &self.remote_scanner_manager,
+        )?;
+        crate::inbox::register_self(
+            ctx,
+            self.partition_selector.clone(),
+            self.partition_store_manager.clone(),
+            &self.remote_scanner_manager,
+        )?;
+        crate::promise::register_self(
+            ctx,
+            self.partition_selector.clone(),
+            self.partition_store_manager.clone(),
+            &self.remote_scanner_manager,
+        )?;
+        crate::vqueue_meta::register_self(
+            ctx,
+            self.partition_selector.clone(),
+            self.partition_store_manager.clone(),
+            &self.remote_scanner_manager,
+        )?;
+        crate::vqueues::register_self(
+            ctx,
+            self.partition_selector.clone(),
+            self.partition_store_manager.clone(),
+            &self.remote_scanner_manager,
+        )?;
+
+        ctx.datafusion_context.sql(SYS_INVOCATION_VIEW).await?;
 
         Ok(())
     }

--- a/crates/storage-query-datafusion/src/remote_query_scanner_manager.rs
+++ b/crates/storage-query-datafusion/src/remote_query_scanner_manager.rs
@@ -14,7 +14,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::{anyhow, bail};
+use async_trait::async_trait;
 use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::common::DataFusionError;
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion::physical_plan::PhysicalExpr;
 use datafusion::physical_plan::metrics::Time;
@@ -24,10 +26,12 @@ use restate_core::Metadata;
 use restate_core::partitions::PartitionRouting;
 use restate_types::NodeId;
 use restate_types::identifiers::PartitionId;
-use restate_types::net::remote_query_scanner::ScannerId;
+use restate_types::net::remote_query_scanner::{RemoteQueryScannerOpen, ScannerId};
 use restate_types::sharding::KeyRange;
 
-use crate::remote_query_scanner_client::{RemoteScannerService, remote_scan_as_datafusion_stream};
+use crate::remote_query_scanner_client::{
+    RemoteScanner, RemoteScannerService, remote_scan_as_datafusion_stream,
+};
 use crate::table_providers::{Scan, ScanPartition};
 
 // A global scanner sequence generate shared across all RemoteScannerManager
@@ -115,6 +119,36 @@ impl PartitionLocator for MetadataAwarePartitionLocator {
     }
 }
 
+/// A locator that reports every partition as local. Used by [`RemoteScannerManager::local_only`].
+struct AlwaysLocalPartitionLocator;
+
+impl PartitionLocator for AlwaysLocalPartitionLocator {
+    fn get_partition_target_node(
+        &self,
+        _partition_id: PartitionId,
+    ) -> anyhow::Result<PartitionLocation> {
+        Ok(PartitionLocation::Local)
+    }
+}
+
+/// A remote-scan service that is never invoked because [`AlwaysLocalPartitionLocator`] keeps all
+/// scans local. Used by [`RemoteScannerManager::local_only`].
+#[derive(Debug)]
+struct NoopRemoteScanner;
+
+#[async_trait]
+impl RemoteScannerService for NoopRemoteScanner {
+    async fn open(
+        &self,
+        _peer: NodeId,
+        _req: RemoteQueryScannerOpen,
+    ) -> Result<RemoteScanner, DataFusionError> {
+        Err(DataFusionError::External(
+            anyhow!("remote scanner is not available in local-only mode").into(),
+        ))
+    }
+}
+
 impl RemoteScannerManager {
     pub fn new(
         remote_scanner: Arc<dyn RemoteScannerService>,
@@ -127,6 +161,18 @@ impl RemoteScannerManager {
             local_store_scanners: LocalPartitionScannerRegistry::default(),
             metadata,
         }
+    }
+
+    /// Builds a manager for a single-process tool that only ever scans local partitions
+    /// (e.g. an offline snapshot inspector). The remote-scan path is never exercised because
+    /// the locator always reports partitions as [`PartitionLocation::Local`]; the metadata only
+    /// needs to be valid enough for local scans.
+    pub fn local_only(metadata: Metadata) -> Self {
+        Self::new(
+            Arc::new(NoopRemoteScanner),
+            Arc::new(AlwaysLocalPartitionLocator),
+            metadata,
+        )
     }
 
     /// Allocates a fresh `ScannerId` for a remote scan initiated from this node.

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -892,6 +892,10 @@ impl StorageOptions {
             })
     }
 
+    pub fn set_rocksdb_memory_budget(&mut self, budget: NonZeroByteCount) {
+        self.rocksdb_memory_budget = Some(budget);
+    }
+
     pub fn data_dir(&self, db_name: &str) -> PathBuf {
         super::data_dir(db_name)
     }

--- a/tools/restate-doctor/Cargo.toml
+++ b/tools/restate-doctor/Cargo.toml
@@ -20,35 +20,51 @@ restate-workspace-hack = { workspace = true }
 
 # Restate crates
 restate-cli-util = { workspace = true }
+restate-core = { workspace = true }
 restate-limiter = { workspace = true }
 restate-log-server = { workspace = true, features = ["expose-internals", "test-util"] }
+restate-metadata-store = { workspace = true }
+restate-object-store-util = { workspace = true }
 restate-partition-store = { workspace = true }
 restate-rocksdb = { workspace = true }
+restate-storage-query-datafusion = { workspace = true }
 restate-util-bytecount = { workspace = true, features = ["serde"] }
 restate-storage-api = { workspace = true }
-restate-types = { workspace = true }
+restate-types = { workspace = true, features = ["clap", "unsafe-mutable-config"] }
 restate-wal-protocol = { workspace = true }
 
 anyhow = { workspace = true }
+arrow = { workspace = true, features = ["prettyprint", "json", "ipc"] }
+async-trait = { workspace = true }
+axum = { workspace = true, features = ["json", "tokio", "http1"] }
 bilrost = { workspace = true }
 bytes = { workspace = true }
+bytestring = { workspace = true }
 clap = { workspace = true, features = ["derive", "env", "wrap_help", "color", "std", "suggestions", "usage"] }
 clap_complete = { workspace = true }
 cling = { workspace = true }
 comfy-table = { workspace = true }
 crossterm = { workspace = true }
 ctrlc = { version = "3.4" }
+datafusion = { workspace = true }
+futures = { workspace = true }
+http = { workspace = true }
+http-body = { workspace = true }
+http-body-util = { workspace = true }
 jiff = { workspace = true }
+object_store = { workspace = true }
 rlimit = { workspace = true }
 rocksdb = { workspace = true }
+rustyline = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["net"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 ulid = { workspace = true }
+url = { workspace = true }
 
 [build-dependencies]
 vergen = { workspace = true, default-features = false, features = [

--- a/tools/restate-doctor/src/app.rs
+++ b/tools/restate-doctor/src/app.rs
@@ -19,6 +19,7 @@ use crate::commands::id;
 use crate::commands::log_server;
 use crate::commands::partition_store;
 use crate::commands::partition_table;
+use crate::commands::snapshot;
 
 /// Restate Doctor - Diagnostic tools Restate storage
 ///
@@ -64,6 +65,8 @@ pub enum Command {
     /// Decode and analyze resource IDs
     #[clap(subcommand)]
     Id(id::IdCommand),
+    /// Run SQL queries against Restate partition snapshots from a repository
+    Snapshot(snapshot::SnapshotArgs),
     /// Generate or install shell completions
     #[clap(subcommand)]
     Completions(Completions),

--- a/tools/restate-doctor/src/commands/mod.rs
+++ b/tools/restate-doctor/src/commands/mod.rs
@@ -13,3 +13,4 @@ pub mod id;
 pub mod log_server;
 pub mod partition_store;
 pub mod partition_table;
+pub mod snapshot;

--- a/tools/restate-doctor/src/commands/snapshot/README.md
+++ b/tools/restate-doctor/src/commands/snapshot/README.md
@@ -1,0 +1,116 @@
+# `restate-doctor snapshot`
+
+An offline tool for inspecting the data inside a Restate **partition snapshot** with SQL — without a
+running cluster.
+
+Normally the only way to run SQL over partition data is through a live worker's admin `/query`
+endpoint (what `restate sql` talks to). When debugging an incident you often have only the snapshot
+repository, not a running cluster. This subcommand points at a snapshot repository (S3 or
+compatible), downloads the partitions' latest snapshots, opens the partition store + DataFusion
+query layer locally, and drops you into an interactive SQL terminal.
+
+## What it does
+
+1. Connects to the snapshot repository and **auto-discovers** the partitions stored under the prefix.
+2. **Auto-detects** the cluster name/fingerprint from the repository so snapshot download validation
+   passes (override with `--cluster-name` if needed).
+3. For each partition, downloads its latest snapshot and imports it into a local RocksDB store under
+   `--cache-dir`. The import is **cached**: a subsequent run against the same `--cache-dir` reuses
+   the local store and skips the download.
+4. Opens the DataFusion query layer over the imported partitions and either starts an interactive
+   REPL (default), runs a single `--query` and exits, or serves the admin-compatible SQL query API
+   over HTTP with `--listen` so existing tooling (e.g. `restate sql`) can be pointed at it.
+
+The tool is strictly read-only: the query engine rejects DDL/DML, and it only ever imports and reads
+partition data — it never writes back to the repository or mutates snapshot contents.
+
+## Usage
+
+```shell
+# Interactive REPL over all partitions in the repository
+restate-doctor snapshot s3://my-bucket/snapshots --aws-region us-east-1 --cache-dir /tmp/snap-dbg
+
+# Against a MinIO / S3-compatible endpoint
+restate-doctor snapshot s3://my-bucket/snapshots \
+    --aws-endpoint-url http://localhost:9000 \
+    --aws-allow-http \
+    --aws-access-key-id minioadmin \
+    --aws-secret-access-key minioadmin \
+    --cache-dir /tmp/snap-dbg
+
+# One-shot query, then exit
+restate-doctor snapshot s3://my-bucket/snapshots --aws-region us-east-1 \
+    --query "SELECT id, target_service_name FROM sys_invocation_status LIMIT 10"
+
+# Restrict to a single partition
+restate-doctor snapshot s3://my-bucket/snapshots --aws-region us-east-1 --partition-id 0
+
+# Serve the admin-compatible SQL query API (defaults to 127.0.0.1:9078)
+restate-doctor snapshot s3://my-bucket/snapshots --aws-region us-east-1 --listen 127.0.0.1:9078
+```
+
+The `--listen` server exposes a single `POST /query` endpoint with the same request/response
+contract as a live worker's admin `/query` endpoint: a JSON body `{"query": "<sql>"}`, returning an
+Arrow IPC stream by default or JSON when the request carries `Accept: application/json`.
+
+```shell
+curl -s http://localhost:9078/query \
+    -H 'content-type: application/json' \
+    -H 'accept: application/json' \
+    -d '{"query":"SELECT service_name, service_key FROM state LIMIT 10"}'
+```
+
+In the REPL, terminate statements with `;`. Use `\q` (or Ctrl-D) to exit; Ctrl-C clears the current
+statement. Query history is persisted under `<cache-dir>/.snapshot-debugger-history`.
+
+```
+sql> SELECT table_name FROM information_schema.tables;
+sql> SELECT service_name, service_key, key FROM state LIMIT 20;
+```
+
+## Options
+
+| Flag | Description |
+| --- | --- |
+| `<repository>` | Snapshot repository base URL, e.g. `s3://my-bucket/snapshots` (positional, required). |
+| `--cache-dir <dir>` | Local directory where snapshots are imported and cached. Default: `./snapshot-debugger-data`. |
+| `--partition-id <id>` | Inspect only this partition instead of all partitions in the repository. |
+| `--cluster-name <name>` | Cluster name to validate snapshots against (auto-detected if omitted). |
+| `--query <sql>` | Run a single query, print the result, and exit (no REPL). |
+| `--listen [<addr>]` | Serve the admin-compatible SQL query API (`POST /query`) instead of the REPL. Defaults to `127.0.0.1:9078` when given without a value. Mutually exclusive with `--query`. |
+| `--aws-region <region>` | AWS region of the object store (also inferable from the environment). |
+| `--aws-endpoint-url <url>` | Object store endpoint override (required for MinIO and other S3-compatible stores). |
+| `--aws-profile <profile>` | AWS configuration profile to use. |
+| `--aws-access-key-id <id>` | S3 access key id (or MinIO username). |
+| `--aws-secret-access-key <key>` | S3 secret access key (or MinIO password). |
+| `--aws-session-token <token>` | S3 session token (for short-term STS credentials). |
+| `--aws-allow-http` | Allow plain HTTP to the object store endpoint (required for non-HTTPS endpoints). |
+
+Standard AWS environment variables and config files are honoured via the AWS SDK, so the
+`--aws-*` flags are only needed to override them.
+
+## Available tables
+
+Only the partition-store-backed tables are exposed (the ones whose data actually lives in a
+snapshot):
+
+- `sys_invocation_status`, `sys_invocation_state`, and the `sys_invocation` view
+- `sys_keyed_service_status`, `sys_locks`, `state`
+- `sys_journal`, `sys_journal_events`
+- `sys_inbox`, `sys_promise`
+- `sys_vqueue_meta`, `sys_vqueues`
+
+Use `SELECT table_name FROM information_schema.tables` to list them at runtime, and
+`DESCRIBE <table>` to see a table's columns.
+
+The cluster-wide tables (`sys_node`, `sys_partition`, `sys_logs`, …) and the schema-registry tables
+(`sys_deployment`, `sys_service`, `sys_rules`) are **not** available: they require a live cluster /
+schema registry that a standalone snapshot has no access to. The leader-owned columns of
+`sys_invocation_state` (invoker retry/failure state) read as `NULL`, since that state is ephemeral
+and never captured in a snapshot.
+
+## Limitations
+
+- Reads the **latest** snapshot per partition; it does not select older retained snapshots.
+- A snapshot reflects a point in time (its `min_applied_lsn`); it is not the live state of a running
+  partition.

--- a/tools/restate-doctor/src/commands/snapshot/mod.rs
+++ b/tools/restate-doctor/src/commands/snapshot/mod.rs
@@ -1,0 +1,431 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Opens Restate partition snapshots from a snapshot repository (S3 or compatible) and runs SQL
+//! queries against them — without a running cluster. It auto-discovers the partitions in the
+//! repository, downloads each partition's latest snapshot (caching the imported store locally so
+//! re-runs skip the download), wires up the partition store and the DataFusion query layer, and
+//! drops you into an interactive SQL terminal.
+
+use std::net::SocketAddr;
+use std::num::NonZeroUsize;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::Context;
+use async_trait::async_trait;
+use bytestring::ByteString;
+use cling::prelude::*;
+use object_store::path::Path as ObjectPath;
+use object_store::{ObjectStore, ObjectStoreExt};
+use tracing::info;
+use url::Url;
+
+use restate_cli_util::{c_println, c_warn};
+use restate_core::task_center::TaskCenterFutureExt;
+use restate_core::{
+    MetadataBuilder, MetadataManager, MetadataWriter, TaskCenterBuilder, spawn_metadata_manager,
+};
+use restate_metadata_store::{
+    MetadataStore, MetadataStoreClient, ProvisionError, ReadError, WriteError,
+};
+use restate_object_store_util::create_object_store_client;
+use restate_partition_store::PartitionStoreManager;
+use restate_partition_store::snapshots::SnapshotRepository;
+use restate_rocksdb::RocksDbManager;
+use restate_storage_query_datafusion::context::{PartitionTables, QueryContext, SelectPartitions};
+use restate_storage_query_datafusion::remote_query_scanner_manager::RemoteScannerManager;
+use restate_types::Version;
+use restate_types::clock::ClockUpkeep;
+use restate_types::config::{Configuration, ObjectStoreOptions, set_current_config};
+use restate_types::errors::GenericError;
+use restate_types::identifiers::PartitionId;
+use restate_types::memory::NonZeroByteCount;
+use restate_types::metadata::{Precondition, VersionedValue};
+use restate_types::net::metadata::MetadataContainer;
+use restate_types::nodes_config::{ClusterFingerprint, NodesConfiguration};
+use restate_types::partition_table::Partition;
+use restate_types::sharding::KeyRange;
+
+mod repl;
+mod server;
+
+/// Run SQL queries against Restate partition snapshots from a repository.
+#[derive(Run, Parser, Collect, Clone)]
+#[cling(run = "run_snapshot")]
+pub struct SnapshotArgs {
+    /// Snapshot repository base URL, e.g. `s3://my-bucket/snapshots`.
+    repository: String,
+
+    /// AWS region of the object store (also inferable from the environment).
+    #[arg(long)]
+    aws_region: Option<String>,
+
+    /// Object store API endpoint URL override (required for Minio and other S3-compatible stores).
+    #[arg(long)]
+    aws_endpoint_url: Option<String>,
+
+    /// AWS configuration profile to use.
+    #[arg(long)]
+    aws_profile: Option<String>,
+
+    /// S3 access key id (or Minio username).
+    #[arg(long)]
+    aws_access_key_id: Option<String>,
+
+    /// S3 secret access key (or Minio password).
+    #[arg(long)]
+    aws_secret_access_key: Option<String>,
+
+    /// S3 session token (for short-term STS credentials).
+    #[arg(long)]
+    aws_session_token: Option<String>,
+
+    /// Allow plain HTTP to the object store endpoint (required for non-HTTPS endpoints).
+    #[arg(long)]
+    aws_allow_http: bool,
+
+    /// Local directory where downloaded snapshots are imported and cached.
+    #[arg(long, default_value = "./snapshot-debugger-data")]
+    cache_dir: PathBuf,
+
+    /// Inspect only this partition id instead of all partitions in the repository.
+    #[arg(long)]
+    partition_id: Option<u16>,
+
+    /// Cluster name to validate snapshots against (auto-detected from the repository if omitted).
+    #[arg(long)]
+    cluster_name: Option<String>,
+
+    /// Run a single SQL query, print the result, and exit (instead of starting the REPL).
+    #[arg(long)]
+    query: Option<String>,
+
+    /// Serve the admin-compatible SQL query API (POST /query) on this address instead of starting
+    /// the REPL. Defaults to 127.0.0.1:9078 when given without a value.
+    #[arg(
+        long,
+        value_name = "ADDR",
+        num_args = 0..=1,
+        default_missing_value = "127.0.0.1:9078",
+        conflicts_with = "query"
+    )]
+    listen: Option<SocketAddr>,
+
+    #[clap(long, default_value = "2147483648")]
+    rocksdb_memory_budget: NonZeroUsize,
+}
+
+impl SnapshotArgs {
+    fn object_store_options(&self) -> ObjectStoreOptions {
+        ObjectStoreOptions {
+            aws_profile: self.aws_profile.clone(),
+            aws_region: self.aws_region.clone(),
+            aws_access_key_id: self.aws_access_key_id.clone(),
+            aws_secret_access_key: self.aws_secret_access_key.clone(),
+            aws_session_token: self.aws_session_token.clone(),
+            aws_endpoint_url: self.aws_endpoint_url.clone(),
+            aws_allow_http: self.aws_allow_http.then_some(true),
+        }
+    }
+}
+
+/// A fixed set of locally-opened partitions handed to the DataFusion query layer.
+#[derive(Clone, Debug)]
+struct LocalPartitions(Arc<Vec<(PartitionId, Partition)>>);
+
+#[async_trait]
+impl SelectPartitions for LocalPartitions {
+    async fn get_live_partitions(&self) -> Result<Vec<(PartitionId, Partition)>, GenericError> {
+        Ok((*self.0).clone())
+    }
+}
+
+/// A metadata store with no backing storage. The debugger publishes the nodes configuration
+/// directly into the in-process metadata manager and never needs durable metadata, so reads are
+/// always empty and writes are accepted as no-ops.
+#[derive(Debug, Default)]
+struct OfflineMetadataStore;
+
+#[async_trait]
+impl MetadataStore for OfflineMetadataStore {
+    async fn get(&self, _key: ByteString) -> Result<Option<VersionedValue>, ReadError> {
+        Ok(None)
+    }
+
+    async fn get_version(&self, _key: ByteString) -> Result<Option<Version>, ReadError> {
+        Ok(None)
+    }
+
+    async fn put(
+        &self,
+        _key: ByteString,
+        _value: VersionedValue,
+        _precondition: Precondition,
+    ) -> Result<(), WriteError> {
+        Ok(())
+    }
+
+    async fn delete(
+        &self,
+        _key: ByteString,
+        _precondition: Precondition,
+    ) -> Result<(), WriteError> {
+        Ok(())
+    }
+
+    async fn provision(
+        &self,
+        _nodes_configuration: &NodesConfiguration,
+    ) -> Result<bool, ProvisionError> {
+        Ok(true)
+    }
+}
+
+pub async fn run_snapshot(args: &SnapshotArgs) -> anyhow::Result<()> {
+    let repository_url =
+        Url::parse(&args.repository).context("failed to parse the snapshot repository URL")?;
+    let object_store_options = args.object_store_options();
+
+    // Seed configuration: the partition store and the snapshot repository both read their settings
+    // from the global configuration, so it must be set before either is created.
+    let mut config = Configuration::default();
+    config.common.set_base_dir(&args.cache_dir);
+    config.worker.snapshots.destination = Some(args.repository.clone());
+    config.worker.snapshots.object_store = object_store_options.clone();
+    config
+        .worker
+        .storage
+        .set_rocksdb_memory_budget(NonZeroByteCount::new(args.rocksdb_memory_budget));
+
+    set_current_config(config.clone());
+
+    // Reuse the ambient multi-threaded Tokio runtime that restate-doctor's `#[tokio::main]` set up,
+    // rather than building a dedicated one. Tracing and CLI context are already initialized by the
+    // top-level `init`, so they are not set up again here.
+    let tc = TaskCenterBuilder::default()
+        .default_runtime_handle(tokio::runtime::Handle::current())
+        .options(config.common.clone())
+        .build()
+        .expect("task center builds")
+        .into_handle();
+
+    // The metadata manager owns the global metadata (incl. the nodes configuration whose cluster
+    // name snapshot downloads are validated against). An in-memory store is enough offline.
+    let metadata_builder = MetadataBuilder::default();
+    let metadata = metadata_builder.to_metadata();
+    let metadata_manager = MetadataManager::new(
+        metadata_builder,
+        MetadataStoreClient::new(OfflineMetadataStore, None),
+    );
+    let metadata_writer = metadata_manager.writer();
+    tc.try_set_global_metadata(metadata);
+
+    let task_center = tc.clone();
+    async move {
+        let _upkeep = ClockUpkeep::start().expect("clock upkeep starts");
+        spawn_metadata_manager(metadata_manager)?;
+
+        let result = run(
+            args,
+            &repository_url,
+            &object_store_options,
+            metadata_writer,
+        )
+        .await;
+
+        task_center.shutdown_node("completed", 0).await;
+        result
+    }
+    .in_tc(&tc)
+    .await
+}
+
+async fn run(
+    args: &SnapshotArgs,
+    repository_url: &Url,
+    object_store_options: &ObjectStoreOptions,
+    metadata_writer: MetadataWriter,
+) -> anyhow::Result<()> {
+    let config = Configuration::pinned();
+
+    // A standalone client used only for discovering partitions and the cluster identity, before
+    // the partition store machinery is up.
+    let object_store = create_object_store_client(
+        repository_url.clone(),
+        object_store_options,
+        &config.worker.snapshots.object_store_retry_policy,
+    )
+    .await
+    .context("failed to connect to the snapshot repository")?;
+    let prefix = ObjectPath::from(repository_url.path());
+
+    let partition_ids = match args.partition_id {
+        Some(id) => vec![PartitionId::new_unchecked(id)],
+        None => discover_partitions(object_store.as_ref(), &prefix).await?,
+    };
+    anyhow::ensure!(
+        !partition_ids.is_empty(),
+        "no partitions found in the snapshot repository at {repository_url}"
+    );
+    c_println!(
+        "Found {} partition(s): {}",
+        partition_ids.len(),
+        partition_ids
+            .iter()
+            .map(|p| p.to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    // Publish a nodes configuration whose cluster identity matches the repository, otherwise the
+    // snapshot download validation (cluster name / fingerprint) rejects every snapshot.
+    let (cluster_name, cluster_fingerprint) = match &args.cluster_name {
+        Some(name) => (name.clone(), None),
+        None => detect_cluster_identity(object_store.as_ref(), &prefix, partition_ids[0]).await?,
+    };
+    info!(%cluster_name, "Using cluster identity for snapshot validation");
+    let nodes_config = NodesConfiguration::new(
+        Version::MIN,
+        cluster_name,
+        cluster_fingerprint.unwrap_or_else(ClusterFingerprint::generate),
+    );
+    metadata_writer
+        .update(MetadataContainer::NodesConfiguration(Arc::new(
+            nodes_config,
+        )))
+        .await?;
+
+    RocksDbManager::init();
+    let manager = PartitionStoreManager::create(true)
+        .await
+        .context("failed to create the partition store manager")?;
+    let snapshot_repository = SnapshotRepository::new_from_config(
+        &config.worker.snapshots,
+        config.worker.storage.snapshots_staging_dir(),
+    )
+    .await?
+    .context("snapshot repository is not configured")?;
+
+    let mut partitions = Vec::with_capacity(partition_ids.len());
+    for partition_id in partition_ids {
+        let partition = open_partition(&manager, &snapshot_repository, partition_id).await?;
+        partitions.push((partition_id, partition));
+    }
+
+    let query_context = QueryContext::create(
+        &config.admin.query_engine,
+        PartitionTables::new(
+            LocalPartitions(Arc::new(partitions)),
+            manager,
+            RemoteScannerManager::local_only(restate_core::Metadata::current()),
+        ),
+    )
+    .await
+    .context("failed to build the query context")?;
+
+    match (&args.query, args.listen) {
+        (Some(query), _) => repl::run_query(&query_context, query).await,
+        (None, Some(addr)) => server::run_server(query_context, addr).await,
+        (None, None) => repl::run_repl(&query_context, &args.cache_dir).await,
+    }
+}
+
+/// Opens a partition store, reusing a previously imported local store when present and otherwise
+/// downloading and importing the partition's latest snapshot from the repository.
+async fn open_partition(
+    manager: &Arc<PartitionStoreManager>,
+    snapshot_repository: &SnapshotRepository,
+    partition_id: PartitionId,
+) -> anyhow::Result<Partition> {
+    let probe = Partition::new(partition_id, KeyRange::FULL);
+    let data_path = Configuration::pinned()
+        .worker
+        .storage
+        .data_dir(probe.db_name(true).as_ref());
+
+    if data_path.exists() {
+        // Reuse the cached import. The key range argument is irrelevant here: no import happens
+        // when a local store already exists, and the real range is read back from the store.
+        let store = manager.open(&probe, None).await?;
+        let range = store.partition_key_range();
+        c_println!("Partition {partition_id}: reusing cached local store");
+        return Ok(Partition::new(partition_id, range));
+    }
+
+    c_println!("Partition {partition_id}: downloading latest snapshot…");
+    let snapshot = snapshot_repository
+        .get_latest(partition_id)
+        .await
+        .with_context(|| format!("failed to download snapshot for partition {partition_id}"))?
+        .with_context(|| format!("no snapshot found for partition {partition_id}"))?;
+    let partition = Partition::new(partition_id, snapshot.key_range);
+    let store = manager.open_from_snapshot(&partition, snapshot).await?;
+    drop(store);
+    Ok(partition)
+}
+
+/// Lists the partition ids present in the repository by enumerating the `<prefix>/<partition_id>/`
+/// directories.
+async fn discover_partitions(
+    object_store: &dyn ObjectStore,
+    prefix: &ObjectPath,
+) -> anyhow::Result<Vec<PartitionId>> {
+    let listing = object_store
+        .list_with_delimiter(Some(prefix))
+        .await
+        .context("failed to list the snapshot repository")?;
+
+    let mut partitions: Vec<PartitionId> = listing
+        .common_prefixes
+        .iter()
+        .filter_map(|path| path.parts().next_back())
+        .filter_map(|segment| segment.as_ref().parse::<u16>().ok())
+        .map(PartitionId::new_unchecked)
+        .collect();
+    partitions.sort();
+    partitions.dedup();
+    Ok(partitions)
+}
+
+/// Reads `latest.json` for a partition to learn the cluster name and fingerprint the snapshots were
+/// written with.
+async fn detect_cluster_identity(
+    object_store: &dyn ObjectStore,
+    prefix: &ObjectPath,
+    partition_id: PartitionId,
+) -> anyhow::Result<(String, Option<ClusterFingerprint>)> {
+    let latest_path = prefix
+        .clone()
+        .join(partition_id.to_string())
+        .join("latest.json");
+    let bytes = object_store
+        .get(&latest_path)
+        .await
+        .with_context(|| format!("failed to read '{latest_path}' from the repository"))?
+        .bytes()
+        .await?;
+
+    let latest: serde_json::Value = serde_json::from_slice(&bytes)?;
+    let cluster_name = latest
+        .get("cluster_name")
+        .and_then(|v| v.as_str())
+        .context("snapshot metadata is missing 'cluster_name'")?
+        .to_owned();
+    let cluster_fingerprint = latest
+        .get("cluster_fingerprint")
+        .and_then(|v| v.as_u64())
+        .and_then(|v| ClusterFingerprint::try_from(v).ok());
+
+    if cluster_fingerprint.is_none() {
+        c_warn!("Snapshot has no cluster fingerprint; skipping fingerprint validation");
+    }
+    Ok((cluster_name, cluster_fingerprint))
+}

--- a/tools/restate-doctor/src/commands/snapshot/repl.rs
+++ b/tools/restate-doctor/src/commands/snapshot/repl.rs
@@ -1,0 +1,120 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Interactive SQL terminal and result rendering for the snapshot debugger.
+
+use std::path::Path;
+use std::time::Instant;
+
+use anyhow::Result;
+use arrow::error::ArrowError;
+use arrow::util::display::{ArrayFormatter, FormatOptions};
+use comfy_table::{Cell, Table};
+use futures::TryStreamExt;
+use rustyline::DefaultEditor;
+use rustyline::error::ReadlineError;
+
+use restate_cli_util::ui::console::{Styled, StyledTable};
+use restate_cli_util::ui::stylesheet::Style;
+use restate_cli_util::{c_eprintln, c_error, c_println};
+use restate_storage_query_datafusion::context::QueryContext;
+
+/// Runs a single query, renders the result as a table, and reports timing.
+pub(crate) async fn run_query(ctx: &QueryContext, query: &str) -> Result<()> {
+    let start = Instant::now();
+    let result = ctx.execute(query).await?;
+    let batches: Vec<_> = result.stream.try_collect().await?;
+
+    let mut table = Table::new_styled();
+    if let Some(first) = batches.first() {
+        let headers: Vec<String> = first
+            .schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().to_uppercase())
+            .collect();
+        table.set_styled_header(headers);
+    }
+
+    let format_options = FormatOptions::default().with_display_error(true);
+    for batch in &batches {
+        let formatters = batch
+            .columns()
+            .iter()
+            .map(|c| ArrayFormatter::try_new(c.as_ref(), &format_options))
+            .collect::<Result<Vec<_>, ArrowError>>()?;
+
+        for row in 0..batch.num_rows() {
+            let cells: Vec<Cell> = formatters.iter().map(|f| Cell::new(f.value(row))).collect();
+            table.add_row(cells);
+        }
+    }
+
+    let row_count = table.row_count();
+    if row_count > 0 {
+        c_println!("{table}");
+    }
+    c_eprintln!(
+        "{} row(s). Query took {:?}",
+        row_count,
+        Styled(Style::Notice, start.elapsed())
+    );
+    Ok(())
+}
+
+/// Starts the interactive SQL terminal, persisting history under the data directory.
+pub(crate) async fn run_repl(ctx: &QueryContext, data_dir: &Path) -> Result<()> {
+    let history_path = data_dir.join(".snapshot-debugger-history");
+    let mut editor = DefaultEditor::new()?;
+    let _ = editor.load_history(&history_path);
+
+    c_println!("Connected. Enter SQL queries terminated by ';'. Type \\q or Ctrl-D to exit.");
+    c_println!("Tip: `SELECT table_name FROM information_schema.tables` lists available tables.");
+
+    let mut buffer = String::new();
+    loop {
+        let prompt = if buffer.is_empty() { "sql> " } else { "  -> " };
+        match editor.readline(prompt) {
+            Ok(line) => {
+                let trimmed = line.trim();
+                if buffer.is_empty() && matches!(trimmed, "\\q" | "quit" | "exit") {
+                    break;
+                }
+                buffer.push_str(&line);
+                buffer.push('\n');
+
+                // Execute once we have a complete, ';'-terminated statement.
+                if buffer.trim_end().ends_with(';') {
+                    let statement = buffer.trim().trim_end_matches(';').trim().to_owned();
+                    buffer.clear();
+                    if statement.is_empty() {
+                        continue;
+                    }
+                    let _ = editor.add_history_entry(&statement);
+                    if let Err(err) = run_query(ctx, &statement).await {
+                        c_error!("{err}");
+                    }
+                }
+            }
+            Err(ReadlineError::Interrupted) => {
+                // Ctrl-C clears the in-progress statement rather than exiting.
+                buffer.clear();
+            }
+            Err(ReadlineError::Eof) => break,
+            Err(err) => {
+                c_error!("{err}");
+                break;
+            }
+        }
+    }
+
+    let _ = editor.save_history(&history_path);
+    Ok(())
+}

--- a/tools/restate-doctor/src/commands/snapshot/server.rs
+++ b/tools/restate-doctor/src/commands/snapshot/server.rs
@@ -1,0 +1,291 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! An HTTP server exposing the admin-compatible SQL query API (`POST /query`) over the opened
+//! snapshots, so existing tooling (e.g. `restate sql`) can be pointed at a snapshot instead of a
+//! live cluster. Mirrors the request/response contract of the worker's `/admin/query` endpoint.
+
+use std::io::Write;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+
+use anyhow::Context as _;
+use arrow::array::RecordBatch;
+use arrow::datatypes::Schema;
+use arrow::ipc::writer::StreamWriter;
+use arrow::json::writer::JsonArray;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::{Json, Router, http};
+use bytes::Bytes;
+use datafusion::error::DataFusionError;
+use datafusion::execution::SendableRecordBatchStream;
+use futures::{Stream, StreamExt, TryStreamExt, ready};
+use http::{HeaderMap, HeaderValue};
+use http_body::Frame;
+use http_body_util::StreamBody;
+use serde::{Deserialize, Serialize};
+use tracing::{Level, enabled, warn};
+
+use restate_cli_util::c_println;
+use restate_storage_query_datafusion::context::QueryContext;
+
+/// SQL query request body, matching the admin `/query` endpoint.
+#[derive(Debug, Deserialize)]
+struct QueryRequest {
+    /// SQL query to run against the snapshot.
+    query: String,
+}
+
+/// Error response body for the query endpoint.
+#[derive(Debug, Serialize)]
+struct QueryErrorBody {
+    message: String,
+}
+
+/// Errors that can occur when executing a query.
+#[derive(Debug, thiserror::Error)]
+enum QueryError {
+    #[error("Datafusion error: {0}")]
+    Datafusion(#[from] DataFusionError),
+}
+
+impl IntoResponse for QueryError {
+    fn into_response(self) -> Response {
+        let status_code = match &self {
+            QueryError::Datafusion(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+        (
+            status_code,
+            Json(QueryErrorBody {
+                message: self.to_string(),
+            }),
+        )
+            .into_response()
+    }
+}
+
+/// Builds the router, binds the listener, and serves the query API until shutdown.
+pub(crate) async fn run_server(ctx: QueryContext, addr: SocketAddr) -> anyhow::Result<()> {
+    let router = Router::new()
+        .route("/query", post(query))
+        .with_state(Arc::new(ctx));
+
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .with_context(|| format!("failed to bind {addr}"))?;
+    let local_addr = listener.local_addr()?;
+    c_println!("Query API listening on http://{local_addr}/query");
+    c_println!(
+        "Try: curl -s http://{local_addr}/query -H 'content-type: application/json' \\\n  -H 'accept: application/json' -d '{{\"query\":\"SELECT table_name FROM information_schema.tables\"}}'"
+    );
+
+    axum::serve(listener, router)
+        .await
+        .context("query API server failed")
+}
+
+/// Query the snapshot state by using SQL. Negotiates the response format via the `Accept` header:
+/// JSON (`application/json`) or, by default, Arrow IPC stream
+/// (`application/vnd.apache.arrow.stream`).
+async fn query(
+    State(ctx): State<Arc<QueryContext>>,
+    headers: HeaderMap,
+    Json(payload): Json<QueryRequest>,
+) -> Result<Response, QueryError> {
+    let query_result = ctx.execute(&payload.query).await?;
+
+    let (result_stream, content_type) = match headers.get(http::header::ACCEPT) {
+        Some(v) if v == HeaderValue::from_static("application/json") => (
+            WriteRecordBatchStream::<JsonWriter>::new(query_result.stream, payload.query)?
+                .map_ok(Frame::data)
+                .left_stream(),
+            "application/json",
+        ),
+        _ => (
+            WriteRecordBatchStream::<StreamWriter<Vec<u8>>>::new(
+                query_result.stream,
+                payload.query,
+            )?
+            .map_ok(Frame::data)
+            .right_stream(),
+            "application/vnd.apache.arrow.stream",
+        ),
+    };
+
+    let mut result_stream = result_stream.peekable();
+
+    // Return an error (instead of just closing the stream) if getting the first record batch fails
+    // (e.g. out of memory).
+    if let Some(Err(_)) = futures::stream::Peekable::peek(Pin::new(&mut result_stream)).await {
+        let err = result_stream.next().await.unwrap().unwrap_err();
+        return Err(err.into());
+    }
+
+    Ok(Response::builder()
+        .header(http::header::CONTENT_TYPE, content_type)
+        .body(StreamBody::new(result_stream))
+        .expect("content-type header is correct")
+        .into_response())
+}
+
+trait RecordBatchWriter
+where
+    Self: Sized,
+{
+    /// Create the writer.
+    fn new(schema: &Schema) -> Result<Self, DataFusionError>;
+
+    /// Write a single batch to the writer.
+    fn write(&mut self, batch: &RecordBatch) -> Result<Bytes, DataFusionError>;
+
+    /// Write footer or termination data, then mark the writer as done.
+    fn finish(&mut self) -> Result<Bytes, DataFusionError>;
+}
+
+impl RecordBatchWriter for StreamWriter<Vec<u8>> {
+    fn new(schema: &Schema) -> Result<Self, DataFusionError> {
+        Ok(Self::try_new(Vec::new(), schema)?)
+    }
+
+    fn write(&mut self, batch: &RecordBatch) -> Result<Bytes, DataFusionError> {
+        self.write(batch)?;
+        let bytes = Bytes::copy_from_slice(self.get_ref());
+        self.get_mut().clear();
+        Ok(bytes)
+    }
+
+    fn finish(&mut self) -> Result<Bytes, DataFusionError> {
+        self.finish()?;
+        let bytes = Bytes::copy_from_slice(self.get_ref());
+        self.get_mut().clear();
+        Ok(bytes)
+    }
+}
+
+struct WriteRecordBatchStream<W> {
+    done: bool,
+    record_batch_stream: SendableRecordBatchStream,
+    stream_writer: W,
+    query: String,
+}
+
+impl<W: RecordBatchWriter> WriteRecordBatchStream<W> {
+    fn new(
+        record_batch_stream: SendableRecordBatchStream,
+        query: String,
+    ) -> Result<Self, DataFusionError> {
+        Ok(WriteRecordBatchStream {
+            done: false,
+            stream_writer: W::new(&record_batch_stream.schema())?,
+            record_batch_stream,
+            query,
+        })
+    }
+}
+
+impl<W: RecordBatchWriter + Unpin> Stream for WriteRecordBatchStream<W> {
+    type Item = Result<Bytes, DataFusionError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.done {
+            return Poll::Ready(None);
+        }
+
+        let record_batch = ready!(self.record_batch_stream.poll_next_unpin(cx));
+
+        if let Some(record_batch) = record_batch {
+            match record_batch.and_then(|record_batch| self.stream_writer.write(&record_batch)) {
+                Ok(bytes) => Poll::Ready(Some(Ok(bytes))),
+                Err(err) => {
+                    if enabled!(Level::DEBUG) {
+                        warn!(query = %self.query, %err, "Query failed");
+                    } else {
+                        warn!(%err, "Query failed");
+                    }
+
+                    self.done = true;
+                    Poll::Ready(Some(Err(err)))
+                }
+            }
+        } else {
+            self.done = true;
+            match self.stream_writer.finish() {
+                Err(err) => Poll::Ready(Some(Err(err))),
+                Ok(bytes) => Poll::Ready(Some(Ok(bytes))),
+            }
+        }
+    }
+}
+
+/// Shared buffer that gives us read-back access to the bytes the JSON writer produces (the arrow
+/// JSON writer owns its sink and exposes no mutable accessor). Uncontended in practice.
+#[derive(Clone)]
+struct LockWriter(Arc<Mutex<Vec<u8>>>);
+
+impl LockWriter {
+    fn new() -> Self {
+        Self(Arc::new(Mutex::new(Vec::new())))
+    }
+
+    fn take(&self) -> Vec<u8> {
+        let mut vec = self.0.lock().expect("lock is not poisoned");
+        let new_vec = Vec::with_capacity(vec.capacity());
+        std::mem::replace(&mut vec, new_vec)
+    }
+}
+
+impl Write for LockWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().expect("lock is not poisoned").write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.0.lock().expect("lock is not poisoned").flush()
+    }
+}
+
+struct JsonWriter {
+    json_writer: arrow::json::Writer<LockWriter, JsonArray>,
+    lock_writer: LockWriter,
+    finished: bool,
+}
+
+impl RecordBatchWriter for JsonWriter {
+    fn new(_schema: &Schema) -> Result<Self, DataFusionError> {
+        let mut lock_writer = LockWriter::new();
+        // We write out under the 'rows' key so that we may add extra keys later (e.g. 'schema').
+        lock_writer.write_all(br#"{"rows":"#)?;
+        Ok(Self {
+            json_writer: arrow::json::Writer::new(lock_writer.clone()),
+            lock_writer,
+            finished: false,
+        })
+    }
+
+    fn write(&mut self, batch: &RecordBatch) -> Result<Bytes, DataFusionError> {
+        self.json_writer.write(batch)?;
+        Ok(Bytes::from(self.lock_writer.take()))
+    }
+
+    fn finish(&mut self) -> Result<Bytes, DataFusionError> {
+        if !self.finished {
+            self.finished = true;
+
+            self.json_writer.finish()?;
+            self.lock_writer.write_all(b"}")?;
+        }
+        Ok(Bytes::from(self.lock_writer.take()))
+    }
+}


### PR DESCRIPTION

## Summary

Adds a `snapshot` subcommand to `restate-doctor` for inspecting the data inside a Restate
**partition snapshot** with SQL — without spinning up a cluster.

Today the only way to run SQL over partition data is through a live worker's admin `/query`
endpoint (what `restate sql` talks to). When debugging an incident we often have only the S3
snapshot repository, not a running cluster. This subcommand points at a snapshot repository (S3 or
compatible), downloads the partitions' latest snapshots, opens the partition store + DataFusion
query layer locally, and drops you into an interactive SQL terminal — alongside the existing
partition-store / log-server / id diagnostics.

## What it does

1. Connects to the snapshot repository and **auto-discovers** the partitions under the prefix
   (or a single one via `--partition-id`).
2. **Auto-detects** the cluster name/fingerprint from the repository so snapshot-download
   validation passes (override with `--cluster-name`).
3. Downloads each partition's latest snapshot and imports it into a local RocksDB store under
   `--cache-dir`. The import is **cached** — a re-run against the same `--cache-dir` reuses the
   local store and skips the download.
4. Opens DataFusion over the imported partitions and runs either a one-shot `--query`, an
   interactive `rustyline` REPL (results rendered as tables, reusing the CLI's rendering), or an
   admin-compatible `POST /query` HTTP server via `--listen`.

The tool is strictly read-only: the query engine rejects DDL/DML, and it only ever imports and
reads partition data.

## Usage

```shell
# Interactive REPL over all partitions
restate-doctor snapshot s3://my-bucket/snapshots --aws-region us-east-1 --cache-dir /tmp/snap-dbg

# MinIO / S3-compatible endpoint
restate-doctor snapshot s3://my-bucket/snapshots \
    --aws-endpoint-url http://localhost:9000 --aws-allow-http \
    --aws-access-key-id minioadmin --aws-secret-access-key minioadmin

# One-shot
restate-doctor snapshot s3://my-bucket/snapshots --aws-region us-east-1 \
    --query "SELECT id, target_service_name FROM sys_invocation_status LIMIT 10"
```

See tools/restate-doctor/src/commands/snapshot/README.md for the full flag list and available
tables.

## Available tables

Only the partition-store-backed tables are exposed (sys_invocation_status, sys_invocation_state,
the sys_invocation view, sys_keyed_service_status, sys_locks, state, sys_journal,
sys_journal_events, sys_inbox, sys_promise, sys_vqueue_meta, sys_vqueues). Cluster-wide and
schema-registry tables are not available offline; the leader-only columns of sys_invocation_state
read as NULL.

## Limitations

- Reads the latest snapshot per partition (no older retained snapshots).
- A snapshot is a point in time (its min_applied_lsn), not live partition state.
