### PR TITLE
[docker] Add support for sapling and dont pollute workdir on local build

### DIFF
--- a/docker/local-fedora.Dockerfile
+++ b/docker/local-fedora.Dockerfile
@@ -11,8 +11,10 @@
 # We do not need the Rust toolchain to run the server binary!
 FROM fedora:latest
 
+ARG RESTATE_BINARY_PATH
+
 # Copy the locally built restate-server binary
-COPY restate-server /usr/local/bin
+COPY $RESTATE_BINARY_PATH /usr/local/bin/restate-server
 
 WORKDIR /
 ENTRYPOINT ["/usr/local/bin/restate-server"]

--- a/justfile
+++ b/justfile
@@ -6,11 +6,21 @@ export RESTATE_TEST_PORTS_POOL := "/tmp/restate_tests_ports_pool"
 
 dev_tools_image := "ghcr.io/restatedev/dev-tools:latest"
 
-# Docker image name & tag. The backtick falls back to "unknown" when git fails,
-# so evaluation doesn't crash inside the docker build context where the
-# worktree's `.git` pointer references a non-existent host path.
+# Docker image name & tag. We detect git first, then Sapling (sl), and fall back
+# to "unknown" when neither works, so evaluation doesn't crash inside the docker
+# build context where the worktree's `.git` pointer references a non-existent host path.
 docker_repo := "localhost/restatedev/restate"
-docker_tag := `if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then echo "$(git rev-parse --abbrev-ref HEAD | sed 's|/|.|g').$(git rev-parse --short HEAD)"; else echo unknown; fi`
+docker_tag := ```
+    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "$(git rev-parse --abbrev-ref HEAD | sed 's|/|.|g').$(git rev-parse --short HEAD)"
+    elif command -v sl >/dev/null 2>&1 && sl root >/dev/null 2>&1; then
+        bookmark="$(sl log -r . -T '{activebookmark}' 2>/dev/null | sed 's|/|.|g')"
+        hash="$(sl log -r . -T '{node|short}' 2>/dev/null)"
+        if [ -n "$bookmark" ]; then echo "$bookmark.$hash"; else echo "$hash"; fi
+    else
+        echo unknown
+    fi
+    ```
 docker_image := docker_repo + ":" + docker_tag
 
 features := ""
@@ -176,12 +186,17 @@ docker-debug:
     docker buildx build . --platform linux/{{ _docker_arch }} --file docker/debug.Dockerfile --tag={{ docker_image }} --progress='{{ DOCKER_PROGRESS }}' --build-arg RESTATE_FEATURES={{ features }} --load
 
 docker-local-fedora:
+    #!/usr/bin/env bash
+    set -euo pipefail
     # Build the restate-server binary locally
     just arch={{ _arch }} features={{ features }} build -p restate-server
-    # Move the binary to the location expected by the Dockerfile
-    cp target/debug/restate-server restate-server
+    # Stage the binary in a temp dir inside the build context.
+    # Hard-link to avoid copying the (large) binary.
+    mkdir -p ./.docker-local-cache
+    trap 'rm -rf "./.docker-local-cache"' EXIT
+    cp -l target/debug/restate-server "./.docker-local-cache/restate-server" 2>/dev/null || cp target/debug/restate-server "./.docker-local-cache/restate-server"
     # Build the Docker image using the local.Dockerfile
-    docker buildx build . --platform linux/{{ _docker_arch }} --file docker/local-fedora.Dockerfile --tag={{ docker_image }} --progress='{{ DOCKER_PROGRESS }}' --load
+    docker buildx build . --platform linux/{{ _docker_arch }} --file docker/local-fedora.Dockerfile --build-arg RESTATE_BINARY_PATH="./.docker-local-cache/restate-server" --tag={{ docker_image }} --progress='{{ DOCKER_PROGRESS }}' --load
 
 notice-file:
     cargo license -d -a --avoid-build-deps --avoid-dev-deps {{ _features }} | (echo "Restate Runtime\nCopyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH <code@restate.dev>\n" && cat) > NOTICE


### PR DESCRIPTION

1. Add support for sapling detection when coming up with a docker tag. Previously, it was always unknown.
2. `just docker-local-fedora` is very handy in building quick docker images from prebuilt binaries, but it pollutes the working tree as it has to copy `restate-server` into a place that's not excluded by dockerignore first. So this PR creates a tmp local dir, and removes it on command exit. Given that the path is also no not stable, the docker image now takes the path as a build arg.

Tested:

```
❯❯❯ just docker-local-fedora
...
 => => exporting manifest list sha256:ed64d43ac75161019e46a97342be639092d006e020b17e70d4b3cb26328591be                                                                                                                                0.0s
 => => naming to localhost/restatedev/restate:cd251354218b                                                                                                                                                                            0.0s
 => => unpacking to localhost/restatedev/restate:cd251354218b

 ...

❯❯❯ docker run --rm -it localhost/restatedev/restate:cd251354218b --version                                                                                                                                   ✘ 1
restate-server 1.7.1-dev
```
