### PR TITLE
Deprecate `OutboxMessage`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8723,6 +8723,7 @@ dependencies = [
  "restate-util-string",
  "restate-workspace-hack",
  "serde",
+ "serde_with",
  "static_assertions",
  "strum",
  "thiserror 2.0.18",

--- a/crates/storage-api/Cargo.toml
+++ b/crates/storage-api/Cargo.toml
@@ -31,6 +31,7 @@ futures = { workspace = true }
 opentelemetry = { workspace = true }
 prost = { workspace = true }
 serde = { workspace = true }
+serde_with = { workspace = true }
 static_assertions = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
+++ b/crates/storage-api/proto/dev/restate/storage/v1/domain.proto
@@ -710,6 +710,13 @@ message OutboxMessage {
     }
   }
 
+  message Opaque{
+    uint64 partition_key = 1;
+    uint32 kind = 2;
+    uint32 codec = 3;
+    bytes message = 4;
+  }
+
   oneof outbox_message {
     OutboxServiceInvocation service_invocation_case = 1;
     OutboxServiceInvocationResponse service_invocation_response = 2;
@@ -717,6 +724,7 @@ message OutboxMessage {
     OutboxCancel cancel = 5;
     AttachInvocationRequest attach_invocation_request = 6;
     NotifySignal notify_signal = 7;
+    Opaque opaque = 8;
   }
 }
 

--- a/crates/storage-api/src/outbox_table/mod.rs
+++ b/crates/storage-api/src/outbox_table/mod.rs
@@ -10,14 +10,28 @@
 
 use std::ops::RangeInclusive;
 
+use bytes::Bytes;
+
 use restate_types::identifiers::{PartitionKey, WithPartitionKey};
 use restate_types::invocation::{
     AttachInvocationRequest, InvocationResponse, InvocationTermination, NotifySignalRequest,
     ServiceInvocation,
 };
+use restate_types::storage::StorageCodecKind;
+use serde_with::{TryFromInto, serde_as};
 
 use crate::Result;
 use crate::protobuf_types::PartitionStoreProtobufValue;
+
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct OpaqueMessage {
+    pub partition_key: PartitionKey,
+    pub kind: u8,
+    #[serde_as(as = "TryFromInto<u8>")]
+    pub codec: StorageCodecKind,
+    pub message: Bytes,
+}
 
 /// Types of outbox messages.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -36,6 +50,14 @@ pub enum OutboxMessage {
 
     /// Notify signal request
     NotifySignal(NotifySignalRequest),
+
+    /// Opaque message
+    ///
+    /// Contains opaque outbox message.
+    /// This will eventually replace the other message types in this enum
+    ///
+    /// Since v1.8
+    Opaque(OpaqueMessage),
 }
 
 impl PartitionStoreProtobufValue for OutboxMessage {
@@ -50,6 +72,7 @@ impl WithPartitionKey for OutboxMessage {
             OutboxMessage::InvocationTermination(it) => it.invocation_id.partition_key(),
             OutboxMessage::AttachInvocation(ai) => ai.partition_key(),
             OutboxMessage::NotifySignal(sig) => sig.partition_key(),
+            OutboxMessage::Opaque(sig) => sig.partition_key,
         }
     }
 }

--- a/crates/storage-api/src/protobuf_types.rs
+++ b/crates/storage-api/src/protobuf_types.rs
@@ -3597,6 +3597,28 @@ pub mod v1 {
                     outbox_message::OutboxMessage::NotifySignal(notify_signal) => {
                         crate::outbox_table::OutboxMessage::NotifySignal(notify_signal.try_into()?)
                     }
+                    outbox_message::OutboxMessage::Opaque(opaque) => {
+                        let msg = crate::outbox_table::OpaqueMessage {
+                            partition_key: opaque.partition_key,
+                            codec: u8::try_from(opaque.codec)
+                                .map_err(|_| {
+                                    ConversionError::InvalidData(anyhow!(
+                                        "codec value does not fit u8"
+                                    ))
+                                })?
+                                .try_into()
+                                .map_err(|_| {
+                                    ConversionError::UnexpectedEnumVariant(
+                                        "codec",
+                                        opaque.codec as i32,
+                                    )
+                                })?,
+                            kind: opaque.kind as u8,
+                            message: opaque.message,
+                        };
+
+                        crate::outbox_table::OutboxMessage::Opaque(msg)
+                    }
                 };
 
                 Ok(result)
@@ -3659,6 +3681,14 @@ pub mod v1 {
                     ),
                     crate::outbox_table::OutboxMessage::NotifySignal(notify_signal) => {
                         outbox_message::OutboxMessage::NotifySignal(notify_signal.into())
+                    }
+                    crate::outbox_table::OutboxMessage::Opaque(opaque) => {
+                        outbox_message::OutboxMessage::Opaque(outbox_message::Opaque {
+                            partition_key: opaque.partition_key,
+                            kind: opaque.kind as u32,
+                            codec: u8::from(opaque.codec).into(),
+                            message: opaque.message,
+                        })
                     }
                 };
 

--- a/crates/types/src/restate_version.rs
+++ b/crates/types/src/restate_version.rs
@@ -238,6 +238,10 @@ pub static RESTATE_VERSION_1_7_0: LazyLock<SemanticRestateVersion> =
 pub static RESTATE_VERSION_1_8_0: LazyLock<SemanticRestateVersion> =
     LazyLock::new(|| SemanticRestateVersion::parse("1.8.0-dev").expect("valid semver version"));
 
+/// Why isn't this value simply v1.8.0? See description of [`RESTATE_VERSION_1_6_0`].
+pub static RESTATE_VERSION_1_9_0: LazyLock<SemanticRestateVersion> =
+    LazyLock::new(|| SemanticRestateVersion::parse("1.9.0-dev").expect("valid semver version"));
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/wal-protocol/src/v2.rs
+++ b/crates/wal-protocol/src/v2.rs
@@ -8,6 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+pub mod commands;
+mod compatibility;
+mod markers;
+
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -16,6 +20,7 @@ use bilrost::{Message, OwnedMessage};
 use bytes::{BufMut, Bytes, BytesMut};
 
 use restate_encoding::U128;
