### PR TITLE
Avoid sending empty trailers

### DIFF
--- a/crates/service-client/src/pool/conn.rs
+++ b/crates/service-client/src/pool/conn.rs
@@ -21,7 +21,7 @@ use futures::never::Never;
 use futures::{FutureExt, ready};
 use h2::client::{ResponseFuture as H2ResponseFuture, SendRequest};
 use h2::{Reason, RecvStream, SendStream};
-use http::{HeaderMap, Request, Response, Uri};
+use http::{Request, Response, Uri};
 use http_body::{Body, Frame};
 use http_body_util::BodyExt;
 use metrics::{counter, histogram};
@@ -819,7 +819,7 @@ where
         }
 
         // Send an explicit end stream
-        self.send_stream.send_trailers(HeaderMap::default())?;
+        self.send_stream.send_data(Bytes::default(), true)?;
 
         Ok(())
     }


### PR DESCRIPTION

Summary:
An issue reported in this thread https://discordapp.com/channels/1128210118216007792/1518587782564413544

After investigation there were 2 issues:
- Wrong nginx configuraiton. This was fixed by enabled http2 end-to-end by using the `grpx_proxy` (docs updated)
- The second issues surfaced later when restart start showing `frame with invalid size` errors.

After investigating this, it was clear that `nginx` doesn't handle empty trailers correctly. We use
empty trailer to explicitly close stream.

Instead we switched to sending empty data frame with END_STREAM flag set, and that seems to be working well
and have the same side effect.
