### PR TITLE
Introduce BecomingLeader leadership state

### DIFF
--- a/crates/storage-query-datafusion/src/partition_state/row.rs
+++ b/crates/storage-query-datafusion/src/partition_state/row.rs
@@ -27,7 +27,7 @@ pub(crate) fn append_partition_row(
     row.fmt_gen_node_id(node_id);
     row.fmt_target_mode(state.planned_mode);
 
-    row.fmt_effective_mode(state.effective_mode);
+    row.fmt_effective_mode(state.effective_mode());
 
     row.updated_at(state.updated_at.as_u64() as i64);
     if let Some(epoch) = state.last_observed_leader_epoch {

--- a/crates/storage-query-datafusion/src/partition_state/schema.rs
+++ b/crates/storage-query-datafusion/src/partition_state/schema.rs
@@ -27,7 +27,7 @@ define_table!(
         /// Observed target run mode of partition (LEADER, FOLLOWER)
         target_mode: DataType::Utf8,
 
-        /// Effective partition run mode of partition (LEADER, FOLLOWER)
+        /// Effective partition run mode of partition (LEADER, BECOMING_LEADING, FOLLOWER)
         effective_mode: DataType::Utf8,
 
         /// Last updated

--- a/crates/types/build.rs
+++ b/crates/types/build.rs
@@ -112,6 +112,10 @@ fn build_restate_proto(out_dir: &Path) -> std::io::Result<()> {
         .enum_attribute("LogServerStatus", "#[derive(::serde::Serialize)]")
         .enum_attribute("WorkerStatus", "#[derive(::serde::Serialize)]")
         .enum_attribute("MetadataServerStatus", "#[derive(::serde::Serialize)]")
+        .enum_attribute(
+            "DetailedRunMode",
+            "#[derive(::strum::Display, ::restate_encoding::NetSerde, ::bilrost::Enumeration)]",
+        )
         .btree_map([
             ".restate.cluster.ClusterState",
             ".restate.cluster.AliveNode",

--- a/crates/types/protobuf/restate/cluster.proto
+++ b/crates/types/protobuf/restate/cluster.proto
@@ -51,6 +51,18 @@ enum RunMode {
   FOLLOWER = 2;
 }
 
+// Since v1.7.3 (if missing, use effective_mode)
+enum DetailedRunMode {
+  DetailedRunMode_UNKNOWN = 0;
+  DetailedRunMode_CANDIDATE = 1;
+  DetailedRunMode_FOLLOWER = 2;
+  // The node is leader but is currently performing data migrations or enabling
+  // certain features. During this time, the node will not be responding to RPC requests
+  // until it completes the process and transitions to Leader (or Follower).
+  DetailedRunMode_BECOMING_LEADER = 3;
+  DetailedRunMode_LEADER = 4;
+}
+
 enum ReplayStatus {
   ReplayStatus_UNKNOWN = 0;
   STARTING = 1;
@@ -80,6 +92,7 @@ message PartitionProcessorStatus {
   repeated string enabled_features = 15;
   // Partition-store on-disk storage version (StorageVersion discriminant).
   optional uint32 storage_version = 16;
+  DetailedRunMode detailed_effective_mode = 17;
 }
 
 message ReplicationProperty { string replication_property = 1; }

--- a/crates/types/src/cluster/cluster_state.rs
+++ b/crates/types/src/cluster/cluster_state.rs
@@ -12,7 +12,6 @@ use std::collections::BTreeMap;
 use std::time::{Duration, Instant};
 
 use prost_dto::IntoProst;
-use serde::{Deserialize, Serialize};
 
 use restate_encoding::NetSerde;
 
@@ -20,6 +19,7 @@ use crate::identifiers::{LeaderEpoch, PartitionId};
 use crate::logs::Lsn;
 use crate::partitions::StorageVersion;
 use crate::partitions::features::PersistedFeatures;
+pub use crate::protobuf::cluster::DetailedRunMode;
 use crate::time::MillisSinceEpoch;
 use crate::{GenerationalNodeId, PlainNodeId, Version};
 
@@ -139,17 +139,7 @@ pub struct DeadNode {
 }
 
 #[derive(
-    Debug,
-    Clone,
-    Copy,
-    Serialize,
-    Deserialize,
-    Eq,
-    PartialEq,
-    IntoProst,
-    strum::Display,
-    bilrost::Enumeration,
-    NetSerde,
+    Debug, Clone, Copy, Eq, PartialEq, IntoProst, strum::Display, bilrost::Enumeration, NetSerde,
 )]
 #[prost(target = "crate::protobuf::cluster::RunMode")]
 #[strum(serialize_all = "snake_case")]
@@ -159,17 +149,7 @@ pub enum RunMode {
 }
 
 #[derive(
-    Debug,
-    Clone,
-    Copy,
-    Eq,
-    PartialEq,
-    Serialize,
-    Deserialize,
-    IntoProst,
-    strum::Display,
-    bilrost::Enumeration,
-    NetSerde,
+    Debug, Clone, Copy, Eq, PartialEq, IntoProst, strum::Display, bilrost::Enumeration, NetSerde,
 )]
 #[prost(target = "crate::protobuf::cluster::ReplayStatus")]
 #[strum(serialize_all = "snake_case")]
@@ -227,6 +207,39 @@ pub struct PartitionProcessorStatus {
     #[bilrost(16)]
     #[into_prost(map = "storage_version_to_u32")]
     pub storage_version: Option<StorageVersion>,
+
+    /// Since v1.7.3 (if Unknown, use effective_mode)
+    #[bilrost(17)]
+    pub detailed_effective_mode: DetailedRunMode,
+}
+
+impl PartitionProcessorStatus {
+    pub fn effective_mode(&self) -> DetailedRunMode {
+        match self.detailed_effective_mode {
+            DetailedRunMode::Unknown => self.effective_mode.into(),
+            other => other,
+        }
+    }
+}
+
+impl From<RunMode> for DetailedRunMode {
+    fn from(value: RunMode) -> Self {
+        match value {
+            RunMode::Leader => DetailedRunMode::Leader,
+            RunMode::Follower => DetailedRunMode::Follower,
+        }
+    }
+}
+
+impl From<DetailedRunMode> for RunMode {
+    fn from(value: DetailedRunMode) -> Self {
+        match value {
+            DetailedRunMode::Unknown | DetailedRunMode::Follower | DetailedRunMode::Candidate => {
+                RunMode::Follower
+            }
+            DetailedRunMode::Leader | DetailedRunMode::BecomingLeader => RunMode::Leader,
+        }
+    }
 }
 
 fn storage_version_to_u32(v: StorageVersion) -> u32 {
@@ -243,6 +256,7 @@ impl Default for PartitionProcessorStatus {
             updated_at: MillisSinceEpoch::now(),
             planned_mode: RunMode::Follower,
             effective_mode: RunMode::Follower,
+            detailed_effective_mode: DetailedRunMode::Follower,
             last_observed_leader_epoch: None,
             last_observed_leader_node: None,
             last_applied_log_lsn: None,

--- a/crates/types/src/partitions/features.rs
+++ b/crates/types/src/partitions/features.rs
@@ -31,7 +31,16 @@ use crate::{RESTATE_VERSION_1_6_0, RESTATE_VERSION_1_7_0, SemanticRestateVersion
 ///
 /// *Since v1.7.0*
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, strum::FromRepr, strum::EnumString, strum::Display,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    strum::FromRepr,
+    strum::EnumString,
+    strum::IntoStaticStr,
+    strum::Display,
 )]
 #[strum(ascii_case_insensitive)]
 #[repr(u16)]

--- a/crates/types/src/partitions/state.rs
+++ b/crates/types/src/partitions/state.rs
@@ -50,6 +50,11 @@ impl PartitionReplicaSetStates {
         partition_id: PartitionId,
         incoming_leader: LeadershipState,
     ) {
+        // filter out invalid leader epochs.
+        if !incoming_leader.current_leader_epoch.is_valid() {
+            return;
+        }
+
         let modified = match self.inner.partitions.entry(partition_id) {
             Entry::Occupied(mut occupied_entry) => occupied_entry
                 .get_mut()

--- a/crates/types/src/protobuf.rs
+++ b/crates/types/src/protobuf.rs
@@ -115,6 +115,31 @@ pub mod cluster {
         }
     }
 
+    impl From<RunMode> for DetailedRunMode {
+        fn from(value: RunMode) -> Self {
+            match value {
+                RunMode::Leader => DetailedRunMode::Leader,
+                RunMode::Follower => DetailedRunMode::Follower,
+                RunMode::Unknown => DetailedRunMode::Unknown,
+            }
+        }
+    }
+
+    impl PartialEq<RunMode> for DetailedRunMode {
+        fn eq(&self, other: &RunMode) -> bool {
+            match (self, other) {
+                (DetailedRunMode::Unknown, _) => false,
+                (_, RunMode::Unknown) => false,
+                (DetailedRunMode::Leader, RunMode::Leader) => true,
+                (DetailedRunMode::Follower, RunMode::Follower) => true,
+                (DetailedRunMode::Leader, RunMode::Follower)
+                | (DetailedRunMode::Follower, RunMode::Leader) => false,
+                (DetailedRunMode::BecomingLeader, _) => false,
+                (DetailedRunMode::Candidate, _) => false,
+            }
+        }
+    }
+
     impl From<crate::replication::ReplicationProperty> for ReplicationProperty {
         fn from(value: crate::replication::ReplicationProperty) -> Self {
             ReplicationProperty {

--- a/crates/worker-api/src/processor/features.rs
+++ b/crates/worker-api/src/processor/features.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use restate_types::partitions::PersistedFeatures;
+use restate_types::partitions::{PartitionFeatureChange, PersistedFeatures};
 
 /// Read-only view of the state-machine features currently enabled for a partition.
 ///
@@ -17,6 +17,9 @@ use restate_types::partitions::PersistedFeatures;
 /// ([`PersistedFeatures`]), depending on what the feature requires. See each method's
 /// doc-comment for the specific gate.
 pub trait PartitionFeatures {
+    /// Whether the feature is enabled on this partition.
+    fn has_feature(&self, feature: PartitionFeatureChange) -> bool;
+
     /// Write to journal v2 instead of journal v1 by default. This is a preparational step for
     /// removing the journal v1 after enabling this feature and migrating all unpinned invocations
     /// from journal v1 to journal v2.
@@ -37,6 +40,15 @@ pub trait PartitionFeatures {
 
 impl PartitionFeatures for PersistedFeatures {
     #[inline]
+    fn has_feature(&self, feature: PartitionFeatureChange) -> bool {
+        match feature {
+            PartitionFeatureChange::EnableJournalV2 => self.journal_v2,
+            PartitionFeatureChange::EnableVqueues => self.vqueues,
+            PartitionFeatureChange::EnableUniqueRandomSeeds => self.unique_random_seeds,
+        }
+    }
+
+    #[inline]
     fn use_journal_v2_as_default(&self) -> bool {
         self.journal_v2
     }
@@ -55,6 +67,10 @@ impl PartitionFeatures for PersistedFeatures {
 // -- Boilerplate --
 
 impl<T: PartitionFeatures> PartitionFeatures for &T {
+    fn has_feature(&self, feature: PartitionFeatureChange) -> bool {
+        (**self).has_feature(feature)
+    }
+
     fn use_journal_v2_as_default(&self) -> bool {
         (**self).use_journal_v2_as_default()
     }
@@ -69,6 +85,10 @@ impl<T: PartitionFeatures> PartitionFeatures for &T {
 }
 
 impl<T: PartitionFeatures> PartitionFeatures for &mut T {
+    fn has_feature(&self, feature: PartitionFeatureChange) -> bool {
+        (**self).has_feature(feature)
+    }
+
     fn use_journal_v2_as_default(&self) -> bool {
         (**self).use_journal_v2_as_default()
     }

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 
 use futures::{StreamExt, TryStreamExt};
 use tokio::sync::mpsc;
+use tokio::time::Instant;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, instrument, warn};
 
@@ -58,6 +59,7 @@ use restate_types::net::partition_processor::{
     PartitionProcessorRpcError, PartitionProcessorRpcResponse,
 };
 use restate_types::partitions::PartitionFeatureChange;
+use restate_types::protobuf::cluster::DetailedRunMode;
 use restate_types::schema::Schema;
 use restate_types::storage::{StorageDecodeError, StorageEncodeError};
 use restate_util_time::DurationExt;
@@ -155,9 +157,19 @@ pub(crate) enum ActionEffect {
     UpsertRuleBook(Arc<restate_limiter::RuleBook>),
     AwaitingRpcSelfProposeDone,
 }
+
 enum State {
     Follower,
     Candidate {
+        at: Instant,
+        leader_epoch: LeaderEpoch,
+        // to be able to move out of it
+        self_proposer: Option<SelfProposer>,
+    },
+    /// A leader that's performing migrations or other tasks before it can operate as a full leader.
+    /// From the perspective of other nodes, it's the effective leader of the partition.
+    BecomingLeader {
+        at: Instant,
         leader_epoch: LeaderEpoch,
         // to be able to move out of it
         self_proposer: Option<SelfProposer>,
@@ -170,6 +182,7 @@ impl State {
         match self {
             State::Follower => None,
             State::Candidate { leader_epoch, .. } => Some(*leader_epoch),
+            State::BecomingLeader { leader_epoch, .. } => Some(*leader_epoch),
             State::Leader(leader_state) => Some(leader_state.leader_epoch),
         }
     }
@@ -201,18 +214,29 @@ where
     }
 
     pub(crate) fn is_leader(&self) -> bool {
-        matches!(self.state, State::Leader(_))
+        matches!(self.state, State::Leader(_) | State::BecomingLeader { .. })
     }
 
     pub(crate) fn partition_id(&self) -> PartitionId {
         self.partition_id
     }
 
-    pub fn effective_mode(&self) -> RunMode {
+    pub fn detailed_effective_mode(&self) -> DetailedRunMode {
         match self.state {
-            State::Follower | State::Candidate { .. } => RunMode::Follower,
-            State::Leader(_) => RunMode::Leader,
+            State::Follower => DetailedRunMode::Follower,
+            State::Candidate { .. } => DetailedRunMode::Candidate,
+            State::BecomingLeader { .. } => DetailedRunMode::BecomingLeader,
+            State::Leader(_) => DetailedRunMode::Leader,
         }
+    }
+
+    pub(super) fn should_process_rpc(&self) -> bool {
+        // In case of BecomingLeader we prefer to park RPC requests
+        // until we transition out of the current state.
+        matches!(
+            self.state,
+            State::Leader(_) | State::Follower | State::Candidate { .. }
+        )
     }
 
     #[instrument(level = "debug", skip_all, fields(leader_epoch = %leadership_info.leader_epoch))]
@@ -270,6 +294,7 @@ where
             .await?;
 
         self.state = State::Candidate {
+            at: Instant::now(),
             leader_epoch,
             self_proposer: Some(self_proposer),
         };
@@ -299,20 +324,40 @@ where
 
         let planned_mode = match &self.state {
             State::Follower => RunMode::Follower,
-            State::Candidate { leader_epoch, .. } => match leader_epoch.cmp(&new_leader_epoch) {
-                Ordering::Less => {
-                    debug!(
-                        "Lost leadership campaign. Conceding to {} at epoch {}",
-                        new_leader_node, new_leader_epoch
-                    );
-                    self.become_follower().await;
-                    RunMode::Follower
+            State::Candidate { leader_epoch, .. } => {
+                match leader_epoch.cmp(&new_leader_epoch) {
+                    Ordering::Less => {
+                        debug!(
+                            "Lost leadership campaign. Conceding to {} at epoch {}",
+                            new_leader_node, new_leader_epoch
+                        );
+                        self.become_follower().await;
+                        RunMode::Follower
+                    }
+                    _ => {
+                        /* nothing do to, we are still candidates for leadership */
+                        RunMode::Leader
+                    }
                 }
-                _ => {
-                    /* nothing do to, we are still candidates for leadership */
-                    RunMode::Leader
+            }
+            State::BecomingLeader { leader_epoch, .. } => {
+                match leader_epoch.cmp(&new_leader_epoch) {
+                    Ordering::Less => {
+                        debug!(
+                            my_leadership_epoch = %leader_epoch,
+                            %new_leader_epoch,
+                            "Every reign must end. Stepping down and becoming an conceding to {} at epoch {}",
+                            new_leader_node, new_leader_epoch
+                        );
+                        self.become_follower().await;
+                        RunMode::Follower
+                    }
+                    _ => {
+                        /* nothing do to, we are still leaders */
+                        RunMode::Leader
+                    }
                 }
-            },
+            }
             State::Leader(leader_state) => match leader_state.leader_epoch.cmp(&new_leader_epoch) {
                 Ordering::Less => {
                     debug!(
@@ -331,59 +376,80 @@ where
         ctx.status_mut().set_planned_run_mode(planned_mode);
     }
 
-    #[instrument(level = "debug", skip_all, fields(leader_epoch = %announce_leader.leader_epoch))]
+    #[instrument(level = "debug", skip_all, fields(leader_epoch = %leader_epoch))]
     pub async fn on_announce_leader(
         &mut self,
         node_ctx: &mut NodeContext,
         ctx: impl Processor + HasVQueuesMut + HasTrimQueue,
         partition_store: &mut PartitionStore,
-        announce_leader: &AnnounceLeaderCommand,
+        leader_epoch: LeaderEpoch,
     ) -> Result<(), Error> {
         match &self.state {
             State::Follower => {
                 debug!("Observed new leader. Staying an obedient follower.");
             }
-            State::Candidate { leader_epoch, .. } => {
-                match leader_epoch.cmp(&announce_leader.leader_epoch) {
-                    Ordering::Less => {
-                        debug!("Lost leadership campaign. Becoming an obedient follower.");
-                        self.become_follower().await;
-                    }
-                    Ordering::Equal => {
-                        debug!("Won the leadership campaign. Becoming the strong leader now.");
-                        self.become_leader(node_ctx, ctx, partition_store).await?
-                    }
-                    Ordering::Greater => {
-                        debug!(
-                            "Observed an intermittent leader. Still believing to win the leadership campaign."
-                        );
-                    }
-                }
+            State::Candidate {
+                leader_epoch: my_leader_epoch,
+                ..
             }
-            State::Leader(leader_state) => {
-                match leader_state.leader_epoch.cmp(&announce_leader.leader_epoch) {
-                    Ordering::Less => {
-                        debug!(
-                            my_leadership_epoch = %leader_state.leader_epoch,
-                            new_leader_epoch = %announce_leader.leader_epoch,
-                            "Every reign must end. Stepping down and becoming an obedient follower."
-                        );
-                        self.become_follower().await;
-                    }
-                    Ordering::Equal => {
-                        warn!(
-                            "Observed another leadership announcement for my own leadership. This should never happen and indicates a bug!"
-                        );
-                    }
-                    Ordering::Greater => {
-                        warn!(
-                            "Observed a leadership announcement for an outdated epoch. This should never happen and indicates a bug!"
-                        );
-                    }
+            | State::BecomingLeader {
+                leader_epoch: my_leader_epoch,
+                ..
+            } => match my_leader_epoch.cmp(&leader_epoch) {
+                Ordering::Less => {
+                    debug!("Lost leadership campaign. Becoming an obedient follower.");
+                    self.become_follower().await;
                 }
-            }
+                Ordering::Equal => {
+                    debug!("Won the leadership campaign. Becoming the strong leader now.");
+                    self.become_leader(node_ctx, ctx, partition_store).await?
+                }
+                Ordering::Greater => {
+                    debug!(
+                        "Observed an intermittent leader. Still believing to win the leadership campaign."
+                    );
+                }
+            },
+            State::Leader(leader_state) => match leader_state.leader_epoch.cmp(&leader_epoch) {
+                Ordering::Less => {
+                    debug!(
+                        my_leadership_epoch = %leader_state.leader_epoch,
+                        new_leader_epoch = %leader_epoch,
+                        "Every reign must end. Stepping down and becoming an obedient follower."
+                    );
+                    self.become_follower().await;
+                }
+                Ordering::Equal => {
+                    warn!(
+                        "Observed another leadership announcement for my own leadership. This should never happen and indicates a bug!"
+                    );
+                }
+                Ordering::Greater => {
+                    warn!(
+                        "Observed a leadership announcement for an outdated epoch. This should never happen and indicates a bug!"
+                    );
+                }
+            },
         }
         Ok(())
+    }
+
+    pub async fn finish_becoming_leader(
+        &mut self,
+        node_ctx: &mut NodeContext,
+        processor: impl Processor + HasTrimQueue + HasVQueuesMut,
+        partition_store: &mut PartitionStore,
+    ) -> Result<(), Error> {
+        if !matches!(
+            self.detailed_effective_mode(),
+            DetailedRunMode::BecomingLeader
+        ) {
+            return Ok(());
+        }
+
+        // finish up becoming a leader.
+        self.become_leader(node_ctx, processor, partition_store)
+            .await
     }
 
     async fn become_leader(
@@ -392,14 +458,135 @@ where
         mut processor: impl Processor + HasTrimQueue + HasVQueuesMut,
         partition_store: &mut PartitionStore,
     ) -> Result<(), Error> {
+        let prev_mode = self.detailed_effective_mode();
+
         if let State::Candidate {
+            at,
+            leader_epoch,
+            self_proposer,
+        }
+        | State::BecomingLeader {
+            at,
             leader_epoch,
             self_proposer,
         } = &mut self.state
         {
-            let schema = Metadata::with_current(|m| m.updateable_schema());
             let live_config = &mut node_ctx.config;
             let config = live_config.live_load();
+
+            let mut self_proposer = self_proposer.take().expect("must be present");
+            self_proposer.mark_as_leader();
+
+            // Collect feature changes to apply as a single VersionBarrierCommand.
+            //
+            // RESTATE_INTERNAL_STATE_MACHINE_FEATURES is a comma-separated list of
+            // PartitionFeatureChange variant names (case-insensitive) used by internal
+            // testing to enable specific features explicitly.
+            let mut feature_changes: Vec<PartitionFeatureChange> =
+                if let Ok(raw) = std::env::var("RESTATE_INTERNAL_STATE_MACHINE_FEATURES") {
+                    raw.split(',')
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .filter_map(|name| match PartitionFeatureChange::from_str(name) {
+                            Ok(change) => Some(change),
+                            Err(_) => {
+                                warn!(
+                                    "Ignoring unknown state-machine feature \
+                                     '{name}' from RESTATE_INTERNAL_STATE_MACHINE_FEATURES"
+                                );
+                                None
+                            }
+                        })
+                        .filter(|change| !processor.fsm().features().has_feature(*change))
+                        .collect()
+                } else {
+                    Vec::new()
+                };
+
+            // Since v1.7.0 we enable by default writing to the journal v2.
+            if !processor.fsm().features().use_journal_v2_as_default() {
+                feature_changes.push(PartitionFeatureChange::EnableJournalV2);
+            }
+
+            // Opt this partition in to vqueues if the operator has flipped the experimental config
+            // flag on and the FSM hasn't already recorded the opt-in. The FSM update itself
+            // happens via `OnVersionBarrierCommand` once this proposed barrier is applied; we do
+            // not touch the local FSM mirror here.
+            if config.common.experimental.is_vqueues_enabled()
+                && !processor.fsm().features().is_vqueues_enabled()
+            {
+                feature_changes.push(PartitionFeatureChange::EnableVqueues);
+            }
+
+            // Persist a unique random seed on new invocations. Needs to be opted-in because
+            // it was only introduced with v1.7.0
+            if config.common.experimental.is_unique_random_seeds_enabled()
+                && !processor.fsm().features().is_unique_random_seeds_enabled()
+            {
+                feature_changes.push(PartitionFeatureChange::EnableUniqueRandomSeeds);
+            }
+
+            if !feature_changes.is_empty() {
+                // Smallest version that supports every listed feature, but never below
+                // the partition's current min_restate_version.
+                let barrier_version = feature_changes
+                    .iter()
+                    .map(|c| c.min_required_version())
+                    .max()
+                    .expect("non-empty")
+                    .max(processor.fsm().min_restate_version())
+                    .clone();
+
+                debug!(
+                    "Proposing VersionBarrier command to enable state-machine features {}",
+                    feature_changes
+                        .iter()
+                        .map(|c| {
+                            let name: &'static str = c.into();
+                            name
+                        })
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+                self_proposer
+                    .self_propose(
+                        processor.key_range().start(),
+                        Command::VersionBarrier(VersionBarrierCommand {
+                            version: barrier_version,
+                            partition_key_range: Keys::RangeInclusive(processor.key_range().into()),
+                            human_reason: Some("Apply state-machine feature changes".to_owned()),
+                            feature_changes: feature_changes.into_iter().map(|c| c.id()).collect(),
+                        }),
+                    )
+                    .await?;
+
+                // Switch to BecomingLeader state until we finish any pending tasks to enable the
+                // new features. We will transition us to an effective leader when the state
+                // machine applies the VersionBarrier command and perform any necessary migrations.
+                //
+                // This will happen by calling become_leader() again.
+                //
+                // Note that between us self proposing and transitioning to a full leader, we may
+                // get preempted by a newer leader. Therefore, we don't perform any migration until
+                // we actually observe the VersionBarrier command back from the log. But we also
+                // don't expect any other commands other than AnnounceLeader (from preemptions) or
+                // VersionBarrier (our own self-proposal) to be next in the log.
+                debug!(
+                    "Transitioning from {prev_mode} -> {}. Spent {} in {prev_mode} mode.",
+                    DetailedRunMode::BecomingLeader,
+                    at.elapsed().friendly(),
+                );
+
+                self.state = State::BecomingLeader {
+                    at: Instant::now(),
+                    leader_epoch: *leader_epoch,
+                    self_proposer: Some(self_proposer),
+                };
+
+                return Ok(());
+            }
+
+            let schema = Metadata::with_current(|m| m.updateable_schema());
 
             let (invoker_tx, invoker_rx) = mpsc::channel(config.worker.internal_queue_length());
             let invoker_rx = ReceiverStream::new(invoker_rx);
@@ -511,80 +698,6 @@ where
                 processor.trim_queue().clone(),
             )?;
 
-            let mut self_proposer = self_proposer.take().expect("must be present");
-            self_proposer.mark_as_leader();
-
-            // Collect feature changes to apply as a single VersionBarrierCommand.
-            //
-            // RESTATE_INTERNAL_STATE_MACHINE_FEATURES is a comma-separated list of
-            // PartitionFeatureChange variant names (case-insensitive) used by internal
-            // testing to enable specific features explicitly.
-            let mut feature_changes: Vec<PartitionFeatureChange> =
-                if let Ok(raw) = std::env::var("RESTATE_INTERNAL_STATE_MACHINE_FEATURES") {
-                    raw.split(',')
-                        .map(str::trim)
-                        .filter(|s| !s.is_empty())
-                        .filter_map(|name| match PartitionFeatureChange::from_str(name) {
-                            Ok(change) => Some(change),
-                            Err(_) => {
-                                warn!(
-                                    "Ignoring unknown state-machine feature \
-                                     '{name}' from RESTATE_INTERNAL_STATE_MACHINE_FEATURES"
-                                );
-                                None
-                            }
-                        })
-                        .collect()
-                } else {
-                    Vec::new()
-                };
-
-            // In v1.7.0 we enable by default writing to the journal v2.
-            if !processor.fsm().features().use_journal_v2_as_default() {
-                feature_changes.push(PartitionFeatureChange::EnableJournalV2);
-            }
-
-            // Opt this partition in to vqueues if the operator has flipped the experimental config
-            // flag on and the FSM hasn't already recorded the opt-in. The FSM update itself
-            // happens via `OnVersionBarrierCommand` once this proposed barrier is applied; we do
-            // not touch the local FSM mirror here.
-            if config.common.experimental.is_vqueues_enabled()
-                && !processor.fsm().features().is_vqueues_enabled()
-            {
-                feature_changes.push(PartitionFeatureChange::EnableVqueues);
-            }
-
-            // Persist a unique random seed on new invocations. Needs to be opted-in because
-            // it was only introduced with v1.7.0
-            if config.common.experimental.is_unique_random_seeds_enabled()
-                && !processor.fsm().features().is_unique_random_seeds_enabled()
-            {
-                feature_changes.push(PartitionFeatureChange::EnableUniqueRandomSeeds);
-            }
-
-            if !feature_changes.is_empty() {
-                // Smallest version that supports every listed feature, but never below
-                // the partition's current min_restate_version.
-                let barrier_version = feature_changes
-                    .iter()
-                    .map(|c| c.min_required_version())
-                    .max()
-                    .expect("non-empty")
-                    .max(processor.fsm().min_restate_version())
-                    .clone();
-
-                self_proposer
-                    .self_propose(
-                        processor.key_range().start(),
-                        Command::VersionBarrier(VersionBarrierCommand {
-                            version: barrier_version,
-                            partition_key_range: Keys::RangeInclusive(processor.key_range().into()),
-                            human_reason: Some("Apply state-machine feature changes".to_owned()),
-                            feature_changes: feature_changes.into_iter().map(|c| c.id()).collect(),
-                        }),
-                    )
-                    .await?;
-            }
             let last_reported_durable_lsn =
                 processor.fsm().durable_point().map(|d| d.durable_point);
 
@@ -594,6 +707,12 @@ where
                 node_ctx.replica_set_states.clone(),
                 partition_store.partition_db().watch_archived_lsn(),
                 Duration::from_secs(5).add_jitter(0.5),
+            );
+
+            debug!(
+                "Transitioning from {prev_mode} -> {}. Spent {} in {prev_mode} mode.",
+                DetailedRunMode::Leader,
+                at.elapsed().friendly(),
             );
 
             self.state = State::Leader(Box::new(LeaderState::new(
@@ -671,10 +790,7 @@ where
         let old_state = mem::replace(&mut self.state, State::Follower);
 
         match old_state {
-            State::Follower => {
-                // nothing to do :-)
-            }
-            State::Candidate { .. } => {
+            State::Follower | State::Candidate { .. } | State::BecomingLeader { .. } => {
                 // nothing to do :-)
             }
             State::Leader(leader_state) => {
@@ -693,7 +809,7 @@ where
         actions: impl Iterator<Item = Action>,
     ) -> Result<(), Error> {
         match &mut self.state {
-            State::Follower | State::Candidate { .. } => {
+            State::Follower | State::Candidate { .. } | State::BecomingLeader { .. } => {
                 // nothing to do :-)
             }
             State::Leader(leader_state) => {
@@ -715,7 +831,8 @@ where
     ) -> Result<Vec<ActionEffect>, Error> {
         match &mut self.state {
             State::Follower => Ok(futures::future::pending::<Vec<_>>().await),
-            State::Candidate { self_proposer, .. } => Err(self_proposer
+            State::Candidate { self_proposer, .. }
+            | State::BecomingLeader { self_proposer, .. } => Err(self_proposer
                 .as_mut()
                 .expect("must be present")
                 .join_on_err()
@@ -730,7 +847,7 @@ where
         action_effects: impl IntoIterator<Item = ActionEffect>,
     ) -> Result<(), Error> {
         match &mut self.state {
-            State::Follower | State::Candidate { .. } => {
+            State::Follower | State::Candidate { .. } | State::BecomingLeader { .. } => {
                 // nothing to do :-)
             }
             State::Leader(leader_state) => {
@@ -785,7 +902,7 @@ impl<T> LeadershipState<T> {
         cmd: Command,
     ) {
         match &mut self.state {
-            State::Follower | State::Candidate { .. } => {
+            State::Follower | State::Candidate { .. } | State::BecomingLeader { .. } => {
                 // Just fail the rpc
                 reciprocal.send(Err(PartitionProcessorRpcError::NotLeader(
                     self.partition_id,
@@ -809,7 +926,7 @@ impl<T> LeadershipState<T> {
         cmd: Command,
     ) {
         match &mut self.state {
-            State::Follower | State::Candidate { .. } => {
+            State::Follower | State::Candidate { .. } | State::BecomingLeader { .. } => {
                 // Just fail the rpc
                 reciprocal.send(Err(PartitionProcessorRpcError::NotLeader(
                     self.partition_id,
@@ -834,9 +951,10 @@ impl<T> LeadershipState<T> {
         success_response: PartitionProcessorRpcResponse,
     ) {
         match &mut self.state {
-            State::Follower | State::Candidate { .. } => reciprocal.send(Err(
-                PartitionProcessorRpcError::NotLeader(self.partition_id),
-            )),
+            State::Follower | State::Candidate { .. } | State::BecomingLeader { .. } => reciprocal
+                .send(Err(PartitionProcessorRpcError::NotLeader(
+                    self.partition_id,
+                ))),
             State::Leader(leader_state) => {
                 leader_state
                     .append_and_respond_asynchronously(
@@ -859,9 +977,9 @@ impl<T> LeadershipState<T> {
         F: FnOnce(Result<(), PartitionProcessorRpcError>) + Send + Sync + 'static,
     {
         match &mut self.state {
-            State::Follower | State::Candidate { .. } => callback(Err(
-                PartitionProcessorRpcError::NotLeader(self.partition_id),
-            )),
+            State::Follower | State::Candidate { .. } | State::BecomingLeader { .. } => callback(
+                Err(PartitionProcessorRpcError::NotLeader(self.partition_id)),
+            ),
             State::Leader(leader_state) => {
                 leader_state
                     .forward_many_with_callback(records, callback)
@@ -932,7 +1050,9 @@ mod tests {
     use restate_types::identifiers::{LeaderEpoch, PartitionId};
     use restate_types::logs::{KeyFilter, Lsn, SequenceNumber};
     use restate_types::partitions::state::PartitionReplicaSetStates;
-    use restate_types::partitions::{Partition, PartitionConfiguration, PersistedFeatures};
+    use restate_types::partitions::{
+        Partition, PartitionConfiguration, PartitionFeatureChange, PersistedFeatures,
+    };
     use restate_types::sharding::KeyRange;
     use restate_types::{GenerationalNodeId, Version};
     use restate_wal_protocol::Command;
@@ -1005,13 +1125,11 @@ mod tests {
 
         assert!(matches!(state.state, State::Candidate { .. }));
 
-        let record = bifrost
+        let mut reader = bifrost
             .create_reader(PARTITION_ID.into(), KeyFilter::Any, Lsn::OLDEST, Lsn::MAX)
-            .expect("valid reader")
-            .next()
-            .await
-            .unwrap()?;
+            .expect("valid reader");
 
+        let record = reader.next().await.unwrap()?;
         let envelope = record.try_decode::<Envelope>().unwrap()?;
 
         let_assert!(Command::AnnounceLeader(announce_leader) = envelope.command);
@@ -1026,8 +1144,32 @@ mod tests {
                 &mut node_ctx,
                 &mut ctx,
                 &mut partition_store,
-                &announce_leader,
+                announce_leader.leader_epoch,
             )
+            .await?;
+
+        // Since v1.7.0, winning the campaign first proposes a VersionBarrier to enable
+        // the journal-v2 default; the processor stays `BecomingLeader` until that barrier
+        // is applied.
+        assert!(matches!(state.state, State::BecomingLeader { .. }));
+
+        let record = reader.next().await.unwrap()?;
+        let envelope = record.try_decode::<Envelope>().unwrap()?;
+        let_assert!(Command::VersionBarrier(barrier) = envelope.command);
+        assert!(
+            barrier
+                .feature_changes
+                .contains(&PartitionFeatureChange::EnableJournalV2.id())
+        );
+
+        // Simulate the barrier being applied to the FSM, then complete the transition
+        // into a full leader (no further feature changes remain to be proposed).
+        ctx.set_enabled_features_in_memory(PersistedFeatures {
+            journal_v2: true,
+            ..PersistedFeatures::default()
+        });
+        state
+            .finish_becoming_leader(&mut node_ctx, &mut ctx, &mut partition_store)
             .await?;
 
         assert!(matches!(state.state, State::Leader(_)));

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -98,6 +98,7 @@ use crate::metric_definitions::{
     PARTITION_LABEL, PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS, REASON_LABEL,
 };
 use crate::partition::leadership::LeadershipState;
+use crate::partition::processor::leadership::LeadershipContext;
 use crate::partition::state_machine::ActionCollector;
 
 /// Information needed to run as leader, including the epoch and partition configurations.
@@ -182,17 +183,14 @@ impl PartitionProcessorBuilder {
             .rule_book_cache
             .notify_observed(ctx.fsm().rule_book());
 
-        let last_leader_epoch = ctx.current_leader_epoch();
-        if last_leader_epoch.is_valid() {
-            node_ctx.replica_set_states.note_observed_leader(
-                ctx.partition_id(),
-                restate_types::partitions::state::LeadershipState {
-                    current_leader_epoch: last_leader_epoch,
-                    // if we don't know the old leader node-id, another node will announce it
-                    current_leader: GenerationalNodeId::INVALID,
-                },
-            );
-        }
+        node_ctx.replica_set_states.note_observed_leader(
+            ctx.partition_id(),
+            restate_types::partitions::state::LeadershipState {
+                current_leader_epoch: ctx.current_leader_epoch(),
+                // if we don't know the old leader node-id, another node will announce it
+                current_leader: GenerationalNodeId::INVALID,
+            },
+        );
 
         let (leader_query_tx, leader_query_rx) = restate_worker_api::channel();
 
@@ -530,7 +528,7 @@ where
                     self.leadership_state.maybe_step_down(&mut self.ctx, new_state.current_leader_epoch, new_state.current_leader).await;
                     self.refresh_status(&mut durable_lsn_watch)?;
                 }
-                Some(msg) = self.network_leader_svc_rx.next() => {
+                Some(msg) = self.network_leader_svc_rx.next(), if self.leadership_state.should_process_rpc() => {
                     // todo: replace the live schema with the leader's consistent schema
                     self.on_rpc(msg, live_schemas.live_load(), &last_applied_lsn_watch).await;
                 }
@@ -702,7 +700,8 @@ where
             self.ctx.merge_with_status(old);
             old.durable_lsn = Some(durable_lsn);
             old.storage_version = Some(self.partition_store.storage_version());
-            old.effective_mode = self.leadership_state.effective_mode();
+            old.effective_mode = self.leadership_state.detailed_effective_mode().into();
+            old.detailed_effective_mode = self.leadership_state.detailed_effective_mode();
             old.updated_at = MillisSinceEpoch::now();
         });
 
@@ -969,10 +968,15 @@ where
                 .await
             }
             v2::CommandKind::VersionBarrier => {
+                let mut leadership = LeadershipContext {
+                    partition_store: &mut self.partition_store,
+                    leadership: &mut self.leadership_state,
+                };
                 VersionBarrierContext {
                     txn,
+                    node_ctx: &mut self.node_ctx,
                     processor: &mut self.ctx,
-                    is_leader: self.leadership_state.is_leader(),
+                    leadership: &mut leadership,
                 }
                 .apply(record.map(v2::Envelope::into_typed))
                 .await

--- a/crates/worker/src/partition/processor.rs
+++ b/crates/worker/src/partition/processor.rs
@@ -26,6 +26,7 @@ pub mod commands;
 mod context;
 mod dedup;
 mod fsm;
+pub mod leadership;
 mod outbox;
 mod status;
 

--- a/crates/worker/src/partition/processor/commands/announce_leader.rs
+++ b/crates/worker/src/partition/processor/commands/announce_leader.rs
@@ -87,7 +87,7 @@ impl<P: Processor + HasFsmMut + HasVQueuesMut + HasTrimQueue + HasStatusMut, T: 
                 self.node_ctx,
                 &mut self.processor,
                 self.partition_store,
-                &announce_leader,
+                announce_leader.leader_epoch,
             )
             .await?;
 

--- a/crates/worker/src/partition/processor/commands/version_barrier.rs
+++ b/crates/worker/src/partition/processor/commands/version_barrier.rs
@@ -8,30 +8,37 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use tracing::debug;
+
 use restate_bifrost::DataRecord;
 use restate_partition_store::PartitionStoreTransaction;
+use restate_storage_api::Transaction;
 use restate_storage_api::inbox_table::ReadInboxTable;
 use restate_storage_api::invocation_status_table::ReadInvocationStatusTable;
 use restate_types::SemanticRestateVersion;
 use restate_types::partitions::features::PartitionFeatureChange;
+use restate_types::protobuf::cluster::DetailedRunMode;
 use restate_types::sharding::KeyRange;
 use restate_wal_protocol::control::VersionBarrierCommand;
 use restate_wal_protocol::v2::{CommandScope, Envelope};
 
 use super::{ApplyPartitionCommand, NextStep};
-use crate::debug_if_leader;
-use crate::partition::ProcessorError;
+use crate::partition::processor::leadership::LeaderPromotion;
 use crate::partition::processor::{
     FsmAccess, FsmMut, HasFsm, HasFsmMut, Processor, ProcessorRawContext,
 };
+use crate::partition::{NodeContext, ProcessorError};
 
-pub struct VersionBarrierContext<'a, 'b> {
+pub struct VersionBarrierContext<'a, 'b, L> {
     pub txn: &'a mut PartitionStoreTransaction<'b>,
+    pub node_ctx: &'a mut NodeContext,
     pub processor: &'a mut ProcessorRawContext,
-    pub is_leader: bool,
+    pub leadership: &'a mut L,
 }
 
-impl ApplyPartitionCommand<VersionBarrierCommand> for VersionBarrierContext<'_, '_> {
+impl<L: LeaderPromotion> ApplyPartitionCommand<VersionBarrierCommand>
+    for VersionBarrierContext<'_, '_, L>
+{
     async fn apply(
         &mut self,
         command: DataRecord<Envelope<VersionBarrierCommand>>,
@@ -127,8 +134,7 @@ impl ApplyPartitionCommand<VersionBarrierCommand> for VersionBarrierContext<'_, 
             .fsm_mut()
             .set_min_restate_version(self.txn, barrier.version)
         {
-            debug_if_leader!(
-                self.is_leader,
+            debug!(
                 "Update a new minimum restate-server version barrier to {}",
                 self.processor.fsm().min_restate_version()
             );
@@ -141,12 +147,27 @@ impl ApplyPartitionCommand<VersionBarrierCommand> for VersionBarrierContext<'_, 
             .fsm_mut()
             .set_enabled_features(self.txn, updated)
         {
-            debug_if_leader!(
-                self.is_leader,
+            debug!(
                 "Applied state-machine feature changes {:?}; new feature set: {:?}",
                 known_changes,
                 self.processor.enabled_features()
             );
+        }
+
+        // Make sure we commit all changes in case we are becoming a leader.
+        self.txn.commit().await?;
+        // if we are in (becoming leader). Time to switch into a full leader.
+        if matches!(
+            self.leadership.current_mode(),
+            DetailedRunMode::BecomingLeader
+        ) {
+            self.leadership
+                .on_barrier_applied(self.node_ctx, &mut self.processor)
+                .await?;
+            assert!(matches!(
+                self.leadership.current_mode(),
+                DetailedRunMode::Leader
+            ));
         }
 
         Ok(NextStep::AdvanceLastAppliedLsn {
@@ -205,8 +226,8 @@ mod tests {
 
     use googletest::prelude::*;
 
-    use restate_bifrost::DataRecord;
-    use restate_core::TaskCenter;
+    use restate_bifrost::{Bifrost, DataRecord};
+    use restate_core::{TaskCenter, TestCoreEnv};
     use restate_partition_store::{PartitionStore, PartitionStoreManager};
     use restate_rocksdb::RocksDbManager;
     use restate_storage_api::Transaction;
@@ -216,22 +237,51 @@ mod tests {
         CompletedInvocation, InFlightInvocationMetadata, InvocationStatus,
         WriteInvocationStatusTable,
     };
-    use restate_types::SemanticRestateVersion;
+    use restate_types::config::Configuration;
     use restate_types::identifiers::{InvocationId, PartitionId, PartitionKey, ServiceId};
     use restate_types::invocation::InvocationTarget;
     use restate_types::logs::{Keys, Lsn, SequenceNumber};
     use restate_types::partitions::Partition;
     use restate_types::partitions::features::{PartitionFeatureChange, PersistedFeatures};
+    use restate_types::partitions::state::PartitionReplicaSetStates;
+    use restate_types::protobuf::cluster::DetailedRunMode;
     use restate_types::sharding::KeyRange;
     use restate_types::state_mut::ExternalStateMutation;
     use restate_types::time::NanosSinceEpoch;
+    use restate_types::{GenerationalNodeId, SemanticRestateVersion};
+    use restate_vqueues::context::HasVQueuesMut;
     use restate_wal_protocol::control::VersionBarrierCommand;
     use restate_wal_protocol::v2::{self, Command, CommandScope};
+    use restate_worker_api::invoker::capacity::InvokerCapacity;
+    use restate_worker_api::processor::Processor;
 
     use super::{ApplyPartitionCommand, VersionBarrierContext};
-    use crate::partition::ProcessorError;
+    use crate::RuleBookCacheHandle;
+    use crate::partition::leadership::trim_queue::HasTrimQueue;
     use crate::partition::processor::ProcessorRawContext;
     use crate::partition::processor::commands::NextStep;
+    use crate::partition::processor::leadership::LeaderPromotion;
+    use crate::partition::{NodeContext, ProcessorError};
+    use crate::partition_processor_manager::PartitionLeaderHandlesRegistry;
+
+    /// No-op [`LeaderPromotion`]: the version-barrier command logic under test never
+    /// depends on a real leadership transition. Reporting `Follower` keeps `apply` from
+    /// attempting the become-leader step, so `on_barrier_applied` is never reached.
+    struct NoLeadershipPromotion;
+
+    impl LeaderPromotion for NoLeadershipPromotion {
+        async fn on_barrier_applied(
+            &mut self,
+            _node_ctx: &mut NodeContext,
+            _processor: impl Processor + HasTrimQueue + HasVQueuesMut,
+        ) -> std::result::Result<(), ProcessorError> {
+            Ok(())
+        }
+
+        fn current_mode(&self) -> DetailedRunMode {
+            DetailedRunMode::Follower
+        }
+    }
 
     async fn open_store() -> PartitionStore {
         RocksDbManager::init();
@@ -271,6 +321,7 @@ mod tests {
     /// Mirrors the dispatcher: the transaction is committed on success and rolled
     /// back (dropped) on error.
     async fn apply_barrier(
+        node_ctx: &mut NodeContext,
         processor: &mut ProcessorRawContext,
         storage: &mut PartitionStore,
         command: VersionBarrierCommand,
@@ -284,10 +335,12 @@ mod tests {
         );
 
         let mut txn = storage.transaction();
+        let mut leadership = NoLeadershipPromotion;
         let next_step = VersionBarrierContext {
             txn: &mut txn,
+            node_ctx,
             processor,
-            is_leader: false,
+            leadership: &mut leadership,
         }
         .apply(record.map(v2::Envelope::into_typed))
         .await?;
@@ -342,6 +395,9 @@ mod tests {
 
     #[restate_core::test]
     async fn stop_at_version_barrier() {
+        let env = TestCoreEnv::create_with_single_node(1, 0).await;
+        let bifrost = Bifrost::init_in_memory(env.metadata_writer).await;
+
         let mut storage = open_store().await;
         let mut processor = processor(PersistedFeatures::default());
 
@@ -351,7 +407,18 @@ mod tests {
             eq(std::cmp::Ordering::Greater)
         );
 
+        let mut node_ctx = NodeContext::new(
+            GenerationalNodeId::new(1, 0),
+            Configuration::live(),
+            PartitionReplicaSetStates::default(),
+            RuleBookCacheHandle::detached(),
+            bifrost,
+            InvokerCapacity::new_unlimited(),
+            PartitionLeaderHandlesRegistry::default(),
+        );
+
         let result = apply_barrier(
+            &mut node_ctx,
             &mut processor,
             &mut storage,
             barrier(unrealistic_future_version.clone(), Vec::new()),
@@ -369,10 +436,23 @@ mod tests {
 
     #[restate_core::test]
     async fn update_at_version_barrier() {
+        let env = TestCoreEnv::create_with_single_node(1, 0).await;
+        let bifrost = Bifrost::init_in_memory(env.metadata_writer).await;
         let mut storage = open_store().await;
         let mut processor = processor(PersistedFeatures::default());
 
+        let mut node_ctx = NodeContext::new(
+            GenerationalNodeId::new(1, 0),
+            Configuration::live(),
+            PartitionReplicaSetStates::default(),
+            RuleBookCacheHandle::detached(),
+            bifrost,
+            InvokerCapacity::new_unlimited(),
+            PartitionLeaderHandlesRegistry::default(),
+        );
+
         apply_barrier(
+            &mut node_ctx,
             &mut processor,
             &mut storage,
             barrier(SemanticRestateVersion::current().clone(), Vec::new()),
@@ -386,6 +466,7 @@ mod tests {
 
         // Re-apply the same version: no-op.
         apply_barrier(
+            &mut node_ctx,
             &mut processor,
             &mut storage,
             barrier(SemanticRestateVersion::current().clone(), Vec::new()),
@@ -399,6 +480,7 @@ mod tests {
 
         // Apply an older version: succeeds but the min version doesn't regress.
         apply_barrier(
+            &mut node_ctx,
             &mut processor,
             &mut storage,
             barrier(SemanticRestateVersion::parse("0.1.0").unwrap(), Vec::new()),
@@ -413,8 +495,20 @@ mod tests {
 
     #[restate_core::test]
     async fn apply_known_feature_change() {
+        let env = TestCoreEnv::create_with_single_node(1, 0).await;
+        let bifrost = Bifrost::init_in_memory(env.metadata_writer).await;
         let mut storage = open_store().await;
         let mut processor = processor(PersistedFeatures::default());
+
+        let mut node_ctx = NodeContext::new(
+            GenerationalNodeId::new(1, 0),
+            Configuration::live(),
+            PartitionReplicaSetStates::default(),
+            RuleBookCacheHandle::detached(),
+            bifrost,
+            InvokerCapacity::new_unlimited(),
+            PartitionLeaderHandlesRegistry::default(),
+        );
 
         // PSF starts empty.
         assert_that!(
@@ -425,6 +519,7 @@ mod tests {
         // Enable vqueues, then re-apply: idempotent.
         for _ in 0..2 {
             apply_barrier(
+                &mut node_ctx,
                 &mut processor,
                 &mut storage,
                 barrier(
@@ -443,11 +538,24 @@ mod tests {
 
     #[restate_core::test]
     async fn migration_required_when_inbox_non_empty() {
+        let env = TestCoreEnv::create_with_single_node(1, 0).await;
+        let bifrost = Bifrost::init_in_memory(env.metadata_writer).await;
         let mut storage = open_store().await;
         let mut processor = processor(PersistedFeatures::default());
         seed_inbox_state_mutation(&mut storage).await;
 
+        let mut node_ctx = NodeContext::new(
+            GenerationalNodeId::new(1, 0),
+            Configuration::live(),
+            PartitionReplicaSetStates::default(),
+            RuleBookCacheHandle::detached(),
+            bifrost,
+            InvokerCapacity::new_unlimited(),
+            PartitionLeaderHandlesRegistry::default(),
+        );
+
         let result = apply_barrier(
+            &mut node_ctx,
             &mut processor,
             &mut storage,
             barrier(
@@ -472,11 +580,24 @@ mod tests {
 
     #[restate_core::test]
     async fn migration_required_when_non_completed_invocation_present() {
+        let env = TestCoreEnv::create_with_single_node(1, 0).await;
+        let bifrost = Bifrost::init_in_memory(env.metadata_writer).await;
         let mut storage = open_store().await;
         let mut processor = processor(PersistedFeatures::default());
         seed_invoked_status(&mut storage).await;
 
+        let mut node_ctx = NodeContext::new(
+            GenerationalNodeId::new(1, 0),
+            Configuration::live(),
+            PartitionReplicaSetStates::default(),
+            RuleBookCacheHandle::detached(),
+            bifrost,
+            InvokerCapacity::new_unlimited(),
+            PartitionLeaderHandlesRegistry::default(),
+        );
+
         let result = apply_barrier(
+            &mut node_ctx,
             &mut processor,
             &mut storage,
             barrier(
@@ -500,11 +621,24 @@ mod tests {
 
     #[restate_core::test]
     async fn only_completed_invocation_does_not_block_enable() {
+        let env = TestCoreEnv::create_with_single_node(1, 0).await;
+        let bifrost = Bifrost::init_in_memory(env.metadata_writer).await;
         let mut storage = open_store().await;
         let mut processor = processor(PersistedFeatures::default());
         seed_completed_status(&mut storage).await;
 
+        let mut node_ctx = NodeContext::new(
+            GenerationalNodeId::new(1, 0),
+            Configuration::live(),
+            PartitionReplicaSetStates::default(),
+            RuleBookCacheHandle::detached(),
+            bifrost,
+            InvokerCapacity::new_unlimited(),
+            PartitionLeaderHandlesRegistry::default(),
+        );
+
         apply_barrier(
+            &mut node_ctx,
             &mut processor,
             &mut storage,
             barrier(
@@ -522,6 +656,8 @@ mod tests {
 
     #[restate_core::test]
     async fn no_op_reapply_skips_probe() {
+        let env = TestCoreEnv::create_with_single_node(1, 0).await;
+        let bifrost = Bifrost::init_in_memory(env.metadata_writer).await;
         // Start with vqueues already enabled, then seed an inbox entry that would
         // normally trip the gate. The barrier re-apply must succeed because the
         // change does not flip a feature off->on.
@@ -533,7 +669,18 @@ mod tests {
         });
         seed_inbox_state_mutation(&mut storage).await;
 
+        let mut node_ctx = NodeContext::new(
+            GenerationalNodeId::new(1, 0),
+            Configuration::live(),
+            PartitionReplicaSetStates::default(),
+            RuleBookCacheHandle::detached(),
+            bifrost,
+            InvokerCapacity::new_unlimited(),
+            PartitionLeaderHandlesRegistry::default(),
+        );
+
         apply_barrier(
+            &mut node_ctx,
             &mut processor,
             &mut storage,
             barrier(
@@ -547,10 +694,24 @@ mod tests {
 
     #[restate_core::test]
     async fn reject_unknown_feature_change_id() {
+        let env = TestCoreEnv::create_with_single_node(1, 0).await;
+        let bifrost = Bifrost::init_in_memory(env.metadata_writer).await;
+
         let mut storage = open_store().await;
         let mut processor = processor(PersistedFeatures::default());
 
+        let mut node_ctx = NodeContext::new(
+            GenerationalNodeId::new(1, 0),
+            Configuration::live(),
+            PartitionReplicaSetStates::default(),
+            RuleBookCacheHandle::detached(),
+            bifrost,
+            InvokerCapacity::new_unlimited(),
+            PartitionLeaderHandlesRegistry::default(),
+        );
+
         let result = apply_barrier(
+            &mut node_ctx,
             &mut processor,
             &mut storage,
             barrier(

--- a/crates/worker/src/partition/processor/leadership.rs
+++ b/crates/worker/src/partition/processor/leadership.rs
@@ -1,0 +1,52 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use restate_core::network::TransportConnect;
+use restate_partition_store::PartitionStore;
+use restate_types::protobuf::cluster::DetailedRunMode;
+use restate_vqueues::context::HasVQueuesMut;
+use restate_worker_api::processor::Processor;
+
+use crate::partition::leadership::LeadershipState;
+use crate::partition::leadership::trim_queue::HasTrimQueue;
+use crate::partition::{NodeContext, ProcessorError};
+
+/// The leadership promotion controls
+pub trait LeaderPromotion {
+    async fn on_barrier_applied(
+        &mut self,
+        node_ctx: &mut NodeContext,
+        processor: impl Processor + HasTrimQueue + HasVQueuesMut,
+    ) -> Result<(), ProcessorError>;
+
+    fn current_mode(&self) -> DetailedRunMode;
+}
+
+pub(crate) struct LeadershipContext<'a, T> {
+    pub leadership: &'a mut LeadershipState<T>,
+    pub partition_store: &'a mut PartitionStore,
+}
+
+impl<T: TransportConnect> LeaderPromotion for LeadershipContext<'_, T> {
+    fn current_mode(&self) -> DetailedRunMode {
+        self.leadership.detailed_effective_mode()
+    }
+
+    async fn on_barrier_applied(
+        &mut self,
+        node_ctx: &mut NodeContext,
+        processor: impl Processor + HasTrimQueue + HasVQueuesMut,
+    ) -> Result<(), ProcessorError> {
+        self.leadership
+            .finish_becoming_leader(node_ctx, processor, self.partition_store)
+            .await?;
+        Ok(())
+    }
+}

--- a/tools/restatectl/src/commands/partition/list.rs
+++ b/tools/restatectl/src/commands/partition/list.rs
@@ -21,7 +21,7 @@ use restate_core::protobuf::cluster_ctrl_svc::{ClusterStateRequest, new_cluster_
 use restate_types::logs::Lsn;
 use restate_types::nodes_config::Role;
 use restate_types::protobuf::cluster::{
-    DeadNode, PartitionProcessorStatus, ReplayStatus, RunMode, node_state,
+    DeadNode, DetailedRunMode, PartitionProcessorStatus, ReplayStatus, RunMode, node_state,
 };
 use restate_types::{GenerationalNodeId, PlainNodeId, Version};
 
@@ -177,6 +177,7 @@ pub async fn list_partitions(
                 Cell::new(processor.host_node),
                 render_mode(
                     processor.status.planned_mode(),
+                    processor.status.detailed_effective_mode(),
                     processor.status.effective_mode(),
                     outdated_leadership_epoch,
                 ),
@@ -285,15 +286,25 @@ pub async fn list_partitions(
     Ok(())
 }
 
-fn render_mode(planned: RunMode, effective: RunMode, outdated_leadership_epoch: bool) -> Cell {
-    match (planned, planned == effective, outdated_leadership_epoch) {
+fn render_mode(
+    planned: RunMode,
+    detailed_mode: DetailedRunMode,
+    effective: RunMode,
+    outdated_leadership_epoch: bool,
+) -> Cell {
+    let detailed: DetailedRunMode = match detailed_mode {
+        DetailedRunMode::Unknown => effective.into(),
+        other => other,
+    };
+
+    match (planned, detailed == planned, outdated_leadership_epoch) {
         (RunMode::Leader, true, false) => Cell::new("Leader")
             .fg(Color::Blue)
             .add_attribute(Attribute::Bold),
         (RunMode::Leader, true, true) => Cell::new("Leader").fg(Color::Red),
         (RunMode::Follower, true, _) => Cell::new("Follower"),
-        (_, false, false) => Cell::new(format!("{effective}->{planned}")).fg(Color::Magenta),
-        (_, false, true) => Cell::new(format!("{effective}->{planned}")).fg(Color::Red),
+        (_, false, false) => Cell::new(format!("{detailed}->{planned}")).fg(Color::Magenta),
+        (_, false, true) => Cell::new(format!("{detailed}->{planned}")).fg(Color::Red),
         (RunMode::Unknown, _, _) => Cell::new("UNKNOWN").fg(Color::Red),
     }
 }


### PR DESCRIPTION

This introduces a new transitional state when a partition leader expects to perform migrations or feature enablement during its leadership transition. The leader will transition to `BecomingLeader` and waits for the version barrier
to be reached before creating its actuators. The leader will (not) be processing RPCs until the version barrier is reached and applied.


In this changeset, we park RPC calls when we are in `BecomingLeader` until leader finishes any migration.

This is to reduce churn during leadership transitions. The same flow applies to the `BecomingLeader` state.

Additionally, the new `BecomingLeader` state is observable via `restatectl status` command while maintaining backwards compatibility. Older versions of `restatectl` will report `Leader` state when the partition is in `BecomingLeader`. New
`restatectl` versions will present two new states: `Candidate` and `BecomingLeader` to improve observability during leadership changes.
