### PR TITLE
Actually store the schema in partition store

### DIFF
--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -878,6 +878,7 @@ impl<S> StateMachineApplyContext<'_, S> {
                 {
                     // only update if schema is none or has a smaller version
                     debug!("Schema updated to version '{}'", upsert.schema.version());
+                    self.storage.put_schema(&upsert.schema)?;
                     *self.schema = Some(upsert.schema);
                 }
 


### PR DESCRIPTION

Fixes a lingering issue since v1.6 when we introduced UpsertSchema command (in #3860) which evidently never stored the schema on partition store. This was never a problem but since v1.7.0+vqueues we started to rely on it.

This has been working because the leader would be sending the schema on every leadership and keeps it in-memory. The risk is that followers that pull
a snapshot will not pick up the schema until the next leader writes it.
