### PR TITLE
[docker] introduce a new restate-tools docker image

### DIFF
--- a/.github/workflows/docker-tools.yml
+++ b/.github/workflows/docker-tools.yml
@@ -1,0 +1,113 @@
+name: Build Tools Docker image
+
+# Builds the CLI tools image (restate, restatectl, restate-doctor) from
+# docker/tools.Dockerfile and pushes it to ghcr.io/restatedev/restate-tools.
+# Runs daily so the tools image tracks the latest main.
+
+on:
+  schedule:
+    # Run daily at 02:00 UTC
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+env:
+  REPOSITORY_OWNER: ${{ github.repository_owner }}
+  GHCR_REGISTRY: "ghcr.io"
+  GHCR_REGISTRY_USERNAME: ${{ github.actor }}
+  GHCR_REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  IMAGE_NAME: restate-tools
+
+jobs:
+  build-and-push-image:
+    if: github.repository_owner == 'restatedev'
+    runs-on: warp-ubuntu-latest-x64-16x
+    timeout-minutes: 70
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install cargo-hakari
+        if: ${{ hashFiles('.config/hakari.toml') != '' }}
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hakari
+
+      - name: Disable hakari
+        if: ${{ hashFiles('.config/hakari.toml') != '' }}
+        run: cargo hakari disable
+
+      # this is needed to be able to load and push a multiplatform image in one step
+      - name: Set up Docker containerd snapshotter
+        uses: depot/use-containerd-snapshotter-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          # https://docs.warpbuild.com/cache/docker-layer-caching#step-1-set-up-docker-buildx-action
+          driver-opts: |
+            network=host
+
+      - name: Cache sccache
+        id: cache
+        uses: WarpBuilds/cache@v1
+        with:
+          path: sccache-cache
+          key: ${{ runner.os }}-sccache-tools-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Inject sccache-cache into Docker
+        uses: reproducible-containers/buildkit-cache-dance@v3.1.2
+        with:
+          cache-map: |
+            {
+              "sccache-cache": "/var/cache/sccache"
+            }
+          skip-extraction: ${{ steps.cache.outputs.cache-hit }}
+
+      - name: Log into GitHub container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GHCR_REGISTRY }}
+          username: ${{ env.GHCR_REGISTRY_USERNAME }}
+          password: ${{ env.GHCR_REGISTRY_TOKEN }}
+
+      - name: Extract base image from Dockerfile
+        id: base-image
+        run: |
+          BASE_IMAGE=$(grep 'FROM.*AS tools' docker/tools.Dockerfile | head -1 | awk '{print $2}')
+          echo "name=${BASE_IMAGE}" >> $GITHUB_OUTPUT
+          echo "Base image: ${BASE_IMAGE}"
+
+          # Get the base image digest for the amd64 platform
+          BASE_DIGEST=$(docker buildx imagetools inspect "${BASE_IMAGE}" --raw | \
+            jq -r '.manifests[] | select(.platform.architecture == "amd64") | .digest' 2>/dev/null | head -1 || true)
+          echo "digest=${BASE_DIGEST}" >> $GITHUB_OUTPUT
+          echo "Base image digest: ${BASE_DIGEST}"
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GHCR_REGISTRY }}/${{ env.REPOSITORY_OWNER }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=true
+          tags: |
+            type=raw,value={{date 'YYYYMMDD'}}
+          labels: |
+            org.opencontainers.image.base.name=${{ steps.base-image.outputs.name }}
+            org.opencontainers.image.base.digest=${{ steps.base-image.outputs.digest }}
+
+      - name: Build and push Docker image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: "docker/tools.Dockerfile"
+          tags: ${{ steps.meta.outputs.tags }}
+          outputs: type=registry
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64,linux/amd64
+          network: host
+          cache-from: type=gha,url=http://127.0.0.1:49160/,version=1
+          cache-to: type=gha,url=http://127.0.0.1:49160/,mode=max,version=1

--- a/docker/tools.Dockerfile
+++ b/docker/tools.Dockerfile
@@ -47,18 +47,16 @@ RUN --mount=type=cache,target=/var/cache/sccache \
     mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restatectl target/restatectl && \
     mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restate target/restate && \
     mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restate-doctor target/restate-doctor;
-RUN cp docker/scripts/no-restate-debug-symbols.sh target/download-restate-debug-symbols.sh
 
 FROM debian:trixie-slim AS tools
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    jq curl iproute2 iputils-ping tcpdump procps htop sysstat \
-    less ca-certificates file neovim \
+    jq curl iproute2 iputils-ping tcpdump procps htop sysstat iotop \
+    less ca-certificates file neovim binutils linux-perf \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /restate/NOTICE /NOTICE
 COPY --from=builder /restate/LICENSE /LICENSE
 # copy OS roots
 COPY --from=builder /etc/ssl /etc/ssl
-COPY --from=builder /restate/target/download-restate-debug-symbols.sh /usr/local/bin
 COPY --from=builder /restate/target/restatectl /usr/local/bin
 COPY --from=builder /restate/target/restate /usr/local/bin
 COPY --from=builder /restate/target/restate-doctor /usr/local/bin

--- a/docker/tools.Dockerfile
+++ b/docker/tools.Dockerfile
@@ -51,7 +51,7 @@ RUN --mount=type=cache,target=/var/cache/sccache \
 FROM debian:trixie-slim AS tools
 RUN apt-get update && apt-get install --no-install-recommends -y \
     jq curl iproute2 iputils-ping tcpdump procps htop sysstat iotop \
-    less ca-certificates file neovim binutils linux-perf \
+    less ca-certificates file neovim binutils linux-perf du-dust \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /restate/NOTICE /NOTICE
 COPY --from=builder /restate/LICENSE /LICENSE

--- a/docker/tools.Dockerfile
+++ b/docker/tools.Dockerfile
@@ -1,0 +1,66 @@
+# Copyright (c) 2023 - 2024 Restate Software, Inc., Restate GmbH.
+# All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# NB this version is also pinned in dist-workspace.toml for release binary builds
+FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:1.17.0 AS planner
+COPY . .
+RUN just chef-prepare
+
+FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:1.17.0 AS base
+COPY --from=planner /restate/recipe.json recipe.json
+COPY justfile justfile
+
+# avoid sharing sccache port between multiplatform builds - they share a network but not a filesystem, so it won't work
+FROM base AS base-amd64
+ARG SCCACHE_SERVER_PORT=4226
+
+FROM base AS base-arm64
+ARG SCCACHE_SERVER_PORT=4227
+
+FROM base-$TARGETARCH AS builder
+ARG SCCACHE_SERVER_PORT
+ARG TARGETARCH
+
+ENV RUSTC_WRAPPER=/usr/bin/sccache
+ENV SCCACHE_DIR=/var/cache/sccache
+
+# Adding new env vars here to get a build working? They're probably also needed in release-build-setup.yml!
+
+# Overrides the behaviour of the release profile re including debug symbols, which in our repo is not to include them.
+# Should be set to 'false' or 'true'. See https://doc.rust-lang.org/cargo/reference/environment-variables.html
+ARG CARGO_PROFILE_RELEASE_DEBUG=false
+# Avoids feature unification by building the three binaries individually
+ARG RESTATE_FEATURES=''
+RUN just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES chef-cook --release -p restate-cli -p restate-doctor -p restatectl
+COPY . .
+
+RUN --mount=type=cache,target=/var/cache/sccache \
+    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --release -p restate-cli -p restate-doctor -p restatectl && \
+    just notice-file && \
+    mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restatectl target/restatectl && \
+    mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restate target/restate && \
+    mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restate-doctor target/restate-doctor;
+RUN cp docker/scripts/no-restate-debug-symbols.sh target/download-restate-debug-symbols.sh
+
+FROM debian:trixie-slim AS tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    jq curl iproute2 iputils-ping tcpdump procps htop sysstat \
+    less ca-certificates file neovim \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /restate/NOTICE /NOTICE
+COPY --from=builder /restate/LICENSE /LICENSE
+# copy OS roots
+COPY --from=builder /etc/ssl /etc/ssl
+COPY --from=builder /restate/target/download-restate-debug-symbols.sh /usr/local/bin
+COPY --from=builder /restate/target/restatectl /usr/local/bin
+COPY --from=builder /restate/target/restate /usr/local/bin
+COPY --from=builder /restate/target/restate-doctor /usr/local/bin
+WORKDIR /
+ENTRYPOINT [ "/bin/bash" ]

--- a/docker/tools.Dockerfile
+++ b/docker/tools.Dockerfile
@@ -51,7 +51,7 @@ RUN --mount=type=cache,target=/var/cache/sccache \
 FROM debian:trixie-slim AS tools
 RUN apt-get update && apt-get install --no-install-recommends -y \
     jq curl iproute2 iputils-ping tcpdump procps htop sysstat iotop \
-    less ca-certificates file neovim binutils linux-perf du-dust \
+    less ca-certificates file neovim binutils linux-perf du-dust hwinfo \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /restate/NOTICE /NOTICE
 COPY --from=builder /restate/LICENSE /LICENSE

--- a/docker/tools.Dockerfile
+++ b/docker/tools.Dockerfile
@@ -61,4 +61,4 @@ COPY --from=builder /restate/target/restatectl /usr/local/bin
 COPY --from=builder /restate/target/restate /usr/local/bin
 COPY --from=builder /restate/target/restate-doctor /usr/local/bin
 WORKDIR /
-ENTRYPOINT [ "/bin/bash" ]
+CMD [ "/bin/bash" ]


### PR DESCRIPTION
This PR introduces a new `restate-tools` image that contains our typical CLI tools `restate` and `restatectl` but also includes `restate-doctor` and bunch of useful linux tooling (top, ss, etc). This image doesn't contain the server though. This is mostly meant to be an internal tool rather than a customer facing one.