### PR TITLE
[Minor] Do not decode OutboxMessage when finding the tail sequence number

### DIFF
--- a/crates/partition-store/src/outbox_table/mod.rs
+++ b/crates/partition-store/src/outbox_table/mod.rs
@@ -56,9 +56,9 @@ fn get_outbox_head_seq_number<S: StorageAccess>(
     storage.get_first_blocking(
         TableScan::KeyRangeInclusiveInSinglePartition(partition_id, start, end),
         |kv| {
-            if let Some((k, v)) = kv {
-                let (seq_no, _) = decode_key_value(k, v)?;
-                Ok(Some(seq_no))
+            if let Some((mut k, _)) = kv {
+                let key = OutboxKey::deserialize_from(&mut k)?;
+                Ok(Some(key.message_index))
             } else {
                 Ok(None)
             }


### PR DESCRIPTION

A bit of mechanical empathy. No need to decode the outbox message body if we don't need to read it.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/5003).
* #5004
* __->__ #5003