### PR TITLE
Upgrade to rust-rocksdb 0.50.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9218,8 +9218,8 @@ dependencies = [
 
 [[package]]
 name = "rust-librocksdb-sys"
-version = "0.44.0+11.1.1"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=432ac4288a219dd70d4c71ccfcd0ad51d6bcc0d1#432ac4288a219dd70d4c71ccfcd0ad51d6bcc0d1"
+version = "0.46.0+11.1.1"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=619c950cdbe8817cc57bdfca909f3fc047bfe093#619c950cdbe8817cc57bdfca909f3fc047bfe093"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -9228,14 +9228,15 @@ dependencies = [
  "libc",
  "libz-sys",
  "lz4-sys",
+ "pkg-config",
  "tikv-jemalloc-sys",
  "zstd-sys",
 ]
 
 [[package]]
 name = "rust-rocksdb"
-version = "0.48.0"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=432ac4288a219dd70d4c71ccfcd0ad51d6bcc0d1#432ac4288a219dd70d4c71ccfcd0ad51d6bcc0d1"
+version = "0.50.0"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=619c950cdbe8817cc57bdfca909f3fc047bfe093#619c950cdbe8817cc57bdfca909f3fc047bfe093"
 dependencies = [
  "libc",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,10 +229,10 @@ reqwest = { version = "0.12", default-features = false, features = [
     "stream",
 ] }
 rlimit = { version = "0.10.2" }
-rocksdb = { version = "0.48.0", package = "rust-rocksdb", features = [
+rocksdb = { version = "0.50.0", package = "rust-rocksdb", features = [
     "multi-threaded-cf",
     "jemalloc",
-], git = "https://github.com/restatedev/rust-rocksdb", rev = "432ac4288a219dd70d4c71ccfcd0ad51d6bcc0d1" }
+], git = "https://github.com/restatedev/rust-rocksdb", rev = "619c950cdbe8817cc57bdfca909f3fc047bfe093" }
 rstest = "0.26.1"
 rustls = { version = "0.23.35", default-features = false, features = ["ring"] }
 schemars = { version = "1.2", features = ["bytes1"] }


### PR DESCRIPTION

The rust-rocksdb fork also includes single-delete support in write-batch and write-batch-with-index.
