### PR TITLE
[chore] Bump jemalloc and rocksdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4734,9 +4734,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc_pprof"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d44c349cfe2654897fadcb9de4f0bfbf48288ec344f700b2bd59f152dd209"
+checksum = "0bb2dfa20a68824f4c8c1aa271617d0ee0d9b707a866d56b7d7ee39c60c235a8"
 dependencies = [
  "anyhow",
  "libc",
@@ -9451,8 +9451,8 @@ dependencies = [
 
 [[package]]
 name = "rust-librocksdb-sys"
-version = "0.46.0+11.1.1"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=619c950cdbe8817cc57bdfca909f3fc047bfe093#619c950cdbe8817cc57bdfca909f3fc047bfe093"
+version = "0.47.1+11.1.2"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=c9ce6e982362da2b2bb783c28056b2603aba50df#c9ce6e982362da2b2bb783c28056b2603aba50df"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -9462,14 +9462,15 @@ dependencies = [
  "libz-sys",
  "lz4-sys",
  "pkg-config",
+ "rustflags",
  "tikv-jemalloc-sys",
  "zstd-sys",
 ]
 
 [[package]]
 name = "rust-rocksdb"
-version = "0.50.0"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=619c950cdbe8817cc57bdfca909f3fc047bfe093#619c950cdbe8817cc57bdfca909f3fc047bfe093"
+version = "0.51.0"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=c9ce6e982362da2b2bb783c28056b2603aba50df#c9ce6e982362da2b2bb783c28056b2603aba50df"
 dependencies = [
  "libc",
  "parking_lot",
@@ -9498,6 +9499,12 @@ checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
+
+[[package]]
+name = "rustflags"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a39e0e9135d7a7208ee80aa4e3e4b88f0f5ad7be92153ed70686c38a03db2e63"
 
 [[package]]
 name = "rustix"
@@ -10583,9 +10590,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-ctl"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+checksum = "3a184c43b8ab2f41df2733b55556e3f5f632f4aeaa205b1bb018f574b7f5f142"
 dependencies = [
  "libc",
  "paste",
@@ -10594,9 +10601,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
 dependencies = [
  "cc",
  "libc",
@@ -10604,9 +10611,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,10 +229,10 @@ reqwest = { version = "0.12", default-features = false, features = [
     "stream",
 ] }
 rlimit = { version = "0.11.0" }
-rocksdb = { version = "0.50.0", package = "rust-rocksdb", features = [
+rocksdb = { version = "0.51.0", package = "rust-rocksdb", features = [
     "multi-threaded-cf",
     "jemalloc",
-], git = "https://github.com/restatedev/rust-rocksdb", rev = "619c950cdbe8817cc57bdfca909f3fc047bfe093" }
+], git = "https://github.com/restatedev/rust-rocksdb", rev = "c9ce6e982362da2b2bb783c28056b2603aba50df" }
 rstest = "0.26.1"
 rustls = { version = "0.23.35", default-features = false, features = ["ring"] }
 rustyline = { version = "14.0.0" }
@@ -251,12 +251,12 @@ tempfile = "3.24.0"
 test-log = { version = "0.2.19", default-features = false, features = [
     "trace",
 ] }
-tikv-jemallocator = { version = "0.6", features = [
+tikv-jemallocator = { version = "0.7", features = [
     "unprefixed_malloc_on_supported_platforms",
     "profiling",
 ] }
-tikv-jemalloc-ctl = { version = "0.6", features = ["stats"] }
-tikv-jemalloc-sys = { version = "0.6", features = ["profiling"] }
+tikv-jemalloc-ctl = { version = "0.7", features = ["stats"] }
+tikv-jemalloc-sys = { version = "0.7", features = ["profiling"] }
 thiserror = "2.0"
 tokio = { version = "1.48.0", default-features = false, features = [
     "rt-multi-thread",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -82,7 +82,7 @@ tonic = { workspace = true, features = ["gzip", "zstd"] }
 tracing = { workspace = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-jemalloc_pprof = { version = "0.8.2", default-features = false, features = ["symbolize"] }
+jemalloc_pprof = { version = "0.9", default-features = false, features = ["symbolize"] }
 tikv-jemalloc-ctl = { workspace = true }
 tikv-jemalloc-sys = { workspace = true }
 

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -286,7 +286,7 @@ clap = { version = "4" }
 crossterm = { version = "0.29" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["aws-lc-rs", "webpki-tokio"] }
-jemalloc_pprof = { version = "0.8", default-features = false, features = ["flamegraph", "symbolize"] }
+jemalloc_pprof = { version = "0.9", default-features = false, features = ["flamegraph", "symbolize"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
 mio = { version = "1", features = ["net", "os-ext"] }
@@ -298,8 +298,8 @@ quick-xml = { version = "0.39", features = ["overlapped-lists", "serialize"] }
 rustix = { version = "1", features = ["fs", "stdio", "termios"] }
 sha2 = { version = "0.10", features = ["asm"] }
 signal-hook = { version = "0.3" }
-tikv-jemalloc-ctl = { version = "0.6", features = ["stats", "use_std"] }
-tikv-jemalloc-sys = { version = "0.6", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
+tikv-jemalloc-ctl = { version = "0.7", features = ["stats", "use_std"] }
+tikv-jemalloc-sys = { version = "0.7", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["aws-lc-rs"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
@@ -308,7 +308,7 @@ clap = { version = "4" }
 crossterm = { version = "0.29" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["aws-lc-rs", "webpki-tokio"] }
-jemalloc_pprof = { version = "0.8", default-features = false, features = ["flamegraph", "symbolize"] }
+jemalloc_pprof = { version = "0.9", default-features = false, features = ["flamegraph", "symbolize"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
 mio = { version = "1", features = ["net", "os-ext"] }
@@ -320,8 +320,8 @@ quick-xml = { version = "0.39", features = ["overlapped-lists", "serialize"] }
 rustix = { version = "1", features = ["fs", "stdio", "termios"] }
 sha2 = { version = "0.10", features = ["asm"] }
 signal-hook = { version = "0.3" }
-tikv-jemalloc-ctl = { version = "0.6", features = ["stats", "use_std"] }
-tikv-jemalloc-sys = { version = "0.6", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
+tikv-jemalloc-ctl = { version = "0.7", features = ["stats", "use_std"] }
+tikv-jemalloc-sys = { version = "0.7", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["aws-lc-rs"] }
 
 [target.aarch64-apple-darwin.dependencies]
@@ -331,7 +331,7 @@ crossterm = { version = "0.29" }
 errno = { version = "0.3" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["aws-lc-rs", "webpki-tokio"] }
-jemalloc_pprof = { version = "0.8", default-features = false, features = ["flamegraph", "symbolize"] }
+jemalloc_pprof = { version = "0.9", default-features = false, features = ["flamegraph", "symbolize"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
 num = { version = "0.4" }
@@ -343,8 +343,8 @@ rustix = { version = "1", features = ["fs", "stdio", "termios"] }
 security-framework-sys = { version = "2" }
 sha2 = { version = "0.10", features = ["asm"] }
 signal-hook = { version = "0.3" }
-tikv-jemalloc-ctl = { version = "0.6", features = ["stats", "use_std"] }
-tikv-jemalloc-sys = { version = "0.6", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
+tikv-jemalloc-ctl = { version = "0.7", features = ["stats", "use_std"] }
+tikv-jemalloc-sys = { version = "0.7", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["aws-lc-rs"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
@@ -354,7 +354,7 @@ crossterm = { version = "0.29" }
 errno = { version = "0.3" }
 getrandom-9fbad63c4bcf4a8f = { package = "getrandom", version = "0.4", default-features = false, features = ["std", "sys_rng"] }
 hyper-rustls = { version = "0.27", default-features = false, features = ["aws-lc-rs", "webpki-tokio"] }
-jemalloc_pprof = { version = "0.8", default-features = false, features = ["flamegraph", "symbolize"] }
+jemalloc_pprof = { version = "0.9", default-features = false, features = ["flamegraph", "symbolize"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
 miniz_oxide = { version = "0.8", default-features = false, features = ["simd", "with-alloc"] }
 num = { version = "0.4" }
@@ -366,8 +366,8 @@ rustix = { version = "1", features = ["fs", "stdio", "termios"] }
 security-framework-sys = { version = "2" }
 sha2 = { version = "0.10", features = ["asm"] }
 signal-hook = { version = "0.3" }
-tikv-jemalloc-ctl = { version = "0.6", features = ["stats", "use_std"] }
-tikv-jemalloc-sys = { version = "0.6", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
+tikv-jemalloc-ctl = { version = "0.7", features = ["stats", "use_std"] }
+tikv-jemalloc-sys = { version = "0.7", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["aws-lc-rs"] }
 
 ### END HAKARI SECTION


### PR DESCRIPTION

Jemalloc can finally be updated to 0.7. I've also upgraded rust-rocksdb to 0.51.0 including the change to pin it to the latest jemalloc as well.
