### PR TITLE
[df] Fix schema column type mismatches between vqueue and non vqueue tables

### DIFF
--- a/crates/storage-query-datafusion/src/invocation_status/schema.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/schema.rs
@@ -23,7 +23,7 @@ define_table!(sys_invocation_status(
 
     /// The VQueue assigned to the the invocation. NULL if invocation was not migrated to vqueues.
     /// Since v1.7.0.
-    vqueue_id: DataType::Utf8,
+    vqueue_id: DataType::LargeUtf8,
 
     /// Either `inboxed` or `scheduled` or `invoked` or `suspended` or `paused` or `completed`
     status: DataType::LargeUtf8,
@@ -53,11 +53,11 @@ define_table!(sys_invocation_status(
 
     /// The scope of the invocation for vqueue partitioning, if scoped. NULL for unscoped invocations.
     /// Since v1.7.0.
-    scope: DataType::Utf8,
+    scope: DataType::LargeUtf8,
 
     /// The limit key that was used for the invocation. NULL if no limit key was set.
     /// Since v1.7.0.
-    limit_key: DataType::Utf8,
+    limit_key: DataType::LargeUtf8,
 
     /// Idempotency key, if any.
     idempotency_key: DataType::LargeUtf8,

--- a/crates/storage-query-datafusion/src/locks/schema.rs
+++ b/crates/storage-query-datafusion/src/locks/schema.rs
@@ -20,7 +20,7 @@ define_table!(sys_locks(
 
     /// The scope of this lock. Only present if this is a scoped lock (i.e. a lock of a scoped virtual
     /// object).
-    scope: DataType::Utf8,
+    scope: DataType::LargeUtf8,
 
     /// The name of the lock (in the format of `service/key`)
     lock_name: DataType::LargeUtf8,

--- a/crates/storage-query-datafusion/src/promise/schema.rs
+++ b/crates/storage-query-datafusion/src/promise/schema.rs
@@ -20,7 +20,7 @@ define_table!(sys_promise(
 
     /// The scope of the workflow instance, if scoped. NULL for unscoped entries.
     /// Since v1.7.0
-    scope: DataType::Utf8,
+    scope: DataType::LargeUtf8,
 
     /// The name of the workflow service.
     service_name: DataType::LargeUtf8,

--- a/crates/storage-query-datafusion/src/rules/schema.rs
+++ b/crates/storage-query-datafusion/src/rules/schema.rs
@@ -14,14 +14,14 @@ use datafusion::arrow::datatypes::DataType;
 
 define_table!(sys_rules(
     /// Rule pattern in canonical display form (e.g. `scope/*/tenant`).
-    pattern: DataType::Utf8,
+    pattern: DataType::LargeUtf8,
 
     /// Concurrency limit imposed by this rule. Null means the
     /// rule does not constrain concurrency.
     concurrency: DataType::UInt32,
 
     /// Free-form description set by the operator.
-    description: DataType::Utf8,
+    description: DataType::LargeUtf8,
 
     /// True when the rule is parked (treated as absent at runtime).
     disabled: DataType::Boolean,

--- a/crates/storage-query-datafusion/src/scheduler_status/schema.rs
+++ b/crates/storage-query-datafusion/src/scheduler_status/schema.rs
@@ -19,17 +19,17 @@ define_table!(sys_scheduler(
     partition_key: DataType::UInt64,
 
     /// Identifier of the scheduled vqueue (vq_...).
-    id: DataType::Utf8,
+    id: DataType::LargeUtf8,
 
     /// Number of entries currently waiting in the inbox stage.
     num_inbox: DataType::UInt64,
 
     /// High-level scheduler state (dormant, blocked, scheduled, ...).
-    status: DataType::Utf8,
+    status: DataType::LargeUtf8,
 
     /// Identifier of the head entry if the scheduler has already advanced to it.
     /// Null when the head has not yet been materialized
-    head_entry_id: DataType::Utf8,
+    head_entry_id: DataType::LargeUtf8,
 
     /// Earliest time when the head entry becomes runnable.
     ///
@@ -37,10 +37,10 @@ define_table!(sys_scheduler(
     scheduled_at: TimestampMillisecond,
 
     /// The current resource blocking the queue from dequeuing.
-    blocked_on: DataType::Utf8,
+    blocked_on: DataType::LargeUtf8,
 
     /// Detailed blocking resource when status is `blocked`.
-    blocked_on_json: DataType::Utf8,
+    blocked_on_json: DataType::LargeUtf8,
 
     /// Time the head entry spent waiting on global invoker concurrency.
     invoker_concurrency_block_duration: DataType::Duration,

--- a/crates/storage-query-datafusion/src/state/schema.rs
+++ b/crates/storage-query-datafusion/src/state/schema.rs
@@ -20,7 +20,7 @@ define_table!(state(
 
     /// The scope of the Virtual Object instance, if scoped. NULL for unscoped entries.
     /// Since v1.7.0
-    scope: DataType::Utf8,
+    scope: DataType::LargeUtf8,
 
     /// The name of the invoked service.
     service_name: DataType::LargeUtf8,

--- a/crates/storage-query-datafusion/src/tests.rs
+++ b/crates/storage-query-datafusion/src/tests.rs
@@ -13,8 +13,8 @@ use std::time::{Duration, SystemTime};
 
 use bytes::Bytes;
 use datafusion::arrow::array::{
-    ArrayRef, DurationMillisecondArray, LargeStringArray, ListArray, StringArray,
-    TimestampMillisecondArray, UInt32Array, UInt64Array,
+    ArrayRef, DurationMillisecondArray, LargeStringArray, ListArray, TimestampMillisecondArray,
+    UInt32Array, UInt64Array,
 };
 use datafusion::arrow::record_batch::RecordBatch;
 use futures::StreamExt;
@@ -162,12 +162,12 @@ async fn query_sys_scheduler() {
         all!(row!(
             0,
             {
-                "id" => StringArray: eq(qid.to_string()),
-                "status" => StringArray: eq("blocked"),
-                "head_entry_id" => StringArray: eq(expected_head_entry_display),
+                "id" => LargeStringArray: eq(qid.to_string()),
+                "status" => LargeStringArray: eq("blocked"),
+                "head_entry_id" => LargeStringArray: eq(expected_head_entry_display),
                 "num_inbox" => UInt64Array: eq(7),
-                "blocked_on" => StringArray: eq(expected_blocked_on),
-                "blocked_on_json" => StringArray: eq(expected_blocked_on_json),
+                "blocked_on" => LargeStringArray: eq(expected_blocked_on),
+                "blocked_on_json" => LargeStringArray: eq(expected_blocked_on_json),
                 "invoker_concurrency_block_duration" => DurationMillisecondArray: eq(15),
                 "concurrency_rules_block_duration" => DurationMillisecondArray: eq(35),
                 "deployment_concurrency_block_duration" => DurationMillisecondArray: eq(45),
@@ -572,8 +572,8 @@ fn extract_nullable_string(column: &ArrayRef, row: usize) -> Option<Option<Strin
 
     let column = column
         .as_any()
-        .downcast_ref::<StringArray>()
-        .expect("Downcast ref to StringArray");
+        .downcast_ref::<LargeStringArray>()
+        .expect("Downcast ref to LargeStringArray");
     if column.len() <= row {
         return None;
     }

--- a/crates/storage-query-datafusion/src/user_limits/schema.rs
+++ b/crates/storage-query-datafusion/src/user_limits/schema.rs
@@ -19,16 +19,16 @@ define_table!(sys_user_limits(
     partition_key: DataType::UInt64,
 
     /// The scope this counter belongs to.
-    scope: DataType::Utf8,
+    scope: DataType::LargeUtf8,
 
     /// The level-1 key component (null for scope-level counters).
-    l1: DataType::Utf8,
+    l1: DataType::LargeUtf8,
 
     /// The level-2 key component (null for scope-level and L1-level counters).
-    l2: DataType::Utf8,
+    l2: DataType::LargeUtf8,
 
     /// The hierarchy level: "Scope", "Level1", or "Level2".
-    level: DataType::Utf8,
+    level: DataType::LargeUtf8,
 
     /// Current concurrency usage at this counter.
     usage: DataType::UInt32,
@@ -39,7 +39,7 @@ define_table!(sys_user_limits(
     /// The rule pattern that defines the limit (null if unlimited).
     /// Resolved from the rule handle; shows "[removed]" if the rule was
     /// deleted since the counter was created.
-    rule_pattern: DataType::Utf8,
+    rule_pattern: DataType::LargeUtf8,
 
     /// Available capacity (limit - usage). Null if unlimited.
     available: DataType::UInt32,

--- a/crates/storage-query-datafusion/src/vqueue_entry_status/schema.rs
+++ b/crates/storage-query-datafusion/src/vqueue_entry_status/schema.rs
@@ -19,18 +19,21 @@ define_table!(sys_vqueue_entry_status(
     partition_key: DataType::UInt64,
 
     /// Identifier of the entry.
-    entry_id: DataType::Utf8,
+    ///
+    /// Due to quirks in DataFusion, this should remain `LargeUtf8` to match
+    /// `id` in `sys_invocation_status` for dynamic filter pushdown.
+    entry_id: DataType::LargeUtf8,
 
     /// The VQueue Identifier (vq_...).
-    vqueue_id: DataType::Utf8,
+    vqueue_id: DataType::LargeUtf8,
 
     /// The stage this entry currently belongs to. Choices are 'inbox', 'running', 'paused',
     /// 'suspended', and 'finished'.
-    stage: DataType::Utf8,
+    stage: DataType::LargeUtf8,
 
     /// The entry processing status. Examples are `new`, `scheduled`, `started`,
     /// `backing-off`, `yielded`, `killed`, `cancelled`, `failed`, and `succeeded`.
-    status: DataType::Utf8,
+    status: DataType::LargeUtf8,
 
     /// Whether this entry currently holds a lock.
     has_lock: DataType::Boolean,
@@ -42,7 +45,7 @@ define_table!(sys_vqueue_entry_status(
     sequence_number: DataType::UInt64,
 
     /// Entry kind (`invocation` or `state-mutation`).
-    entry_kind: DataType::Utf8,
+    entry_kind: DataType::LargeUtf8,
 
     /// Creation timestamp of the entry.
     created_at: TimestampMillisecond,
@@ -75,7 +78,7 @@ define_table!(sys_vqueue_entry_status(
     first_runnable_at: TimestampMillisecond,
 
     /// If set, the entry's pinned deployment identifier.
-    deployment: DataType::Utf8,
+    deployment: DataType::LargeUtf8,
 
     /// If set, the amount of memory in bytes the invocation seems to require on the invoker side.
     needed_memory: DataType::UInt64,

--- a/crates/storage-query-datafusion/src/vqueue_entry_status/tests.rs
+++ b/crates/storage-query-datafusion/src/vqueue_entry_status/tests.rs
@@ -11,8 +11,8 @@
 use std::num::NonZeroUsize;
 
 use datafusion::arrow::array::{
-    BooleanArray, DurationMillisecondArray, StringArray, TimestampMillisecondArray, UInt32Array,
-    UInt64Array,
+    BooleanArray, DurationMillisecondArray, LargeStringArray, TimestampMillisecondArray,
+    UInt32Array, UInt64Array,
 };
 use datafusion::arrow::record_batch::RecordBatch;
 use futures::StreamExt;
@@ -131,14 +131,14 @@ async fn get_vqueue_entry_status_header_fields() {
         all!(row!(
             0,
             {
-                "entry_id" => StringArray: eq(entry_id),
-                "vqueue_id" => StringArray: eq(qid.to_string()),
-                "stage" => StringArray: eq("running"),
-                "status" => StringArray: eq("started"),
+                "entry_id" => LargeStringArray: eq(entry_id),
+                "vqueue_id" => LargeStringArray: eq(qid.to_string()),
+                "stage" => LargeStringArray: eq("running"),
+                "status" => LargeStringArray: eq("started"),
                 "has_lock" => BooleanArray: eq(true),
                 "next_at" => TimestampMillisecondArray: eq(key.run_at().as_unix_millis().as_u64() as i64),
                 "sequence_number" => UInt64Array: eq(42),
-                "entry_kind" => StringArray: eq("invocation"),
+                "entry_kind" => LargeStringArray: eq("invocation"),
                 "created_at" => TimestampMillisecondArray: eq(created_at.to_unix_millis().as_u64() as i64),
                 "transitioned_at" => TimestampMillisecondArray: eq(transitioned_at.to_unix_millis().as_u64() as i64),
                 "num_attempts" => UInt32Array: eq(3),
@@ -149,7 +149,7 @@ async fn get_vqueue_entry_status_header_fields() {
                 "first_attempt_at" => TimestampMillisecondArray: eq(first_attempt_at.to_unix_millis().as_u64() as i64),
                 "latest_attempt_at" => TimestampMillisecondArray: eq(latest_attempt_at.to_unix_millis().as_u64() as i64),
                 "first_runnable_at" => TimestampMillisecondArray: eq(first_runnable_at.as_u64() as i64),
-                "deployment" => StringArray: eq("dp_status"),
+                "deployment" => LargeStringArray: eq("dp_status"),
                 "needed_memory" => UInt64Array: eq(needed_memory.get() as u64),
                 "retry_attempts" => UInt32Array: eq(7),
                 "retry_count_since_last_stored_command" => UInt32Array: eq(2),

--- a/crates/storage-query-datafusion/src/vqueue_meta/schema.rs
+++ b/crates/storage-query-datafusion/src/vqueue_meta/schema.rs
@@ -19,7 +19,7 @@ define_table!(sys_vqueue_meta(
     partition_key: DataType::UInt64,
 
     /// The VQueue Identifier (vq_...)
-    id: DataType::Utf8,
+    id: DataType::LargeUtf8,
 
     /// Whether this vqueue is active or not. An active vqueue
     /// is a vqueue that is not paused, and has non-finished
@@ -30,18 +30,18 @@ define_table!(sys_vqueue_meta(
     queue_is_paused: DataType::Boolean,
 
     /// Service name linked to this vqueue
-    service_name: DataType::Utf8,
+    service_name: DataType::LargeUtf8,
 
     /// The scope of this vqueue.
-    scope: DataType::Utf8,
+    scope: DataType::LargeUtf8,
 
     /// The name of the limit-key assigned to this vqueue
-    limit_key: DataType::Utf8,
+    limit_key: DataType::LargeUtf8,
 
     /// The name of the lock (in the format of `service/key`)
     ///
     /// This is only set if this is a vqueue for a virtual object.
-    lock_name: DataType::Utf8,
+    lock_name: DataType::LargeUtf8,
 
     /// When was this vqueue first created
     created_at: TimestampMillisecond,

--- a/crates/storage-query-datafusion/src/vqueues/schema.rs
+++ b/crates/storage-query-datafusion/src/vqueues/schema.rs
@@ -21,11 +21,11 @@ define_table!(sys_vqueues(
     partition_key: DataType::UInt64,
 
     /// The VQueue Identifier (vq_...).
-    id: DataType::Utf8,
+    id: DataType::LargeUtf8,
 
     /// The stage this entry currently belongs to. Choices are 'inbox', 'running', 'paused',
     /// 'suspended', and 'finished'.
-    stage: DataType::Utf8,
+    stage: DataType::LargeUtf8,
 
     /// The entry processing status. Examples are `new`, `scheduled`, `started`,
     /// `backing-off`, `yielded`, `killed`, `cancelled`, `failed`, and `succeeded`.
@@ -34,7 +34,7 @@ define_table!(sys_vqueues(
     /// to transitioning into the current stage. We preserve the last known status
     /// because it will be useful to know when the entry transitions out of the
     /// current stage.
-    status: DataType::Utf8,
+    status: DataType::LargeUtf8,
 
     /// Whether this entry currently holds a lock.
     has_lock: DataType::Boolean,
@@ -47,10 +47,13 @@ define_table!(sys_vqueues(
     sequence_number: DataType::UInt64,
 
     /// Identifier of the entry.
-    entry_id: DataType::Utf8,
+    ///
+    /// Due to quirks in DataFusion, this should remain `LargeUtf8` to match
+    /// `id` in `sys_invocation_status` for dynamic filter pushdown.
+    entry_id: DataType::LargeUtf8,
 
     /// Entry kind (`invocation` or `state-mutation`).
-    entry_kind: DataType::Utf8,
+    entry_kind: DataType::LargeUtf8,
 
     /// Creation timestamp of the entry.
     created_at: TimestampMillisecond,
@@ -83,5 +86,8 @@ define_table!(sys_vqueues(
     first_runnable_at: TimestampMillisecond,
 
     /// If set, the entry's pinned deployment identifier.
-    deployment: DataType::Utf8,
+    ///
+    /// Due to quirks in DataFusion, this should remain `LargeUtf8` to match
+    /// `id` in `sys_deployment` for dynamic filter pushdown.
+    deployment: DataType::LargeUtf8,
 ));

--- a/crates/storage-query-datafusion/src/vqueues/tests.rs
+++ b/crates/storage-query-datafusion/src/vqueues/tests.rs
@@ -11,7 +11,7 @@
 use crate::mocks::*;
 use crate::row;
 
-use datafusion::arrow::array::{StringArray, TimestampMillisecondArray, UInt32Array};
+use datafusion::arrow::array::{LargeStringArray, TimestampMillisecondArray, UInt32Array};
 use datafusion::arrow::record_batch::RecordBatch;
 use futures::StreamExt;
 use googletest::all;
@@ -96,8 +96,8 @@ async fn get_vqueue_entry_value_fields() {
         all!(row!(
             0,
             {
-                "stage" => StringArray: eq("inbox"),
-                "status" => StringArray: eq("backing-off"),
+                "stage" => LargeStringArray: eq("inbox"),
+                "status" => LargeStringArray: eq("backing-off"),
                 "num_attempts" => UInt32Array: eq(3),
                 "num_pauses" => UInt32Array: eq(2),
                 "num_suspensions" => UInt32Array: eq(4),
@@ -108,7 +108,7 @@ async fn get_vqueue_entry_value_fields() {
                 "latest_attempt_at" => TimestampMillisecondArray: eq(latest_attempt_at.to_unix_millis().as_u64() as i64),
                 "first_runnable_at" => TimestampMillisecondArray: eq(value.stats.first_runnable_at.as_u64() as i64),
                 "run_at" => TimestampMillisecondArray: eq(key.run_at().as_unix_millis().as_u64() as i64),
-                "deployment" => StringArray: eq("dp_123"),
+                "deployment" => LargeStringArray: eq("dp_123"),
             }
         ))
     );
@@ -165,11 +165,11 @@ async fn vqueue_stage_filter_and_unfiltered_scan() {
     assert_that!(
         all_stages,
         all!(
-            row!(0, { "stage" => StringArray: eq("finished") }),
-            row!(1, { "stage" => StringArray: eq("inbox") }),
-            row!(2, { "stage" => StringArray: eq("paused") }),
-            row!(3, { "stage" => StringArray: eq("running") }),
-            row!(4, { "stage" => StringArray: eq("suspended") })
+            row!(0, { "stage" => LargeStringArray: eq("finished") }),
+            row!(1, { "stage" => LargeStringArray: eq("inbox") }),
+            row!(2, { "stage" => LargeStringArray: eq("paused") }),
+            row!(3, { "stage" => LargeStringArray: eq("running") }),
+            row!(4, { "stage" => LargeStringArray: eq("suspended") })
         )
     );
 
@@ -189,8 +189,8 @@ async fn vqueue_stage_filter_and_unfiltered_scan() {
     assert_that!(
         filtered_stages,
         all!(
-            row!(0, { "stage" => StringArray: eq("paused") }),
-            row!(1, { "stage" => StringArray: eq("running") })
+            row!(0, { "stage" => LargeStringArray: eq("paused") }),
+            row!(1, { "stage" => LargeStringArray: eq("running") })
         )
     );
 }


### PR DESCRIPTION



For future reference, here's an example of a problematic query:

```
SELECT ss.id AS id FROM sys_invocation_status ss LEFT JOIN sys_invocation_state sis ON sis.id = ss.id WHERE ss.status IN ('invoked') AND ((ss.status = 'invoked' AND
  sis.in_flight) OR (ss.status = 'invoked' AND (sis.in_flight IS NOT TRUE) AND (sis.retry_count > 0 OR ss.id IN (SELECT entry_id FROM sys_vqueues WHERE stage = 'inbox' AND status = 'backing-off'))))  LIMIT 250
```

and here's claude's summary to the problem:

```
It's DataFusion's join dynamic-filter pushdown pushing a LargeUtf8 InList onto a raw Utf8 column. The EXPLAIN of the query shows it precisely:

  HashJoinExec: join_type=LeftMark, on=[(id@0, sys_vqueues.entry_id@0)]
    ├─ build: ss ⋈ sis   → key = ss.id           (LargeUtf8)
    └─ probe: sys_vqueues
          ProjectionExec: CAST(entry_id AS LargeUtf8) as sys_vqueues.entry_id
            PartitionedExecutionPlan: table="sys_vqueues", projection=[stage,status,entry_id],
                predicate = DynamicFilter [ empty ] AND stage=inbox AND status=backing-off

  The join key needs CAST(entry_id AS LargeUtf8) because sys_vqueues.entry_id is Utf8 while sys_invocation_status.id is LargeUtf8. At runtime the hash join builds a dynamic filter from its build-side id values (LargeUtf8) and pushes it
  to the probe. But the DynamicFilter gets pushed below the CAST projection, onto the scan's raw entry_id (Utf8). So the filter materializes as entry_id (Utf8) IN (LargeUtf8 ids). When that predicate is serialized and the sys_vqueues
  remote scanner rebuilds it (scanner_task.rs:76 → decode_expr → parse_physical_expr), DataFusion's in_list() asserts datatype_is_logically_equal and blows up. The CAST that would make it legal is lost in the push-through-projection.
```

This PR changes all vqueue strings to be large utf8s instead of just utf8 to match the ones in the other tables we have and get around this problem altogether.

Also made sure that 1.7.0 will continue to work normally against this change:

```
docker run --rm --network=host -it --entrypoint /usr/local/bin/restate docker.restate.dev/restatedev/restate:1.7.0 sql "select id from sys_vqueues limit 10"
 ID
 vq_1exNT2b177hE1hKd7fIOARnMqeQY9IQtHy
 vq_1exNT2b177hE1hKd7fIOARnMqeQY9IQtHy
 vq_1exNT2b177hE1hKd7fIOARnMqeQY9IQtHy
 vq_1exNT2b177hE1hKd7fIOARnMqeQY9IQtHy
 vq_1exNT2b177hE1hKd7fIOARnMqeQY9IQtHy
 vq_1exNT2b177hE1hKd7fIOARnMqeQY9IQtHy
 vq_1exNT2b177hE1hKd7fIOARnMqeQY9IQtHy
 vq_1exNT2b177hE1hKd7fIOARnMqeQY9IQtHy
 vq_1exNT2b177hE1hKd7fIOARnMqeQY9IQtHy
 vq_1exNT2b177hE1hKd7fIOARnMqeQY9IQtHy

10 rows. Query took 7.49ms
```
