### PR TITLE
Update partition status after partition-wide commands

### DIFF
--- a/crates/wal-protocol/src/v2.rs
+++ b/crates/wal-protocol/src/v2.rs
@@ -273,6 +273,7 @@ impl<C: Command> From<Envelope<C>> for Envelope<Raw> {
 /// In some cases, the actual command may be carrying a single partition key but that
 /// doesn't affect that the command is still scoped to the partition-range that starts
 /// with this partition key.
+#[derive(Debug, Copy, Clone)]
 pub enum CommandScope {
     /// The command operates on the partition-range level. It affects the processor's state
     /// machine rather than a single invocation, vqueue, or other key-scoped resources.

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -83,7 +83,7 @@ use restate_util_string::{ReString, ToReString};
 use restate_util_time::DurationExt;
 use restate_vqueues::context::HasVQueues;
 use restate_wal_protocol::control::{CurrentReplicaSetConfiguration, NextReplicaSetConfiguration};
-use restate_wal_protocol::v2::{CommandScope, Dedup};
+use restate_wal_protocol::v2::CommandScope;
 use restate_wal_protocol::{Envelope, v2};
 use restate_worker_api::{LeaderQueryCommand, LeaderQueryReceiver};
 
@@ -522,37 +522,21 @@ where
                 _ = self.target_leader_state_rx.changed() => {
                     let target_leader_state = self.target_leader_state_rx.borrow_and_update().clone();
                     self.on_target_leader_state(target_leader_state).await.context("failed handling target leader state change")?;
+                    self.refresh_status(&mut durable_lsn_watch)?;
                 }
                 Ok(()) = watch_leader_changes.changed() => {
                     // cloning to avoid holding the underlying RwLock.
                     let new_state = *watch_leader_changes.borrow_and_update();
                     self.leadership_state.maybe_step_down(&mut self.ctx, new_state.current_leader_epoch, new_state.current_leader).await;
+                    self.refresh_status(&mut durable_lsn_watch)?;
                 }
                 Some(msg) = self.network_leader_svc_rx.next() => {
                     // todo: replace the live schema with the leader's consistent schema
                     self.on_rpc(msg, live_schemas.live_load(), &last_applied_lsn_watch).await;
                 }
                 _ = status_update_timer.tick() => {
-                    let durable_lsn = if durable_lsn_watch.has_changed().map_err(|e| ProcessorError::Other(e.into()))? {
-                        let durable_lsn = durable_lsn_watch
-                                .borrow_and_update()
-                                .unwrap_or(Lsn::INVALID);
-                        self.node_ctx.replica_set_states.note_durable_lsn(
-                            partition_id,
-                            my_node,
-                            durable_lsn,
-                        );
-                        durable_lsn
-                    } else {
-                        durable_lsn_watch.borrow().unwrap_or(Lsn::INVALID)
-                    };
-                    self.status_watch_tx.send_modify(|old| {
-                        self.ctx.merge_with_status(old);
-                        old.durable_lsn = Some(durable_lsn);
-                        old.storage_version = Some(self.partition_store.storage_version());
-                        old.effective_mode = self.leadership_state.effective_mode();
-                        old.updated_at = MillisSinceEpoch::now();
-                    });
+                    // Update the status to ensure changes are observable
+                    self.refresh_status(&mut durable_lsn_watch)?;
                 }
                 // Awaiting the first record is the only stream `.await` and is cancellation-safe:
                 // if this branch is dropped before a record is ready, nothing has been consumed.
@@ -585,10 +569,17 @@ where
                             &leader_record_write_to_read_latency,
                         )
                         .await? {
-                            NextStep::AdvanceLastAppliedLsn(lsn, ref dedup ) => {
+                            NextStep::AdvanceLastAppliedLsn { lsn, ref dedup, scope } => {
                                 self.ctx.dedup_mut().store_dedup_information(&mut txn, dedup)?;
                                 self.ctx.update_last_applied_lsn(&mut txn, lsn)?;
+                                if matches!(scope, CommandScope::PartitionScoped) {
+                                    // Update the status to ensure changes are observable
+                                    self.refresh_status(&mut durable_lsn_watch)?;
+                                }
                             },
+                            NextStep::SkipUntil(lsn) => {
+                                self.ctx.update_last_applied_lsn(&mut txn, lsn)?;
+                            }
                         }
 
                         if count >= max_batching_size {
@@ -685,6 +676,37 @@ where
             rpc::Replier::new(response_tx),
         )
         .await;
+    }
+
+    fn refresh_status(
+        &mut self,
+        durable_lsn_watch: &mut watch::Receiver<Option<Lsn>>,
+    ) -> Result<(), ProcessorError> {
+        let durable_lsn = if durable_lsn_watch
+            .has_changed()
+            .map_err(|e| ProcessorError::Other(e.into()))?
+        {
+            let durable_lsn = durable_lsn_watch
+                .borrow_and_update()
+                .unwrap_or(Lsn::INVALID);
+            self.node_ctx.replica_set_states.note_durable_lsn(
+                self.ctx.partition_id(),
+                self.node_ctx.my_node_id().as_plain(),
+                durable_lsn,
+            );
+            durable_lsn
+        } else {
+            durable_lsn_watch.borrow().unwrap_or(Lsn::INVALID)
+        };
+        self.status_watch_tx.send_modify(|old| {
+            self.ctx.merge_with_status(old);
+            old.durable_lsn = Some(durable_lsn);
+            old.storage_version = Some(self.partition_store.storage_version());
+            old.effective_mode = self.leadership_state.effective_mode();
+            old.updated_at = MillisSinceEpoch::now();
+        });
+
+        Ok(())
     }
 
     async fn on_rpc(
@@ -851,7 +873,7 @@ where
             Err(DataRecordError::Filtered { to, .. }) => {
                 // We advance our applied lsn to the end of the filtered gap
                 // Update replay status
-                return Ok(NextStep::AdvanceLastAppliedLsn(to, Dedup::None));
+                return Ok(NextStep::SkipUntil(to));
             }
             Err(DataRecordError::DataLoss { from, to }) => {
                 let log_id = self.ctx.log_id();
@@ -884,10 +906,11 @@ where
                 "Ignoring outdated or duplicate message: {:?}",
                 envelope.as_ref().header()
             );
-            return Ok(NextStep::AdvanceLastAppliedLsn(lsn, Dedup::None));
+            return Ok(NextStep::SkipUntil(lsn));
         }
 
-        match envelope.as_ref().scope() {
+        let scope = envelope.as_ref().scope();
+        match scope {
             CommandScope::PartitionScoped => {
                 self.apply_partition_command(envelope, txn, action_collector)
                     .await
@@ -902,7 +925,7 @@ where
                     self.leadership_state.is_leader(),
                 )
                 .await?;
-                Ok(NextStep::AdvanceLastAppliedLsn(lsn, dedup))
+                Ok(NextStep::AdvanceLastAppliedLsn { lsn, dedup, scope })
             }
         }
     }

