### PR TITLE
Do not store locks in virtual_object_status with vqueues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8428,6 +8428,7 @@ dependencies = [
  "restate-types",
  "restate-util-bytecount",
  "restate-util-string",
+ "restate-util-time",
  "restate-workspace-hack",
  "rust-rocksdb",
  "serde",

--- a/crates/partition-store/Cargo.toml
+++ b/crates/partition-store/Cargo.toml
@@ -21,9 +21,10 @@ restate-limiter = { workspace = true, features = ["rule-book"] }
 restate-memory = { workspace = true }
 restate-object-store-util = { workspace = true }
 restate-rocksdb = { workspace = true }
-restate-util-bytecount = { workspace = true, features = ["serde"] }
 restate-storage-api = { workspace = true }
 restate-types = { workspace = true }
+restate-util-bytecount = { workspace = true, features = ["serde"] }
+restate-util-time = { workspace = true }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/partition-store/src/lib.rs
+++ b/crates/partition-store/src/lib.rs
@@ -40,6 +40,7 @@ mod tests;
 
 pub use error::*;
 pub use journal_table_v2::{OrphanCleanupResult, cleanup_orphaned_completion_id_index_entries};
+pub use migrations::MigrationError;
 pub use partition_db::PartitionDb;
 pub use partition_store::*;
 pub use partition_store_manager::*;

--- a/crates/partition-store/src/migrations.rs
+++ b/crates/partition-store/src/migrations.rs
@@ -18,6 +18,8 @@ use std::sync::Arc;
 use anyhow::Context;
 use bytes::BytesMut;
 use rocksdb::WriteBatch;
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
 use restate_clock::{AtomicStorage, HlcClock, WallClock};
@@ -27,6 +29,7 @@ use restate_types::config::Configuration;
 use restate_types::partitions::StorageVersion;
 use restate_types::sharding::KeyRange;
 use restate_types::sharding::subsharding::ShardPlan;
+use restate_util_time::DurationExt;
 
 use crate::fsm_table::append_storage_version_to_wb;
 use crate::{PartitionDb, PartitionStore, Result};
@@ -38,6 +41,16 @@ use self::migrate_to_scoped_state_table::{
     append_delete_state_data, migrate_to_scoped_state_table,
 };
 
+/// Migration error
+#[derive(Debug, thiserror::Error)]
+pub enum MigrationError {
+    #[error("migration barrier: {0}")]
+    MigrationBarrier(String),
+    #[error("migration was cancelled")]
+    MigrationCancelled,
+    #[error("error during migration: {0}")]
+    StorageError(#[from] StorageError),
+}
 /// Runs the migrations needed to transition the [`StorageVersion`] from current to the target
 /// storage version. A failure can leave the storage version at any valid version between current
 /// and target.
@@ -45,9 +58,14 @@ pub async fn run_migrations_up_to(
     mut current: StorageVersion,
     target: StorageVersion,
     storage: &mut PartitionStore,
-) -> Result<StorageVersion> {
+    cancel: CancellationToken,
+    config: &Configuration,
+) -> Result<StorageVersion, MigrationError> {
     while current < target {
-        current = do_migration(current, storage).await?;
+        if cancel.is_cancelled() {
+            return Err(MigrationError::MigrationCancelled);
+        }
+        current = do_migration(current, storage, cancel.clone(), config).await?;
     }
     Ok(current)
 }
@@ -65,23 +83,26 @@ pub async fn run_migrations_up_to(
 async fn do_migration(
     current: StorageVersion,
     storage: &mut PartitionStore,
-) -> Result<StorageVersion> {
+    cancel: CancellationToken,
+    config: &Configuration,
+) -> Result<StorageVersion, MigrationError> {
     let new_storage_version = match current {
         StorageVersion::None => {
             // Version 1.6+ does not support upgrading from pre-1.5
             // The InvocationStatusV1 migration was removed in 1.6
-            return Err(StorageError::Generic(anyhow::anyhow!(
+            return Err(MigrationError::MigrationBarrier(
                 "Cannot upgrade from version <1.5 directly to 1.6 or later. \
                  Please upgrade to version 1.5 first, which will migrate your data, \
                  and then upgrade to 1.6+"
-            )));
+                    .to_owned(),
+            ));
         }
         StorageVersion::V1_5 => {
-            let config = Configuration::pinned();
+            let start = Instant::now();
             let key_range = storage.partition_key_range();
             let partition_id = storage.partition_id();
             let partition_db = storage.partition_db().clone();
-            let mut ctx = MigrationContext::new(&config, &partition_db, key_range);
+            let mut ctx = MigrationContext::new(config, &partition_db, key_range, cancel);
             let new_storage_version = StorageVersion::ScopedStateAndPromise;
 
             migrate_to_scoped_state_table(&mut ctx)?;
@@ -97,6 +118,7 @@ async fn do_migration(
             append_delete_promise_data(&ctx, &mut wb);
             append_storage_version_to_wb(&cf_handle, &mut wb, partition_id, new_storage_version)?;
 
+            ctx.fail_if_cancelled()?;
             let mut opts = rocksdb::WriteOptions::default();
             opts.disable_wal(true);
             partition_db
@@ -113,8 +135,12 @@ async fn do_migration(
                 .map_err(StorageError::Generic)?;
             debug!(
                 %partition_id,
-                "Finalized scoped state/promise migration"
+                "Finalized scoped state/promise migration in {}", start.elapsed().friendly()
             );
+
+            // todo: Add flush + compact_range(s) to the deleted data to reduce the space
+            // amplification expected after the state migration. Alternatively, one compaction
+            // after all migrations are done.
             new_storage_version
         }
         StorageVersion::ScopedStateAndPromise => {
@@ -132,11 +158,17 @@ pub struct MigrationContext<'a> {
     arena: BytesMut,
     partition_db: &'a PartitionDb,
     key_range: KeyRange,
+    cancel: CancellationToken,
 }
 
 #[allow(dead_code)]
 impl<'a> MigrationContext<'a> {
-    pub fn new(config: &Configuration, partition_db: &'a PartitionDb, key_range: KeyRange) -> Self {
+    pub fn new(
+        config: &Configuration,
+        partition_db: &'a PartitionDb,
+        key_range: KeyRange,
+        cancel: CancellationToken,
+    ) -> Self {
         Self {
             clock: HlcClock::new(
                 config.common.hlc_max_drift(),
@@ -147,6 +179,7 @@ impl<'a> MigrationContext<'a> {
             arena: BytesMut::default(),
             partition_db,
             key_range,
+            cancel,
         }
     }
 
@@ -171,6 +204,15 @@ impl<'a> MigrationContext<'a> {
             arena: BytesMut::default(),
             partition_db: self.partition_db,
             key_range,
+            cancel: self.cancel.clone(),
+        }
+    }
+
+    fn fail_if_cancelled(&self) -> Result<(), MigrationError> {
+        if self.cancel.is_cancelled() {
+            Err(MigrationError::MigrationCancelled)
+        } else {
+            Ok(())
         }
     }
 }
@@ -220,7 +262,13 @@ mod tests {
             .expect("DB storage creation succeeds");
 
         let config = Configuration::default();
-        let mut ctx = MigrationContext::new(&config, store.partition_db(), KeyRange::new(1, 100));
+        let cancel = CancellationToken::new();
+        let mut ctx = MigrationContext::new(
+            &config,
+            store.partition_db(),
+            KeyRange::new(1, 100),
+            cancel.clone(),
+        );
         ctx.arena.extend_from_slice(b"dirty parent arena");
 
         let mut split = ctx.split(NonZeroU16::new(2).expect("two is non-zero"));
@@ -252,7 +300,7 @@ mod tests {
         assert!(left_timestamp < right_timestamp);
 
         let single_key_ctx =
-            MigrationContext::new(&config, store.partition_db(), KeyRange::new(42, 42));
+            MigrationContext::new(&config, store.partition_db(), KeyRange::new(42, 42), cancel);
         let single_key_ranges = single_key_ctx
             .split(NonZeroU16::new(2).expect("two is non-zero"))
             .map(|ctx| ctx.key_range)
@@ -295,7 +343,7 @@ mod tests {
             .expect("seeding unknown storage version should succeed");
 
         let err = store
-            .verify_and_run_migrations(&Configuration::pinned())
+            .verify_and_run_migrations(CancellationToken::new(), &Configuration::pinned())
             .await
             .expect_err("unknown storage version should fail verify_and_run_migrations");
         let msg = err.to_string();

--- a/crates/partition-store/src/migrations/migrate_to_scoped_promise_table.rs
+++ b/crates/partition-store/src/migrations/migrate_to_scoped_promise_table.rs
@@ -20,7 +20,7 @@ use crate::keys::{EncodeTableKeyPrefix, KeyKind};
 use crate::promise_table::PromiseKey;
 use crate::scan::{PhysicalScan, TableScan};
 
-use super::MigrationContext;
+use super::{MigrationContext, MigrationError};
 
 /// Length of a `KeyKind | partition_key` prefix.
 const KEY_PREFIX_LEN: usize = KeyKind::SERIALIZED_LENGTH + std::mem::size_of::<PartitionKey>();
@@ -30,7 +30,9 @@ const KEY_PREFIX_LEN: usize = KeyKind::SERIALIZED_LENGTH + std::mem::size_of::<P
 /// unchanged.
 ///
 /// We use direct rocksdb access because no async operations are needed.
-pub fn migrate_to_scoped_promise_table(ctx: &mut MigrationContext<'_>) -> Result<(), StorageError> {
+pub fn migrate_to_scoped_promise_table(
+    ctx: &mut MigrationContext<'_>,
+) -> Result<(), MigrationError> {
     let rocks = ctx.partition_db.rocksdb();
     let key_range = ctx.key_range;
     let mut counter = 0;
@@ -43,14 +45,14 @@ pub fn migrate_to_scoped_promise_table(ctx: &mut MigrationContext<'_>) -> Result
 
     // 1 MiB batches
     let mut wb = WriteBatch::with_capacity_bytes(1024 * 1024);
-    let arena = &mut ctx.arena;
-    arena.clear();
+    ctx.arena.clear();
 
     let mut opts = rocksdb::WriteOptions::default();
     // We disable WAL since bifrost is our durable distributed log.
     opts.disable_wal(true);
 
     while iterator.valid() {
+        ctx.fail_if_cancelled()?;
         // safe to unwrap because the iterator is valid
         let (mut key, value) = iterator.item().unwrap();
         // Advance past the legacy `KeyKind::Promise` prefix and the partition_key.
@@ -60,12 +62,12 @@ pub fn migrate_to_scoped_promise_table(ctx: &mut MigrationContext<'_>) -> Result
         debug_assert_eq!(kind, KeyKind::Promise);
         let partition_key: PartitionKey = crate::keys::deserialize(&mut key)?;
 
-        KeyKind::ScopedPromise.serialize(arena);
-        crate::keys::serialize(&partition_key, arena);
+        KeyKind::ScopedPromise.serialize(&mut ctx.arena);
+        crate::keys::serialize(&partition_key, &mut ctx.arena);
         // unscoped
-        arena.put_u8(b'u');
-        arena.put_slice(key);
-        let new_key = arena.split().freeze();
+        ctx.arena.put_u8(b'u');
+        ctx.arena.put_slice(key);
+        let new_key = ctx.arena.split().freeze();
 
         wb.put_cf(ctx.partition_db.cf_handle(), new_key, value);
         counter += 1;
@@ -75,7 +77,8 @@ pub fn migrate_to_scoped_promise_table(ctx: &mut MigrationContext<'_>) -> Result
             rocks
                 .inner()
                 .write_batch(&wb, &opts)
-                .context("failed to write batch")?;
+                .context("failed to write batch")
+                .map_err(StorageError::Generic)?;
             wb.clear();
         }
 
@@ -94,7 +97,8 @@ pub fn migrate_to_scoped_promise_table(ctx: &mut MigrationContext<'_>) -> Result
         rocks
             .inner()
             .write_batch(&wb, &opts)
-            .context("failed to write batch")?;
+            .context("failed to write batch")
+            .map_err(StorageError::Generic)?;
     }
 
     debug!("Finished migrating {} promises", counter);

--- a/crates/partition-store/src/migrations/migrate_to_scoped_state_table.rs
+++ b/crates/partition-store/src/migrations/migrate_to_scoped_state_table.rs
@@ -20,7 +20,7 @@ use crate::keys::{EncodeTableKeyPrefix, KeyKind};
 use crate::scan::{PhysicalScan, TableScan};
 use crate::state_table::StateKey;
 
-use super::MigrationContext;
+use super::{MigrationContext, MigrationError};
 
 /// Length of a `KeyKind | partition_key` prefix.
 const KEY_PREFIX_LEN: usize = KeyKind::SERIALIZED_LENGTH + std::mem::size_of::<PartitionKey>();
@@ -29,7 +29,7 @@ const KEY_PREFIX_LEN: usize = KeyKind::SERIALIZED_LENGTH + std::mem::size_of::<P
 /// table with `scope = None`. The value bytes are copied through unchanged.
 ///
 /// We use direct rocksdb access because no async operations are needed.
-pub fn migrate_to_scoped_state_table(ctx: &mut MigrationContext<'_>) -> Result<(), StorageError> {
+pub fn migrate_to_scoped_state_table(ctx: &mut MigrationContext<'_>) -> Result<(), MigrationError> {
     let rocks = ctx.partition_db.rocksdb();
     let key_range = ctx.key_range;
     let mut counter = 0;
@@ -42,14 +42,14 @@ pub fn migrate_to_scoped_state_table(ctx: &mut MigrationContext<'_>) -> Result<(
 
     // 1 MiB batches
     let mut wb = WriteBatch::with_capacity_bytes(1024 * 1024);
-    let arena = &mut ctx.arena;
-    arena.clear();
+    ctx.arena.clear();
 
     let mut opts = rocksdb::WriteOptions::default();
     // We disable WAL since bifrost is our durable distributed log.
     opts.disable_wal(true);
 
     while iterator.valid() {
+        ctx.fail_if_cancelled()?;
         // safe to unwrap because the iterator is valid
         let (mut key, value) = iterator.item().unwrap();
         // Advance past the legacy `KeyKind::State` prefix and the partition_key.
@@ -59,12 +59,12 @@ pub fn migrate_to_scoped_state_table(ctx: &mut MigrationContext<'_>) -> Result<(
         debug_assert_eq!(kind, KeyKind::State);
         let partition_key: PartitionKey = crate::keys::deserialize(&mut key)?;
 
-        KeyKind::ScopedState.serialize(arena);
-        crate::keys::serialize(&partition_key, arena);
+        KeyKind::ScopedState.serialize(&mut ctx.arena);
+        crate::keys::serialize(&partition_key, &mut ctx.arena);
         // unscoped
-        arena.put_u8(b'u');
-        arena.put_slice(key);
-        let new_key = arena.split().freeze();
+        ctx.arena.put_u8(b'u');
+        ctx.arena.put_slice(key);
+        let new_key = ctx.arena.split().freeze();
 
         wb.put_cf(ctx.partition_db.cf_handle(), new_key, value);
         counter += 1;
@@ -74,7 +74,8 @@ pub fn migrate_to_scoped_state_table(ctx: &mut MigrationContext<'_>) -> Result<(
             rocks
                 .inner()
                 .write_batch(&wb, &opts)
-                .context("failed to write batch")?;
+                .context("failed to write batch")
+                .map_err(StorageError::Generic)?;
             wb.clear();
         }
 
@@ -93,7 +94,8 @@ pub fn migrate_to_scoped_state_table(ctx: &mut MigrationContext<'_>) -> Result<(
         rocks
             .inner()
             .write_batch(&wb, &opts)
-            .context("failed to write batch")?;
+            .context("failed to write batch")
+            .map_err(StorageError::Generic)?;
     }
 
     debug!("Finished migrating {} state entries", counter);

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -26,7 +26,8 @@ use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tokio_stream::wrappers::ReceiverStream;
-use tracing::{debug, trace};
+use tokio_util::sync::CancellationToken;
+use tracing::{info, trace};
 
 use restate_core::ShutdownError;
 use restate_rocksdb::{IoMode, IterAction, Priority, RocksDb, RocksError};
@@ -50,6 +51,7 @@ use crate::fsm_table::{
     put_jc_orphan_cleanup_done,
 };
 use crate::keys::{EncodeTableKey, EncodeTableKeyPrefix, KeyKind};
+use crate::migrations::MigrationError;
 use crate::migrations::run_migrations_up_to;
 use crate::partition_db::PartitionDb;
 use crate::scan::PhysicalScan;
@@ -681,8 +683,9 @@ impl PartitionStore {
 
     pub async fn verify_and_run_migrations(
         &mut self,
+        cancel: CancellationToken,
         config: &Configuration,
-    ) -> Result<(), StorageError> {
+    ) -> Result<(), MigrationError> {
         // The target schema version is gated by the operator opt-in. Without
         // the flag we leave the partition at `V1_5` so a downgrade to a
         // pre-`ScopedStateAndPromise` binary stays possible. With the flag
@@ -718,11 +721,14 @@ impl PartitionStore {
         let mut storage_version = get_storage_version_from_partition_db(self.partition_db())?;
         if storage_version < target {
             // We need to run some migrations!
-            debug!(
-                "Running storage migration from {:?} to {:?}",
-                storage_version, target
-            );
-            storage_version = run_migrations_up_to(storage_version, target, self).await?;
+            if !is_empty {
+                info!(
+                    "Running storage migration from {:?} to {:?}",
+                    storage_version, target
+                );
+            }
+            storage_version =
+                run_migrations_up_to(storage_version, target, self, cancel, config).await?;
         }
         self.set_storage_version(storage_version);
         Ok(())

--- a/crates/partition-store/src/tests/migrations_test/migrate_to_locks_table.rs
+++ b/crates/partition-store/src/tests/migrations_test/migrate_to_locks_table.rs
@@ -14,6 +14,8 @@ use std::ops::ControlFlow;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
+use tokio_util::sync::CancellationToken;
+
 use restate_clock::ClockUpkeep;
 use restate_rocksdb::RocksDbManager;
 use restate_storage_api::Transaction;
@@ -107,11 +109,13 @@ async fn migrate_to_locks_table_moves_service_status_locks_to_lock_table() {
     txn.commit().await.expect("commit should succeed");
     drop(txn);
 
+    let cancel = CancellationToken::new();
     let config = Configuration::default();
     let mut ctx = MigrationContext::new(
         &config,
         rocksdb.partition_db(),
         rocksdb.partition_key_range(),
+        cancel,
     );
     crate::migrations::migrate_to_locks_table::migrate_to_locks_table(&mut ctx)
         .expect("migration should succeed");
@@ -197,7 +201,8 @@ async fn migrate_to_locks_table_runs_split_ranges_concurrently_with_shared_conte
     drop(txn);
 
     let config = Configuration::default();
-    let ctx = MigrationContext::new(&config, rocksdb.partition_db(), key_range);
+    let cancel = CancellationToken::new();
+    let ctx = MigrationContext::new(&config, rocksdb.partition_db(), key_range, cancel);
     let contexts = ctx
         .split(NonZeroU16::new(2).expect("two is non-zero"))
         .collect::<Vec<_>>();

--- a/crates/partition-store/src/tests/migrations_test/migrate_to_scoped_promise_table.rs
+++ b/crates/partition-store/src/tests/migrations_test/migrate_to_scoped_promise_table.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 use bytes::BytesMut;
 use bytestring::ByteString;
 use rocksdb::WriteBatch;
+use tokio_util::sync::CancellationToken;
 
 use restate_rocksdb::RocksDbManager;
 use restate_storage_api::Transaction;
@@ -82,11 +83,13 @@ async fn migrate_to_scoped_promise_table_moves_unscoped_promises_to_scoped_table
     txn.commit().await.expect("commit should succeed");
     drop(txn);
 
+    let cancel = CancellationToken::new();
     let config = Configuration::default();
     let mut ctx = MigrationContext::new(
         &config,
         rocksdb.partition_db(),
         rocksdb.partition_key_range(),
+        cancel,
     );
     migrate_to_scoped_promise_table::migrate_to_scoped_promise_table(&mut ctx)
         .expect("migration should succeed");

--- a/crates/partition-store/src/tests/migrations_test/migrate_to_scoped_state_table.rs
+++ b/crates/partition-store/src/tests/migrations_test/migrate_to_scoped_state_table.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 
 use bytes::{Bytes, BytesMut};
 use rocksdb::WriteBatch;
+use tokio_util::sync::CancellationToken;
 
 use restate_rocksdb::RocksDbManager;
 use restate_storage_api::Transaction;
@@ -71,10 +72,12 @@ async fn migrate_to_scoped_state_table_moves_unscoped_state_to_scoped_table() {
     drop(txn);
 
     let config = Configuration::default();
+    let cancel = CancellationToken::new();
     let mut ctx = MigrationContext::new(
         &config,
         rocksdb.partition_db(),
         rocksdb.partition_key_range(),
+        cancel,
     );
     migrate_to_scoped_state_table::migrate_to_scoped_state_table(&mut ctx)
         .expect("migration should succeed");

--- a/crates/partition-store/src/tests/migrations_test/verify_and_run_migrations.rs
+++ b/crates/partition-store/src/tests/migrations_test/verify_and_run_migrations.rs
@@ -13,6 +13,7 @@
 
 use bytes::{Bytes, BytesMut};
 use bytestring::ByteString;
+use tokio_util::sync::CancellationToken;
 
 use restate_rocksdb::RocksDbManager;
 use restate_storage_api::Transaction;
@@ -182,8 +183,9 @@ async fn flag_off_keeps_partition_at_v1_5() {
     assert!(legacy_state_before > 0);
     assert!(legacy_promise_before > 0);
 
+    let cancel = CancellationToken::new();
     store
-        .verify_and_run_migrations(&Configuration::pinned())
+        .verify_and_run_migrations(cancel, &Configuration::pinned())
         .await
         .expect("verify with flag off");
 
@@ -224,8 +226,9 @@ async fn flag_on_migrates_and_bumps_version() {
 
     // Now turn the flag back on and run migrations.
     with_migrate_scoped_tables(true);
+    let cancel = CancellationToken::new();
     store
-        .verify_and_run_migrations(&Configuration::pinned())
+        .verify_and_run_migrations(cancel, &Configuration::pinned())
         .await
         .expect("verify with flag on");
 
@@ -255,8 +258,9 @@ async fn flag_on_migrates_and_bumps_version() {
     }
 
     // Idempotency: a second verify is a no-op.
+    let cancel = CancellationToken::new();
     store
-        .verify_and_run_migrations(&Configuration::pinned())
+        .verify_and_run_migrations(cancel, &Configuration::pinned())
         .await
         .expect("second verify");
     assert_eq!(
@@ -285,8 +289,9 @@ async fn flag_on_writes_post_migration_land_in_scoped() {
         .expect("open");
 
     // Empty partition + flag on → fast path initializes at ScopedStateAndPromise.
+    let cancel = CancellationToken::new();
     store
-        .verify_and_run_migrations(&Configuration::pinned())
+        .verify_and_run_migrations(cancel, &Configuration::pinned())
         .await
         .expect("verify fresh");
     assert_eq!(

--- a/crates/worker/src/metric_definitions.rs
+++ b/crates/worker/src/metric_definitions.rs
@@ -28,6 +28,7 @@ pub const LEADER_LABEL_FOLLOWER: &str = "0";
 //                     not configured.
 pub const PARTITION_BLOCKED_FLARE: &str = "restate.partition.blocked_flare";
 pub const FLARE_REASON_VERSION_BARRIER: &str = "version_barrier";
+pub const FLARE_REASON_MIGRATION_BARRIER: &str = "migration_barrier";
 pub const FLARE_REASON_SNAPSHOT_UNAVAILABLE: &str = "snapshot-unavailable";
 
 pub const PARTITION_APPLY_COMMAND: &str = "restate.partition.apply_command_duration.seconds";

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -40,19 +40,21 @@ use std::time::Duration;
 
 use anyhow::Context;
 use futures::{FutureExt, StreamExt};
-use metrics::{gauge, histogram};
+use metrics::histogram;
 use tokio::sync::watch;
 use tokio::time::{Instant, MissedTickBehavior};
-use tracing::{debug, error, info, instrument, trace, warn};
+use tracing::{debug, error, instrument, trace, warn};
 
 use restate_bifrost::loglet::FindTailOptions;
 use restate_bifrost::{DataRecord, DataRecordError, LogEntry};
 use restate_core::network::{
     Incoming, Oneshot, Reciprocal, Rpc, ServiceMessage, ServiceStream, TransportConnect, Verdict,
 };
-use restate_core::{Metadata, ShutdownError, TaskCenter, TaskKind, cancellation_watcher};
+use restate_core::{Metadata, ShutdownError, TaskCenter, TaskKind, cancellation_token};
 use restate_ingestion_client::IngestionClient;
-use restate_partition_store::{PartitionDb, PartitionStore, PartitionStoreTransaction};
+use restate_partition_store::{
+    MigrationError, PartitionDb, PartitionStore, PartitionStoreTransaction,
+};
 use restate_platform::memory::EstimatedMemorySize;
 use restate_storage_api::deduplication_table::{
     DedupSequenceNumber, ProducerId, ReadDeduplicationTable,
@@ -79,7 +81,6 @@ use restate_types::storage::{
 };
 use restate_types::time::MillisSinceEpoch;
 use restate_types::{GenerationalNodeId, SemanticRestateVersion, Version};
-use restate_util_string::{ReString, ToReString};
 use restate_util_time::DurationExt;
 use restate_vqueues::context::HasVQueues;
 use restate_wal_protocol::control::{CurrentReplicaSetConfiguration, NextReplicaSetConfiguration};
@@ -94,8 +95,7 @@ use self::processor::commands::{
 use self::processor::*;
 use self::state_machine::StateMachine;
 use crate::metric_definitions::{
-    FLARE_REASON_VERSION_BARRIER, LEADER_LABEL, LEADER_LABEL_LEADER, PARTITION_BLOCKED_FLARE,
-    PARTITION_LABEL, PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS, REASON_LABEL,
+    LEADER_LABEL, LEADER_LABEL_LEADER, PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS,
 };
 use crate::partition::leadership::LeadershipState;
 use crate::partition::processor::leadership::LeadershipContext;
@@ -168,7 +168,6 @@ impl PartitionProcessorBuilder {
             node_ctx,
         } = self;
 
-        let partition_id_str = partition_db.partition().id().to_restring();
         let mut partition_store = PartitionStore::from(partition_db);
 
         let ctx =
@@ -198,7 +197,6 @@ impl PartitionProcessorBuilder {
             LeadershipState::new(ctx.partition_id(), ingestion_client, leader_query_tx);
 
         Ok(PartitionProcessor {
-            partition_id_str,
             partition_store,
             ctx,
             node_ctx,
@@ -212,7 +210,6 @@ impl PartitionProcessorBuilder {
 }
 
 pub struct PartitionProcessor<T> {
-    partition_id_str: ReString,
     partition_store: PartitionStore,
     ctx: ProcessorRawContext,
     node_ctx: NodeContext,
@@ -285,6 +282,10 @@ pub enum ProcessorError {
     MigrationRequired {
         features: Vec<PartitionFeatureChange>,
     },
+    #[error(
+        "partition is blocked; restate-server cannot perform data migration. reason='{reason}'"
+    )]
+    MigrationBarrier { reason: String },
     #[error(transparent)]
     ActionEffect(#[from] leadership::Error),
     #[error(transparent)]
@@ -316,28 +317,46 @@ where
     pub async fn run(mut self) -> Result<(), ProcessorError> {
         debug!("Starting the partition processor.");
 
-        let res = tokio::select! {
-            res = self.run_inner() => {
-                match res.as_ref() {
-                    // run_inner never returns normally
-                    Ok(_) => warn!("Shutting partition processor down because it stopped unexpectedly."),
-                    Err(ProcessorError::TrimGapEncountered { trim_gap_end, read_pointer }) =>
-                        info!(
-                            %read_pointer,
-                            %trim_gap_end,
-                            "Shutting partition processor down because it encountered a trim gap in the log."
-                        ),
-                    Err(ProcessorError::VersionBarrier{ .. }) => {
-                        gauge!(PARTITION_BLOCKED_FLARE, PARTITION_LABEL => self.partition_id_str, REASON_LABEL => FLARE_REASON_VERSION_BARRIER).set(1);
-                    }
-                    Err(err) => warn!("Shutting partition processor down because of error: {err}"),
-                }
-                res
-            },
-            _ = cancellation_watcher() => {
+        let cancel = cancellation_token();
+        // Run migrations first.
+        //
+        // Important to note: This only runs the migration for the given partition store. In a setup,
+        // where not every node runs every partition, it can happen that partition data remains
+        // untouched when going from one version to the next.
+        // todo https://github.com/restatedev/restate/issues/4175.
+        //
+        // This will fail with StorageError::MigrationCancelled if the current task was cancelled
+        // during the migration phase.
+        match self
+            .partition_store
+            .verify_and_run_migrations(cancel.clone(), self.node_ctx.config.live_load())
+            .await
+        {
+            Ok(()) => {}
+            Err(MigrationError::MigrationCancelled) => {
+                debug!(
+                    "Shutting partition processor during data migration because it was cancelled."
+                );
+                return Ok(());
+            }
+            Err(MigrationError::MigrationBarrier(reason)) => {
+                return Err(ProcessorError::MigrationBarrier { reason });
+            }
+            Err(MigrationError::StorageError(err)) => {
+                warn!(
+                    "Shutting partition processor during data migration down because of error: {err}"
+                );
+                return Err(err.into());
+            }
+        }
+
+        // Note: Boxing because it's a rather large future (>35KiB)
+        let res = match cancel.run_until_cancelled(Box::pin(self.run_inner())).await {
+            Some(res) => res,
+            None => {
                 debug!("Shutting partition processor down because it was cancelled.");
                 Ok(())
-            },
+            }
         };
 
         // clean up pending rpcs and stop child tasks
@@ -396,14 +415,6 @@ where
     }
 
     async fn run_inner(&mut self) -> Result<(), ProcessorError> {
-        // Important to note: This only runs the migration for the given partition store. In a setup,
-        // where not every node runs every partition, it can happen that partition data remains
-        // untouched when going from one version to the next.
-        // todo https://github.com/restatedev/restate/issues/4175.
-        self.partition_store
-            .verify_and_run_migrations(self.node_ctx.config.live_load())
-            .await?;
-
         let last_applied_lsn_watch = self.ctx.subscribe_to_last_applied_lsn();
 
         let log_id = self.ctx.log_id();

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -3130,26 +3130,6 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
         match status {
             InvocationStatus::Scheduled(ScheduledInvocation { metadata, .. })
             | InvocationStatus::Inboxed(InboxedInvocation { metadata, .. }) => {
-                // Validate that if VO, that it's not locked already.
-                let invocation_target = &metadata.invocation_target;
-                if matches!(
-                    invocation_target.invocation_target_ty(),
-                    InvocationTargetType::VirtualObject(VirtualObjectHandlerType::Exclusive)
-                ) {
-                    let keyed_service_id = invocation_target.as_keyed_service_id().expect(
-                        "When the handler type is Exclusive, the invocation target must have a key",
-                    );
-                    // Lock the service in the old status table.
-                    // Obsolete: Remove in lieu of using Locks when service status table is fully migrated to
-                    // locks table.
-                    self.storage
-                        .put_virtual_object_status(
-                            &keyed_service_id,
-                            &VirtualObjectStatus::Locked(invocation_id),
-                        )
-                        .map_err(Error::Storage)?;
-                }
-
                 let (metadata, invocation_input) =
                     InFlightInvocationMetadata::from_pre_flight_invocation_metadata(
                         metadata,

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -85,8 +85,9 @@ use restate_worker_api::invoker::capacity::InvokerCapacity;
 use restate_worker_api::{ProcessorsManagerCommand, ProcessorsManagerHandle};
 
 use crate::metric_definitions::{
-    ERROR_STOP, FLARE_REASON_SNAPSHOT_UNAVAILABLE, GAP_STOP, PARTITION_BLOCKED_FLARE,
-    PARTITION_IS_EFFECTIVE_LEADER, PARTITION_START, REASON_LABEL, STARTUP_ERROR_STOP, TYPE_LABEL,
+    ERROR_STOP, FLARE_REASON_MIGRATION_BARRIER, FLARE_REASON_SNAPSHOT_UNAVAILABLE,
+    FLARE_REASON_VERSION_BARRIER, GAP_STOP, PARTITION_BLOCKED_FLARE, PARTITION_IS_EFFECTIVE_LEADER,
+    PARTITION_START, REASON_LABEL, STARTUP_ERROR_STOP, TYPE_LABEL,
 };
 use crate::metric_definitions::{NORMAL_STOP, PARTITION_TIME_SINCE_LAST_STATUS_UPDATE};
 use crate::metric_definitions::{NUM_ACTIVE_PARTITIONS, PARTITION_APPLIED_LSN_LAG};
@@ -607,6 +608,18 @@ where
                             );
 
                             match &result {
+                                Err(e @ ProcessorError::VersionBarrier { .. }) => {
+                                    counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => ERROR_STOP).increment(1);
+                                    gauge!(PARTITION_BLOCKED_FLARE, PARTITION_LABEL => partition_id.to_string(), REASON_LABEL => FLARE_REASON_VERSION_BARRIER).set(1);
+                                    error!(%partition_id, "Partition processor start error: {e}");
+                                    RestartDelay::MaxBackoff
+                                }
+                                Err(e @ ProcessorError::MigrationBarrier { .. }) => {
+                                    counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => ERROR_STOP).increment(1);
+                                    gauge!(PARTITION_BLOCKED_FLARE, PARTITION_LABEL => partition_id.to_string(), REASON_LABEL => FLARE_REASON_MIGRATION_BARRIER).set(1);
+                                    error!(%partition_id, "Partition processor start error: {e}");
+                                    RestartDelay::MaxBackoff
+                                }
                                 Err(ProcessorError::TrimGapEncountered {
                                     read_pointer: sequence_number,
                                     trim_gap_end: to_lsn,

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -209,7 +209,7 @@ where
                     let run_result = async move {
                         let pp = pp_builder
                             .build(ingestion_client, db).await?;
-                        Box::pin(pp.run()).await
+                        pp.run().await
                     }
                     .await;
 


### PR DESCRIPTION

This is not needed and needs to be removed to avoid repopulating this table after vqueues migration.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/5027).
* #5028
* __->__ #5027
* #5023