### PR TITLE
partition-store: one-time vqueue/lock compaction to make SingleDelete safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7658,7 +7658,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "jiff",
- "object_store 0.13.2",
+ "object_store",
  "restate-cli-util",
  "restate-core",
  "restate-limiter",

--- a/crates/partition-store/src/error.rs
+++ b/crates/partition-store/src/error.rs
@@ -15,6 +15,7 @@ use codederror::CodedError;
 use restate_core::ShutdownError;
 use restate_rocksdb::RocksError;
 use restate_storage_api::StorageError;
+use restate_types::cluster_marker::ClusterValidationError;
 use restate_types::identifiers::PartitionId;
 
 #[derive(Debug, thiserror::Error)]
@@ -33,6 +34,8 @@ pub enum OpenError {
     RocksDb(#[from] RocksError),
     #[error("open failed due to partition data error: {0}")]
     Storage(#[from] StorageError),
+    #[error("open failed while updating the cluster marker: {0}")]
+    ClusterMarker(#[from] ClusterValidationError),
 }
 
 #[derive(Debug, thiserror::Error, CodedError)]

--- a/crates/partition-store/src/locks_table/mod.rs
+++ b/crates/partition-store/src/locks_table/mod.rs
@@ -209,7 +209,7 @@ impl WriteLockTable for PartitionStoreTransaction<'_> {
             key_buf.split()
         };
 
-        self.raw_delete_cf(KeyKind::Lock, key_buf);
+        self.raw_single_delete_cf(KeyKind::Lock, key_buf);
     }
 }
 

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -875,6 +875,14 @@ impl PartitionStoreTransaction<'_> {
             .delete_cf(self.data_cf_handle, key);
     }
 