--- a/crates/worker/src/partition/processor/commands.rs
+++ b/crates/worker/src/partition/processor/commands.rs
@@ -25,13 +25,21 @@ pub use version_barrier::VersionBarrierContext;
 
 use restate_bifrost::DataRecord;
 use restate_types::logs::Lsn;
-use restate_wal_protocol::v2::{self, Envelope};
+use restate_wal_protocol::v2::{self, CommandScope, Envelope};
 
 use crate::partition::ProcessorError;
 
 #[derive(Debug)]
 pub enum NextStep {
-    AdvanceLastAppliedLsn(Lsn, v2::Dedup),
+    /// The record covers a range of LSNs (e.g. a filter gap or duplicate). Applying this record
+    /// advances the processor's applied LSN to the supplied value.
+    SkipUntil(Lsn),
+
+    AdvanceLastAppliedLsn {
+        lsn: Lsn,
+        dedup: v2::Dedup,
+        scope: CommandScope,
+    },
 }
 
 /// Applies a single partition-scoped record to the processor.

--- a/crates/worker/src/partition/processor/commands/announce_leader.rs
+++ b/crates/worker/src/partition/processor/commands/announce_leader.rs
@@ -15,7 +15,7 @@ use restate_storage_api::Transaction;
 use restate_storage_api::fsm_table::CachedEpochMetadata;
 use restate_vqueues::context::HasVQueuesMut;
 use restate_wal_protocol::control::AnnounceLeaderCommand;
-use restate_wal_protocol::v2::Envelope;
+use restate_wal_protocol::v2::{CommandScope, Envelope};
 
 use super::{ApplyPartitionCommand, NextStep};
 use crate::partition::leadership::LeadershipState;
