### PR TITLE
[Ingress] drain HTTP connections during shutdown

### DIFF
--- a/crates/core/src/task_center/task_kind.rs
+++ b/crates/core/src/task_center/task_kind.rs
@@ -87,9 +87,6 @@ pub enum TaskKind {
     /// An http2 stream handler created by the client-side of the connection.
     #[strum(props(OnError = "log", runtime = "default"))]
     H2ClientStream,
-    /// A type for ingress until we start enforcing timeouts for inflight requests. This enables us
-    /// to shut down cleanly without waiting indefinitely.
-    #[strum(props(OnCancel = "abort"))]
     HttpIngressRole,
     WorkerRole,
     RoleRunner,

--- a/crates/ingress-http/src/server.rs
+++ b/crates/ingress-http/src/server.rs
@@ -21,6 +21,8 @@ use hyper_util::server::conn::auto;
 use metrics::counter;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_util::either::Either;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
 use tower::{ServiceBuilder, ServiceExt};
 use tower_http::classify::ServerErrorsFailureClass;
 use tower_http::cors::CorsLayer;
@@ -30,7 +32,7 @@ use tower_http::trace::TraceLayer;
 use tracing::{Span, debug, info, info_span, instrument};
 
 use restate_core::network::hyper_error_status;
-use restate_core::{TaskCenter, TaskKind, cancellation_watcher};
+use restate_core::{TaskCenter, TaskCenterFutureExt, cancellation_token, task_center};
 use restate_types::config::IngressOptions;
 use restate_types::errors::GenericError;
 use restate_types::health::HealthStatus;
@@ -197,7 +199,7 @@ where
         // Tracked upstream in https://github.com/tower-rs/tower-http/pull/679  once merged,
         // move `CorsLayer` above `RequestBodyLimitLayer`.
 
-        let mut shutdown = std::pin::pin!(cancellation_watcher());
+        let shutdown = cancellation_token();
 
         if let Some(uds_path) = listeners.uds_address() {
             Span::current().record("uds.path", uds_path.display().to_string());
@@ -208,6 +210,9 @@ where
         }
         info!("Ingress HTTP listening");
         health.update(IngressStatus::Ready);
+
+        let mut inflight = TaskTracker::default();
+        let force_shutdown = CancellationToken::new();
 
         // UDS
         loop {
@@ -221,6 +226,9 @@ where
                                 peer_addr,
                                 service.clone(),
                                 http2_max_concurrent_streams,
+                                shutdown.child_token(),
+                                force_shutdown.child_token(),
+                                &mut inflight,
                             )?;
                         }
                         Either::Right(unix_stream) => {
@@ -229,16 +237,40 @@ where
                                 peer_addr,
                                 service.clone(),
                                 http2_max_concurrent_streams,
+                                shutdown.child_token(),
+                                force_shutdown.child_token(),
+                                &mut inflight,
                             )?;
                         }
 
                     }
                 }
-                  _ = &mut shutdown => {
-                    return Ok(());
+                  _ = shutdown.cancelled() => {
+                      info!("HTTP ingress shutdown requested");
+                      drop(listeners);
+                      inflight.close();
+                      break;
                 }
             }
         }
+
+        // drain in-flight requests (give them some time to finish)
+        match tokio::time::timeout(Duration::from_secs(5), inflight.wait()).await {
+            Ok(()) => {
+                info!("All in-flight HTTP ingress connections drained");
+            }
+            Err(_) => {
+                info!(
+                    in_flight_tasks = inflight.len(),
+                    "HTTP Ingress drain timeout elapsed; cancelling in-flight work",
+                );
+                // The force token wraps every tracked future, so this drops remaining
+                // connection/request work instead of just stopping the wait.
+                force_shutdown.cancel();
+                inflight.wait().await;
+            }
+        }
+        return Ok(());
     }
 
     fn handle_connection<S, T, F, B>(
@@ -246,6 +278,9 @@ where
         remote_peer: SocketAddress,
         handler: T,
         http2_max_concurrent_streams: Option<NonZeroU32>,
+        drain: CancellationToken,
+        force_shutdown: CancellationToken,
+        inflight: &mut TaskTracker,
     ) -> anyhow::Result<()>
     where
         S: AsyncWrite + AsyncRead + Unpin + Send + 'static,
@@ -273,10 +308,15 @@ where
             },
         ));
 
+        let tc_executor = TaskCenterExecutor::new(
+            TaskCenter::current(),
+            inflight.clone(),
+            force_shutdown.clone(),
+        );
+
         // Spawn a tokio task to serve the connection
