### PR TITLE
regression: return proper META0014 error message

### DIFF
--- a/crates/service-client/src/http.rs
+++ b/crates/service-client/src/http.rs
@@ -354,8 +354,8 @@ impl Body for ResponseBody {
 pub enum HttpError {
     #[error(transparent)]
     Http(#[from] http::Error),
-    #[error("server possibly supports only HTTP1.1, consider discovery with --use-http1.1.\nReason: {}", FormatHyperError(.0))]
-    PossibleHTTP11Only(#[source] hyper_util::client::legacy::Error),
+    #[error("server possibly supports only HTTP1.1, consider discovery with --use-http1.1.")]
+    PossibleHTTP11Only,
     #[error("server possibly supports only HTTP/2, consider discovering without --use-http1.1.\nReason: {}", FormatHyperError(.0))]
     PossibleHTTP2Only(#[source] hyper_util::client::legacy::Error),
     #[error("unable to reach the remote endpoint.\nReason: {}", FormatHyperError(.0))]
@@ -363,7 +363,21 @@ pub enum HttpError {
     #[error("{}", FormatHyperError(.0))]
     Hyper(#[source] hyper_util::client::legacy::Error),
     #[error("h2 pool connection error: {0}")]
-    PoolError(#[from] pool::Error),
+    PoolError(pool::Error),
+}
+
+impl From<pool::Error> for HttpError {
+    fn from(value: pool::Error) -> Self {
+        match &value {
+            pool::Error::H2(err)
+                if let Some(reason) = err.reason()
+                    && reason == h2::Reason::FRAME_SIZE_ERROR =>
+            {
+                HttpError::PossibleHTTP11Only
+            }
+            _ => HttpError::PoolError(value),
+        }
+    }
 }
 
 impl HttpError {
@@ -373,7 +387,7 @@ impl HttpError {
         match self {
             HttpError::Hyper(err) => err.is_retryable(),
             HttpError::Http(err) => err.is_retryable(),
-            HttpError::PossibleHTTP11Only(_) => false,
+            HttpError::PossibleHTTP11Only => false,
             HttpError::PossibleHTTP2Only(_) => false,
             HttpError::Connect(_) => true,
             HttpError::PoolError(_) => true,
@@ -429,7 +443,7 @@ impl HttpError {
 impl From<hyper_util::client::legacy::Error> for HttpError {
     fn from(err: hyper_util::client::legacy::Error) -> Self {
         if Self::is_possible_h11_only_error(&err) {
-            Self::PossibleHTTP11Only(err)
+            Self::PossibleHTTP11Only
         } else if Self::is_possible_h2_only_error(&err) {
             Self::PossibleHTTP2Only(err)
         } else if err.is_connect() {

--- a/crates/service-protocol-v4/src/discovery.rs
+++ b/crates/service-protocol-v4/src/discovery.rs
@@ -136,7 +136,7 @@ impl CodedError for DiscoveryError {
             // special code for possible http1.1 errors
             DiscoveryError::Client(ServiceClientError::Http(
                 _,
-                restate_service_client::HttpError::PossibleHTTP11Only(_),
+                restate_service_client::HttpError::PossibleHTTP11Only,
             )) => Some(&META0014),
             DiscoveryError::Client(_) => Some(&META0003),
             DiscoveryError::UnsupportedServiceProtocol { .. } => Some(&META0012),


### PR DESCRIPTION

Summary:
A regression caused h2 "frame with invalid size" to return as
generic h2 error. This error used to be specially handled and
translated to META0014 error (server possibly supports only HTTP1.1, consider discovery with --use-http1.1.)