+use restate_types::errors::ConversionError;
 use restate_types::identifiers::{LeaderEpoch, PartitionId};
 use restate_types::logs::{BodyWithKeys, HasRecordKeys, Keys};
 use restate_types::storage::{
@@ -25,9 +30,7 @@ use restate_types::storage::{
 use restate_util_string::ReString;
 
 use crate::v1;
-
-pub mod commands;
-mod compatibility;
+pub use markers::OutboxMessage;
 
 mod sealed {
     pub trait Sealed {}
@@ -303,6 +306,7 @@ pub enum CommandScope {
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, bilrost::Enumeration, strum::Display, strum::IntoStaticStr,
 )]
+#[repr(u8)]
 pub enum CommandKind {
     Unknown = 0,
 
@@ -331,6 +335,9 @@ pub enum CommandKind {
     /// Truncate the message outbox up to, and including, the specified index.
     TruncateOutbox = 9,
     /// Proxy a service invocation through this partition processor, to reuse the deduplication id map.
+    ///
+    // Drop in v1.8 it's not used at the moment and is only here
+    // for backward compatibility with V1.
     ProxyThrough = 10,
     /// Attach to an existing invocation
     AttachInvocation = 11,
@@ -380,6 +387,54 @@ pub enum CommandKind {
     /// payload is bilrost encoded [`invocation::PauseInvocationCommand`]
     /// *Since v1.7.0
     PauseInvocation = 25,
+}
+
+impl From<CommandKind> for u8 {
+    fn from(value: CommandKind) -> Self {
+        value as u8
+    }
+}
+
+impl TryFrom<u8> for CommandKind {
+    type Error = ConversionError;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        let v = match value {
+            0 => Self::Unknown,
+            1 => Self::AnnounceLeader,
+            2 => Self::VersionBarrier,
+            3 => Self::UpdatePartitionDurability,
+            4 => Self::PatchState,
+            5 => Self::TerminateInvocation,
+            6 => Self::PurgeInvocation,
+            7 => Self::PurgeJournal,
+            8 => Self::Invoke,
+            9 => Self::TruncateOutbox,
+            10 => Self::ProxyThrough,
+            11 => Self::AttachInvocation,
+            12 => Self::ResumeInvocation,
+            13 => Self::RestartAsNewInvocation,
+            14 => Self::InvokerEffect,
+            15 => Self::Timer,
+            16 => Self::ScheduleTimer,
+            17 => Self::InvocationResponse,
+            18 => Self::NotifyGetInvocationOutputResponse,
+            19 => Self::NotifySignal,
+            20 => Self::UpsertSchema,
+            21 => Self::UpsertRuleBook,
+            22 => Self::VQSchedulerDecisions,
+            23 => Self::VQueuesPause,
+            24 => Self::VQueuesResume,
+            25 => Self::PauseInvocation,
+            other => {
+                return Err(ConversionError::unexpected_enum_variant(
+                    "CommandKind",
+                    i32::from(other),
+                ));
+            }
+        };
+
+        Ok(v)
+    }
 }
 
 mod bilrost_encoding {

--- a/crates/wal-protocol/src/v2/commands.rs
+++ b/crates/wal-protocol/src/v2/commands.rs
@@ -13,8 +13,8 @@ use serde::{Deserialize, Serialize};
 pub use restate_storage_api::vqueue_table::scheduler::SchedulerDecisionsCommand;
 use restate_types::{
     bilrost_storage_encode_decode, flexbuffers_storage_encode_decode,
-    identifiers::{WithInvocationId, WithPartitionKey},
-    invocation,
+    identifiers::{EntryIndex, InvocationId, WithInvocationId, WithPartitionKey},
+    invocation::{self, JournalCompletionTarget, ResponseResult},
     logs::{HasRecordKeys, Keys},
     message::MessageIndex,
     state_mut,
@@ -23,7 +23,7 @@ use restate_types::{
 use super::sealed::Sealed;
 use super::{Command, CommandKind};
 pub use crate::control::UpsertRuleBookCommand;
-use crate::timer;
+use crate::{timer, v2::OutboxMessage};
 // Re-epxort vqueues commands
 pub use crate::invocation::PauseInvocationCommand;
 pub use crate::vqueues::{VQueuesPauseCommand, VQueuesResumeCommand};
@@ -70,6 +70,18 @@ flexbuffers_storage_encode_decode!(TerminateInvocationCommand);
 impl HasRecordKeys for TerminateInvocationCommand {
     fn record_keys(&self) -> Keys {
         Keys::Single(self.invocation_id.partition_key())
+    }
+}
+
+impl WithPartitionKey for TerminateInvocationCommand {
+    fn partition_key(&self) -> restate_types::sharding::PartitionKey {
+        self.0.invocation_id.partition_key()
+    }
+}
+
+impl OutboxMessage for TerminateInvocationCommand {
+    fn into_outbox_message(self) -> restate_storage_api::outbox_table::OutboxMessage {
+        restate_storage_api::outbox_table::OutboxMessage::InvocationTermination(self.0)
     }
 }
 
@@ -131,6 +143,17 @@ impl HasRecordKeys for InvokeCommand {
     }
 }
 
+impl WithPartitionKey for InvokeCommand {
+    fn partition_key(&self) -> restate_types::sharding::PartitionKey {
+        self.0.partition_key()
+    }
+}
+impl OutboxMessage for InvokeCommand {
+    fn into_outbox_message(self) -> restate_storage_api::outbox_table::OutboxMessage {
+        restate_storage_api::outbox_table::OutboxMessage::ServiceInvocation(Box::new(self.0))
+    }
+}
+
 #[derive(Debug, Clone, bilrost::Message)]
 pub struct TruncateOutboxCommand {
     #[bilrost(1)]
@@ -155,7 +178,19 @@ flexbuffers_storage_encode_decode!(AttachInvocationCommand);
 
 impl HasRecordKeys for AttachInvocationCommand {
     fn record_keys(&self) -> Keys {
-        Keys::Single(self.partition_key())
+        Keys::Single(self.0.partition_key())
+    }
+}
+
+impl WithPartitionKey for AttachInvocationCommand {
+    fn partition_key(&self) -> restate_types::sharding::PartitionKey {
+        self.0.partition_key()
+    }
+}
+
+impl OutboxMessage for AttachInvocationCommand {
+    fn into_outbox_message(self) -> restate_storage_api::outbox_table::OutboxMessage {
+        restate_storage_api::outbox_table::OutboxMessage::AttachInvocation(self.0)
     }
 }
 
@@ -268,7 +303,35 @@ flexbuffers_storage_encode_decode!(InvocationResponseCommand);
 
 impl HasRecordKeys for InvocationResponseCommand {
     fn record_keys(&self) -> Keys {
-        Keys::Single(self.partition_key())
+        Keys::Single(self.0.partition_key())
+    }
+}
+
+impl WithPartitionKey for InvocationResponseCommand {
+    fn partition_key(&self) -> restate_types::sharding::PartitionKey {
+        self.0.partition_key()
+    }
+}
+
+impl OutboxMessage for InvocationResponseCommand {
+    fn into_outbox_message(self) -> restate_storage_api::outbox_table::OutboxMessage {
+        restate_storage_api::outbox_table::OutboxMessage::ServiceResponse(self.0)
+    }
+}
+
+impl InvocationResponseCommand {
+    pub fn from_awakeable_completion(
+        invocation_id: InvocationId,
+        entry_index: EntryIndex,
+        result: ResponseResult,
+    ) -> InvocationResponseCommand {
+        Self::from(invocation::InvocationResponse {
+            target: JournalCompletionTarget {
+                caller_id: invocation_id,
+                caller_completion_id: entry_index,
+            },
+            result,
+        })
     }
 }
 
@@ -308,7 +371,19 @@ flexbuffers_storage_encode_decode!(NotifySignalCommand);
 
 impl HasRecordKeys for NotifySignalCommand {
     fn record_keys(&self) -> Keys {
-        Keys::Single(self.partition_key())
+        Keys::Single(self.0.partition_key())
+    }
+}
+
+impl WithPartitionKey for NotifySignalCommand {
+    fn partition_key(&self) -> restate_types::sharding::PartitionKey {
+        self.0.partition_key()
+    }
+}
+
+impl OutboxMessage for NotifySignalCommand {
+    fn into_outbox_message(self) -> restate_storage_api::outbox_table::OutboxMessage {
+        restate_storage_api::outbox_table::OutboxMessage::NotifySignal(self.0)
     }
 }
 

--- a/crates/wal-protocol/src/v2/markers.rs
+++ b/crates/wal-protocol/src/v2/markers.rs
@@ -1,0 +1,18 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use restate_types::sharding::WithPartitionKey;
+
+pub trait OutboxMessage: super::Command + WithPartitionKey {
+    /// Helper function that is only here to facilitate migration to opaque outbox message
+    ///
+    /// Drop in v1.9
+    fn into_outbox_message(self) -> restate_storage_api::outbox_table::OutboxMessage;
+}

--- a/crates/worker/src/partition/processor.rs
+++ b/crates/worker/src/partition/processor.rs
@@ -37,6 +37,8 @@ pub use restate_vqueues::context::{HasVQueues, HasVQueuesMut};
 pub use restate_worker_api::processor::*;
 pub use status::HasStatusMut;
 
+use crate::partition::processor::context::HasEncodingArena;
+
 use self::fsm::Fsm;
 
 /// The full set of processor-context capabilities required by the state-machine
@@ -46,6 +48,12 @@ use self::fsm::Fsm;
 /// `ProcessorRawContext` (and test doubles) qualify automatically. Handlers that
 /// only need a narrower capability should bound on that capability directly (e.g.
 /// [`HasOutboxMut`]) rather than on this bundle.
-pub trait ProcessorContext: Processor + HasFsmMut + HasOutboxMut + HasVQueuesMut {}
+pub trait ProcessorContext:
+    Processor + HasFsmMut + HasOutboxMut + HasVQueuesMut + HasEncodingArena
+{
+}
 
-impl<T: Processor + HasFsmMut + HasOutboxMut + HasVQueuesMut> ProcessorContext for T {}
+impl<T: Processor + HasFsmMut + HasOutboxMut + HasVQueuesMut + HasEncodingArena> ProcessorContext
+    for T
+{
+}

--- a/crates/worker/src/partition/processor/context.rs
+++ b/crates/worker/src/partition/processor/context.rs
@@ -10,6 +10,7 @@
 
 use std::sync::Arc;
 
+use bytes::BytesMut;
 use metrics::gauge;
 use tokio::sync::watch;
 use tracing::info;
@@ -58,6 +59,21 @@ pub struct ProcessorRawContext {
     trim_queue: TrimQueue,
     /// The vqueues metadata cache
     vqueues: VQueuesMetaCache,
+    /// Helper encoding arena
+    encoding_arena: BytesMut,
+}
+
+pub trait HasEncodingArena {
+    fn encoding_arena(&mut self) -> &mut BytesMut;
+}
+
+impl<T> HasEncodingArena for &mut T
+where
+    T: HasEncodingArena,
+{
+    fn encoding_arena(&mut self) -> &mut BytesMut {
+        T::encoding_arena(self)
+    }
 }
 
 impl ProcessorRawContext {
@@ -118,6 +134,7 @@ impl ProcessorRawContext {
             status,
             trim_queue,
             vqueues,
+            encoding_arena: BytesMut::with_capacity(128 * 1024),
         })
     }
 
@@ -134,6 +151,7 @@ impl ProcessorRawContext {
             outbox: Outbox::new_empty(),
             trim_queue: TrimQueue::default(),
             vqueues: VQueuesMetaCache::new_empty(VQUEUE_CACHE_CAPACITY),
+            encoding_arena: BytesMut::with_capacity(128 * 1024),
         }
     }
 
@@ -296,5 +314,12 @@ impl HasStatusMut for ProcessorRawContext {
     #[inline]
     fn status_mut(&mut self) -> &mut Status {
         &mut self.status
+    }
+}
+
+impl HasEncodingArena for ProcessorRawContext {
+    #[inline]
+    fn encoding_arena(&mut self) -> &mut BytesMut {
+        &mut self.encoding_arena
     }
 }

--- a/crates/worker/src/partition/shuffle.rs
+++ b/crates/worker/src/partition/shuffle.rs
@@ -10,6 +10,7 @@
 
 use std::future::Future;
 
+use anyhow::Context;
 use async_channel::{TryRecvError, TrySendError};
 use metrics::{counter, gauge};
 use tokio::sync::watch;
@@ -25,7 +26,7 @@ use restate_wal_protocol::v2::commands::{
     AttachInvocationCommand, InvocationResponseCommand, InvokeCommand, NotifySignalCommand,
     TerminateInvocationCommand,
 };
-use restate_wal_protocol::v2::{Dedup, Envelope, Raw};
+use restate_wal_protocol::v2::{CommandKind, Dedup, Envelope, Raw};
 
 use crate::metric_definitions::{
     PARTITION_LABEL, PARTITION_SHUFFLE_INFLIGHT_RECORDS, PARTITION_SHUFFLE_MESSAGE_COUNT,
@@ -63,10 +64,10 @@ pub(crate) fn wrap_outbox_message_in_envelope(
     message: OutboxMessage,
     seq_number: MessageIndex,
     shuffle_metadata: &ShuffleMetadata,
-) -> Envelope<Raw> {
+) -> anyhow::Result<Envelope<Raw>> {
     let dedup = create_dedup(seq_number, shuffle_metadata);
 
-    match message {
+    let envelope = match message {
         OutboxMessage::AttachInvocation(payload) => {
             Envelope::new(dedup, AttachInvocationCommand::from(payload)).into_raw()
         }
@@ -82,7 +83,16 @@ pub(crate) fn wrap_outbox_message_in_envelope(
         OutboxMessage::ServiceResponse(payload) => {
             Envelope::new(dedup, InvocationResponseCommand::from(payload)).into_raw()
         }
-    }
+        OutboxMessage::Opaque(opaque) => {
+            let kind: CommandKind = opaque
+                .kind
+                .try_into()
+                .context("Opaque outbox message has unknown command kind")?;
+            Envelope::from_bytes_unchecked(kind, opaque.codec, dedup, opaque.message)
+        }
+    };
+
+    Ok(envelope)
 }
 
 fn create_dedup(seq_number: MessageIndex, shuffle_metadata: &ShuffleMetadata) -> Dedup {
@@ -362,7 +372,7 @@ mod state_machine {
                             Ordering::Equal => {
                                 let partition_key = message.partition_key();
                                 let envelope =
-                                    wrap_outbox_message_in_envelope(message, sn, &self.metadata);
+                                    wrap_outbox_message_in_envelope(message, sn, &self.metadata)?;
 
                                 self.state = State::Ingesting {
                                     ingest: self.ingestion.ingest(
@@ -414,7 +424,8 @@ mod state_machine {
                                 );
                                 let partition_key = message.partition_key();
                                 let envelope =
-                                    wrap_outbox_message_in_envelope(message, sn, &self.metadata);
+                                    wrap_outbox_message_in_envelope(message, sn, &self.metadata)?;
+
                                 self.state = State::Ingesting {
                                     ingest: self.ingestion.ingest(
                                         partition_key,

--- a/crates/worker/src/partition/state_machine/entries/attach_invocation_command.rs
+++ b/crates/worker/src/partition/state_machine/entries/attach_invocation_command.rs
@@ -9,10 +9,11 @@
 // by the Apache License, Version 2.0.
 
 use restate_storage_api::fsm_table::WriteFsmTable;
-use restate_storage_api::outbox_table::{OutboxMessage, WriteOutboxTable};
+use restate_storage_api::outbox_table::WriteOutboxTable;
 use restate_storage_api::timer_table::WriteTimerTable;
 use restate_types::invocation::{AttachInvocationRequest, ServiceInvocationResponseSink};
 use restate_types::journal_v2::AttachInvocationCommand;
+use restate_wal_protocol::v2::commands;
 
 use crate::partition::processor::ProcessorContext;
 use crate::partition::state_machine::entries::ApplyJournalCommandEffect;
@@ -28,14 +29,16 @@ where
     P: ProcessorContext,
 {
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S, P>) -> Result<(), Error> {
-        ctx.do_enqueue_into_outbox(OutboxMessage::AttachInvocation(AttachInvocationRequest {
-            invocation_query: self.entry.target.into(),
-            block_on_inflight: true,
-            response_sink: ServiceInvocationResponseSink::partition_processor(
-                self.invocation_id,
-                self.entry.completion_id,
-            ),
-        }))?;
+        ctx.do_enqueue_into_outbox(commands::AttachInvocationCommand::from(
+            AttachInvocationRequest {
+                invocation_query: self.entry.target.into(),
+                block_on_inflight: true,
+                response_sink: ServiceInvocationResponseSink::partition_processor(
+                    self.invocation_id,
+                    self.entry.completion_id,
+                ),
+            },
+        ))?;
 
         Ok(())
     }

--- a/crates/worker/src/partition/state_machine/entries/call_commands.rs
+++ b/crates/worker/src/partition/state_machine/entries/call_commands.rs
@@ -13,13 +13,14 @@ use std::collections::VecDeque;
 use restate_service_protocol_v4::entry_codec::ServiceProtocolV4Codec;
 use restate_storage_api::fsm_table::WriteFsmTable;
 use restate_storage_api::invocation_status_table::InvocationStatus;
-use restate_storage_api::outbox_table::{OutboxMessage, WriteOutboxTable};
+use restate_storage_api::outbox_table::WriteOutboxTable;
 use restate_types::identifiers::InvocationId;
 use restate_types::invocation::{ServiceInvocation, ServiceInvocationResponseSink, Source};
 use restate_types::journal_v2::command::{CallCommand, CallRequest, OneWayCallCommand};
 use restate_types::journal_v2::raw::RawEntry;
 use restate_types::journal_v2::{CallInvocationIdCompletion, CompletionId, Entry};
 use restate_types::time::MillisSinceEpoch;
+use restate_wal_protocol::v2::commands;
 
 use crate::partition::processor::ProcessorContext;
 use crate::partition::state_machine::entries::ApplyJournalCommandEffect;
@@ -136,9 +137,7 @@ where
             )
         };
 
-        ctx.do_enqueue_into_outbox(OutboxMessage::ServiceInvocation(Box::new(
-            service_invocation,
-        )))?;
+        ctx.do_enqueue_into_outbox(commands::InvokeCommand::from(service_invocation))?;
 
         // Notify the invocation id back
         self.completions_to_process.push_back(

--- a/crates/worker/src/partition/state_machine/entries/complete_awakeable_command.rs
+++ b/crates/worker/src/partition/state_machine/entries/complete_awakeable_command.rs
@@ -9,17 +9,17 @@
 // by the Apache License, Version 2.0.
 
 use restate_storage_api::fsm_table::WriteFsmTable;
-use restate_storage_api::outbox_table::{OutboxMessage, WriteOutboxTable};
+use restate_storage_api::outbox_table::WriteOutboxTable;
 use restate_storage_api::state_table::WriteStateTable;
 use restate_types::invocation::{NotifySignalRequest, ResponseResult};
 use restate_types::journal_v2::{
     CompleteAwakeableCommand, CompleteAwakeableId, CompleteAwakeableResult, Signal, SignalResult,
 };
+use restate_wal_protocol::v2::commands::{self, InvocationResponseCommand};
 
 use crate::partition::processor::ProcessorContext;
 use crate::partition::state_machine::entries::ApplyJournalCommandEffect;
 use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
-use crate::partition::types::OutboxMessageExt;
 
 pub(super) type ApplyCompleteAwakeableCommand<'e> =
     ApplyJournalCommandEffect<'e, CompleteAwakeableCommand>;
@@ -31,21 +31,23 @@ where
     P: ProcessorContext,
 {
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S, P>) -> Result<(), Error> {
-        ctx.do_enqueue_into_outbox(match self.entry.id {
+        match self.entry.id {
             CompleteAwakeableId::Old(old_awakeable_id) => {
                 let (invocation_id, entry_index) = old_awakeable_id.into_inner();
-                OutboxMessage::from_awakeable_completion(
+                let cmd = InvocationResponseCommand::from_awakeable_completion(
                     invocation_id,
                     entry_index,
                     match self.entry.result {
                         CompleteAwakeableResult::Success(s) => ResponseResult::Success(s),
                         CompleteAwakeableResult::Failure(f) => ResponseResult::Failure(f.into()),
                     },
-                )
+                );
+
+                ctx.do_enqueue_into_outbox(cmd)
             }
             CompleteAwakeableId::New(new_awakeable_id) => {
                 let (invocation_id, signal_id) = new_awakeable_id.into_inner();
-                OutboxMessage::NotifySignal(NotifySignalRequest {
+                let cmd = commands::NotifySignalCommand::from(NotifySignalRequest {
                     invocation_id,
                     signal: Signal::new(
                         signal_id,
@@ -54,10 +56,10 @@ where
                             CompleteAwakeableResult::Failure(f) => SignalResult::Failure(f),
                         },
                     ),
-                })
+                });
+                ctx.do_enqueue_into_outbox(cmd)
             }
-        })?;
-        Ok(())
+        }
     }
 }
 

--- a/crates/worker/src/partition/state_machine/entries/complete_promise_command.rs
+++ b/crates/worker/src/partition/state_machine/entries/complete_promise_command.rs
@@ -8,12 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::debug_if_leader;
-use crate::partition::processor::ProcessorContext;
-use crate::partition::state_machine::entries::ApplyJournalCommandEffect;
-use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
+use tracing::warn;
+
 use restate_storage_api::fsm_table::WriteFsmTable;
-use restate_storage_api::outbox_table::{OutboxMessage, WriteOutboxTable};
+use restate_storage_api::outbox_table::WriteOutboxTable;
 use restate_storage_api::promise_table::{
     Promise, PromiseState, ReadPromiseTable, WritePromiseTable,
 };
@@ -24,7 +22,12 @@ use restate_types::journal_v2::{
     CompletePromiseCommand, CompletePromiseCompletion, CompletePromiseResult, CompletePromiseValue,
     EntryMetadata,
 };
-use tracing::warn;
+use restate_wal_protocol::v2::commands;
+
+use crate::debug_if_leader;
+use crate::partition::processor::ProcessorContext;
+use crate::partition::state_machine::entries::ApplyJournalCommandEffect;
+use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
 
 pub(super) type ApplyCompletePromiseCommand<'e> =
     ApplyJournalCommandEffect<'e, CompletePromiseCommand>;
@@ -81,7 +84,7 @@ where
                     //  because we have the guarantee the the listener has the same partition key, so we could just process the command now.
                     //  Because we still miss the API for doing that, for now we use the outbox.
                     for listener in listeners {
-                        ctx.do_enqueue_into_outbox(OutboxMessage::ServiceResponse(
+                        ctx.do_enqueue_into_outbox(commands::InvocationResponseCommand::from(
                             InvocationResponse {
                                 target: listener,
                                 result: match self.entry.value.clone() {

--- a/crates/worker/src/partition/state_machine/entries/get_invocation_output_command.rs
+++ b/crates/worker/src/partition/state_machine/entries/get_invocation_output_command.rs
@@ -9,10 +9,11 @@
 // by the Apache License, Version 2.0.
 
 use restate_storage_api::fsm_table::WriteFsmTable;
-use restate_storage_api::outbox_table::{OutboxMessage, WriteOutboxTable};
+use restate_storage_api::outbox_table::WriteOutboxTable;
 use restate_storage_api::timer_table::WriteTimerTable;
 use restate_types::invocation::{AttachInvocationRequest, ServiceInvocationResponseSink};
 use restate_types::journal_v2::GetInvocationOutputCommand;
+use restate_wal_protocol::v2::commands;
 
 use crate::partition::processor::*;
 use crate::partition::state_machine::entries::ApplyJournalCommandEffect;
@@ -28,14 +29,16 @@ where
     P: ProcessorContext,
 {
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S, P>) -> Result<(), Error> {
-        ctx.do_enqueue_into_outbox(OutboxMessage::AttachInvocation(AttachInvocationRequest {
-            invocation_query: self.entry.target.into(),
-            block_on_inflight: false,
-            response_sink: ServiceInvocationResponseSink::partition_processor(
-                self.invocation_id,
-                self.entry.completion_id,
-            ),
-        }))?;
+        ctx.do_enqueue_into_outbox(commands::AttachInvocationCommand::from(
+            AttachInvocationRequest {
+                invocation_query: self.entry.target.into(),
+                block_on_inflight: false,
+                response_sink: ServiceInvocationResponseSink::partition_processor(
+                    self.invocation_id,
+                    self.entry.completion_id,
+                ),
+            },
+        ))?;
 
         Ok(())
     }

--- a/crates/worker/src/partition/state_machine/entries/send_signal_command.rs
+++ b/crates/worker/src/partition/state_machine/entries/send_signal_command.rs
@@ -9,10 +9,11 @@
 // by the Apache License, Version 2.0.
 
 use restate_storage_api::fsm_table::WriteFsmTable;
-use restate_storage_api::outbox_table::{OutboxMessage, WriteOutboxTable};
+use restate_storage_api::outbox_table::WriteOutboxTable;
 use restate_storage_api::state_table::WriteStateTable;
 use restate_types::invocation::NotifySignalRequest;
 use restate_types::journal_v2::{SendSignalCommand, Signal};
+use restate_wal_protocol::v2::commands;
 
 use crate::partition::processor::ProcessorContext;
 use crate::partition::state_machine::entries::ApplyJournalCommandEffect;
@@ -27,7 +28,7 @@ where
     P: ProcessorContext,
 {
     async fn apply(self, ctx: &'ctx mut StateMachineApplyContext<'s, S, P>) -> Result<(), Error> {
-        ctx.do_enqueue_into_outbox(OutboxMessage::NotifySignal(NotifySignalRequest {
+        ctx.do_enqueue_into_outbox(commands::NotifySignalCommand::from(NotifySignalRequest {
             invocation_id: self.entry.target_invocation_id,
             signal: Signal::new(self.entry.signal_id, self.entry.result),
         }))?;

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -51,7 +51,7 @@ use restate_storage_api::journal_events::WriteJournalEventsTable;
 use restate_storage_api::journal_table::ReadJournalTable;
 use restate_storage_api::journal_table::{JournalEntry, WriteJournalTable};
 use restate_storage_api::lock_table::WriteLockTable;
-use restate_storage_api::outbox_table::{OutboxMessage, WriteOutboxTable};
+use restate_storage_api::outbox_table::{OpaqueMessage, OutboxMessage, WriteOutboxTable};
 use restate_storage_api::promise_table::{
     Promise, PromiseState, ReadPromiseTable, WritePromiseTable,
 };
@@ -67,7 +67,6 @@ use restate_storage_api::vqueue_table::{EntryStatusHeader, ReadVQueueTable, Writ
 use restate_storage_api::{Result as StorageResult, journal_table};
 use restate_storage_api::{StorageError, journal_table_v2};
 use restate_tracing_instrumentation as instrumentation;
-use restate_types::RestateVersion;
 use restate_types::clock::UniqueTimestamp;
 use restate_types::errors::{
     ALREADY_COMPLETED_INVOCATION_ERROR, CANCELED_INVOCATION_ERROR, GenericError, InvocationError,
@@ -99,7 +98,6 @@ use restate_types::journal::enriched::{
     AwakeableEnrichmentResult, CallEnrichmentResult, EnrichedEntryHeader,
 };
 use restate_types::journal::raw::{EntryHeader, RawEntryCodec, RawEntryCodecError};
-use restate_types::journal::*;
 use restate_types::journal_v2;
 use restate_types::journal_v2::command::{OutputCommand, OutputResult};
 use restate_types::journal_v2::raw::RawEntry;
@@ -112,9 +110,13 @@ use restate_types::message::MessageIndex;
 use restate_types::service_protocol::ServiceProtocolVersion;
 use restate_types::state_mut::ExternalStateMutation;
 use restate_types::state_mut::StateMutationVersion;
-use restate_types::storage::{StorageDecodeError, StoredRawEntry, StoredRawEntryHeader};
+use restate_types::storage::{
+    StorageDecodeError, StorageEncodeError, StoredRawEntry, StoredRawEntryHeader,
+};
 use restate_types::time::MillisSinceEpoch;
 use restate_types::vqueues::{self, EntryId, VQueueId};
+use restate_types::{RESTATE_VERSION_1_9_0, journal::*};
+use restate_types::{RestateVersion, SemanticRestateVersion};
 use restate_util_string::ReString;
 use restate_vqueues::{VQueue, VQueueHandle};
 use restate_wal_protocol::timer::TimerKeyDisplay;
@@ -130,7 +132,7 @@ use crate::metric_definitions::{
 };
 use crate::partition::processor::*;
 use crate::partition::state_machine::lifecycle::OnCancelCommand;
-use crate::partition::types::{InvokerEffectKind, OutboxMessageExt};
+use crate::partition::types::InvokerEffectKind;
 
 use super::processor::{FsmAccess, OutboxAccess, OutboxMut};
 
@@ -162,6 +164,8 @@ pub enum Error {
     EnvelopeDecoding(#[from] StorageDecodeError),
     #[error("Bifrost envelope has unknown command kind")]
     UnknownCommandKind,
+    #[error("Failed to encode outbox message: {0}")]
+    Outbox(StorageEncodeError),
 }
 
 #[macro_export]
@@ -471,9 +475,7 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
                 let inner = envelope
                     .into_typed::<commands::ProxyThroughCommand>()
                     .into_inner()?;
-                self.do_enqueue_into_outbox(OutboxMessage::ServiceInvocation(Box::new(
-                    inner.invocation.into(),
-                )))?;
+                self.do_enqueue_into_outbox(inner.invocation)?;
                 Ok(())
             }
             CommandKind::AttachInvocation => {
@@ -2104,7 +2106,7 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
         };
 
         for invocation_id in invocation_ids_to_kill {
-            self.do_enqueue_into_outbox(OutboxMessage::InvocationTermination(
+            self.do_enqueue_into_outbox(commands::TerminateInvocationCommand::from(
                 InvocationTermination {
                     invocation_id,
                     flavor: TerminationFlavor::Kill,
@@ -2158,7 +2160,7 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
                 } => {
                     // For calls, we don't immediately complete the call entry with cancelled,
                     // but we let the cancellation result propagate from the callee.
-                    self.do_enqueue_into_outbox(OutboxMessage::InvocationTermination(
+                    self.do_enqueue_into_outbox(commands::TerminateInvocationCommand::from(
                         InvocationTermination {
                             invocation_id: enrichment_result.invocation_id,
                             flavor: TerminationFlavor::Cancel,
@@ -2880,10 +2882,12 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
         for response_sink in response_sinks {
             match response_sink {
                 ServiceInvocationResponseSink::PartitionProcessor(target) => self
-                    .do_enqueue_into_outbox(OutboxMessage::ServiceResponse(InvocationResponse {
-                        target,
-                        result: result.clone(),
-                    }))?,
+                    .do_enqueue_into_outbox(commands::InvocationResponseCommand::from(
+                        InvocationResponse {
+                            target,
+                            result: result.clone(),
+                        },
+                    ))?,
                 ServiceInvocationResponseSink::Ingress { request_id } => self
                     .send_ingress_response(
                     request_id,
@@ -3527,12 +3531,14 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
                             }) => {
                                 // Send response to listeners
                                 for listener in listeners {
-                                    self.do_enqueue_into_outbox(OutboxMessage::ServiceResponse(
-                                        InvocationResponse {
-                                            target: listener,
-                                            result: completion.clone().into(),
-                                        },
-                                    ))?;
+                                    self.do_enqueue_into_outbox(
+                                        commands::InvocationResponseCommand::from(
+                                            InvocationResponse {
+                                                target: listener,
+                                                result: completion.clone().into(),
+                                            },
+                                        ),
+                                    )?;
                                 }
 
                                 // Now register the promise completion
@@ -3603,7 +3609,7 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
                             journal_entry.deserialize_entry_ref::<ProtobufRawEntryCodec>()?
                     );
 
-                    let service_invocation = Box::new(ServiceInvocation {
+                    let service_invocation = ServiceInvocation {
                         invocation_id: *callee_invocation_id,
                         invocation_target: callee_invocation_target.clone(),
                         argument: request.parameter,
@@ -3625,11 +3631,9 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
                         limit_key: Default::default(),
                         submit_notification_sink: None,
                         restate_version: RestateVersion::current(),
-                    });
+                    };
 
-                    self.do_enqueue_into_outbox(OutboxMessage::ServiceInvocation(
-                        service_invocation,
-                    ))?;
+                    self.do_enqueue_into_outbox(commands::InvokeCommand::from(service_invocation))?;
                 } else {
                     // no action needed for an invoke entry that has been completed by the deployment
                 }
@@ -3658,7 +3662,7 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
                     Some(MillisSinceEpoch::new(invoke_time))
                 };
 
-                let service_invocation = Box::new(ServiceInvocation {
+                let service_invocation = ServiceInvocation {
                     invocation_id: *callee_invocation_id,
                     invocation_target: callee_invocation_target.clone(),
                     argument: request.parameter,
@@ -3676,9 +3680,9 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
                     limit_key: Default::default(),
                     submit_notification_sink: None,
                     restate_version: RestateVersion::current(),
-                });
+                };
 
-                self.do_enqueue_into_outbox(OutboxMessage::ServiceInvocation(service_invocation))?;
+                self.do_enqueue_into_outbox(commands::InvokeCommand::from(service_invocation))?;
             }
             EnrichedEntryHeader::Awakeable { is_completed, .. } => {
                 debug_assert!(!is_completed, "Awakeable entry must not be completed.");
@@ -3714,14 +3718,16 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
 
                 // Check is this is old or new awakeable id
                 if AwakeableIdentifier::from_str(&entry.id).is_ok() {
-                    self.do_enqueue_into_outbox(OutboxMessage::from_awakeable_completion(
-                        *invocation_id,
-                        *entry_index,
-                        entry.result.into(),
-                    ))?;
+                    self.do_enqueue_into_outbox(
+                        commands::InvocationResponseCommand::from_awakeable_completion(
+                            *invocation_id,
+                            *entry_index,
+                            entry.result.into(),
+                        ),
+                    )?;
                 } else if let Ok(new_awk_id) = ExternalSignalIdentifier::from_str(&entry.id) {
                     let (invocation_id, signal_id) = new_awk_id.into_inner();
-                    self.do_enqueue_into_outbox(OutboxMessage::NotifySignal(
+                    self.do_enqueue_into_outbox(commands::NotifySignalCommand::from(
                         NotifySignalRequest {
                             invocation_id,
                             signal: Signal::new(
@@ -3809,7 +3815,7 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
                         )
                         .await?
                     {
-                        self.do_enqueue_into_outbox(OutboxMessage::AttachInvocation(
+                        self.do_enqueue_into_outbox(commands::AttachInvocationCommand::from(
                             AttachInvocationRequest {
                                 invocation_query,
                                 block_on_inflight: true,
@@ -3836,7 +3842,7 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
                         )
                         .await?
                     {
-                        self.do_enqueue_into_outbox(OutboxMessage::AttachInvocation(
+                        self.do_enqueue_into_outbox(commands::AttachInvocationCommand::from(
                             AttachInvocationRequest {
                                 invocation_query,
                                 block_on_inflight: false,
@@ -3896,7 +3902,7 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
         };
 
         if let Some(target_invocation_id) = target_invocation_id {
-            self.do_enqueue_into_outbox(OutboxMessage::InvocationTermination(
+            self.do_enqueue_into_outbox(commands::TerminateInvocationCommand::from(
                 InvocationTermination {
                     invocation_id: target_invocation_id,
                     flavor: TerminationFlavor::Cancel,
@@ -4624,11 +4630,13 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
         Ok(())
     }
 
-    fn do_enqueue_into_outbox(&mut self, message: OutboxMessage) -> Result<(), Error>
+    fn do_enqueue_into_outbox<M>(&mut self, message: M) -> Result<(), Error>
     where
+        M: v2::OutboxMessage,
         S: WriteOutboxTable + WriteFsmTable,
     {
         let seq_number = self.processor.outbox().outbox_tail();
+
         // TODO Here we could add an optimization to immediately execute outbox message command
         //  for partition_key within the range of this PP, but this is problematic due to how we tie
         //  the effects buffer with tracing. Once we solve that, we could implement that by roughly uncommenting this code :)
@@ -4641,69 +4649,28 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
         //                 state
         //             ).await
         //         }
-        if self.is_leader {
-            match &message {
-                OutboxMessage::ServiceInvocation(service_invocation) => {
-                    debug!(
-                        rpc.service = %service_invocation.invocation_target.service_name(),
-                        rpc.method = %service_invocation.invocation_target.handler_name(),
-                        restate.invocation.id = %service_invocation.invocation_id,
-                        restate.invocation.target = %service_invocation.invocation_target,
-                        restate.outbox.seq = seq_number,
-                        "Effect: Send service invocation to partition processor"
-                    )
-                }
-                OutboxMessage::ServiceResponse(InvocationResponse {
-                    result: ResponseResult::Success(_),
-                    target,
-                }) => {
-                    debug!(
-                        restate.invocation.id = %target.caller_id,
-                        restate.outbox.seq = seq_number,
-                        "Effect: Send success response to another invocation for completion id {}",
-                        target.caller_completion_id
-                    )
-                }
-                OutboxMessage::InvocationTermination(invocation_termination) => {
-                    debug!(
-                        restate.invocation.id = %invocation_termination.invocation_id,
-                        restate.outbox.seq = seq_number,
-                        "Effect: Send invocation termination command '{:?}' to partition processor",
-                        invocation_termination.flavor
-                    )
-                }
-                OutboxMessage::ServiceResponse(InvocationResponse {
-                    result: ResponseResult::Failure(e),
-                    target,
-                }) => {
-                    debug!(
-                        restate.invocation.id = %target.caller_id,
-                        restate.outbox.seq = seq_number,
-                        "Effect: Send failure '{}' response to another invocation for completion id {}",
-                        e,
-                        target.caller_completion_id
-                    )
-                }
-                OutboxMessage::AttachInvocation(AttachInvocationRequest {
-                    invocation_query,
-                    ..
-                }) => {
-                    debug!(
-                        restate.outbox.seq = seq_number,
-                        "Effect: Enqueuing attach invocation request to '{:?}'", invocation_query,
-                    )
-                }
-                OutboxMessage::NotifySignal(NotifySignalRequest {
-                    invocation_id,
-                    signal,
-                }) => {
-                    debug!(
-                        restate.outbox.seq = seq_number,
-                        "Notifying signal to {invocation_id} with signal id {:?}", signal.id,
-                    )
-                }
-            }
-        }
+
+        debug_if_leader!(
+            self.is_leader,
+            restate.outbox.seq = seq_number,
+            restate.partition.key = message.partition_key(),
+            "Send outbox message with command kind {}",
+            M::KIND
+        );
+        let arena = self.processor.encoding_arena();
+        // Only write opaque message from restate v1.9.0
+        let message = if SemanticRestateVersion::current() < &RESTATE_VERSION_1_9_0 {
+            message.into_outbox_message()
+        } else {
+            message.encode(arena).map_err(Error::Outbox)?;
+
+            OutboxMessage::Opaque(OpaqueMessage {
+                partition_key: message.partition_key(),
+                codec: message.default_codec(),
+                kind: M::KIND.into(),
+                message: arena.split().freeze(),
+            })
+        };
 
         self.processor
             .outbox_mut()

--- a/crates/worker/src/partition/types.rs
+++ b/crates/worker/src/partition/types.rs
@@ -8,34 +8,5 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use restate_storage_api::outbox_table::OutboxMessage;
-use restate_types::identifiers::{EntryIndex, InvocationId};
-use restate_types::invocation::{InvocationResponse, JournalCompletionTarget, ResponseResult};
-
 pub(crate) type InvokerEffect = restate_worker_api::invoker::FencedEffect;
 pub(crate) type InvokerEffectKind = restate_worker_api::invoker::EffectKind;
-
-// Extension methods to the OutboxMessage type
-pub(crate) trait OutboxMessageExt {
-    fn from_awakeable_completion(
-        invocation_id: InvocationId,
-        entry_index: EntryIndex,
-        result: ResponseResult,
-    ) -> OutboxMessage;
-}
-
-impl OutboxMessageExt for OutboxMessage {
-    fn from_awakeable_completion(
-        invocation_id: InvocationId,
-        entry_index: EntryIndex,
-        result: ResponseResult,
-    ) -> OutboxMessage {
-        OutboxMessage::ServiceResponse(InvocationResponse {
-            target: JournalCompletionTarget {
-                caller_id: invocation_id,
-                caller_completion_id: entry_index,
-            },
-            result,
-        })
-    }
-}


### PR DESCRIPTION

Summary:
This removes the `OutboxMessage` to:
- Unify usage of v2 Command(s)
- Avoid unecessary decoding of payloads when reading
  from the outbox and instead forward as is to remote partitions.
