### PR TITLE
[Restate UI] Update to v1.0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8947,8 +8947,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "1.0.9"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v1.0.9#202850da158fcde3a5580a71f6a7e4a81a587f90"
+version = "1.0.10"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v1.0.10#03b6fdb92599c095f2ffa6bdccd0a5c48a463924"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -39,7 +39,7 @@ restate-util-time = { workspace = true }
 restate-types = { workspace = true }
 restate-util-string = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "1.0.9", tag = "v1.0.9" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "1.0.10", tag = "v1.0.10" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v1.0.10
published at https://github.com/restatedev/restate-web-ui/releases/download/v1.0.10/ui-v1.0.10.zip