### PR TITLE
[Worker] Limit record batch reads by size in bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7403,6 +7403,7 @@ dependencies = [
  "restate-log-server",
  "restate-memory",
  "restate-metadata-store",
+ "restate-platform",
  "restate-rocksdb",
  "restate-storage-api",
  "restate-test-util",

--- a/crates/bifrost/Cargo.toml
+++ b/crates/bifrost/Cargo.toml
@@ -22,11 +22,12 @@ restate-core = { workspace = true }
 restate-futures-util = { workspace = true }
 restate-memory = { workspace = true }
 restate-metadata-store = { workspace = true }
+restate-platform = { workspace = true }
 restate-rocksdb = { workspace = true, optional = true }
 restate-test-util = { workspace = true, optional = true }
+restate-types = { workspace = true }
 restate-util-bytecount = { workspace = true, features = ["serde"] }
 restate-util-time = { workspace = true }
-restate-types = { workspace = true }
 
 ahash = { workspace = true }
 adaptive-timeout = { workspace = true, features = ["tokio", "sync"] }

--- a/crates/bifrost/src/record.rs
+++ b/crates/bifrost/src/record.rs
@@ -13,6 +13,8 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use bytes::Bytes;
+
+use restate_platform::memory::EstimatedMemorySize;
 use restate_types::logs::{BodyWithKeys, HasRecordKeys, Keys, Lsn, Record};
 use restate_types::logs::{LogletOffset, SequenceNumber};
 use restate_types::storage::{PolyBytes, StorageDecode, StorageDecodeError, StorageEncode};
@@ -56,6 +58,15 @@ impl LogEntry<LogletOffset> {
         LogEntry {
             offset: base_lsn.offset_by(self.offset),
             record,
+        }
+    }
+}
+
+impl<S> EstimatedMemorySize for LogEntry<S> {
+    fn estimated_memory_size(&self) -> usize {
+        match &self.record {
+            MaybeRecord::TrimGap(_) | MaybeRecord::Filtered(_) | MaybeRecord::DataLoss(_) => 0,
+            MaybeRecord::Data(record) => record.estimated_memory_size(),
         }
     }
 }

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -12,11 +12,11 @@ use std::num::{NonZero, NonZeroU8, NonZeroU32, NonZeroU64, NonZeroUsize};
 use std::path::PathBuf;
 use std::time::Duration;
 
-use restate_serde_util::SerdeableHeaderHashMap;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use tracing::warn;
 
+use restate_serde_util::SerdeableHeaderHashMap;
 use restate_util_bytecount::{ByteCount, NonZeroByteCount};
 use restate_util_time::{FriendlyDuration, NonZeroFriendlyDuration};
 
