### PR TITLE
[PartitionStore] Make storage-version lazy

### DIFF
--- a/crates/partition-store/src/fsm_table/mod.rs
+++ b/crates/partition-store/src/fsm_table/mod.rs
@@ -9,7 +9,7 @@
 // by the Apache License, Version 2.0.
 
 use crate::TableKind::PartitionStateMachine;
-use crate::keys::{EncodeTableKeyPrefix, KeyKind, define_table_key};
+use crate::keys::{EncodeTableKey, KeyKind, define_table_key};
 use crate::{
     PaddedPartitionId, PartitionDb, PartitionStore, PartitionStoreTransaction, StorageAccess,
 };
@@ -26,7 +26,7 @@ use restate_types::message::MessageIndex;
 use restate_types::partitions::StorageVersion;
 use restate_types::partitions::features::PersistedStateMachineFeatures;
 use restate_types::schema::Schema;
-use restate_types::storage::StorageCodec;
+use restate_types::storage::{StorageCodec, StorageDecode};
 
 define_table_key!(
     PartitionStateMachine,
@@ -42,6 +42,24 @@ fn create_key(
     PartitionStateMachineKey {
         partition_id: partition_id.into(),
         state_id,
+    }
+}
+
+// 'ps' | PaddedPartitionId | state_id
+static_assertions::const_assert_eq!(PartitionStateMachineKey::serialized_length_fixed(), 18);
+
+impl PartitionStateMachineKey {
+    pub const fn serialized_length_fixed() -> usize {
+        KeyKind::SERIALIZED_LENGTH
+            + std::mem::size_of::<PaddedPartitionId>()
+            + std::mem::size_of::<u64>()
+    }
+
+    #[inline]
+    pub fn to_bytes(&self) -> [u8; Self::serialized_length_fixed()] {
+        let mut buf = [0u8; Self::serialized_length_fixed()];
+        EncodeTableKey::serialize_to(self, &mut buf.as_mut());
+        buf
     }
 }
 
@@ -130,44 +148,9 @@ pub async fn get_locally_durable_lsn(partition_store: &mut PartitionStore) -> Re
     .map(|opt| opt.map(|seq_number| Lsn::from(u64::from(seq_number))))
 }
 
