### PR TITLE
[doctor] Default to secondary reading mode

### DIFF
--- a/tools/restate-doctor/src/commands/log_server/mod.rs
+++ b/tools/restate-doctor/src/commands/log_server/mod.rs
@@ -44,21 +44,22 @@ pub struct LogServerOpts {
     #[arg(long, short)]
     pub path: Option<PathBuf>,
 
-    /// Open database as a secondary instance.
+    /// DANGER: open the database in RocksDB read-only mode instead of as a
+    /// secondary instance.
     ///
-    /// This allows analysis while the Restate server is running.
-    /// Without this flag, the database is opened in read-only mode
-    /// which requires exclusive access (server must be stopped).
+    /// Read-only mode requires exclusive access and WILL corrupt the database
+    /// if a Restate server currently has it open. Only use it when the server
+    /// is stopped. The default (secondary) mode is always safe.
     #[arg(long)]
-    pub secondary: bool,
+    pub read_only: bool,
 }
 
 impl LogServerOpts {
     pub fn open_mode(&self) -> OpenMode {
-        if self.secondary {
-            OpenMode::Secondary
-        } else {
+        if self.read_only {
             OpenMode::ReadOnly
+        } else {
+            OpenMode::Secondary
         }
     }
 }

--- a/tools/restate-doctor/src/commands/partition_store.rs
+++ b/tools/restate-doctor/src/commands/partition_store.rs
@@ -44,21 +44,22 @@ pub struct PartitionStoreOpts {
     #[arg(long, short)]
     pub path: Option<PathBuf>,
 
-    /// Open database as a secondary instance.
+    /// DANGER: open the database in RocksDB read-only mode instead of as a
+    /// secondary instance.
     ///
-    /// This allows analysis while the Restate server is running.
-    /// Without this flag, the database is opened in read-only mode
-    /// which requires exclusive access (server must be stopped).
+    /// Read-only mode requires exclusive access and WILL corrupt the database
+    /// if a Restate server currently has it open. Only use it when the server
+    /// is stopped. The default (secondary) mode is always safe.
     #[arg(long)]
-    pub secondary: bool,
+    pub read_only: bool,
 }
 
 impl PartitionStoreOpts {
     pub fn open_mode(&self) -> OpenMode {
-        if self.secondary {
-            OpenMode::Secondary
-        } else {
+        if self.read_only {
             OpenMode::ReadOnly
+        } else {
+            OpenMode::Secondary
         }
     }
 }

--- a/tools/restate-doctor/src/util/rocksdb.rs
+++ b/tools/restate-doctor/src/util/rocksdb.rs
@@ -14,17 +14,24 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
+use restate_cli_util::c_warn;
+use restate_cli_util::ui::console::confirm_or_exit;
 use restate_partition_store::keys::KeyKind;
 use rocksdb::{ColumnFamilyDescriptor, DB, LiveFile, Options};
 
-/// Mode for opening the database
+/// Mode for opening the database.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum OpenMode {
-    /// Open in read-only mode (requires exclusive access)
+    /// Open as a secondary instance (default). Safe to run while the primary
+    /// (Restate server) has the database open read-write, and equally fine when
+    /// the server is stopped.
     #[default]
-    ReadOnly,
-    /// Open as secondary instance (can run while primary is active)
     Secondary,
+    /// Open in RocksDB read-only mode.
+    ///
+    /// DANGEROUS: this WILL corrupt the database if a Restate server currently
+    /// has it open. Only use when the server is fully stopped.
+    ReadOnly,
 }
 
 /// The default column family name in RocksDB (not used for partition data)
@@ -102,10 +109,12 @@ pub fn extract_file_number(filename: &str) -> Option<u64> {
         .and_then(|s| s.parse::<u64>().ok())
 }
 
-/// Open a RocksDB database for read-only analysis with default CF options.
+/// Open a RocksDB database for analysis with default CF options.
 ///
-/// If `max_open_files` is `Some`, limits the number of open file handles RocksDB will use.
-/// This is useful in environments where the file descriptor limit cannot be increased.
+/// See [`OpenMode`] for the trade-offs between secondary (default, safe) and
+/// read-only mode. If `max_open_files` is `Some`, limits the number of open
+/// file handles RocksDB will use in read-only mode; it is ignored in secondary
+/// mode as it requires setting this to `-1` (unlimited).
 pub fn open_partition_store_db(
     path: impl AsRef<Path>,
     mode: OpenMode,
@@ -122,7 +131,7 @@ pub fn open_partition_store_db(
     })
 }
 