@@ -113,6 +113,10 @@ impl<P: Processor + HasFsmMut + HasVQueuesMut + HasTrimQueue + HasStatusMut, T: 
             },
         );
 
-        Ok(NextStep::AdvanceLastAppliedLsn(lsn, header.into_dedup()))
+        Ok(NextStep::AdvanceLastAppliedLsn {
+            lsn,
+            dedup: header.into_dedup(),
+            scope: CommandScope::PartitionScoped,
+        })
     }
 }

--- a/crates/worker/src/partition/processor/commands/truncate_outbox.rs
+++ b/crates/worker/src/partition/processor/commands/truncate_outbox.rs
@@ -10,8 +10,8 @@
 
 use restate_bifrost::DataRecord;
 use restate_partition_store::PartitionStoreTransaction;
-use restate_wal_protocol::v2::Envelope;
 use restate_wal_protocol::v2::commands::TruncateOutboxCommand;
+use restate_wal_protocol::v2::{CommandScope, Envelope};
 
 use super::{ApplyPartitionCommand, NextStep};
 use crate::partition::ProcessorError;
@@ -35,7 +35,11 @@ impl<P: HasOutboxMut> ApplyPartitionCommand<TruncateOutboxCommand>
         self.processor
             .outbox_mut()
             .truncate_outbox_to(self.txn, truncate.index)?;
-        Ok(NextStep::AdvanceLastAppliedLsn(lsn, header.into_dedup()))
+        Ok(NextStep::AdvanceLastAppliedLsn {
+            lsn,
+            dedup: header.into_dedup(),
+            scope: CommandScope::PartitionScoped,
+        })
     }
 }
 

--- a/crates/worker/src/partition/processor/commands/update_durability.rs
+++ b/crates/worker/src/partition/processor/commands/update_durability.rs
@@ -14,7 +14,7 @@ use restate_bifrost::DataRecord;
 use restate_partition_store::PartitionStoreTransaction;
 use restate_storage_api::fsm_table::PartitionDurability;
 use restate_wal_protocol::control::UpdatePartitionDurabilityCommand;
-use restate_wal_protocol::v2::Envelope;
+use restate_wal_protocol::v2::{CommandScope, Envelope};
 
 use super::{ApplyPartitionCommand, NextStep};
 use crate::partition::ProcessorError;
@@ -42,7 +42,11 @@ impl<P: Processor + HasFsmMut + HasTrimQueue>
                 partition_durability.partition_id,
                 self.processor.partition_id()
             );
-            return Ok(NextStep::AdvanceLastAppliedLsn(lsn, header.into_dedup()));
+            return Ok(NextStep::AdvanceLastAppliedLsn {
+                lsn,
+                dedup: header.into_dedup(),
+                scope: CommandScope::PartitionScoped,
+            });
         }
 
         let partition_durability = PartitionDurability {
@@ -55,6 +59,11 @@ impl<P: Processor + HasFsmMut + HasTrimQueue>
                 .fsm_mut()
                 .set_durable_point(self.txn, partition_durability);
         }
-        Ok(NextStep::AdvanceLastAppliedLsn(lsn, header.into_dedup()))
+
+        Ok(NextStep::AdvanceLastAppliedLsn {
+            lsn,
+            dedup: header.into_dedup(),
+            scope: CommandScope::PartitionScoped,
+        })
     }
 }

--- a/crates/worker/src/partition/processor/commands/upsert_rule_book.rs
+++ b/crates/worker/src/partition/processor/commands/upsert_rule_book.rs
@@ -15,7 +15,7 @@ use restate_core::network::TransportConnect;
 use restate_partition_store::PartitionStoreTransaction;
 use restate_types::Versioned;
 use restate_wal_protocol::control::UpsertRuleBookCommand;
-use restate_wal_protocol::v2::Envelope;
+use restate_wal_protocol::v2::{CommandScope, Envelope};
 
 use super::{ApplyPartitionCommand, NextStep};
 use crate::partition::leadership::LeadershipState;
@@ -50,7 +50,11 @@ impl<P: Processor + HasFsmMut, T: TransportConnect> ApplyPartitionCommand<Upsert
                 new_book.version(),
                 current_version,
             );
