### PR TITLE
[Restate UI] Update to v1.0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9068,8 +9068,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "1.0.10"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v1.0.10#03b6fdb92599c095f2ffa6bdccd0a5c48a463924"
+version = "1.0.11"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v1.0.11#c71cc54ac2e78971c20a6712538e10c27cf856f5"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -39,7 +39,7 @@ restate-util-time = { workspace = true }
 restate-types = { workspace = true }
 restate-util-string = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "1.0.10", tag = "v1.0.10" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "1.0.11", tag = "v1.0.11" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v1.0.11
published at https://github.com/restatedev/restate-web-ui/releases/download/v1.0.11/ui-v1.0.11.zip