-/// Open a RocksDB database for read-only analysis with per-CF options.
+/// Open a RocksDB database for analysis with per-CF options.
 ///
 /// `cf_opts_fn` is called for each column family name and should return the
 /// `Options` to use when opening that CF. This is required when the database
@@ -151,8 +160,26 @@ pub fn open_db_with_cf_options(
     );
 
     let mut opts = Options::default();
-    if let Some(limit) = max_open_files {
-        opts.set_max_open_files(limit);
+    match mode {
+        // A secondary reading mode must set `max_open_files` must be -1 (unlimited). Reject
+        // any other explicit value.
+        OpenMode::Secondary => {
+            if let Some(limit) = max_open_files
+                && limit != -1
+            {
+                bail!(
+                    "--limit-open-files must be -1 (unlimited) in secondary mode; \
+                     a secondary instance needs load all the files in case the primary \
+                     unlinks them. Got {limit}."
+                );
+            }
+            opts.set_max_open_files(-1);
+        }
+        OpenMode::ReadOnly => {
+            if let Some(limit) = max_open_files {
+                opts.set_max_open_files(limit);
+            }
+        }
     }
 
     opts.set_disable_auto_compactions(true);
@@ -163,20 +190,28 @@ pub fn open_db_with_cf_options(
         .collect();
 
     let db = match mode {
-        OpenMode::ReadOnly => DB::open_cf_descriptors_read_only(&opts, &path, descriptors, false)
-            .context(
-            "Failed to open database in read-only mode. \
-                 This requires exclusive access - is the Restate server running? \
-                 Try using --secondary to analyze while the server is active.",
-        )?,
         OpenMode::Secondary => {
-            // Secondary mode requires a secondary path for WAL replay
+            // Secondary mode requires a secondary path for WAL replay / catch-up.
             let secondary_path = std::env::temp_dir()
                 .join(format!("restate-doctor-secondary-{}", std::process::id()));
             std::fs::create_dir_all(&secondary_path)?;
 
             DB::open_cf_descriptors_as_secondary(&opts, &path, &secondary_path, descriptors)
                 .context("Failed to open database as secondary instance.")?
+        }
+        OpenMode::ReadOnly => {
+            c_warn!(
+                "Opening the database in READ-ONLY mode. This is UNSAFE if a Restate server \
+                 currently has this database open and WILL corrupt a running server's database. Only \
+                 use read-only mode when the server is fully stopped. The default secondary mode \
+                 is always safe."
+            );
+            confirm_or_exit("Are you sure you want to open the database in read-only mode?")?;
+            DB::open_cf_descriptors_read_only(&opts, &path, descriptors, false).context(
+                "Failed to open database in read-only mode. This requires exclusive access - is \
+                 the Restate server running? Omit --read-only to open a safe secondary instance \
+                 instead.",
+            )?
         }
     };
 


### PR DESCRIPTION

ReadOnly mode is unsafe to be used while there's an active read-write reader for the database (e.g. an alive restate-server). It runs a purge for obselete SST files on destruction,
which can delete some SST files that the primary write that it wasn't aware of resulting into corrupting the db.

This PR changes the default to secondary reading mode, which should be safe to use while there's an active primary instance. It comes with the caveat that it must open all SST files
so that they're still reachable for it even if the primary unlinks them. As such, the --limit-open-files flag is now rejected in the secondary reading mode.

The read-only mode is still available via the --read-only flag but shows a strong warning about using it while there's an active primary instance.
