### PR TITLE
terminal invocation failure metric by service, handler, and error code

### DIFF
--- a/crates/worker/src/metric_definitions.rs
+++ b/crates/worker/src/metric_definitions.rs
@@ -13,8 +13,12 @@
 use metrics::{Unit, describe_counter, describe_gauge, describe_histogram};
 
 pub const TYPE_LABEL: &str = "type";
+pub const STATUS_LABEL: &str = "status";
+pub const ERROR_CODE_LABEL: &str = "error_code";
 pub const PARTITION_LABEL: &str = "partition";
 pub const REASON_LABEL: &str = "reason";
+pub const RPC_SERVICE_LABEL: &str = "rpc.service";
+pub const RPC_METHOD_LABEL: &str = "rpc.method";
 pub const LEADER_LABEL: &str = "leader";
 pub const LEADER_LABEL_LEADER: &str = "1";
 pub const LEADER_LABEL_FOLLOWER: &str = "0";
@@ -60,6 +64,11 @@ pub const PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS: &str =
 
 pub const PARTITION_SHUFFLE_MESSAGE_COUNT: &str = "restate.partition.shuffle.message.count";
 pub const PARTITION_SHUFFLE_INFLIGHT_COUNT: &str = "restate.partition.shuffle.inflight.count";
+
+pub const INVOCATION_FAILURES: &str = "restate.invocation.failures.total";
+pub const INVOCATION_FAILURE_STATUS_FAILED: &str = "failed";
+pub const INVOCATION_FAILURE_STATUS_CANCELLED: &str = "cancelled";
+pub const INVOCATION_FAILURE_STATUS_KILLED: &str = "killed";
 
 pub(crate) fn describe_metrics() {
     describe_gauge!(
@@ -154,5 +163,13 @@ pub(crate) fn describe_metrics() {
         PARTITION_SHUFFLE_INFLIGHT_COUNT,
         Unit::Count,
         "Number of inflight records by source partition"
+    );
+
+    describe_counter!(
+        INVOCATION_FAILURES,
+        Unit::Count,
+        "Number of invocations that reached a non-success terminal state, labeled by target service \
+         (rpc.service), handler (rpc.method), terminal status (failed/cancelled/killed), and error \
+         code. Counts terminal invocation outcomes only, not per-attempt execution failures"
     );
 }

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -36,6 +36,11 @@ use restate_clock::RoughTimestamp;
 use restate_limiter::LimitKey;
 use restate_limiter::RuleBook;
 
+use crate::metric_definitions::{
+    ERROR_CODE_LABEL, INVOCATION_FAILURE_STATUS_CANCELLED, INVOCATION_FAILURE_STATUS_FAILED,
+    INVOCATION_FAILURE_STATUS_KILLED, INVOCATION_FAILURES, RPC_METHOD_LABEL, RPC_SERVICE_LABEL,
+    STATUS_LABEL,
+};
 use crate::rule_book_cache::RuleBookCacheHandle;
 use restate_service_protocol::codec::ProtobufRawEntryCodec;
 use restate_service_protocol_v4::entry_codec::ServiceProtocolV4Codec;
@@ -2154,6 +2159,11 @@ impl<S> StateMachineApplyContext<'_, S> {
             input.span_context(),
             Err(&error),
         );
+        self.record_invocation_failure_metric(
+            &invocation_target,
+            Self::invocation_failure_status(Some(termination_flavor), &error),
+            &error,
+        );
 
         Ok(())
     }
@@ -2267,6 +2277,11 @@ impl<S> StateMachineApplyContext<'_, S> {
             &invocation_target,
             input.span_context(),
             Err(&error),
+        );
+        self.record_invocation_failure_metric(
+            &invocation_target,
+            Self::invocation_failure_status(Some(termination_flavor), &error),
+            &error,
         );
 
         Ok(())
@@ -3025,6 +3040,16 @@ impl<S> StateMachineApplyContext<'_, S> {
 
         let vqueue_id = invocation_metadata.vqueue_id.clone();
         let mut end_status = vqueue_table::Status::Succeeded;
+
+        let has_override = response_result_override.is_some();
+        if let Some(ResponseResult::Failure(error)) = &response_result_override {
+            self.record_invocation_failure_metric(
+                &invocation_target,
+                Self::invocation_failure_status(flavor, error),
+                error,
+            );
+        }
+
         // If there are any response sinks, or we need to store back the completed status,
         //  we need to find the latest output entry
         if !invocation_metadata.response_sinks.is_empty() || !completion_retention.is_zero() {
@@ -3082,6 +3107,15 @@ impl<S> StateMachineApplyContext<'_, S> {
                     ResponseResult::Failure(err) => Err(err),
                 },
             );
+            // Explicit-result failures are recorded before the block; here we only account for
+            // failures discovered by reading the output entry.
+            if !has_override && let ResponseResult::Failure(error) = &response_result {
+                self.record_invocation_failure_metric(
+                    &invocation_target,
+                    Self::invocation_failure_status(flavor, error),
+                    error,
+                );
+            }
 
             // Store the completed status, if needed
             if !completion_retention.is_zero() {
@@ -4520,6 +4554,39 @@ impl<S> StateMachineApplyContext<'_, S> {
                 }
             }
         }
+    }
+
+    fn invocation_failure_status(
+        flavor: Option<TerminationFlavor>,
+        error: &InvocationError,
+    ) -> &'static str {
+        match flavor {
+            Some(TerminationFlavor::Kill) => INVOCATION_FAILURE_STATUS_KILLED,
+            Some(TerminationFlavor::Cancel) => INVOCATION_FAILURE_STATUS_CANCELLED,
+            None if error.code() == restate_types::errors::codes::ABORTED => {
+                INVOCATION_FAILURE_STATUS_CANCELLED
+            }
+            None => INVOCATION_FAILURE_STATUS_FAILED,
+        }
+    }
+
+    fn record_invocation_failure_metric(
+        &self,
+        invocation_target: &InvocationTarget,
+        status: &'static str,
+        error: &InvocationError,
+    ) {
+        if !self.is_leader {
+            return;
+        }
+        counter!(
+            INVOCATION_FAILURES,
+            STATUS_LABEL => status,
+            RPC_SERVICE_LABEL => invocation_target.service_name().to_string(),
+            RPC_METHOD_LABEL => invocation_target.handler_name().to_string(),
+            ERROR_CODE_LABEL => u16::from(error.code()).to_string(),
+        )
+        .increment(1);
     }
 
     fn handle_outgoing_message(&mut self, message: OutboxMessage) -> Result<(), Error>


### PR DESCRIPTION
To see which handler is terminally failing.
Added a new counter "restate.invocation.failures.total" with following labels:
- rpc.service 
- rpc.method
- status 
- error_code

issue -> https://github.com/restatedev/restate/issues/4990
