### PR TITLE
envelope-v2: Move `ingestion` to use V2

### DIFF
--- a/crates/admin/src/rest_api/invocations.rs
+++ b/crates/admin/src/rest_api/invocations.rs
@@ -12,6 +12,7 @@ use axum::Json;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use futures::future;
+use serde::Deserialize;
 use tracing::warn;
 
 use restate_admin_rest_model::invocations::{
@@ -28,12 +29,12 @@ use restate_types::invocation::client::{
 };
 use restate_types::invocation::{InvocationTermination, PurgeInvocationRequest, TerminationFlavor};
 use restate_types::journal_v2::EntryIndex;
-use restate_wal_protocol::{Command, Envelope};
-use serde::Deserialize;
+use restate_types::logs::{BodyWithKeys, Keys};
+use restate_wal_protocol::v2;
+use restate_wal_protocol::v2::commands;
 
 use super::error::*;
 use crate::generate_meta_api_error;
-use crate::rest_api::create_envelope_header;
 use crate::state::AdminServiceState;
 
 #[derive(Debug, Default, Deserialize, utoipa::ToSchema)]
@@ -88,30 +89,43 @@ where
         .parse::<InvocationId>()
         .map_err(|e| MetaApiError::InvalidField("invocation_id", e.to_string()))?;
 
-    let cmd = match mode.unwrap_or_default() {
-        DeletionMode::Cancel => Command::TerminateInvocation(InvocationTermination {
-            invocation_id,
-            flavor: TerminationFlavor::Cancel,
-            response_sink: None,
-        }),
-        DeletionMode::Kill => Command::TerminateInvocation(InvocationTermination {
-            invocation_id,
-            flavor: TerminationFlavor::Kill,
-            response_sink: None,
-        }),
-        DeletionMode::Purge => Command::PurgeInvocation(PurgeInvocationRequest {
-            invocation_id,
-            response_sink: None,
-        }),
+    let envelope = match mode.unwrap_or_default() {
+        DeletionMode::Cancel => v2::Envelope::new(
+            v2::Dedup::None,
+            commands::TerminateInvocationCommand::from(InvocationTermination {
+                invocation_id,
+                flavor: TerminationFlavor::Cancel,
+                response_sink: None,
+            }),
+        )
+        .into_raw(),
+        DeletionMode::Kill => v2::Envelope::new(
+            v2::Dedup::None,
+            commands::TerminateInvocationCommand::from(InvocationTermination {
+                invocation_id,
+                flavor: TerminationFlavor::Kill,
+                response_sink: None,
+            }),
+        )
+        .into_raw(),
+        DeletionMode::Purge => v2::Envelope::new(
+            v2::Dedup::None,
+            commands::PurgeInvocationCommand::from(PurgeInvocationRequest {
+                invocation_id,
+                response_sink: None,
+            }),
+        )
+        .into_raw(),
     };
 
     let partition_key = invocation_id.partition_key();
 
-    let envelope = Envelope::new(create_envelope_header(partition_key), cmd);
-
     let result = state
         .ingestion_client
-        .ingest(partition_key, envelope)
+        .ingest(
+            partition_key,
+            BodyWithKeys::new(envelope, Keys::Single(partition_key)),
+        )
         .await
         .map_err(|err| {
             warn!("Could not ingest invocation termination command: {err}");

--- a/crates/admin/src/rest_api/mod.rs
+++ b/crates/admin/src/rest_api/mod.rs
@@ -29,10 +29,8 @@ use utoipa::OpenApi;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
 use restate_core::network::TransportConnect;
-use restate_types::identifiers::PartitionKey;
 use restate_types::invocation::client::InvocationClient;
 use restate_types::schema::registry::{DiscoveryClient, MetadataService, TelemetryClient};
-use restate_wal_protocol::{Destination, Header, Source};
 
 use crate::state::AdminServiceState;
 
@@ -185,16 +183,6 @@ where
             axum::routing::get(|| async move { axum::Json(api) }),
         )
         .with_state(state)
-}
-
-fn create_envelope_header(partition_key: PartitionKey) -> Header {
-    Header {
-        source: Source::ControlPlane {},
-        dest: Destination::Processor {
-            partition_key,
-            dedup: None,
-        },
-    }
 }
 
 /// # Error description response

--- a/crates/admin/src/rest_api/services.rs
+++ b/crates/admin/src/rest_api/services.rs
@@ -8,12 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use tracing::{debug, warn};
-
 use axum::Json;
 use axum::extract::{Path, State};
 use bytes::Bytes;
 use http::StatusCode;
+use tracing::{debug, warn};
 
 use restate_admin_rest_model::services::ListServicesResponse;
 use restate_admin_rest_model::services::*;
@@ -22,13 +21,14 @@ use restate_core::network::TransportConnect;
 use restate_errors::warn_it;
 use restate_types::config::Configuration;
 use restate_types::identifiers::{ServiceId, WithPartitionKey};
+use restate_types::logs::{BodyWithKeys, Keys};
 use restate_types::schema::registry::MetadataService;
 use restate_types::schema::service::ServiceMetadata;
 use restate_types::state_mut::ExternalStateMutation;
 use restate_types::{Scope, schema};
-use restate_wal_protocol::{Command, Envelope};
+use restate_wal_protocol::v2;
+use restate_wal_protocol::v2::commands;
 
-use super::create_envelope_header;
 use super::error::*;
 use crate::state::AdminServiceState;
 
@@ -250,14 +250,17 @@ where
         state: new_state,
     };
 
-    let envelope = Envelope::new(
-        create_envelope_header(partition_key),
-        Command::PatchState(patch_state),
+    let envelop = v2::Envelope::new(
+        v2::Dedup::None,
+        commands::PatchStateCommand::from(patch_state),
     );
 
     let result = state
         .ingestion_client
-        .ingest(partition_key, envelope)
+        .ingest(
+            partition_key,
+            BodyWithKeys::new(envelop.into_raw(), Keys::Single(partition_key)),
+        )
         .await
         .map_err(|err| {
             warn!("Could not ingest state patching command: {err}");

--- a/crates/admin/src/service.rs
+++ b/crates/admin/src/service.rs
@@ -13,8 +13,6 @@ use std::time::Duration;
 
 use axum::error_handling::HandleErrorLayer;
 use http::{Request, Response, StatusCode};
-use restate_ingestion_client::IngestionClient;
-use restate_wal_protocol::Envelope;
 use tower::ServiceBuilder;
 use tower_http::classify::ServerErrorsFailureClass;
 use tower_http::compression::CompressionLayer;
@@ -24,6 +22,7 @@ use tracing::{Span, debug, info, info_span};
 use restate_admin_rest_model::version::AdminApiVersion;
 use restate_core::network::{TransportConnect, net_util};
 use restate_core::{MetadataWriter, TaskCenter};
+use restate_ingestion_client::IngestionClient;
 use restate_limiter::rule_book::RuleBookObserver;
 use restate_metadata_store::MetadataStoreClient;
 use restate_service_client::HttpClient;
@@ -36,6 +35,7 @@ use restate_types::net::address::AdminPort;
 use restate_types::net::listener::Listeners;
 use restate_types::schema::registry::SchemaRegistry;
 use restate_util_time::DurationExt;
+use restate_wal_protocol::v2::{Envelope, Raw};
 
 use crate::rest_api::{MAX_ADMIN_API_VERSION, MIN_ADMIN_API_VERSION};
 use crate::schema_registry_integration::{MetadataService, TelemetryClient};
@@ -47,7 +47,7 @@ pub struct BuildError(#[from] restate_service_client::BuildError);
 
 pub struct AdminService<Metadata, Discovery, Telemetry, Invocations, Transport> {
     listeners: Listeners<AdminPort>,
-    ingestion_client: IngestionClient<Transport, Envelope>,
+    ingestion_client: IngestionClient<Transport, Envelope<Raw>>,
     schema_registry: SchemaRegistry<Metadata, Discovery, Telemetry>,
     serdes_client: SerdesClient,
     invocation_client: Invocations,
@@ -65,7 +65,7 @@ where
     pub fn new(
         listeners: Listeners<AdminPort>,
         metadata_writer: MetadataWriter,
-        ingestion_client: IngestionClient<Transport, Envelope>,
+        ingestion_client: IngestionClient<Transport, Envelope<Raw>>,
         invocation_client: Invocations,
         serdes_client: SerdesClient,
         service_discovery: ServiceDiscovery,

--- a/crates/admin/src/state.rs
+++ b/crates/admin/src/state.rs
@@ -8,6 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::Arc;
+
 use restate_core::network::TransportConnect;
 use restate_ingestion_client::IngestionClient;
 use restate_limiter::rule_book::RuleBookObserver;
@@ -15,15 +17,14 @@ use restate_metadata_store::MetadataStoreClient;
 use restate_service_protocol_v4::serdes::SerdesClient;
 use restate_storage_query_datafusion::context::QueryContext;
 use restate_types::schema::registry::SchemaRegistry;
-use restate_wal_protocol::Envelope;
-use std::sync::Arc;
+use restate_wal_protocol::v2::{Envelope, Raw};
 
 #[derive(Clone, derive_builder::Builder)]
 pub struct AdminServiceState<Metadata, Discovery, Telemetry, Invocations, Transport> {
     pub schema_registry: SchemaRegistry<Metadata, Discovery, Telemetry>,
     pub serdes_client: SerdesClient,
     pub invocation_client: Invocations,
-    pub ingestion_client: IngestionClient<Transport, Envelope>,
+    pub ingestion_client: IngestionClient<Transport, Envelope<Raw>>,
     /// Used by handlers that mutate cluster-global metadata-store keys
     /// directly (e.g. the rule book) via `read_modify_write`.
     pub metadata_store_client: MetadataStoreClient,
@@ -41,7 +42,7 @@ where
         schema_registry: SchemaRegistry<Metadata, Discovery, Telemetry>,
         serdes_client: SerdesClient,
         invocation_client: Invocations,
-        ingestion_client: IngestionClient<Transport, Envelope>,
+        ingestion_client: IngestionClient<Transport, Envelope<Raw>>,
         metadata_store_client: MetadataStoreClient,
         query_context: Option<QueryContext>,
         rule_book_observer: Option<Arc<dyn RuleBookObserver>>,

--- a/crates/ingestion-client/src/client.rs
+++ b/crates/ingestion-client/src/client.rs
@@ -21,7 +21,7 @@ use restate_core::{
 use restate_types::{
     identifiers::PartitionKey,
     live::Live,
-    logs::{HasRecordKeys, Keys},
+    logs::{BodyWithKeys, HasRecordKeys, Keys},
     net::ingest::IngestRecord,
     partitions::{FindPartition, PartitionTable, PartitionTableError},
     storage::{StorageCodec, StorageEncode},
@@ -268,6 +268,16 @@ impl InputRecord<String> {
             keys: Keys::None,
             record: s.into(),
         }
+    }
+}
+
+impl<T> From<BodyWithKeys<T>> for InputRecord<T>
+where
+    T: StorageEncode,
+{
+    fn from(value: BodyWithKeys<T>) -> Self {
+        let (keys, record) = value.split();
+        Self { keys, record }
     }
 }
 

--- a/crates/ingress-kafka/src/builder.rs
+++ b/crates/ingress-kafka/src/builder.rs
@@ -18,21 +18,20 @@ use opentelemetry::trace::{Span, SpanContext, TraceContextExt};
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use rdkafka::Message;
 use rdkafka::message::BorrowedMessage;
+use rdkafka::message::Headers;
 use tracing::{info_span, trace};
 
-use rdkafka::message::Headers;
-
-use restate_storage_api::deduplication_table::DedupInformation;
 use restate_types::Scope;
-use restate_types::identifiers::{InvocationId, WithPartitionKey, partitioner};
+use restate_types::identifiers::{InvocationId, partitioner};
 use restate_types::invocation::{Header, InvocationTarget, ServiceInvocation, SpanRelation};
 use restate_types::limit_key::LimitKey;
 use restate_types::live::Live;
 use restate_types::schema::Schema;
 use restate_types::schema::invocation_target::{DeploymentStatus, InvocationTargetResolver};
 use restate_types::schema::subscriptions::{EventInvocationTargetTemplate, Sink, Subscription};
+use restate_types::sharding::{PartitionKey, WithPartitionKey};
 use restate_util_string::{ReString, RestateString, RestrictedValueError};
-use restate_wal_protocol::{Command, Destination, Envelope, Source};
+use restate_wal_protocol::v2::{Dedup, Envelope, commands};
 
 use crate::Error;
 
@@ -62,7 +61,7 @@ impl EnvelopeBuilder {
         producer_id: u128,
         consumer_group_id: &str,
         msg: BorrowedMessage<'_>,
-    ) -> Result<Envelope, Error> {
+    ) -> Result<(PartitionKey, Envelope<commands::InvokeCommand>), Error> {
         // Prepare ingress span
         let ingress_span = info_span!(
             "kafka_ingress_consume",
@@ -106,7 +105,11 @@ impl EnvelopeBuilder {
             (None, LimitKey::None)
         };
 
-        let dedup = DedupInformation::producer(producer_id, msg.offset() as u64);
+        let dedup = Dedup::Arbitrary {
+            prefix: None,
+            producer_id: producer_id.into(),
+            seq: msg.offset() as u64,
+        };
 
         let invocation = InvocationBuilder::create(
             &self.subscription,
@@ -130,23 +133,11 @@ impl EnvelopeBuilder {
             cause,
         })?;
 
-        Ok(self.wrap_service_invocation_in_envelope(invocation, dedup))
-    }
-
-    fn wrap_service_invocation_in_envelope(
-        &self,
-        service_invocation: Box<ServiceInvocation>,
-        dedup_information: DedupInformation,
-    ) -> Envelope {
-        let header = restate_wal_protocol::Header {
-            source: Source::Ingress {},
-            dest: Destination::Processor {
-                partition_key: service_invocation.partition_key(),
-                dedup: Some(dedup_information),
-            },
-        };
-
-        Envelope::new(header, Command::Invoke(service_invocation))
+        let partition_key = invocation.partition_key();
+        Ok((
+            partition_key,
+            Envelope::new(dedup, commands::InvokeCommand::from(invocation)),
+        ))
     }
 
     fn generate_events_attributes(msg: &impl Message, subscription_id: &str) -> Vec<Header> {
@@ -225,7 +216,7 @@ impl InvocationBuilder {
         topic: &str,
         partition: i32,
         offset: i64,
-    ) -> Result<Box<ServiceInvocation>, anyhow::Error> {
+    ) -> Result<ServiceInvocation, anyhow::Error> {
         let Sink::Invocation {
             event_invocation_target_template,
         } = subscription.sink();
@@ -325,11 +316,11 @@ impl InvocationBuilder {
         );
 
         // Finally generate service invocation
-        let mut service_invocation = Box::new(ServiceInvocation::initialize(
+        let mut service_invocation = ServiceInvocation::initialize(
             invocation_id,
             invocation_target,
             restate_types::invocation::Source::Subscription(subscription.id()),
-        ));
+        );
         service_invocation.with_related_span(SpanRelation::parent(ingress_span_context));
         service_invocation.argument = payload;
         service_invocation.headers = headers;

--- a/crates/ingress-kafka/src/consumer_task.rs
+++ b/crates/ingress-kafka/src/consumer_task.rs
@@ -26,19 +26,20 @@ use rdkafka::error::KafkaError;
 use rdkafka::topic_partition_list::TopicPartitionListElem;
 use rdkafka::types::RDKafkaErrorCode;
 use rdkafka::{ClientConfig, ClientContext, Message, Statistics};
+use tokio::sync::{mpsc, oneshot};
+use tracing::{debug, instrument, trace, warn};
 
 use restate_core::network::{NetworkSender, Swimlane, TransportConnect};
 use restate_core::{Metadata, TaskCenter, TaskHandle, TaskKind, task_center};
 use restate_ingestion_client::{IngestionClient, IngestionError, RecordCommit};
+use restate_types::identifiers::SubscriptionId;
 use restate_types::identifiers::partitioner::HashPartitioner;
-use restate_types::identifiers::{SubscriptionId, WithPartitionKey};
+use restate_types::logs::{BodyWithKeys, Keys};
 use restate_types::net::ingest::{DedupSequenceNrQueryRequest, ProducerId, ResponseStatus};
 use restate_types::partitions::FindPartition;
 use restate_types::retries::RetryPolicy;
 use restate_types::schema::subscriptions::{EventInvocationTargetTemplate, Sink};
-use restate_wal_protocol::Envelope;
-use tokio::sync::{mpsc, oneshot};
-use tracing::{debug, instrument, trace, warn};
+use restate_wal_protocol::v2::{Envelope, Raw};
 
 use crate::Error;
 use crate::builder::EnvelopeBuilder;
@@ -50,7 +51,7 @@ type MessageConsumer<T> = StreamConsumer<RebalanceContext<T>>;
 pub struct ConsumerTask<T> {
     client_config: ClientConfig,
     topics: Vec<String>,
-    ingestion: IngestionClient<T, Envelope>,
+    ingestion: IngestionClient<T, Envelope<Raw>>,
     builder: EnvelopeBuilder,
 }
 
@@ -61,7 +62,7 @@ where
     pub fn new(
         client_config: ClientConfig,
         topics: Vec<String>,
-        ingestion: IngestionClient<T, Envelope>,
+        ingestion: IngestionClient<T, Envelope<Raw>>,
         builder: EnvelopeBuilder,
     ) -> Self {
         Self {
@@ -167,7 +168,7 @@ struct RebalanceContext<T: TransportConnect> {
     consumer: OnceLock<Weak<MessageConsumer<T>>>,
     topic_partition_tasks: parking_lot::Mutex<HashMap<TopicPartition, AbortOnDrop>>,
     failures_tx: mpsc::UnboundedSender<Error>,
-    ingestion: IngestionClient<T, Envelope>,
+    ingestion: IngestionClient<T, Envelope<Raw>>,
     builder: EnvelopeBuilder,
     consumer_group_id: String,
 }
@@ -324,7 +325,7 @@ where
     T: TransportConnect,
     C: ConsumerContext,
 {
-    ingestion: IngestionClient<T, Envelope>,
+    ingestion: IngestionClient<T, Envelope<Raw>>,
     builder: EnvelopeBuilder,
     topic_partition: TopicPartition,
     topic_partition_consumer: StreamPartitionQueue<C>,
@@ -339,7 +340,7 @@ where
     C: ConsumerContext,
 {
     fn new(
-        ingestion: IngestionClient<T, Envelope>,
+        ingestion: IngestionClient<T, Envelope<Raw>>,
         builder: EnvelopeBuilder,
         topic_partition: TopicPartition,
         topic_partition_consumer: StreamPartitionQueue<C>,
@@ -530,11 +531,11 @@ where
                         "Ingesting kafka message"
                     );
 
-                    let envelope = self.builder.build(producer_id, &self.consumer_group_id, msg)?;
+                    let (partition_key, envelope) = self.builder.build(producer_id, &self.consumer_group_id, msg)?;
 
                     let commit_token = self
                         .ingestion
-                        .ingest(envelope.partition_key(), envelope)
+                        .ingest(partition_key,  BodyWithKeys::new(envelope.into_raw(), Keys::Single(partition_key)))
                         .await?
                         .map(|_| offset);
 

--- a/crates/ingress-kafka/src/subscription_controller.rs
+++ b/crates/ingress-kafka/src/subscription_controller.rs
@@ -11,7 +11,6 @@
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
-use restate_wal_protocol::Envelope;
 use tokio::sync::mpsc;
 use tracing::{error, warn};
 
@@ -24,6 +23,7 @@ use restate_types::retries::RetryPolicy;
 use restate_types::schema::Schema;
 use restate_types::schema::kafka::KafkaCluster;
 use restate_types::schema::subscriptions::{Source, Subscription};
+use restate_wal_protocol::v2::{Envelope, Raw};
 
 use super::*;
 use crate::builder::EnvelopeBuilder;
@@ -32,7 +32,7 @@ use crate::subscription_controller::task_orchestrator::TaskOrchestrator;
 // For simplicity of the current implementation, this currently lives in this module
 // In future versions, we should either pull this out in a separate process, or generify it and move it to the worker, or an ad-hoc module
 pub struct Service<T> {
-    ingestion: IngestionClient<T, Envelope>,
+    ingestion: IngestionClient<T, Envelope<Raw>>,
     schema: Live<Schema>,
 
     commands_tx: SubscriptionCommandSender,
@@ -43,7 +43,7 @@ impl<T> Service<T>
 where
     T: TransportConnect,
 {
-    pub fn new(ingestion: IngestionClient<T, Envelope>, schema: Live<Schema>) -> Self {
+    pub fn new(ingestion: IngestionClient<T, Envelope<Raw>>, schema: Live<Schema>) -> Self {
         metric_definitions::describe_metrics();
         let (commands_tx, commands_rx) = mpsc::channel(10);
 

--- a/crates/node/src/roles/admin.rs
+++ b/crates/node/src/roles/admin.rs
@@ -45,7 +45,8 @@ use restate_types::partition_table::PartitionTable;
 use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::protobuf::common::AdminStatus;
 use restate_types::retries::RetryPolicy;
-use restate_wal_protocol::Envelope;
+use restate_wal_protocol::v2::Envelope;
+use restate_wal_protocol::v2::Raw;
 use restate_worker_api::PartitionProcessorInvocationClient;
 
 #[derive(Debug, thiserror::Error, CodedError)]
@@ -82,7 +83,7 @@ impl<T: TransportConnect> AdminRole<T> {
     pub async fn create(
         health_status: HealthStatus<AdminStatus>,
         bifrost: Bifrost,
-        ingestion_client: IngestionClient<T, Envelope>,
+        ingestion_client: IngestionClient<T, Envelope<Raw>>,
         updateable_config: Live<Configuration>,
         partition_routing: PartitionRouting,
         partition_table: Live<PartitionTable>,

--- a/crates/node/src/roles/worker.rs
+++ b/crates/node/src/roles/worker.rs
@@ -24,7 +24,8 @@ use restate_storage_query_datafusion::remote_query_scanner_manager::RemoteScanne
 use restate_types::health::HealthStatus;
 use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::protobuf::common::WorkerStatus;
-use restate_wal_protocol::Envelope;
+use restate_wal_protocol::v2::Envelope;
+use restate_wal_protocol::v2::Raw;
 use restate_worker::{RuleBookCacheHandle, Worker};
 use restate_worker_api::ProcessorsManagerHandle;
 
@@ -54,7 +55,7 @@ where
         partition_store_manager: Arc<PartitionStoreManager>,
         networking: Networking<T>,
         bifrost: Bifrost,
-        ingestion_client: IngestionClient<T, Envelope>,
+        ingestion_client: IngestionClient<T, Envelope<Raw>>,
         metadata_writer: MetadataWriter,
         remote_scanner_manager: RemoteScannerManager,
     ) -> Result<Self, WorkerRoleBuildError> {

--- a/crates/types/src/cluster_marker.rs
+++ b/crates/types/src/cluster_marker.rs
@@ -33,6 +33,7 @@ const TMP_CLUSTER_MARKER_FILE_NAME: &str = ".tmp-cluster-marker";
 ///
 /// To reduce the risk of unexpected incompatibility issues, the minimum tracks the
 /// version we allow restate to downgrade to according to the compatibility policy.
+// todo(azmy): Bump to 1.7 before Restate v1.8.0 because of envelope v2
 const COMPATIBILITY_INFORMATION: CompatibilityInformation = CompatibilityInformation::new(
     SemanticRestateVersion::new(1, 6, 0),
     SemanticRestateVersion::new(1, 6, 0),

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -26,10 +26,6 @@ mod subscription_integration;
 use std::sync::Arc;
 
 use codederror::CodedError;
-use restate_core::network::Swimlane;
-use restate_ingestion_client::SessionOptions;
-use restate_types::net::connect_opts::GrpcConnectionOptions;
-use restate_wal_protocol::Envelope;
 use tracing::info;
 
 use restate_bifrost::Bifrost;
@@ -37,11 +33,13 @@ use restate_core::MetadataKind;
 use restate_core::cancellation_watcher;
 use restate_core::network::MessageRouterBuilder;
 use restate_core::network::Networking;
+use restate_core::network::Swimlane;
 use restate_core::network::TransportConnect;
 use restate_core::partitions::PartitionRouting;
 use restate_core::{Metadata, TaskKind};
 use restate_core::{MetadataWriter, TaskCenter};
 use restate_ingestion_client::IngestionClient;
+use restate_ingestion_client::SessionOptions;
 use restate_ingress_kafka::Service as IngressKafkaService;
 use restate_partition_store::PartitionStoreManager;
 use restate_partition_store::snapshots::SnapshotRepository;
@@ -51,11 +49,13 @@ use restate_types::Version;
 use restate_types::Versioned;
 use restate_types::config::Configuration;
 use restate_types::health::HealthStatus;
+use restate_types::net::connect_opts::GrpcConnectionOptions;
 use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::protobuf::common::WorkerStatus;
 use restate_types::schema::Redaction;
 use restate_types::schema::kafka::KafkaClusterResolver;
 use restate_types::schema::subscriptions::SubscriptionResolver;
+use restate_wal_protocol::v2::{Envelope, Raw};
 use restate_worker_api::ProcessorsManagerHandle;
 
 use crate::partition_processor_manager::PartitionProcessorManager;
@@ -113,7 +113,7 @@ where
         partition_store_manager: Arc<PartitionStoreManager>,
         networking: Networking<T>,
         bifrost: Bifrost,
-        ingestion_client: IngestionClient<T, Envelope>,
+        ingestion_client: IngestionClient<T, Envelope<Raw>>,
         router_builder: &mut MessageRouterBuilder,
         metadata_writer: MetadataWriter,
         remote_scanner_manager: RemoteScannerManager,
@@ -131,7 +131,7 @@ where
         let schema = metadata.updateable_schema();
 
         // ingress_kafka
-        let ingress_kafka = IngressKafkaService::new(ingestion_client.clone(), schema.clone());
+        let ingress_kafka = IngressKafkaService::new(ingestion_client, schema.clone());
 
         let subscription_controller_handle =
             SubscriptionControllerHandle::new(ingress_kafka.create_command_sender());

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -65,11 +65,12 @@ use restate_util_time::DurationExt;
 use restate_vqueues::context::{HasVQueues, HasVQueuesMut};
 use restate_vqueues::scheduler::{self};
 use restate_vqueues::{ResourceManager, SchedulerService, VQueuesMeta};
+use restate_wal_protocol::Command;
 use restate_wal_protocol::control::{
     AnnounceLeaderCommand, UpdatePartitionDurabilityCommand, VersionBarrierCommand,
 };
 use restate_wal_protocol::timer::TimerKeyValue;
-use restate_wal_protocol::{Command, Envelope};
+use restate_wal_protocol::v2::{Envelope, Raw};
 use restate_worker_api::invoker::InvokerHandle;
 use restate_worker_api::{
     LeaderQueryCommand, LeaderQueryRequest, LeaderQueryResponse, LeaderQuerySender,
@@ -227,7 +228,7 @@ pub(crate) struct LeadershipState<T> {
     state: State,
 
     partition_id: PartitionId,
-    ingestion_client: IngestionClient<T, Envelope>,
+    ingestion_client: IngestionClient<T, Envelope<Raw>>,
     leader_query_tx: LeaderQuerySender,
 
     /// Set when `become_leader` installs `State::Leader`, cleared by
@@ -242,7 +243,7 @@ where
 {
     pub(crate) fn new(
         partition_id: PartitionId,
-        ingestion_client: IngestionClient<T, Envelope>,
+        ingestion_client: IngestionClient<T, Envelope<Raw>>,
         leader_query_tx: LeaderQuerySender,
     ) -> Self {
         Self {
@@ -733,7 +734,7 @@ where
             let (shuffle_tx, shuffle_rx) = tokio::sync::watch::channel(None);
 
             let shuffle = Shuffle::new(
-                ShuffleMetadata::new(processor.partition_id(), *leader_epoch),
+                ShuffleMetadata::new(processor.partition_id()),
                 OutboxReader::from(partition_store.clone()),
                 shuffle_tx,
                 config.worker.internal_queue_length(),

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -158,7 +158,7 @@ impl PartitionProcessorBuilder {
 
     pub async fn build<T>(
         self,
-        ingestion_client: IngestionClient<T, Envelope>,
+        ingestion_client: IngestionClient<T, v2::Envelope<v2::Raw>>,
         partition_db: PartitionDb,
     ) -> Result<PartitionProcessor<T>, ProcessorError>
     where

--- a/crates/worker/src/partition/shuffle.rs
+++ b/crates/worker/src/partition/shuffle.rs
@@ -18,16 +18,18 @@ use tracing::debug;
 use restate_core::cancellation_token;
 use restate_core::network::TransportConnect;
 use restate_ingestion_client::IngestionClient;
-use restate_storage_api::deduplication_table::DedupInformation;
 use restate_storage_api::outbox_table::OutboxMessage;
-use restate_types::identifiers::{LeaderEpoch, PartitionId, PartitionKey, WithPartitionKey};
+use restate_types::identifiers::PartitionId;
 use restate_types::message::MessageIndex;
-use restate_wal_protocol::{Destination, Envelope, Header, Source};
+use restate_wal_protocol::v2::commands::{
+    AttachInvocationCommand, InvocationResponseCommand, InvokeCommand, NotifySignalCommand,
+    TerminateInvocationCommand,
+};
+use restate_wal_protocol::v2::{Dedup, Envelope, Raw};
 
 use crate::metric_definitions::{
     PARTITION_LABEL, PARTITION_SHUFFLE_INFLIGHT_RECORDS, PARTITION_SHUFFLE_MESSAGE_COUNT,
 };
-use crate::partition::types::OutboxMessageExt;
 
 #[derive(Debug)]
 pub(crate) struct NewOutboxMessage {
@@ -61,30 +63,32 @@ pub(crate) fn wrap_outbox_message_in_envelope(
     message: OutboxMessage,
     seq_number: MessageIndex,
     shuffle_metadata: &ShuffleMetadata,
-) -> Envelope {
-    Envelope::new(
-        create_header(message.partition_key(), seq_number, shuffle_metadata),
-        message.to_command(),
-    )
+) -> Envelope<Raw> {
+    let dedup = create_dedup(seq_number, shuffle_metadata);
+
+    match message {
+        OutboxMessage::AttachInvocation(payload) => {
+            Envelope::new(dedup, AttachInvocationCommand::from(payload)).into_raw()
+        }
+        OutboxMessage::InvocationTermination(payload) => {
+            Envelope::new(dedup, TerminateInvocationCommand::from(payload)).into_raw()
+        }
+        OutboxMessage::ServiceInvocation(payload) => {
+            Envelope::new(dedup, InvokeCommand::from(*payload)).into_raw()
+        }
+        OutboxMessage::NotifySignal(payload) => {
+            Envelope::new(dedup, NotifySignalCommand::from(payload)).into_raw()
+        }
+        OutboxMessage::ServiceResponse(payload) => {
+            Envelope::new(dedup, InvocationResponseCommand::from(payload)).into_raw()
+        }
+    }
 }
 
-fn create_header(
-    dest_partition_key: PartitionKey,
-    seq_number: MessageIndex,
-    shuffle_metadata: &ShuffleMetadata,
-) -> Header {
-    Header {
-        source: Source::Processor {
-            partition_key: None,
-            leader_epoch: shuffle_metadata.leader_epoch,
-        },
-        dest: Destination::Processor {
-            partition_key: dest_partition_key,
-            dedup: Some(DedupInformation::cross_partition(
-                shuffle_metadata.partition_id,
-                seq_number,
-            )),
-        },
+fn create_dedup(seq_number: MessageIndex, shuffle_metadata: &ShuffleMetadata) -> Dedup {
+    Dedup::ForeignPartition {
+        partition: shuffle_metadata.partition_id,
+        seq: seq_number,
     }
 }
 
@@ -151,22 +155,18 @@ impl HintSender {
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct ShuffleMetadata {
     partition_id: PartitionId,
-    leader_epoch: LeaderEpoch,
 }
 
 impl ShuffleMetadata {
-    pub(crate) fn new(partition_id: PartitionId, leader_epoch: LeaderEpoch) -> Self {
-        ShuffleMetadata {
-            partition_id,
-            leader_epoch,
-        }
+    pub(crate) fn new(partition_id: PartitionId) -> Self {
+        ShuffleMetadata { partition_id }
     }
 }
 
 pub(crate) struct Shuffle<T, OR> {
     metadata: ShuffleMetadata,
     outbox_reader: OR,
-    ingestion_client: IngestionClient<T, Envelope>,
+    ingestion_client: IngestionClient<T, Envelope<Raw>>,
     // used to tell partition processor about outbox truncations
     truncation_tx: watch::Sender<Option<OutboxTruncation>>,
     hint_rx: async_channel::Receiver<NewOutboxMessage>,
@@ -184,7 +184,7 @@ where
         outbox_reader: OR,
         truncation_tx: watch::Sender<Option<OutboxTruncation>>,
         channel_size: usize,
-        ingestion_client: IngestionClient<T, Envelope>,
+        ingestion_client: IngestionClient<T, Envelope<Raw>>,
     ) -> Self {
         let (hint_tx, hint_rx) = async_channel::bounded(channel_size);
 
@@ -277,8 +277,12 @@ mod state_machine {
     use restate_core::network::TransportConnect;
     use restate_ingestion_client::{IngestFuture, IngestionClient, RecordCommit};
     use restate_storage_api::outbox_table::OutboxMessage;
-    use restate_types::{identifiers::WithPartitionKey, message::MessageIndex};
-    use restate_wal_protocol::Envelope;
+    use restate_types::{
+        identifiers::WithPartitionKey,
+        logs::{BodyWithKeys, Keys},
+        message::MessageIndex,
+    };
+    use restate_wal_protocol::v2::{Envelope, Raw};
 
     use crate::partition::shuffle::{
         NewOutboxMessage, OutboxReaderError, ShuffleMetadata, wrap_outbox_message_in_envelope,
@@ -311,7 +315,7 @@ mod state_machine {
 
     pub struct StateMachine<T, R> {
         metadata: ShuffleMetadata,
-        ingestion: IngestionClient<T, Envelope>,
+        ingestion: IngestionClient<T, Envelope<Raw>>,
         hint_rx: async_channel::Receiver<NewOutboxMessage>,
         reader: Option<R>,
         read_fut: ReadFuture<R>,
@@ -326,7 +330,7 @@ mod state_machine {
     {
         pub fn new(
             metadata: ShuffleMetadata,
-            ingestion: IngestionClient<T, Envelope>,
+            ingestion: IngestionClient<T, Envelope<Raw>>,
             reader: R,
             hint_rx: async_channel::Receiver<NewOutboxMessage>,
         ) -> Self {
@@ -356,12 +360,15 @@ mod state_machine {
 
                         match sn.cmp(&self.next_sequence_number) {
                             Ordering::Equal => {
+                                let partition_key = message.partition_key();
                                 let envelope =
                                     wrap_outbox_message_in_envelope(message, sn, &self.metadata);
+
                                 self.state = State::Ingesting {
-                                    ingest: self
-                                        .ingestion
-                                        .ingest(envelope.partition_key(), envelope),
+                                    ingest: self.ingestion.ingest(
+                                        partition_key,
+                                        BodyWithKeys::new(envelope, Keys::Single(partition_key)),
+                                    ),
                                     sn,
                                 };
                             }
@@ -405,12 +412,14 @@ mod state_machine {
                                     sn >= self.next_sequence_number,
                                     "message sequence numbers must not decrease"
                                 );
+                                let partition_key = message.partition_key();
                                 let envelope =
                                     wrap_outbox_message_in_envelope(message, sn, &self.metadata);
                                 self.state = State::Ingesting {
-                                    ingest: self
-                                        .ingestion
-                                        .ingest(envelope.partition_key(), envelope),
+                                    ingest: self.ingestion.ingest(
+                                        partition_key,
+                                        BodyWithKeys::new(envelope, Keys::Single(partition_key)),
+                                    ),
                                     sn,
                                 };
                             }
@@ -430,7 +439,6 @@ mod ingestion_client_tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use anyhow::{Context, anyhow};
-    use assert2::let_assert;
     use futures::StreamExt;
     use restate_core::partitions::PartitionRouting;
     use restate_ingestion_client::{IngestionClient, SessionOptions};
@@ -439,6 +447,8 @@ mod ingestion_client_tests {
     use restate_types::net::partition_processor::PartitionLeaderService;
     use restate_types::partitions::state::{LeadershipState, PartitionReplicaSetStates};
     use restate_types::storage::StorageCodec;
+    use restate_wal_protocol::v2::commands::InvokeCommand;
+    use restate_wal_protocol::v2::{CommandKind, Envelope, Raw};
     use test_log::test;
     use tokio::sync::watch;
 
@@ -454,7 +464,6 @@ mod ingestion_client_tests {
     use restate_types::invocation::ServiceInvocation;
     use restate_types::message::MessageIndex;
     use restate_types::partition_table::PartitionTable;
-    use restate_wal_protocol::{Command, Envelope};
 
     use crate::partition::shuffle::{OutboxReader, OutboxReaderError, Shuffle, ShuffleMetadata};
 
@@ -576,12 +585,15 @@ mod ingestion_client_tests {
             let (r, body) = incoming.split();
             r.send(ResponseStatus::Ack.into());
             for mut record in body.records {
-                let envelope = StorageCodec::decode::<Envelope, _>(&mut record.record)
+                let envelope = StorageCodec::decode::<Envelope<Raw>, _>(&mut record.record)
                     .context("Failed to decode envelope")?;
 
-                let_assert!(Command::Invoke(service_invocation) = envelope.command);
+                assert!(CommandKind::Invoke == envelope.kind());
+                let envelope: Envelope<InvokeCommand> = envelope.into_typed();
+                let service_invocation: ServiceInvocation = envelope.into_inner().unwrap().into();
+
                 let invocation_id = service_invocation.invocation_id;
-                messages.push(*service_invocation);
+                messages.push(service_invocation);
 
                 if last_invocation_id == invocation_id {
                     break 'out;
@@ -622,7 +634,7 @@ mod ingestion_client_tests {
         #[allow(dead_code)]
         env: TestCoreEnv<FailingConnector>,
         stream: ServiceStream<PartitionLeaderService>,
-        ingestion: IngestionClient<FailingConnector, Envelope>,
+        ingestion: IngestionClient<FailingConnector, Envelope<Raw>>,
         shuffle: Shuffle<FailingConnector, OR>,
     }
 
@@ -634,7 +646,7 @@ mod ingestion_client_tests {
             PartitionTable::with_equally_sized_partitions(Version::MIN, 1),
         );
 
-        let metadata = ShuffleMetadata::new(PartitionId::from(0), LeaderEpoch::from(0));
+        let metadata = ShuffleMetadata::new(PartitionId::from(0));
 
         let partition_replica_set_states = PartitionReplicaSetStates::default();
 

--- a/crates/worker/src/partition/types.rs
+++ b/crates/worker/src/partition/types.rs
@@ -11,7 +11,6 @@
 use restate_storage_api::outbox_table::OutboxMessage;
 use restate_types::identifiers::{EntryIndex, InvocationId};
 use restate_types::invocation::{InvocationResponse, JournalCompletionTarget, ResponseResult};
-use restate_wal_protocol::Command;
 
 pub(crate) type InvokerEffect = restate_worker_api::invoker::FencedEffect;
 pub(crate) type InvokerEffectKind = restate_worker_api::invoker::EffectKind;
@@ -23,8 +22,6 @@ pub(crate) trait OutboxMessageExt {
         entry_index: EntryIndex,
         result: ResponseResult,
     ) -> OutboxMessage;
-
-    fn to_command(self) -> Command;
 }
 
 impl OutboxMessageExt for OutboxMessage {
@@ -40,15 +37,5 @@ impl OutboxMessageExt for OutboxMessage {
             },
             result,
         })
-    }
-
-    fn to_command(self) -> Command {
-        match self {
-            OutboxMessage::ServiceInvocation(si) => Command::Invoke(si),
-            OutboxMessage::ServiceResponse(sr) => Command::InvocationResponse(sr),
-            OutboxMessage::InvocationTermination(it) => Command::TerminateInvocation(it),
-            OutboxMessage::AttachInvocation(ai) => Command::AttachInvocation(ai),
-            OutboxMessage::NotifySignal(notify_signal) => Command::NotifySignal(notify_signal),
-        }
     }
 }

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -80,7 +80,7 @@ use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::protobuf::common::WorkerStatus;
 use restate_util_string::format_restring;
 use restate_util_time::DurationExt;
-use restate_wal_protocol::Envelope;
+use restate_wal_protocol::v2::{Envelope, Raw};
 use restate_worker_api::invoker::capacity::InvokerCapacity;
 use restate_worker_api::{ProcessorsManagerCommand, ProcessorsManagerHandle};
 
@@ -132,7 +132,7 @@ pub struct PartitionProcessorManager<T> {
 
     invoker_capacity: InvokerCapacity,
 
-    ingestion_client: IngestionClient<T, Envelope>,
+    ingestion_client: IngestionClient<T, Envelope<Raw>>,
 
     /// Built in `new`; the polling task is spawned at the start of `run`.
     rule_book_cache_task: Option<RuleBookCache>,
@@ -209,7 +209,7 @@ where
         router_builder: &mut MessageRouterBuilder,
         bifrost: Bifrost,
         snapshot_repository: Option<SnapshotRepository>,
-        ingestion_client: IngestionClient<T, Envelope>,
+        ingestion_client: IngestionClient<T, Envelope<Raw>>,
     ) -> Self {
         let config = updateable_config.pinned();
         let ppm_svc_rx = router_builder.register_service(BackPressureMode::Lossy);

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -24,7 +24,7 @@ use restate_platform::prelude::ReString;
 use restate_types::cluster::cluster_state::PartitionProcessorStatus;
 use restate_types::logs::Lsn;
 use restate_types::partitions::Partition;
-use restate_wal_protocol::Envelope;
+use restate_wal_protocol::v2::{Envelope, Raw};
 
 use crate::PartitionProcessorBuilder;
 use crate::partition::NodeContext;
@@ -37,7 +37,7 @@ pub struct SpawnPartitionProcessorTask<T> {
     partition: Partition,
     partition_store_manager: Arc<PartitionStoreManager>,
     fast_forward_lsn: Option<Lsn>,
-    ingestion_client: IngestionClient<T, Envelope>,
+    ingestion_client: IngestionClient<T, Envelope<Raw>>,
 }
 
 impl<T> SpawnPartitionProcessorTask<T>
@@ -50,7 +50,7 @@ where
         partition: Partition,
         partition_store_manager: Arc<PartitionStoreManager>,
         fast_forward_lsn: Option<Lsn>,
-        ingestion_client: IngestionClient<T, Envelope>,
+        ingestion_client: IngestionClient<T, Envelope<Raw>>,
     ) -> Self {
         Self {
             node_ctx,


### PR DESCRIPTION
Switch the code paths that uses IngestionClient to start ingesting
v2 Envelope instead of v1