-            return Ok(NextStep::AdvanceLastAppliedLsn(lsn, header.into_dedup()));
+            return Ok(NextStep::AdvanceLastAppliedLsn {
+                lsn,
+                dedup: header.into_dedup(),
+                scope: CommandScope::PartitionScoped,
+            });
         }
 
         debug!(
@@ -79,6 +83,10 @@ impl<P: Processor + HasFsmMut, T: TransportConnect> ApplyPartitionCommand<Upsert
         // Persist within the apply transaction.
         self.processor.fsm_mut().set_rule_book(self.txn, new_book);
 
-        Ok(NextStep::AdvanceLastAppliedLsn(lsn, header.into_dedup()))
+        Ok(NextStep::AdvanceLastAppliedLsn {
+            lsn,
+            dedup: header.into_dedup(),
+            scope: CommandScope::PartitionScoped,
+        })
     }
 }

--- a/crates/worker/src/partition/processor/commands/upsert_schema.rs
+++ b/crates/worker/src/partition/processor/commands/upsert_schema.rs
@@ -16,7 +16,7 @@ use restate_bifrost::DataRecord;
 use restate_partition_store::PartitionStoreTransaction;
 use restate_types::Versioned;
 use restate_wal_protocol::control::UpsertSchemaCommand;
-use restate_wal_protocol::v2::Envelope;
+use restate_wal_protocol::v2::{CommandScope, Envelope};
 
 use crate::partition::ProcessorError;
 use crate::partition::processor::{FsmAccess, FsmMut, HasFsmMut, Processor};
@@ -49,6 +49,11 @@ impl<P: Processor + HasFsmMut> ApplyPartitionCommand<UpsertSchemaCommand>
                 .fsm_mut()
                 .set_schema(self.txn, Arc::new(upsert.schema));
         }
-        Ok(NextStep::AdvanceLastAppliedLsn(lsn, header.into_dedup()))
+
+        Ok(NextStep::AdvanceLastAppliedLsn {
+            lsn,
+            dedup: header.into_dedup(),
+            scope: CommandScope::PartitionScoped,
+        })
     }
 }

--- a/crates/worker/src/partition/processor/commands/version_barrier.rs
+++ b/crates/worker/src/partition/processor/commands/version_barrier.rs
@@ -16,7 +16,7 @@ use restate_types::SemanticRestateVersion;
 use restate_types::partitions::features::PartitionFeatureChange;
 use restate_types::sharding::KeyRange;
 use restate_wal_protocol::control::VersionBarrierCommand;
-use restate_wal_protocol::v2::Envelope;
+use restate_wal_protocol::v2::{CommandScope, Envelope};
 
 use super::{ApplyPartitionCommand, NextStep};
 use crate::debug_if_leader;
@@ -149,7 +149,11 @@ impl ApplyPartitionCommand<VersionBarrierCommand> for VersionBarrierContext<'_, 
             );
         }
 
-        Ok(NextStep::AdvanceLastAppliedLsn(lsn, header.into_dedup()))
+        Ok(NextStep::AdvanceLastAppliedLsn {
+            lsn,
+            dedup: header.into_dedup(),
+            scope: CommandScope::PartitionScoped,
+        })
     }
 }
 
@@ -222,7 +226,7 @@ mod tests {
     use restate_types::state_mut::ExternalStateMutation;
     use restate_types::time::NanosSinceEpoch;
     use restate_wal_protocol::control::VersionBarrierCommand;
-    use restate_wal_protocol::v2::{self, Command};
+    use restate_wal_protocol::v2::{self, Command, CommandScope};
 
     use super::{ApplyPartitionCommand, VersionBarrierContext};
     use crate::partition::ProcessorError;
@@ -290,10 +294,11 @@ mod tests {
 
         assert_that!(
             next_step,
-            pat!(NextStep::AdvanceLastAppliedLsn(
-                eq(Lsn::OLDEST),
-                eq(v2::Dedup::None)
-            ))
+            pat!(NextStep::AdvanceLastAppliedLsn {
+                lsn: eq(Lsn::OLDEST),
+                dedup: eq(v2::Dedup::None),
+                scope: pat!(CommandScope::PartitionScoped),
+            })
         );
 
         txn.commit().await.unwrap();


### PR DESCRIPTION

This helps us make the status more observable in particular after leadership changes, rulebook applications and such.
