### PR TITLE
[VQueues] Use single-delete for vqueues and locks

### DIFF
--- a/crates/partition-store/src/locks_table/mod.rs
+++ b/crates/partition-store/src/locks_table/mod.rs
@@ -209,7 +209,7 @@ impl WriteLockTable for PartitionStoreTransaction<'_> {
             key_buf.split()
         };
 
-        self.raw_delete_cf(KeyKind::Lock, key_buf);
+        self.raw_single_delete_cf(KeyKind::Lock, key_buf);
     }
 }
 

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -875,6 +875,14 @@ impl PartitionStoreTransaction<'_> {
             .delete_cf(self.data_cf_handle, key);
     }
 
+    #[inline]
+    pub fn raw_single_delete_cf(&mut self, _key_kind: KeyKind, key: impl AsRef<[u8]>) {
+        self.write_batch_with_index
+            .as_mut()
+            .expect("transaction valid")
+            .single_delete_cf(self.data_cf_handle, key);
+    }
+
     pub(crate) fn prefix_iterator(
         &self,
         table: TableKind,

--- a/crates/partition-store/src/vqueue_table/mod.rs
+++ b/crates/partition-store/src/vqueue_table/mod.rs
@@ -225,7 +225,7 @@ impl WriteVQueueTable for PartitionStoreTransaction<'_> {
 
     fn delete_vqueue_inbox(&mut self, qid: &VQueueId, stage: Stage, key: &EntryKey) {
         // Note: the key kind here is not used, so we always use the InboxKey.
-        self.raw_delete_cf(
+        self.raw_single_delete_cf(
             KeyKind::VQueueInboxStage,
             inbox::encode_stage_key(stage, qid, key),
         );
@@ -244,7 +244,7 @@ impl WriteVQueueTable for PartitionStoreTransaction<'_> {
         ActiveKeyRef::builder()
             .qid(qid)
             .serialize_to(&mut key_buffer.as_mut());
-        self.raw_delete_cf(KeyKind::VQueueActive, key_buffer);
+        self.raw_single_delete_cf(KeyKind::VQueueActive, key_buffer);
     }
 
     fn put_vqueue_entry_status(
@@ -293,6 +293,7 @@ impl WriteVQueueTable for PartitionStoreTransaction<'_> {
             .id(id)
             .serialize_to(&mut key_buffer.as_mut());
 
+        // Cannot use single delete because we constantly overwrite the same key on transitions
         self.raw_delete_cf(KeyKind::VQueueEntryStatus, key_buffer);
     }
 
@@ -331,7 +332,7 @@ impl WriteVQueueTable for PartitionStoreTransaction<'_> {
             key_buf.split()
         };
 
-        self.raw_delete_cf(KeyKind::VQueueInput, key_buf);
+        self.raw_single_delete_cf(KeyKind::VQueueInput, key_buf);
     }
 }
 


### PR DESCRIPTION

This requires a full compaction + bottommost-level-compaction on the key range of vqueues (v..v+1) and locks before this can be released.


This is a safe change because the two scenarios at which problems can occur are:
- Moving to single delete for an entry that has consecutive puts. Single delete will not make an older put appear.
- A case where a Delete is followed by a SingleDelete with no puts in between. In all cases that I moved, we don't re-delete a previously deleted value.

This is also rollback safe.