@@ -65,11 +65,22 @@ pub struct WorkerOptions {
 
     pub invoker: InvokerOptions,
 
-    /// # Maximum command batch size for partition processors
+    /// # Maximum command batch size (count) for partition processors
     ///
-    /// The maximum number of commands a partition processor will apply in a batch. The larger this
-    /// value is, the higher the throughput and latency are.
+    /// The maximum number of Bifrost log records a partition processor will process opportunistically
+    /// in a single batch. The larger this value is, the higher the throughput and latency are.
     max_command_batch_size: NonZeroUsize,
+
+    /// # Maximum command batch size (in bytes) for partition processors
+    ///
+    /// Caps the total bytes of Bifrost log records processed opportunistically by the partition processor in
+    /// a single iteration. This works in conjunction with `max-command-batch-size` which caps the
+    /// number of records. The processor will process the batch when whichever limit is hit first.
+    ///
+    /// Default: 1 MiB
+    ///
+    /// Since v1.7.1
+    pub max_command_batch_bytes: NonZeroByteCount,
 
     /// # Snapshots
     ///
@@ -181,6 +192,7 @@ impl Default for WorkerOptions {
             storage: StorageOptions::default(),
             invoker: Default::default(),
             max_command_batch_size: NonZeroUsize::new(32).expect("Non zero number"),
+            max_command_batch_bytes: NonZeroByteCount::new(NonZeroUsize::new(1024 * 1024).unwrap()),
             snapshots: SnapshotsOptions::default(),
             // 10 minutes delayed trimming by default to give time for followers to catch up
             // to the new durable LSN before observing the trim gap.

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -339,7 +339,7 @@ where
     pub async fn on_announce_leader(
         &mut self,
         announce_leader: &AnnounceLeaderCommand,
-        partition_store: &mut PartitionStore,
+        partition_store: PartitionStore,
         replica_set_states: &PartitionReplicaSetStates,
         config: &Configuration,
         vqueues_cache: &mut VQueuesMetaCache,
@@ -409,7 +409,7 @@ where
     #[allow(clippy::too_many_arguments)]
     async fn become_leader(
         &mut self,
-        partition_store: &mut PartitionStore,
+        mut partition_store: PartitionStore,
         replica_set_states: PartitionReplicaSetStates,
         vqueues_cache: &mut VQueuesMetaCache,
         config: &Configuration,
@@ -497,7 +497,7 @@ where
             }
 
             let (fencing_tokens, next_fencing_token) =
-                Self::resume_invoked_invocations(&mut invoker_handle, partition_store).await?;
+                Self::resume_invoked_invocations(&mut invoker_handle, &mut partition_store).await?;
 
             let timer_service = TimerService::new(
                 TokioClock,
@@ -1055,12 +1055,12 @@ mod tests {
         assert!(announce_leader.current_config.is_some());
         assert!(announce_leader.next_config.is_none());
 
-        let mut partition_store = partition_store_manager.open(&PARTITION, None).await?;
+        let partition_store = partition_store_manager.open(&PARTITION, None).await?;
         let rule_book = RuleBook::default();
         state
             .on_announce_leader(
                 &announce_leader,
-                &mut partition_store,
+                partition_store.clone(),
                 &replica_set_states,
                 &Configuration::pinned(),
                 &mut VQueuesMetaCache::new_empty(1024),

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -33,7 +33,7 @@ use std::time::Duration;
 
 use anyhow::Context;
 use assert2::let_assert;
-use futures::{FutureExt, Stream, StreamExt};
+use futures::{FutureExt, StreamExt};
 use metrics::{gauge, histogram};
 use tokio::sync::watch;
 use tokio::time::{Instant, MissedTickBehavior};
@@ -49,6 +49,7 @@ use restate_core::{
 };
 use restate_ingestion_client::IngestionClient;
 use restate_partition_store::{PartitionStore, PartitionStoreTransaction};
+use restate_platform::memory::EstimatedMemorySize;
 use restate_storage_api::deduplication_table::{
     DedupInformation, DedupSequenceNumber, ProducerId, ReadDeduplicationTable,
     WriteDeduplicationTable,
@@ -62,6 +63,7 @@ use restate_types::cluster::cluster_state::{PartitionProcessorStatus, ReplayStat
 use restate_types::config::Configuration;
 use restate_types::epoch::EpochMetadata;
 use restate_types::identifiers::LeaderEpoch;
+use restate_types::live::Live;
 use restate_types::logs::{
     KeyFilter, Keys, Lsn, MatchKeyQuery, Record, RecordDecodeError, SequenceNumber,
 };
@@ -254,6 +256,7 @@ impl PartitionProcessorBuilder {
             bifrost,
             target_leader_state_rx,
             network_leader_svc_rx: rpc_rx,
+            config: Configuration::live(),
             status_watch_tx,
             leader_query_rx,
             status,
@@ -338,6 +341,7 @@ pub struct PartitionProcessor<T> {
     leader_query_rx: LeaderQueryReceiver,
     status: PartitionProcessorStatus,
     replica_set_states: PartitionReplicaSetStates,
+    config: Live<Configuration>,
 
     partition_store: PartitionStore,
     trim_queue: TrimQueue,
@@ -572,7 +576,6 @@ where
             self.status.replay_status = ReplayStatus::CatchingUp;
         }
 
-        let mut live_config = Configuration::live();
         let mut live_schemas = Metadata::with_current(|m| m.updateable_schema());
 
         // Telemetry setup
@@ -580,12 +583,16 @@ where
         let follower_record_write_to_read_latency = histogram!(PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS, LEADER_LABEL => LEADER_LABEL_FOLLOWER);
         // Start reading after the last applied lsn
 
-        let mut record_stream = self.bifrost.create_reader(
-            log_id,
-            KeyFilter::Within(self.partition_store.partition_key_range().into()),
-            last_applied_lsn.next(),
-            Lsn::MAX,
-        )?;
+        let mut record_stream = std::pin::pin!(
+            self.bifrost
+                .create_reader(
+                    log_id,
+                    KeyFilter::Within(self.partition_store.partition_key_range().into()),
+                    last_applied_lsn.next(),
+                    Lsn::MAX,
+                )?
+                .peekable()
+        );
 
         // avoid synchronized timers.
         let mut status_update_timer =
@@ -599,8 +606,6 @@ where
         .await?;
 
         let mut action_collector = ActionCollector::default();
-        let mut command_buffer =
-            Vec::with_capacity(live_config.live_load().worker.max_command_batch_size());
 
         let mut watch_leader_changes = self.replica_set_states.watch_leadership_state(partition_id);
         watch_leader_changes.mark_changed();
@@ -621,7 +626,7 @@ where
         let mut transaction = partition_store_cloned.transaction();
 
         loop {
-            let config = live_config.live_load();
+            let config = self.config.live_load();
             tokio::select! {
                 _ = self.target_leader_state_rx.changed() => {
                     let target_leader_state = self.target_leader_state_rx.borrow_and_update().clone();
@@ -665,116 +670,71 @@ where
                         old.updated_at = MillisSinceEpoch::now();
                     });
                 }
-                operation = Self::read_entries(&mut record_stream, config.worker.max_command_batch_size(), &mut command_buffer) => {
-                    // check that reading has succeeded
-                    operation?;
+                // Awaiting the first record is the only stream `.await` and is cancellation-safe:
+                // if this branch is dropped before a record is ready, nothing has been consumed.
+                // Subsequent records are drained synchronously below (`now_or_never`), so the
+                // applied-but-uncommitted records can never be lost to select cancellation.
+                maybe_first = record_stream.next() => {
+                    let Some(first) = maybe_first else {
+                        return Err(ProcessorError::LogReadStreamTerminated);
+                    };
+                    let first = first?;
 
                     transaction.clear();
-
                     // clear buffers used when applying the next record
                     action_collector.clear();
 
-                    for entry in command_buffer.drain(..) {
-                        let Some((lsn, record)) = self.maybe_advance(entry, &mut transaction, &started_at)? else {
-                            // this happens when we are reading a filtered gap
-                            continue;
-                        };
+                    let max_batching_size = config.worker.max_command_batch_size();
+                    // This is a sanity check. max_command_batch is in fact, non-zero usize.
+                    debug_assert!(max_batching_size > 0);
+                    let bytes_limit = config.worker.max_command_batch_bytes.as_usize();
 
-                        if self.leadership_state.is_leader() {
-                            leader_record_write_to_read_latency.record(record.created_at().elapsed());
-                        } else {
-                            follower_record_write_to_read_latency.record(record.created_at().elapsed());
-                        }
-
-                        let record = LsnEnvelope {
-                            lsn,
-                            keys: record.keys().clone(),
-                            created_at: record.created_at(),
-                            envelope: Self::decode_record(record)?,
-                        };
-
-                        let maybe_announce_leader = self.apply_record(
-                            record,
+                    // Apply the batch one record at a time, seeded with the record we just awaited.
+                    // The first record is always applied, which guarantees forward progress even
+                    // when a single record is larger than `bytes_limit`. Further records are pulled
+                    // only while immediately available and within the record-count and byte limits.
+                    let mut accumulated_bytes = 0;
+                    let mut count = 0usize;
+                    let mut next_entry = Some(first);
+                    while let Some(entry) = next_entry.take() {
+                        accumulated_bytes += entry.estimated_memory_size();
+                        count += 1;
+                        self.apply_log_entry(
+                            entry,
                             &mut transaction,
                             &mut action_collector,
                             &mut vqueues,
+                            &started_at,
+                            &leader_record_write_to_read_latency,
+                            &follower_record_write_to_read_latency,
                         )
                         .await?;
 
-                        if let Some(announce_leader) = maybe_announce_leader {
-                            // update partition store with latest epoch metadata
-                            if let Some(current_config) = &announce_leader.current_config {
-                                let announced = CachedEpochMetadata {
-                                    version: announce_leader.epoch_version.unwrap(),
-                                    leader_node_id: announce_leader.node_id,
-                                    leader_epoch: announce_leader.leader_epoch,
-                                    current: current_config.to_current_replica_set_state(),
-                                    next: announce_leader.next_config.as_ref().map(|v| v.to_next_replica_set_state()),
-                                };
-
-                                if self.cached_epoch_metadata.as_ref().is_none_or(|c| c.version < announced.version) {
-                                    transaction.put_partition_config_state(&announced)?;
-                                    self.cached_epoch_metadata = Some(announced);
-                                }
-                            };
-
-                            // commit all changes so far, this is important so that the actuators see all changes
-                            // when becoming leader.
-                            transaction.commit().await?;
-                            // Notify all lsn watchers that the lsn has been committed
-
-                            self.last_applied_log_lsn_watch.send_replace(lsn);
-
-                            // We can ignore all actions collected so far because as a new leader we have to instruct the
-                            // actuators afresh.
-                            action_collector.clear();
-
-                            self.status.last_observed_leader_epoch = Some(announce_leader.leader_epoch);
-                            self.status.last_observed_leader_node = Some(announce_leader.node_id);
-
-                            self.replica_set_states.note_observed_leader(
-                                partition_id,
-                                restate_types::partitions::state::LeadershipState {
-                                    current_leader_epoch: announce_leader.leader_epoch,
-                                    current_leader: announce_leader.node_id,
-                                }
-                            );
-
-                            let is_leader = self.leadership_state.on_announce_leader(
-                                &announce_leader,
-                                &mut partition_store,
-                                &self.replica_set_states,
-                                config,
-                                &mut vqueues,
-                                &self.state_machine.rule_book,
-                                &self.state_machine,
-                                &self.state_machine.min_restate_version,
-                            )
-                            .await?;
-
-                            Span::current().record("is_leader", is_leader);
-
-                            if is_leader {
-                                if let Some(cached) = &self.cached_epoch_metadata {
-                                    self.replica_set_states.note_observed_membership(
-                                        partition_id,
-                                        restate_types::partitions::state::LeadershipState {
-                                            current_leader_epoch: cached.leader_epoch,
-                                            current_leader: cached.leader_node_id,
-                                        },
-                                        &cached.current.replica_set,
-                                        &cached.next.as_ref().map(|c| &c.replica_set).cloned(),
-                                    );
-                                }
-                                self.status.effective_mode = RunMode::Leader;
-                            } else {
-                                // make sure that we set our effective_mode to follower also when
-                                // not being explicitly asked by the PPM
-                                self.status.effective_mode = RunMode::Follower;
-                            }
-
-                            transaction.clear();
+                        if count >= max_batching_size {
+                            break;
                         }
+
+                        // Peek primes `Peekable`'s slot without consuming, so we can decide against
+                        // pulling the next record before committing to it.
+                        let next_size = match record_stream.as_mut().peek().now_or_never() {
+                            Some(Some(Ok(peeked))) => peeked.estimated_memory_size(),
+                            // Not immediately available, stream terminated, or an error: stop the
+                            // batch. Termination/errors resurface on the next `next().await`.
+                            _ => break,
+                        };
+                        if accumulated_bytes + next_size > bytes_limit {
+                            // Leave the peeked record in the slot; it leads the next batch.
+                            break;
+                        }
+
+                        // The slot was primed by the peek above: immediately ready and `Ok`.
+                        next_entry = Some(
+                            record_stream
+                                .next()
+                                .now_or_never()
+                                .expect("peeked record is buffered")
+                                .expect("stream cannot terminate after a successful peek")?,
+                        );
                     }
 
                     // Commit our changes and notify actuators about actions if we are the leader
@@ -1170,37 +1130,126 @@ where
         Ok(is_duplicate)
     }
 
-    /// Tries to read as many records from the `log_reader` as are immediately available and stops
-    /// reading at `max_batching_size`. Trim gaps will result in an immediate error.
-    async fn read_entries<S>(
-        log_reader: &mut S,
-        max_batching_size: usize,
-        record_buffer: &mut Vec<LogEntry>,
-    ) -> Result<(), ProcessorError>
-    where
-        S: Stream<Item = Result<LogEntry, restate_bifrost::Error>> + Unpin,
-    {
-        // beyond this point we must not await; otherwise we are no longer cancellation safe
-        let first_record = log_reader.next().await;
-
-        let Some(first_record) = first_record else {
-            return Err(ProcessorError::LogReadStreamTerminated);
+    /// Applies a single log entry to the in-flight `transaction`, advancing the FSM and, when the
+    /// entry announces a new leader, committing the batch so far and reacting to the leadership
+    /// change. Filtered gaps only advance the applied LSN and return without applying a record.
+    #[allow(clippy::too_many_arguments)]
+    async fn apply_log_entry(
+        &mut self,
+        entry: LogEntry,
+        txn: &mut PartitionStoreTransaction<'_>,
+        action_collector: &mut ActionCollector,
+        vqueues: &mut VQueuesMetaCache,
+        started_at: &Instant,
+        leader_record_write_to_read_latency: &metrics::Histogram,
+        follower_record_write_to_read_latency: &metrics::Histogram,
+    ) -> Result<(), ProcessorError> {
+        let Some((lsn, record)) = self.maybe_advance(entry, txn, started_at)? else {
+            // this happens when we are reading a filtered gap
+            return Ok(());
         };
 
-        record_buffer.clear();
-        record_buffer.push(first_record?);
+        if self.leadership_state.is_leader() {
+            leader_record_write_to_read_latency.record(record.created_at().elapsed());
+        } else {
+            follower_record_write_to_read_latency.record(record.created_at().elapsed());
+        }
 
-        while record_buffer.len() < max_batching_size {
-            // read more message from the stream but only if they are immediately available
-            if let Some(record) = log_reader.next().now_or_never() {
-                let Some(record) = record else {
-                    return Err(ProcessorError::LogReadStreamTerminated);
+        let record = LsnEnvelope {
+            lsn,
+            keys: record.keys().clone(),
+            created_at: record.created_at(),
+            envelope: Self::decode_record(record)?,
+        };
+
+        let maybe_announce_leader = self
+            .apply_record(record, txn, action_collector, vqueues)
+            .await?;
+
+        if let Some(announce_leader) = maybe_announce_leader {
+            let partition_id = self.partition_store.partition_id();
+
+            // update partition store with latest epoch metadata
+            if let Some(current_config) = &announce_leader.current_config {
+                let announced = CachedEpochMetadata {
+                    version: announce_leader.epoch_version.unwrap(),
+                    leader_node_id: announce_leader.node_id,
+                    leader_epoch: announce_leader.leader_epoch,
+                    current: current_config.to_current_replica_set_state(),
+                    next: announce_leader
+                        .next_config
+                        .as_ref()
+                        .map(|v| v.to_next_replica_set_state()),
                 };
-                record_buffer.push(record?);
+
+                if self
+                    .cached_epoch_metadata
+                    .as_ref()
+                    .is_none_or(|c| c.version < announced.version)
+                {
+                    txn.put_partition_config_state(&announced)?;
+                    self.cached_epoch_metadata = Some(announced);
+                }
+            };
+
+            // commit all changes so far, this is important so that the actuators see all changes
+            // when becoming leader.
+            txn.commit().await?;
+            // Notify all lsn watchers that the lsn has been committed
+
+            self.last_applied_log_lsn_watch.send_replace(lsn);
+
+            // We can ignore all actions collected so far because as a new leader we have to instruct the
+            // actuators afresh.
+            action_collector.clear();
+
+            self.status.last_observed_leader_epoch = Some(announce_leader.leader_epoch);
+            self.status.last_observed_leader_node = Some(announce_leader.node_id);
+
+            self.replica_set_states.note_observed_leader(
+                partition_id,
+                restate_types::partitions::state::LeadershipState {
+                    current_leader_epoch: announce_leader.leader_epoch,
+                    current_leader: announce_leader.node_id,
+                },
+            );
+
+            let is_leader = self
+                .leadership_state
+                .on_announce_leader(
+                    &announce_leader,
+                    self.partition_store.clone(),
+                    &self.replica_set_states,
+                    self.config.live_load(),
+                    vqueues,
+                    &self.state_machine.rule_book,
+                    &self.state_machine,
+                    &self.state_machine.min_restate_version,
+                )
+                .await?;
+
+            Span::current().record("is_leader", is_leader);
+
+            if is_leader {
+                if let Some(cached) = &self.cached_epoch_metadata {
+                    self.replica_set_states.note_observed_membership(
+                        partition_id,
+                        restate_types::partitions::state::LeadershipState {
+                            current_leader_epoch: cached.leader_epoch,
+                            current_leader: cached.leader_node_id,
+                        },
+                        &cached.current.replica_set,
+                        &cached.next.as_ref().map(|c| &c.replica_set).cloned(),
+                    );
+                }
+                self.status.effective_mode = RunMode::Leader;
             } else {
-                // no more immediately available records found
-                break;
+                // make sure that we set our effective_mode to follower also when
+                // not being explicitly asked by the PPM
+                self.status.effective_mode = RunMode::Follower;
             }
+
+            txn.clear();
         }
 
         Ok(())


### PR DESCRIPTION

Add the `max_command_batch_bytes` worker option (default 1 MiB). The
partition processor now seals a command batch when it reaches either the
record count (`max-command-batch-size`) or this byte size, whichever comes
first, bounding the in-memory size of a batch.

Reads stream directly from a peekable log stream and apply records one at a
time, dropping the intermediate buffer.
