### PR TITLE
follow-up: short-circuit when max depth is reached

### DIFF
--- a/crates/invoker-impl/src/error.rs
+++ b/crates/invoker-impl/src/error.rs
@@ -190,9 +190,9 @@ pub(crate) enum InvokerError {
     #[error("{0}")]
     #[code(restate_errors::RT0001)]
     OutOfMemory(InvocationMemoryExhausted),
-    #[error("maximum awaited future depth limit of {limit} has been reached. got '{depth}'")]
+    #[error("maximum awaited future depth limit of {limit} has been reached.")]
     #[code(restate_errors::RT0025)]
-    MaxFutureDepthReached { limit: usize, depth: usize },
+    MaxFutureDepthReached { limit: usize },
 }
 
 /// Describes a memory budget exhaustion that occurred during invocation

--- a/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
+++ b/crates/invoker-impl/src/invocation_task/service_protocol_runner_v4.rs
@@ -1419,11 +1419,9 @@ where
             return TerminalLoopState::Failed(InvokerError::EmptyAwaitingOnMessage);
         };
 
-        let depth = awaiting_on.depth();
-        if depth > self.max_awaited_future_depth {
+        if awaiting_on.is_too_deep(self.max_awaited_future_depth) {
             return TerminalLoopState::Failed(InvokerError::MaxFutureDepthReached {
                 limit: self.max_awaited_future_depth,
-                depth,
             });
         }
 
@@ -1448,11 +1446,9 @@ where
             return TerminalLoopState::Failed(InvokerError::EmptySuspensionMessage);
         };
 
-        let depth = awaiting_on.depth();
-        if depth > self.max_awaited_future_depth {
+        if awaiting_on.is_too_deep(self.max_awaited_future_depth) {
             return TerminalLoopState::Failed(InvokerError::MaxFutureDepthReached {
                 limit: self.max_awaited_future_depth,
-                depth,
             });
         }
 

--- a/crates/service-protocol-v4/src/lib.rs
+++ b/crates/service-protocol-v4/src/lib.rs
@@ -77,21 +77,27 @@ pub mod proto {
         }
 
         impl super::Future {
-            // Gets the maximum depth of this future non-recursively
+            // Checks whether the nesting depth of this future stays within
+            // `max_depth`, returning `true` as soon as the bound is exceeded.
             //
-            // To avoid possible stack overflow for deeply nested futures
-            // this function does some heap allocations. It's advised to
-            // calculate the depth once and keep it around if you need to
-            // do multiple calculations against it
-            pub fn depth(&self) -> usize {
-                let mut depth = 0;
-                let mut stack = vec![DepthStackFrame {
+            // The traversal is iterative rather than recursive to avoid a
+            // possible stack overflow on deeply nested futures. It trades that
+            // for some heap allocation: an explicit stack pre-sized to
+            // `max_depth`.
+            pub fn is_too_deep(&self, max_depth: usize) -> bool {
+                let mut stack = Vec::with_capacity(max_depth.min(128));
+                stack.push(DepthStackFrame {
                     inner: self,
                     cursor: 0,
-                }];
+                });
 
+                let mut depth = 0;
                 while let Some(mut current) = stack.pop() {
                     depth = depth.max(stack.len());
+                    if depth > max_depth {
+                        return true;
+                    }
+
                     if current.cursor >= current.inner.nested_futures.len() {
                         continue;
                     }
@@ -105,10 +111,11 @@ pub mod proto {
                     });
                 }
 
-                depth
+                false
             }
         }
 
+        pub struct MaxDepthReached;
         struct DepthStackFrame<'a> {
             inner: &'a super::Future,
             cursor: usize,
@@ -188,7 +195,7 @@ pub mod proto {
                 ..Default::default()
             };
 
-            assert_eq!(fut.depth(), 0);
+            assert!(!fut.is_too_deep(0));
 
             // Fut([Fut, Fut]) --> max depth is 1
             let fut = super::Future {
@@ -203,7 +210,8 @@ pub mod proto {
                 ..Default::default()
             };
 
-            assert_eq!(fut.depth(), 1);
+            assert!(!fut.is_too_deep(1));
+            assert!(fut.is_too_deep(0));
 
             // Fut([Fut([Fut]), Fut]) --> max depth is 2
             let fut = super::Future {
@@ -221,7 +229,9 @@ pub mod proto {
                 ..Default::default()
             };
 
-            assert_eq!(fut.depth(), 2);
+            assert!(!fut.is_too_deep(2));
+            assert!(!fut.is_too_deep(3));
+            assert!(fut.is_too_deep(1));
 
             let mut fut = super::Future {
                 ..Default::default()
@@ -234,7 +244,8 @@ pub mod proto {
                 };
             }
 
-            assert_eq!(fut.depth(), 10);
+            assert!(!fut.is_too_deep(10));
+            assert!(fut.is_too_deep(9));
         }
     }
 }

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -473,7 +473,7 @@ pub struct InvokerOptions {
     ///
     /// Default: `1000`.
     ///
-    /// Since v1.7.2
+    /// Since v1.7.3
     pub max_awaited_future_depth: usize,
 }
 


### PR DESCRIPTION

Summary:
Avoid unnecessary iteration and short circuit once max depth
is reached
