### PR TITLE
fix documentation

### DIFF
--- a/crates/types/src/config/bifrost.rs
+++ b/crates/types/src/config/bifrost.rs
@@ -39,7 +39,6 @@ pub struct BifrostOptions {
     ///
     /// Default: Replicated
     pub default_provider: ProviderKind,
-    #[cfg_attr(feature = "schemars", schemars(with = "String"))]
     /// Configuration of local loglet provider
     pub local: LocalLogletOptions,
     /// Configuration of replicated loglet provider
@@ -221,8 +220,9 @@ pub struct LocalLogletOptions {
     /// Maximum number of concurrent flush operations for the local-loglet database.
     ///
     /// If unset, defaults to 1 (local-loglet has a lightweight workload).
+    ///
+    /// Since v1.7.0
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "schemars", schemars(skip))]
     rocksdb_max_background_flushes: Option<NonZeroU32>,
 
     /// # Max background compactions
@@ -230,8 +230,9 @@ pub struct LocalLogletOptions {
     /// Maximum number of concurrent compaction operations for the local-loglet database.
     ///
     /// If unset, defaults to 1.
+    ///
+    /// Since v1.7.0
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "schemars", schemars(skip))]
     rocksdb_max_background_compactions: Option<NonZeroU32>,
 }
 

--- a/crates/types/src/config/log_server.rs
+++ b/crates/types/src/config/log_server.rs
@@ -121,8 +121,9 @@ pub struct LogServerOptions {
     /// Maximum number of concurrent compaction operations for this database.
     ///
     /// If unset, defaults are computed based on CPU count and active node roles.
+    ///
+    /// Since v1.7.0
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "schemars", schemars(skip))]
     rocksdb_max_background_compactions: Option<NonZeroU32>,
 
     /// # Write Batch (in bytes)

--- a/crates/types/src/config/metadata_server.rs
+++ b/crates/types/src/config/metadata_server.rs
@@ -72,8 +72,9 @@ pub struct MetadataServerOptions {
     /// Maximum number of concurrent flush operations for this database.
     ///
     /// If unset, defaults to 1 (metadata-server has a lightweight workload).
+    ///
+    /// Since v1.7.0
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "schemars", schemars(skip))]
     rocksdb_max_background_flushes: Option<NonZeroU32>,
 
     /// # Max background compactions
@@ -81,8 +82,9 @@ pub struct MetadataServerOptions {
     /// Maximum number of concurrent compaction operations for this database.
     ///
     /// If unset, defaults to 1.
+    ///
+    /// Since v1.7.0
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "schemars", schemars(skip))]
     rocksdb_max_background_compactions: Option<NonZeroU32>,
 }
 

--- a/crates/types/src/config/mod.rs
+++ b/crates/types/src/config/mod.rs
@@ -563,6 +563,20 @@ fn read_subdirs(dir: &PathBuf) -> Vec<PathBuf> {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "schemars")]
+    use schemars::generate::SchemaSettings;
+
+    #[cfg(feature = "schemars")]
+    fn schema_definition_properties<'a>(
+        schema: &'a serde_json::Value,
+        definition: &str,
+    ) -> &'a serde_json::Map<String, serde_json::Value> {
+        schema
+            .pointer(&format!("/$defs/{definition}/properties"))
+            .and_then(serde_json::Value::as_object)
+            .expect("schema definition has properties")
+    }
+
     #[test]
     fn read_subdirs_did_not_exist() {
         let temp_dir = tempfile::tempdir().unwrap();
@@ -643,5 +657,41 @@ mod tests {
             InvalidConfigurationError::RequiredNodeName(_) => {}
             _ => panic!("Shoule be RequiredNodeName error"),
         }
+    }
+
+    #[cfg(feature = "schemars")]
+    #[test]
+    fn configuration_schema_exposes_supported_background_budget_keys() {
+        let schema = serde_json::to_value(
+            SchemaSettings::draft2020_12()
+                .into_generator()
+                .into_root_schema_for::<Configuration>(),
+        )
+        .expect("schema is serializable");
+
+        let worker_storage = schema_definition_properties(&schema, "StorageOptions");
+        assert!(worker_storage.contains_key("rocksdb-max-background-flushes"));
+        assert!(worker_storage.contains_key("rocksdb-max-background-compactions"));
+
+        let metadata_server = schema_definition_properties(&schema, "MetadataServerOptions");
+        assert!(metadata_server.contains_key("rocksdb-max-background-flushes"));
+        assert!(metadata_server.contains_key("rocksdb-max-background-compactions"));
+
+        let bifrost = schema_definition_properties(&schema, "BifrostOptions");
+        assert_eq!(
+            bifrost
+                .get("local")
+                .and_then(|value| value.get("$ref"))
+                .and_then(serde_json::Value::as_str),
+            Some("#/$defs/LocalLoglet")
+        );
+
+        let local_loglet = schema_definition_properties(&schema, "LocalLoglet");
+        assert!(local_loglet.contains_key("rocksdb-max-background-flushes"));
+        assert!(local_loglet.contains_key("rocksdb-max-background-compactions"));
+
+        let log_server = schema_definition_properties(&schema, "LogServer");
+        assert!(log_server.contains_key("rocksdb-max-background-compactions"));
+        assert!(!log_server.contains_key("rocksdb-max-background-flushes"));
     }
 }

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -832,8 +832,9 @@ pub struct StorageOptions {
     /// across databases.
     ///
     /// If unset, defaults are computed based on CPU count and active node roles.
+    ///
+    /// Since v1.7.0
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "schemars", schemars(skip))]
     rocksdb_max_background_flushes: Option<NonZeroU32>,
 
     /// # Max background compactions