+    #[inline]
+    pub fn raw_single_delete_cf(&mut self, _key_kind: KeyKind, key: impl AsRef<[u8]>) {
+        self.write_batch_with_index
+            .as_mut()
+            .expect("transaction valid")
+            .single_delete_cf(self.data_cf_handle, key);
+    }
+
     pub(crate) fn prefix_iterator(
         &self,
         table: TableKind,

--- a/crates/partition-store/src/partition_store_manager.rs
+++ b/crates/partition-store/src/partition_store_manager.rs
@@ -12,12 +12,17 @@ use std::path::Path;
 use std::sync::{Arc, Weak};
 
 use ahash::HashMap;
+use bytes::Bytes;
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
+use rocksdb::BottommostLevelCompaction;
 use tokio::sync::Mutex as AsyncMutex;
 use tracing::{debug, error, info, instrument, warn};
 
-use restate_rocksdb::{CfPrefixPattern, DbSpecBuilder, RocksDb, RocksDbManager, RocksError};
+use restate_rocksdb::{
+    CfName, CfPrefixPattern, DbSpecBuilder, RocksDb, RocksDbManager, RocksError,
+};
 use restate_storage_api::fsm_table::ReadFsmTable;
+use restate_types::cluster_marker::ClusterMarker;
 use restate_types::config::Configuration;
 use restate_types::identifiers::{PartitionId, SnapshotId};
 use restate_types::logs::{Lsn, SequenceNumber};
@@ -25,6 +30,7 @@ use restate_types::partitions::Partition;
 use restate_types::protobuf::common::DatabaseKind;
 
 use crate::SnapshotError;
+use crate::keys::KeyKind;
 use crate::memory::MemoryController;
 use crate::partition_db::{AllDataCf, PartitionCell, PartitionDb, RocksConfigurator};
 use crate::snapshots::{LocalPartitionSnapshot, PartitionSnapshotStatus, Snapshots};
@@ -228,6 +234,30 @@ impl PartitionStoreManager {
         partition: &Partition,
         target_lsn: Option<Lsn>,
     ) -> Result<PartitionStore, OpenError> {
+        let partition_store = self.open_inner(partition, target_lsn).await?;
+        // Before the partition processor can issue any `SingleDelete` on the vqueue/lock ranges,
+        // make sure no legacy `Delete` tombstones survive for them by compacting those ranges once.
+        // Recorded in the cluster marker so we don't recompact on every startup; always redone after
+        // a snapshot restore. Gating is off in tests/tools, which never touch the marker.
+        let partition_id = partition.partition_id;
+        if !ClusterMarker::is_partition_single_delete_safe(partition_id)? {
+            debug!("Running range compaction to enable single-delete safety");
+            self.compact_vqueue_and_lock_ranges(
+                partition_store.partition_db().rocksdb(),
+                partition,
+            )
+            .await?;
+            ClusterMarker::mark_partition_single_delete_safe(partition_id)?;
+        }
+
+        Ok(partition_store)
+    }
+
+    async fn open_inner(
+        &self,
+        partition: &Partition,
+        target_lsn: Option<Lsn>,
+    ) -> Result<PartitionStore, OpenError> {
         let rocksdb = self.open_rocksdb(partition).await?;
 
         // If we already have the partition locally and we don't have a fast-forward target, or the
@@ -298,8 +328,8 @@ impl PartitionStoreManager {
                 // Play it safe and keep the partition store intact; we can't do much else at this
                 // point. We'll likely halt again as soon as the processor starts up.
                 let recovery_guide_msg = "The partition's log is trimmed to a point from which this processor can not resume. \
-                Visit https://docs.restate.dev/operate/clusters#handling-missing-snapshots \
-                to learn more about how to recover this processor.";
+                    Visit https://docs.restate.dev/operate/clusters#handling-missing-snapshots \
+                    to learn more about how to recover this processor.";
 
                 if let Some(snapshot) = maybe_snapshot {
                     warn!(
@@ -326,6 +356,43 @@ impl PartitionStoreManager {
                 }
             }
         }
+    }
+
+    /// Runs a forced bottommost-level compaction over the vqueue (`q*`) and lock (`lo`) key ranges
+    /// of the partition's column family, so that any legacy `Delete` tombstones are physically
+    /// dropped and `SingleDelete` becomes safe to use on those keys.
+    async fn compact_vqueue_and_lock_ranges(
+        &self,
+        rocksdb: &Arc<RocksDb>,
+        partition: &Partition,
+    ) -> Result<(), RocksError> {
+        let cf = CfName::from(partition.cf_name());
+
+        // VQueues own every key that starts with b"q" (see `keys.rs`): compact [b"q", b"r").
+        rocksdb
+            .clone()
+            .compact_range(
+                cf.clone(),
+                Some(Bytes::from_static(b"q")),
+                Some(Bytes::from_static(b"r")),
+                BottommostLevelCompaction::Force,
+            )
+            .await?;
+
+        // Locks live under the `KeyKind::Lock` prefix.
+        rocksdb
+            .clone()
+            .compact_range(
+                cf,
+                Some(Bytes::copy_from_slice(KeyKind::Lock.as_bytes())),
+                Some(Bytes::copy_from_slice(
+                    &KeyKind::Lock.exclusive_upper_bound(),
+                )),
+                BottommostLevelCompaction::Force,
+            )
+            .await?;
+
+        Ok(())
     }
 
     /// Closes a partition store for the given partition

--- a/crates/partition-store/src/tests/mod.rs
+++ b/crates/partition-store/src/tests/mod.rs
@@ -38,6 +38,7 @@ mod journal_table_v2_test;
 mod locks_table_test;
 mod outbox_table_test;
 mod promise_table_test;
+mod single_delete_rollback_test;
 mod snapshots_test;
 mod state_table_test;
 mod timer_table_test;

--- a/crates/partition-store/src/tests/single_delete_rollback_test.rs
+++ b/crates/partition-store/src/tests/single_delete_rollback_test.rs
@@ -1,0 +1,211 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Rollback-safety tests for the `Delete` -> `SingleDelete` migration.
+//!
+//! `SingleDelete` is only correct when a key carries exactly one live `Put`; a `SingleDelete`
+//! sitting above more than one un-deleted `Put` can let a stale value resurface after compaction.
+//! Across a version rollback an older binary still issues a regular `Delete`, so the migration
+//! relies on a forced bottommost compaction over the vqueue/lock ranges (run on roll-forward, see
+//! `PartitionStoreManager::compact_vqueue_and_lock_ranges`) to physically drop any legacy `Delete`
+//! tombstones before any `SingleDelete` is issued.
+//!
+//! These tests reproduce the exact `Put`/`Delete`/`SingleDelete` interleavings such a
+//! rollback -> roll-forward(+compaction) cycle produces on the lock range and assert that no stale
+//! value ever resurfaces. The resurfacing bug only manifests *after* compaction merges the SSTs,
+//! so every step is flushed to its own SST (modelling writes by different binary versions over
+//! time) and reads are taken after the same forced compaction the production roll-forward uses.
+
+use bytes::Bytes;
+use rocksdb::BottommostLevelCompaction;
+
+use restate_rocksdb::{CfName, RocksDbManager};
+use restate_types::identifiers::{PartitionId, PartitionKey};
+use restate_types::partitions::Partition;
+use restate_types::sharding::KeyRange;
+
+use crate::keys::KeyKind;
+use crate::{PartitionStore, PartitionStoreManager, TableKind};
+
+const PARTITION: Partition = Partition::new(
+    PartitionId::MIN,
+    KeyRange::new(PartitionKey::MIN, PartitionKey::MAX),
+);
+
+/// A key inside the lock range (`[b"lo", b"lp")`). The exact structure is irrelevant to the
+/// marker-safety property; the key only needs to be byte-stable across ops and live in range.
+fn lock_key(suffix: &str) -> Vec<u8> {
+    let mut key = Vec::with_capacity(2 + 8 + suffix.len());
+    key.extend_from_slice(KeyKind::Lock.as_bytes()); // b"lo"
+    key.extend_from_slice(&[0u8; 8]); // partition-key placeholder
+    key.extend_from_slice(suffix.as_bytes());
+    key
+}
+
+fn raw_put(store: &PartitionStore, key: &[u8], value: &[u8]) {
+    let db = store.partition_db().rocksdb().inner().as_raw_db();
+    let cf = store.partition_db().table_cf_handle(TableKind::Locks);
+    db.put_cf(cf, key, value).expect("put_cf should succeed");
+}
+
+fn raw_delete(store: &PartitionStore, key: &[u8]) {
+    let db = store.partition_db().rocksdb().inner().as_raw_db();
+    let cf = store.partition_db().table_cf_handle(TableKind::Locks);
+    db.delete_cf(cf, key).expect("delete_cf should succeed");
+}
+
+fn raw_single_delete(store: &PartitionStore, key: &[u8]) {
+    let db = store.partition_db().rocksdb().inner().as_raw_db();
+    let cf = store.partition_db().table_cf_handle(TableKind::Locks);
+    db.single_delete_cf(cf, key)
+        .expect("single_delete_cf should succeed");
+}
+
+fn raw_get(store: &PartitionStore, key: &[u8]) -> Option<Vec<u8>> {
+    let db = store.partition_db().rocksdb().inner().as_raw_db();
+    let cf = store.partition_db().table_cf_handle(TableKind::Locks);
+    db.get_cf(cf, key).expect("get_cf should succeed")
+}
+
+fn assert_value(store: &PartitionStore, key: &[u8], expected: Option<&[u8]>) {
+    assert_eq!(raw_get(store, key).as_deref(), expected);
+}
+
+async fn flush(store: &PartitionStore) {
+    store
+        .partition_db()
+        .flush_memtables(true)
+        .await
+        .expect("flush should succeed");
+}
+
+/// Runs the same forced-bottommost compaction over the lock range that the production roll-forward
+/// uses (`PartitionStoreManager::compact_vqueue_and_lock_ranges`), guaranteeing legacy `Delete`
+/// tombstones are physically dropped.
+async fn compact_locks(store: &PartitionStore) {
+    let cf = CfName::from(store.partition_db().partition().cf_name());
+    store
+        .partition_db()
+        .rocksdb()
+        .clone()
+        .compact_range(
+            cf,
+            Some(Bytes::copy_from_slice(KeyKind::Lock.as_bytes())),
+            Some(Bytes::copy_from_slice(
+                &KeyKind::Lock.exclusive_upper_bound(),
+            )),
+            BottommostLevelCompaction::Force,
+        )
+        .await
+        .expect("compaction should succeed");
+}
+
+/// `Put -> SingleDelete` (new), rollback `Put -> Delete -> Put` (old), roll-forward (compact) ->
+/// `SingleDelete` (new).
+async fn put_single_delete_rollback_then_forward(store: &PartitionStore) {
+    let key = lock_key("scenario-a");
+    let (v1, v2, v3) = (b"v1".as_slice(), b"v2".as_slice(), b"v3".as_slice());
+
+    // new code: acquire (Put) -> release (SingleDelete)
+    raw_put(store, &key, v1);
+    flush(store).await;
+    raw_single_delete(store, &key);
+    flush(store).await;
+    assert_value(store, &key, None);
+
+    // rolled back to old code: acquire -> release (regular Delete) -> acquire
+    raw_put(store, &key, v2);
+    flush(store).await;
+    raw_delete(store, &key);
+    flush(store).await;
+    raw_put(store, &key, v3);
+    flush(store).await;
+    assert_value(store, &key, Some(v3));
+
+    // roll-forward compaction over the lock range: v3 must survive, v1/v2 must not resurface.
+    compact_locks(store).await;
+    assert_value(store, &key, Some(v3));
+
+    // new code resumes: release (SingleDelete)
+    raw_single_delete(store, &key);
+    flush(store).await;
+    assert_value(store, &key, None);
+
+    // final compaction must leave nothing resurfaced.
+    compact_locks(store).await;
+    assert_value(store, &key, None);
+}
+
+/// `... -> SingleDelete -> Put -> Delete`: a `SingleDelete` followed by a later `Put` and a
+/// regular `Delete` (old binary) must leave the key absent after compaction.
+async fn single_delete_then_put_delete(store: &PartitionStore) {
+    let key = lock_key("scenario-b");
+    let (w1, w2) = (b"w1".as_slice(), b"w2".as_slice());
+
+    // the single matching Put, then SingleDelete (new code release)
+    raw_put(store, &key, w1);
+    flush(store).await;
+    raw_single_delete(store, &key);
+    flush(store).await;
+    assert_value(store, &key, None);
+
+    // rolled back to old code: acquire (Put) -> release (regular Delete)
+    raw_put(store, &key, w2);
+    flush(store).await;
+    assert_value(store, &key, Some(w2));
+    raw_delete(store, &key);
+    flush(store).await;
+    assert_value(store, &key, None);
+
+    // neither w1 nor w2 may resurface after compaction.
+    compact_locks(store).await;
+    assert_value(store, &key, None);
+}
+
+/// Forward-path invariants the migration relies on in steady state.
+async fn forward_path_invariants(store: &PartitionStore) {
+    // A single Put then SingleDelete is fully removed, even when the Put was already pushed to the
+    // bottom level by an earlier compaction.
+    let key = lock_key("scenario-c-1");
+    raw_put(store, &key, b"a");
+    flush(store).await;
+    compact_locks(store).await;
+    raw_single_delete(store, &key);
+    flush(store).await;
+    compact_locks(store).await;
+    assert_value(store, &key, None);
+
+    // A SingleDelete must not remove a later Put.
+    let key = lock_key("scenario-c-2");
+    raw_put(store, &key, b"a");
+    flush(store).await;
+    raw_single_delete(store, &key);
+    flush(store).await;
+    raw_put(store, &key, b"b");
+    flush(store).await;
+    compact_locks(store).await;
+    assert_value(store, &key, Some(b"b".as_slice()));
+}
+
+#[restate_core::test]
+async fn single_delete_rollback_safety() -> googletest::Result<()> {
+    let rocksdb = RocksDbManager::init();
+    let manager = PartitionStoreManager::create(true).await?;
+    // In test builds the cluster-marker gating is stubbed to always-safe, so `open` does not
+    // auto-compact; the scenarios drive `compact_locks` explicitly to model the roll-forward.
+    let store = manager.open(&PARTITION, None).await?;
+
+    put_single_delete_rollback_then_forward(&store).await;
+    single_delete_then_put_delete(&store).await;
+    forward_path_invariants(&store).await;
+
+    rocksdb.shutdown().await;
+    Ok(())
+}

--- a/crates/partition-store/src/vqueue_table/mod.rs
+++ b/crates/partition-store/src/vqueue_table/mod.rs
@@ -225,7 +225,7 @@ impl WriteVQueueTable for PartitionStoreTransaction<'_> {
 
     fn delete_vqueue_inbox(&mut self, qid: &VQueueId, stage: Stage, key: &EntryKey) {
         // Note: the key kind here is not used, so we always use the InboxKey.
-        self.raw_delete_cf(
+        self.raw_single_delete_cf(
             KeyKind::VQueueInboxStage,
             inbox::encode_stage_key(stage, qid, key),
         );
@@ -244,7 +244,7 @@ impl WriteVQueueTable for PartitionStoreTransaction<'_> {
         ActiveKeyRef::builder()
             .qid(qid)
             .serialize_to(&mut key_buffer.as_mut());
-        self.raw_delete_cf(KeyKind::VQueueActive, key_buffer);
+        self.raw_single_delete_cf(KeyKind::VQueueActive, key_buffer);
     }
 
     fn put_vqueue_entry_status(
@@ -293,7 +293,7 @@ impl WriteVQueueTable for PartitionStoreTransaction<'_> {
             .id(id)
             .serialize_to(&mut key_buffer.as_mut());
 
-        self.raw_delete_cf(KeyKind::VQueueEntryStatus, key_buffer);
+        self.raw_single_delete_cf(KeyKind::VQueueEntryStatus, key_buffer);
     }
 
     fn put_vqueue_input_payload<E>(

--- a/crates/rocksdb/src/lib.rs
+++ b/crates/rocksdb/src/lib.rs
@@ -28,11 +28,13 @@ use std::mem::ManuallyDrop;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use bytes::Bytes;
 use rocksdb::ExportImportFilesMetaData;
 use rocksdb::checkpoint::Checkpoint;
 use rocksdb::statistics::Histogram;
 use rocksdb::statistics::HistogramData;
 use rocksdb::statistics::Ticker;
+use rocksdb::{BottommostLevelCompaction, CompactOptions};
 
 use restate_core::ShutdownError;
 use restate_types::protobuf::common::DatabaseKind;
@@ -468,6 +470,38 @@ impl RocksDb {
             .op(move || {
                 let _x = RocksDbReadPerfGuard::new("manual-compaction");
                 self.db.compact_all();
+            })
+            .build()
+            .unwrap();
+
+        manager.async_spawn_unchecked(task).await?;
+        Ok(())
+    }
+
+    /// Runs a manual compaction over `[start_key, end_key)` on the given column family.
+    ///
+    /// `None` bounds mean unbounded. `bottommost` controls whether the bottommost level is
+    /// recompacted (use [`BottommostLevelCompaction::Force`] to guarantee tombstones are dropped).
+    /// The compaction runs on the storage thread-pool, like [`Self::compact_all`].
+    #[tracing::instrument(skip_all, fields(db = %self.name(), cf = %cf))]
+    pub async fn compact_range(
+        self: Arc<Self>,
+        cf: CfName,
+        start_key: Option<Bytes>,
+        end_key: Option<Bytes>,
+        bottommost: BottommostLevelCompaction,
+    ) -> Result<(), RocksError> {
+        let manager = self.manager;
+        let task = StorageTask::default()
+            .kind(StorageTaskKind::Compaction)
+            .op(move || {
+                let _x = RocksDbReadPerfGuard::new("manual-range-compaction");
+                if let Some(cf_handle) = self.db.cf_handle(cf.as_ref()) {
+                    let mut opts = CompactOptions::default();
+                    opts.set_bottommost_level_compaction(bottommost);
+                    self.db
+                        .compact_cf(&cf_handle, &opts, start_key.as_deref(), end_key.as_deref());
+                }
             })
             .build()
             .unwrap();

--- a/crates/types/src/cluster_marker.rs
+++ b/crates/types/src/cluster_marker.rs
@@ -9,13 +9,16 @@
 // by the Apache License, Version 2.0.
 
 use std::cmp::Ordering;
+use std::collections::HashSet;
 use std::fs::{File, OpenOptions};
 use std::path::Path;
+use std::sync::Mutex;
 
 use tracing::debug;
 
 use crate::SemanticRestateVersion;
 use crate::config::node_filepath;
+use crate::identifiers::PartitionId;
 use crate::nodes_config::ClusterFingerprint;
 
 const CLUSTER_MARKER_FILE_NAME: &str = ".cluster-marker";
@@ -127,6 +130,17 @@ pub struct ClusterMarker {
     /// *Since v1.7.0*
     #[serde(default)]
     use_multi_db_layout: bool,
+    /// Partitions whose vqueue (`q*`) and lock (`lo`) key ranges have been compacted so that
+    /// using `SingleDelete` on them is safe (i.e. no surviving legacy `Delete` tombstones).
+    ///
+    /// Tracked here rather than in the partition FSM on purpose: an older binary that doesn't
+    /// know this field drops it when it rewrites the marker, which correctly forces a
+    /// recompaction on the next upgrade (the old binary would have re-introduced `Delete`
+    /// tombstones for these ranges).
+    ///
+    /// *Since v1.7.1*
+    #[serde(default)]
+    single_delete_safe_partitions: HashSet<PartitionId>,
 }
 
 impl ClusterMarker {
@@ -145,6 +159,7 @@ impl ClusterMarker {
             is_provisioned,
             use_multi_db_layout,
             cluster_fingerprint: None,
+            single_delete_safe_partitions: HashSet::new(),
         }
     }
 }
@@ -187,6 +202,74 @@ impl ClusterMarker {
     pub fn uses_multi_db_layout(&self) -> bool {
         self.use_multi_db_layout
     }
+
+    /// Returns `true` if `partition_id`'s vqueue/lock key ranges have already been compacted and
+    /// recorded as safe to `SingleDelete`.
+    ///
+    /// Reads the marker file directly without taking [`CLUSTER_MARKER_WRITE_LOCK`]: the write path
+    /// swaps the file in atomically (tmp-file + `rename`), so a concurrent read sees either the old
+    /// or the new file in full, never a torn read.
+    pub fn is_partition_single_delete_safe(
+        partition_id: PartitionId,
+    ) -> Result<bool, ClusterValidationError> {
+        is_partition_single_delete_safe_inner(
+            node_filepath(CLUSTER_MARKER_FILE_NAME).as_path(),
+            partition_id,
+        )
+    }
+
+    /// Records that `partition_id`'s vqueue/lock ranges have been compacted. Idempotent: a no-op
+    /// (no file write) if the partition is already recorded.
+    pub fn mark_partition_single_delete_safe(
+        partition_id: PartitionId,
+    ) -> Result<(), ClusterValidationError> {
+        mark_partition_single_delete_safe_inner(
+            node_filepath(CLUSTER_MARKER_FILE_NAME).as_path(),
+            partition_id,
+        )
+    }
+}
+
+/// Serializes all read-modify-write updates of the (single, per-process) cluster marker file.
+/// Reads don't take this lock — the atomic `rename` in [`write_new_cluster_marker`] makes them safe.
+static CLUSTER_MARKER_WRITE_LOCK: Mutex<()> = Mutex::new(());
+
+#[cfg(any(test, feature = "test-util"))]
+fn is_partition_single_delete_safe_inner(
+    _cluster_marker_filepath: &Path,
+    _partition_id: PartitionId,
+) -> Result<bool, ClusterValidationError> {
+    Ok(true)
+}
+
+#[cfg(any(test, feature = "test-util"))]
+fn mark_partition_single_delete_safe_inner(
+    _cluster_marker_filepath: &Path,
+    _partition_id: PartitionId,
+) -> Result<(), ClusterValidationError> {
+    Ok(())
+}
+
+#[cfg(not(any(test, feature = "test-util")))]
+fn is_partition_single_delete_safe_inner(
+    cluster_marker_filepath: &Path,
+    partition_id: PartitionId,
+) -> Result<bool, ClusterValidationError> {
+    read_cluster_marker(cluster_marker_filepath)
+        .map(|marker| marker.single_delete_safe_partitions.contains(&partition_id))
+}
+
+#[cfg(not(any(test, feature = "test-util")))]
+fn mark_partition_single_delete_safe_inner(
+    cluster_marker_filepath: &Path,
+    partition_id: PartitionId,
+) -> Result<(), ClusterValidationError> {
+    let _guard = CLUSTER_MARKER_WRITE_LOCK.lock().unwrap();
+    let mut marker = read_cluster_marker(cluster_marker_filepath)?;
+    if marker.single_delete_safe_partitions.insert(partition_id) {
+        write_new_cluster_marker(cluster_marker_filepath, &marker)?;
+    }
+    Ok(())
 }
 
 fn validate_and_update_cluster_marker_inner(
@@ -196,6 +279,7 @@ fn validate_and_update_cluster_marker_inner(
     use_multi_db_layout: bool,
     compatibility_information: &CompatibilityInformation,
 ) -> Result<ClusterMarker, ClusterValidationError> {
+    let _guard = CLUSTER_MARKER_WRITE_LOCK.lock().unwrap();
     let mut cluster_marker = if cluster_marker_filepath.exists() {
         read_cluster_marker(cluster_marker_filepath)?
     } else {
@@ -331,6 +415,7 @@ fn mark_cluster_as_provisioned_inner(
     cluster_marker_filepath: &Path,
     fingerprint: Option<ClusterFingerprint>,
 ) -> Result<(), ClusterValidationError> {
+    let _guard = CLUSTER_MARKER_WRITE_LOCK.lock().unwrap();
     let mut cluster_marker = read_cluster_marker(cluster_marker_filepath)?;
 
     // Reconcile the persisted fingerprint with the input:
@@ -424,6 +509,7 @@ mod tests {
                 is_provisioned: false,
                 use_multi_db_layout: false,
                 cluster_fingerprint: None,
+                single_delete_safe_partitions: Default::default(),
             }
         )
     }
@@ -468,6 +554,7 @@ mod tests {
                 is_provisioned: true,
                 use_multi_db_layout: false,
                 cluster_fingerprint: None,
+                single_delete_safe_partitions: Default::default(),
             }
         );
         Ok(())
@@ -513,6 +600,7 @@ mod tests {
                 is_provisioned: false,
                 use_multi_db_layout: false,
                 cluster_fingerprint: None,
+                single_delete_safe_partitions: Default::default(),
             }
         );
         Ok(())

--- a/tools/pp-bench/src/workload.rs
+++ b/tools/pp-bench/src/workload.rs
@@ -27,6 +27,7 @@
 use std::sync::Arc;
 use std::time::Instant;
 
+use anyhow::Context;
 use hdrhistogram::Histogram;
 
 use restate_cli_util::{c_println, c_success};
@@ -35,6 +36,7 @@ use restate_partition_store::PartitionStoreManager;
 use restate_rocksdb::RocksDbManager;
 use restate_storage_api::Transaction;
 use restate_types::SemanticRestateVersion;
+use restate_types::cluster_marker::ClusterMarker;
 use restate_types::identifiers::PartitionId;
 use restate_types::logs::{Lsn, SequenceNumber};
 use restate_types::partitions::{Partition, PersistedStateMachineFeatures};
@@ -95,6 +97,9 @@ pub async fn run(
     // 2. Set up StateMachine + PartitionStore
     // -----------------------------------------------------------------------
     RocksDbManager::init();
+
+    ClusterMarker::validate_or_create("pp-bench", true)
+        .context("failed to initialize cluster marker")?;
 
     let manager = PartitionStoreManager::create(true).await?;
     let mut partition_store = manager


### PR DESCRIPTION

Summary:
The partition store will use RocksDB `SingleDelete` (instead of `Delete`) to
remove vqueue (`q*`) and lock (`lo`) keys. `SingleDelete` is only correct when a
key has not accumulated regular `Delete` tombstones; clusters that enabled
experimental vqueues in v1.7.0 wrote these keys with `Delete`, so the ranges must
be compacted once before `SingleDelete` is used.

This adds a one-time forced bottommost-level compaction over the vqueue and lock
key ranges the first time a partition is opened by this version:

- `PartitionStoreManager::open` now wraps `open_inner`, gating the compaction on
  the cluster marker. After a successful open it compacts the ranges (if needed)
  and records the partition as single-delete-safe.
- `RocksDb::compact_range` runs a manual range compaction on a column family over
  `[start_key, end_key)` on the storage thread-pool, with configurable bottommost
  level handling.
- Completion is tracked per partition in `ClusterMarker.single_delete_safe_partitions`.
  This lives in the cluster marker rather than the partition FSM on purpose: an
  older binary that doesn't know the field drops it when rewriting the marker,
  which correctly forces a recompaction on the next upgrade. Reads of the marker
  are lock-free (the write path swaps the file in atomically via tmp-file +
  rename); read-modify-write updates are serialized by a process-global mutex.
- Adds an `OpenError::ClusterMarker` variant for marker failures during open.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/4977).
* __->__ #4977
* #4974