-        TaskCenter::spawn(TaskKind::Ingress, "ingress", async move {
-            let shutdown = cancellation_watcher();
-            let mut auto_connection = auto::Builder::new(TaskCenterExecutor);
+        inflight.spawn(async move {
+            let mut auto_connection = auto::Builder::new(tc_executor);
             auto_connection.http2().adaptive_window(true);
 
             if let Some(max_concurrent_streams) = http2_max_concurrent_streams {
@@ -284,37 +324,65 @@ where
                     .http2()
                     .max_concurrent_streams(max_concurrent_streams.get());
             }
-            let serve_connection_fut = auto_connection.serve_connection(io, handler);
+            let mut serve_connection_fut =
+                std::pin::pin!(auto_connection.serve_connection(io, handler));
 
-            tokio::select! {
-                res = serve_connection_fut => {
-                    match res {
-                        Ok(()) => {
-                            counter!(HTTP_CONNECTION_DROPPED, "status" => "success").increment(1);
-                        },
-                        Err(err) => {
-                            if let Some(hyper_error) = err.downcast_ref::<hyper::Error>() {
-                                let status = hyper_error_status(hyper_error);
-                                counter!(HTTP_CONNECTION_DROPPED, "status" => status).increment(1);
-                                debug!("Connection dropped: status={status}, err={hyper_error:?}");
-                            } else {
-                                counter!(HTTP_CONNECTION_DROPPED, "status" => "server-error").increment(1);
-                                debug!("Error when serving the connection: {:?}", err);
+            let mut draining = false;
+            loop {
+                tokio::select! {
+                    res = &mut serve_connection_fut => {
+                        match res {
+                            Ok(()) => {
+                                counter!(HTTP_CONNECTION_DROPPED, "status" => "success").increment(1);
+                                break;
+                            },
+                            Err(err) => {
+                                if let Some(hyper_error) = err.downcast_ref::<hyper::Error>() {
+                                    let status = hyper_error_status(hyper_error);
+                                    counter!(HTTP_CONNECTION_DROPPED, "status" => status).increment(1);
+                                    debug!("Connection dropped: status={status}, err={hyper_error:?}");
+                                } else {
+                                    counter!(HTTP_CONNECTION_DROPPED, "status" => "server-error").increment(1);
+                                    debug!("Error when serving the connection: {:?}", err);
+                                }
+                                break;
                             }
                         }
                     }
+                    _ = drain.cancelled(), if !draining => {
+                        // Ask clients to not send any more requests on this connection
+                        serve_connection_fut.as_mut().graceful_shutdown();
+                        draining = true;
+                    }
+                    _ = force_shutdown.cancelled() => { break; }
                 }
-                _ = shutdown => {}
             }
-            Ok(())
-        })?;
+        }.in_current_tc());
 
         Ok(())
     }
 }
 
-#[derive(Default, Debug, Clone, Copy)]
-struct TaskCenterExecutor;
+#[derive(Clone)]
+struct TaskCenterExecutor {
+    tc: task_center::Handle,
+    inflight: TaskTracker,
+    force_shutdown: CancellationToken,
+}
+
+impl TaskCenterExecutor {
+    fn new(
+        tc: task_center::Handle,
+        inflight: TaskTracker,
+        force_shutdown: CancellationToken,
+    ) -> Self {
+        Self {
+            tc,
+            inflight,
+            force_shutdown,
+        }
+    }
+}
 
 impl<Fut> hyper::rt::Executor<Fut> for TaskCenterExecutor
 where
@@ -322,9 +390,13 @@ where
     Fut::Output: Send + 'static,
 {
     fn execute(&self, fut: Fut) {
-        let _ = TaskCenter::spawn(TaskKind::Ingress, "ingress", async {
-            fut.await;
-            Ok(())
+        let tc = self.tc.clone();
+        let force_shutdown = self.force_shutdown.clone();
+        self.inflight.spawn(async move {
+            tokio::select! {
+                _ = force_shutdown.cancelled() => {}
+                _ = fut.in_tc(&tc) => {}
+            }
         });
     }
 }


### PR DESCRIPTION

Switch ingress shutdown to a graceful drain:

- Stop accepting new sockets by dropping the listener.
- Ask active hyper connections to shut down gracefully.
- For HTTP/2, send GOAWAY so clients stop opening new streams on the existing connection.
- For HTTP/1, disable keep-alive and close after the in-flight request.
- Give in-flight streams and requests up to five seconds to finish.

Track ingress connection/request futures with a local TaskTracker while keeping
them in the current TaskCenter context. This avoids registering each
connection/request as a managed TaskCenter task, reducing TaskCenter mutex
contention on the hot path.

With shutdown bounded locally in ingress, HttpIngressRole no longer needs the
abort-on-cancel policy.