@@ -843,8 +844,9 @@ pub struct StorageOptions {
     /// so it gets a larger share of the compaction budget (~65%).
     ///
     /// If unset, defaults are computed based on CPU count and active node roles.
+    ///
+    /// Since v1.7.0
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "schemars", schemars(skip))]
     rocksdb_max_background_compactions: Option<NonZeroU32>,
 
     /// # Clamps target size for sst files

--- a/release-notes/v1.7.0.md
+++ b/release-notes/v1.7.0.md
@@ -60,7 +60,7 @@
 
 The `rocksdb-max-background-jobs` configuration option has been removed from the shared `rocksdb` config block (which was applied to every database identically). Background work is now controlled per-database with separate flush and compaction concurrency limits that are automatically computed based on the node's CPU count and active roles.
 
-Each database type now has its own `rocksdb-max-background-flushes` and `rocksdb-max-background-compactions` options in its respective config section. A new `export-concurrency-limit` option has been added to the `[worker.snapshots]` section to control the number of concurrent snapshot exports (previously derived from `rocksdb-max-background-jobs`).
+The partition-store, metadata-server, and local-loglet databases now have `rocksdb-max-background-flushes` and `rocksdb-max-background-compactions` options in their respective config sections. The log-server has `rocksdb-max-background-compactions`, while its flush budget is now fixed internally. A new `export-concurrency-limit` option has been added to the `[worker.snapshots]` section to control the number of concurrent snapshot exports (previously derived from `rocksdb-max-background-jobs`).
 
 Previously, every database on a node (partition-store, log-server, metadata-server, local-loglet) was independently allocated the full CPU count as its background job budget, leading to up to `4 * CPU_COUNT` background jobs competing for the same shared thread pool. The new approach splits background work into two dimensions: **flushes** (latency-critical) are allocated equally across databases, while **compactions** (throughput-heavy) are weighted toward the partition-store (~65%). When a role is not active on the node, its budget is redistributed to the remaining databases.
 
@@ -81,10 +81,14 @@ rocksdb-max-background-flushes = 4
 rocksdb-max-background-compactions = 8
 
 [log-server]
-rocksdb-max-background-flushes = 4
 rocksdb-max-background-compactions = 4
 
 [metadata-server]
+rocksdb-max-background-flushes = 1
+rocksdb-max-background-compactions = 1
+
+# If you use local-loglet
+[bifrost.local]
 rocksdb-max-background-flushes = 1
 rocksdb-max-background-compactions = 1
 ```


### PR DESCRIPTION
Fix the generated config schema and migration docs for per-database RocksDB background budgets so they match the actual server behavior. This exposes the supported worker.storage, metadata-server, and bifrost.local flush/compaction settings in the config reference, keeps log-server compactions-only, and corrects the conflicting v1.7.0 migration example.