### PR TITLE
[vqueues] Fix panic on large send delay in eligibility checker

### DIFF
--- a/crates/vqueues/src/scheduler/eligible.rs
+++ b/crates/vqueues/src/scheduler/eligible.rs
@@ -10,6 +10,7 @@
 
 use std::collections::VecDeque;
 use std::task::Poll;
+use std::time::Duration;
 
 use slotmap::SecondaryMap;
 use slotmap::secondary::Entry;
@@ -28,6 +29,16 @@ use super::vqueue_state::VQueueState;
 use crate::VQueuesMeta;
 use crate::cache::VQueueHandle;
 use crate::scheduler::vqueue_state::Eligibility;
+
+/// Tokio's `DelayQueue` timer wheel panics with `invalid deadline` if an entry
+/// is scheduled more than `(1 << 36) - 1` ms (~2.1 years) into the future.
+///
+/// When a vqueue head is scheduled beyond that horizon, we park the timer at
+/// this cap instead of the real delay. This should be safe because when the
+/// vqueue is dequeued from the ready ring, we'll notice that it's still not
+/// eligible and just reschedule it. Now, if this is ever to happen,
+/// I applaud your server's uptime.
+const MAX_PARK: Duration = Duration::from_secs(365 * 24 * 60 * 60);
 
 #[derive(Debug, Copy, Clone)]
 pub(super) struct WakeUp {
@@ -158,8 +169,11 @@ impl EligibilityTracker {
                         }
                         Poll::Ready(Ok(Eligibility::EligibleAt(ts))) => {
                             let ts = ts.as_unix_millis();
-                            let duration = ts.duration_since(SchedulerClock.now_millis());
-                            let timer_key = self.delayed_eligibility.insert(handle, duration);
+                            let timer_key = self.delayed_eligibility.insert(
+                                handle,
+                                // Cap the parked delay. See`MAX_PARK`.
+                                ts.duration_since(SchedulerClock.now_millis()).min(MAX_PARK),
+                            );
                             *current_state = State::Scheduled {
                                 wake_up: WakeUp { ts, timer_key },
                             };
@@ -315,7 +329,10 @@ impl EligibilityTracker {
                         if eligible_at_ts != wake_up.ts {
                             self.delayed_eligibility.reset(
                                 &wake_up.timer_key,
-                                eligible_at_ts.duration_since(SchedulerClock.now_millis()),
+                                // Cap the parked delay. See `MAX_PARK`.
+                                eligible_at_ts
+                                    .duration_since(SchedulerClock.now_millis())
+                                    .min(MAX_PARK),
                             );
 
                             occupied_entry.insert(State::Scheduled {


### PR DESCRIPTION

Fixes #5011

Tokio's `DelayQueue` timer wheel panics with `invalid deadline` if an entry
is scheduled more than `(1 << 36) - 1` ms (~2.1 years) into the future.

This was causing panics when an invocation is scheduled with a delay of greater
than 2.1 years. This PR changes it such that we park in the delay queue for a year
as a max delay. When (and IF) it gets dequeued, it'll be moved back to to the ready
ring (`poll_delayed`), which when it checks its eligibility again, it'll end up
rescheduling it for another year (or less depending on the run at time).


Tested with
```
curl http://localhost:8080/Counter/m/add/send\?delay\=99999999s --json "12"
```

and it's showing the correct time in `sys_vqueues`:

```
❯❯❯ restate sql "select id, status, run_at from sys_vqueues";
 ID                                     STATUS     RUN_AT
 vq_125D4mj8VO2b2fHGnEK5ZlB2qDvSdSlDKP  scheduled  2029-09-07T22:59:01Z
 vq_125D4mj8VO2b2fHGnEK5ZlB2qDvSdSlDKP  scheduled  2029-09-07T22:59:02Z
 vq_125D4mj8VO2b2fHGnEK5ZlB2qDvSdSlDKP  scheduled  2029-09-07T22:59:03Z

3 rows. Query took 6.045302ms
```