-pub(crate) async fn get_storage_version<S: StorageAccess>(
-    storage: &mut S,
-    partition_id: PartitionId,
-) -> Result<StorageVersion> {
-    get::<SequenceNumber, _>(storage, partition_id, fsm_variable::STORAGE_VERSION).and_then(|opt| {
-        let storage_version = if let Some(seq_number) = opt {
-            StorageVersion::try_from(
-                u16::try_from(seq_number.0).map_err(|_| StorageError::DataIntegrityError)?,
-            )?
-        } else {
-            StorageVersion::None
-        };
-
-        Ok(storage_version)
-    })
-}
-
 pub(crate) fn get_storage_version_from_partition_db(db: &PartitionDb) -> Result<StorageVersion> {
-    let cf = db.cf_handle();
-    let key = create_key(db.partition().partition_id, fsm_variable::STORAGE_VERSION);
-    let sequence_number: Option<SequenceNumber> = db
-        .rocksdb()
-        .inner()
-        .as_raw_db()
-        .get_pinned_cf(cf, key.serialize())
-        .map_err(|err| StorageError::Generic(err.into()))?
-        .map(|value| {
-            let mut slice = value.as_ref();
-            StorageCodec::decode::<
-                ProtobufStorageWrapper<
-                    <SequenceNumber as PartitionStoreProtobufValue>::ProtobufType,
-                >,
-                _,
-            >(&mut slice)
-            .map(|v| v.0.into())
-        })
-        .transpose()
-        .map_err(|err| StorageError::Generic(err.into()))?;
+    let sequence_number: Option<SequenceNumber> =
+        get_proto_from_partition_db(db, fsm_variable::STORAGE_VERSION)?;
 
     Ok(if let Some(sequence_number) = sequence_number {
         let raw = u16::try_from(sequence_number.0).map_err(|_| StorageError::DataIntegrityError)?;
@@ -201,7 +184,7 @@ pub(crate) fn append_storage_version_to_wb(
     use restate_types::storage::StorageCodec;
 
     let key = create_key(partition_id, fsm_variable::STORAGE_VERSION);
-    let key_buffer = key.serialize();
+    let key_buffer = key.to_bytes();
 
     let value = SequenceNumber::from(version as u64);
     let mut value_buffer = BytesMut::new();
@@ -213,7 +196,7 @@ pub(crate) fn append_storage_version_to_wb(
     )
     .map_err(|e| restate_storage_api::StorageError::Generic(e.into()))?;
 
-    wb.put_cf(cf_handle, &key_buffer, &value_buffer);
+    wb.put_cf(cf_handle, key_buffer, &value_buffer);
     Ok(())
 }
 
@@ -235,6 +218,89 @@ pub(crate) fn put_jc_orphan_cleanup_done<S: StorageAccess>(
         fsm_variable::JC_ORPHAN_CLEANUP_DONE,
         &SequenceNumber::from(1u64),
     )
+}
+
+/// Reads a `StorageCodec`-encoded value directly from the partition db's column family.
+///
+/// [`PartitionDb`] does not implement [`StorageAccess`], so we read the raw bytes from
+/// RocksDB and decode via the standard prost path rather than the `BytesMut` arena used
+/// by [`PartitionStore`].
+fn get_storage_codec_from_partition_db<V: StorageDecode>(
+    db: &PartitionDb,
+    state_id: u64,
+) -> Result<Option<V>> {
+    let cf = db.cf_handle();
+    let key = create_key(db.partition().id(), state_id);
+    db.rocksdb()
+        .inner()
+        .as_raw_db()
+        .get_pinned_cf(cf, key.to_bytes())
+        .map_err(|err| StorageError::Generic(err.into()))?
+        .map(|value| {
+            let mut slice = value.as_ref();
+            StorageCodec::decode::<V, _>(&mut slice)
+        })
+        .transpose()
+        .map_err(|err| StorageError::Conversion(err.into()))
+}
+
+fn get_proto_from_partition_db<T: PartitionStoreProtobufValue>(
+    db: &PartitionDb,
+    state_id: u64,
+) -> Result<Option<T>>
+where
+    <<T as PartitionStoreProtobufValue>::ProtobufType as TryInto<T>>::Error: Into<anyhow::Error>,
+{
+    get_storage_codec_from_partition_db::<ProtobufStorageWrapper<T::ProtobufType>>(db, state_id)?
+        .map(|wrapper| wrapper.0.try_into())
+        .transpose()
+        .map_err(|err| StorageError::Conversion(err.into()))
+}
+
+impl ReadFsmTable for PartitionDb {
+    async fn get_inbox_seq_number(&mut self) -> Result<MessageIndex> {
+        get_proto_from_partition_db::<SequenceNumber>(self, fsm_variable::INBOX_SEQ_NUMBER)
+            .map(|opt| opt.map(Into::into).unwrap_or_default())
+    }
+
+    async fn get_outbox_seq_number(&mut self) -> Result<MessageIndex> {
+        get_proto_from_partition_db::<SequenceNumber>(self, fsm_variable::OUTBOX_SEQ_NUMBER)
+            .map(|opt| opt.map(Into::into).unwrap_or_default())
+    }
+
+    async fn get_applied_lsn(&mut self) -> Result<Option<Lsn>> {
+        get_proto_from_partition_db::<SequenceNumber>(self, fsm_variable::APPLIED_LSN)
+            .map(|opt| opt.map(|seq_number| Lsn::from(u64::from(seq_number))))
+    }
+
+    async fn get_min_restate_version(&mut self) -> Result<SemanticRestateVersion> {
+        get_proto_from_partition_db::<SemanticRestateVersion>(
+            self,
+            fsm_variable::RESTATE_VERSION_BARRIER,
+        )
+        .map(|opt| opt.unwrap_or_default())
+    }
+
+    async fn get_partition_durability(&mut self) -> Result<Option<PartitionDurability>> {
+        get_proto_from_partition_db::<PartitionDurability>(self, fsm_variable::PARTITION_DURABILITY)
+    }
+
+    async fn get_schema(&mut self) -> Result<Option<Schema>> {
+        get_storage_codec_from_partition_db(self, fsm_variable::SERVICES_SCHEMA_METADATA)
+    }
+
+    async fn get_partition_config_state(&mut self) -> Result<Option<CachedEpochMetadata>> {
+        get_storage_codec_from_partition_db(self, fsm_variable::PARTITION_CONFIG_STATE)
+    }
+
+    async fn get_rule_book(&mut self) -> Result<Option<RuleBook>> {
+        get_storage_codec_from_partition_db(self, fsm_variable::RULE_BOOK)
+    }
+
+    async fn get_state_machine_features(&mut self) -> Result<PersistedStateMachineFeatures> {
+        get_storage_codec_from_partition_db(self, fsm_variable::STATE_MACHINE_FEATURES)
+            .map(|opt| opt.unwrap_or_default())
+    }
 }
 
 impl ReadFsmTable for PartitionStore {

--- a/crates/partition-store/src/partition_db.rs
+++ b/crates/partition-store/src/partition_db.rs
@@ -459,6 +459,15 @@ impl PartitionCell {
         }
     }
 
+    /// Returns the underlying Partition information if the database is open.
+    pub async fn get_partition_if_open(&self) -> Option<Arc<Partition>> {
+        let guard = self.inner.read().await;
+        match &*guard {
+            State::Unknown | State::CfMissing | State::Closed { .. } => None,
+            State::Open { db } => Some(Arc::clone(db.partition())),
+        }
+    }
+
     /// Updates the durable Lsn of the local partition store.
     pub fn note_durable_lsn(&self, lsn: Lsn) {
         let durable_lsn_guard = self.durable_lsn.read();

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -11,7 +11,7 @@
 use std::ops::ControlFlow;
 use std::ops::RangeBounds;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use anyhow::anyhow;
 use bytes::Bytes;
@@ -45,8 +45,8 @@ use restate_types::storage::StorageEncode;
 use restate_types::partitions::StorageVersion;
 
 use crate::fsm_table::{
-    get_locally_durable_lsn, get_storage_version, get_storage_version_from_partition_db,
-    is_jc_orphan_cleanup_done, put_jc_orphan_cleanup_done, put_storage_version,
+    get_locally_durable_lsn, get_storage_version_from_partition_db, is_jc_orphan_cleanup_done,
+    put_jc_orphan_cleanup_done, put_storage_version,
 };
 use crate::keys::{EncodeTableKey, EncodeTableKeyPrefix, KeyKind};
 use crate::migrations::run_migrations_up_to;
@@ -200,7 +200,7 @@ impl TableKind {
 
 pub struct PartitionStore {
     db: PartitionDb,
-    storage_version: StorageVersion,
+    storage_version: OnceLock<StorageVersion>,
     key_buffer: BytesMut,
     value_buffer: BytesMut,
 }
@@ -220,7 +220,7 @@ impl Clone for PartitionStore {
     fn clone(&self) -> Self {
         PartitionStore {
             db: self.db.clone(),
-            storage_version: self.storage_version,
+            storage_version: self.storage_version.clone(),
             key_buffer: BytesMut::default(),
             value_buffer: BytesMut::default(),
         }
@@ -235,20 +235,29 @@ impl From<PartitionDb> for PartitionStore {
 
 impl PartitionStore {
     pub(crate) fn new(db: PartitionDb) -> Self {
-        let storage_version =
-            get_storage_version_from_partition_db(&db).expect("storage version must exist");
-
         Self {
             db,
-            storage_version,
+            storage_version: OnceLock::new(),
             key_buffer: BytesMut::new(),
             value_buffer: BytesMut::new(),
         }
     }
 
+    /// Returns the on-disk storage version, reading it from RocksDB on the first
+    /// call and memoizing it. Clones of PartitionStore will copy the memoized value.
     #[inline]
     pub fn storage_version(&self) -> StorageVersion {
-        self.storage_version
+        *self.storage_version.get_or_init(|| {
+            get_storage_version_from_partition_db(self.partition_db())
+                .expect("storage version must exist")
+        })
+    }
+
+    /// Overwrites the memoized storage version. Requires exclusive access to PartitionStore.
+    fn set_storage_version(&mut self, version: StorageVersion) {
+        // Clear first: the lock is empty afterwards, so `set` cannot fail.
+        self.storage_version.take();
+        let _ = self.storage_version.set(version);
     }
 
     pub fn partition_db(&self) -> &PartitionDb {
@@ -575,6 +584,11 @@ impl PartitionStore {
             }
         };
 
+        // 99.9% of the time, this will return an already loaded value.
+        // If PartitionStore.storage_version() was never called before,
+        // this will fetch the value and cache it.
+        let storage_version = self.storage_version();
+
         PartitionStoreTransaction {
             write_batch_with_index: Some(rocksdb::WriteBatchWithIndex::new(0, true)),
             data_cf_handle,
@@ -582,7 +596,7 @@ impl PartitionStore {
             key_buffer: &mut self.key_buffer,
             value_buffer: &mut self.value_buffer,
             meta: self.db.partition(),
-            storage_version: self.storage_version,
+            storage_version,
             snapshot,
         }
     }
@@ -687,11 +701,15 @@ impl PartitionStore {
             // A fresh partition store cannot have orphaned jc index entries, so mark the
             // cleanup as already done to avoid a needless scan on first startup.
             put_jc_orphan_cleanup_done(self, self.partition_id())?;
-            self.storage_version = target;
+            self.set_storage_version(target);
             return Ok(());
         }
 
-        let mut storage_version = get_storage_version(self, self.partition_id()).await?;
+        // Read the authoritative on-disk version rather than the memoized
+        // `storage_version()`: the cache may hold a stale value (e.g. `None`
+        // memoized by a transaction created before the version was stamped),
+        // and migration decisions must be based on what's actually persisted.
+        let mut storage_version = get_storage_version_from_partition_db(self.partition_db())?;
         if storage_version < target {
             // We need to run some migrations!
             debug!(
@@ -700,7 +718,7 @@ impl PartitionStore {
             );
             storage_version = run_migrations_up_to(storage_version, target, self).await?;
         }
-        self.storage_version = storage_version;
+        self.set_storage_version(storage_version);
 
         Ok(())
     }

--- a/crates/partition-store/src/partition_store_manager.rs
+++ b/crates/partition-store/src/partition_store_manager.rs
@@ -210,6 +210,17 @@ impl PartitionStoreManager {
         cell.clone_db().await
     }
 
+    /// Returns the partition metadata if the database is open locally
+    pub async fn get_local_partition_if_open(
+        &self,
+        partition_id: PartitionId,
+    ) -> Option<Arc<Partition>> {
+        // note: we don't hold the map read lock while trying to acquire the partition cell's lock.
+        // hence the `cloned()` call.
+        let cell = self.state.partitions.read().get(&partition_id).cloned()?;
+        cell.get_partition_if_open().await
+    }
+
     /// Returns a partition store that's already open by a running partition processor
     pub async fn get_partition_store(&self, partition_id: PartitionId) -> Option<PartitionStore> {
         // note: we don't hold the map read lock while trying to acquire the partition cell's lock.

--- a/crates/storage-query-datafusion/src/invocation_state/table.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/table.rs
@@ -76,13 +76,13 @@ async fn partition_key_range(
     partition_id: PartitionId,
 ) -> datafusion::common::Result<KeyRange> {
     partition_store_manager
-        .get_partition_store(partition_id)
+        .get_local_partition_if_open(partition_id)
         .await
         .ok_or_else(|| {
             let err = anyhow!("expecting a partition store");
             DataFusionError::External(err.into())
         })
-        .map(|store| store.partition_key_range())
+        .map(|partition| partition.key_range)
 }
 
 #[derive(derive_more::Debug, Clone)]


### PR DESCRIPTION

- Implement `ReadFsmTable` for `PartitionDb`; FSM keys now serialize into a
  fixed `[u8; N]` array instead of a heap `BytesMut`.
- `PartitionStore::storage_version()` is lazy + memoized (`OnceLock`), removing
  the blocking RocksDB read from `new()`/`From<PartitionDb>`. First access still
  reads once, which in practice almost never happens.
- `verify_and_run_migrations` keeps reading the on-disk version directly, so the
  memoized value is never trusted for migration decisions.
- Add `get_local_partition_if_open()` (manager + cell); datafusion
  `invocation_state` reads the partition key range through it instead of creating
  a full `PartitionStore`, which used to force the storage-version read.
