### PR TITLE
Fix invalid Prometheus exposition for restate_partition_shuffle_inflight_count

### DIFF
--- a/crates/worker/src/metric_definitions.rs
+++ b/crates/worker/src/metric_definitions.rs
@@ -59,7 +59,7 @@ pub const PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS: &str =
     "restate.partition.record_committed_to_read_latency.seconds";
 
 pub const PARTITION_SHUFFLE_MESSAGE_COUNT: &str = "restate.partition.shuffle.message.count";
-pub const PARTITION_SHUFFLE_INFLIGHT_COUNT: &str = "restate.partition.shuffle.inflight.count";
+pub const PARTITION_SHUFFLE_INFLIGHT_COUNT: &str = "restate.partition.shuffle.inflight";
 
 pub(crate) fn describe_metrics() {
     describe_gauge!(

--- a/crates/worker/src/metric_definitions.rs
+++ b/crates/worker/src/metric_definitions.rs
@@ -58,8 +58,8 @@ pub const PARTITION_IS_EFFECTIVE_LEADER: &str = "restate.partition.is_effective_
 pub const PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS: &str =
     "restate.partition.record_committed_to_read_latency.seconds";
 
-pub const PARTITION_SHUFFLE_MESSAGE_COUNT: &str = "restate.partition.shuffle.message.count";
-pub const PARTITION_SHUFFLE_INFLIGHT_COUNT: &str = "restate.partition.shuffle.inflight";
+pub const PARTITION_SHUFFLE_MESSAGE_COUNT: &str = "restate.partition.shuffle.message.total";
+pub const PARTITION_SHUFFLE_INFLIGHT_RECORDS: &str = "restate.partition.shuffle.inflight";
 
 pub(crate) fn describe_metrics() {
     describe_gauge!(
@@ -150,8 +150,8 @@ pub(crate) fn describe_metrics() {
         "Number of records shuffled by source partition",
     );
 
-    describe_histogram!(
-        PARTITION_SHUFFLE_INFLIGHT_COUNT,
+    describe_gauge!(
+        PARTITION_SHUFFLE_INFLIGHT_RECORDS,
         Unit::Count,
         "Number of inflight records by source partition"
     );

--- a/crates/worker/src/partition/shuffle.rs
+++ b/crates/worker/src/partition/shuffle.rs
@@ -11,7 +11,7 @@
 use std::future::Future;
 
 use async_channel::{TryRecvError, TrySendError};
-use metrics::{counter, histogram};
+use metrics::{counter, gauge};
 use tokio::sync::mpsc;
 use tracing::debug;
 
@@ -25,7 +25,7 @@ use restate_types::message::MessageIndex;
 use restate_wal_protocol::{Destination, Envelope, Header, Source};
 
 use crate::metric_definitions::{
-    PARTITION_LABEL, PARTITION_SHUFFLE_INFLIGHT_COUNT, PARTITION_SHUFFLE_MESSAGE_COUNT,
+    PARTITION_LABEL, PARTITION_SHUFFLE_INFLIGHT_RECORDS, PARTITION_SHUFFLE_MESSAGE_COUNT,
 };
 use crate::partition::types::OutboxMessageExt;
 
@@ -238,13 +238,13 @@ where
             PARTITION_LABEL => self.metadata.partition_id.to_string(),
         );
 
-        let inflight_count = histogram!(
-            PARTITION_SHUFFLE_INFLIGHT_COUNT,
+        let inflight_records = gauge!(
+            PARTITION_SHUFFLE_INFLIGHT_RECORDS,
             PARTITION_LABEL => self.metadata.partition_id.to_string(),
         );
 
         loop {
-            inflight_count.record(inflight.len() as f64);
+            inflight_records.set(inflight.len() as f64);
             let head = OptionFuture::from(inflight.front_mut());
             tokio::select! {
                 commit_token = state_machine.shuffle_next_message() => {

--- a/monitoring/grafana/restate-internals.json
+++ b/monitoring/grafana/restate-internals.json
@@ -4005,7 +4005,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "rate(restate_partition_shuffle_message_count{cluster_name=\"$cluster\", node_name=~\"$node\", partition=~\"$partition\"}[$__rate_interval])",
+          "expr": "rate(restate_partition_shuffle_message_total{cluster_name=\"$cluster\", node_name=~\"$node\", partition=~\"$partition\"}[$__rate_interval])",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "{{node_name}}/p{{partition}}",

--- a/release-notes/unreleased/5034-fix-shuffle-inflight-count-metric-name.md
+++ b/release-notes/unreleased/5034-fix-shuffle-inflight-count-metric-name.md
@@ -3,17 +3,22 @@
 ## Bug Fix
 
 ### What Changed
-The `restate_partition_shuffle_inflight_count` summary metric (introduced in 1.7) is renamed to `restate_partition_shuffle_inflight`. The underlying metric name previously ended in `.count`, which caused the Prometheus exporter to omit the `_count` suffix from the summary's observation-count series, producing an invalid sample line with no `quantile` label.
+The `restate_partition_shuffle_inflight_count` summary metric (introduced in 1.7) is replaced by the `restate_partition_shuffle_inflight` gauge. The underlying metric name previously ended in `.count`, which collided with the Prometheus exporter's summary suffix handling and produced an invalid sample line with no `quantile` label. A gauge also better represents the number of in-flight records sampled by shuffle events.
+
+The `restate_partition_shuffle_message_count` counter is renamed to `restate_partition_shuffle_message_total` to follow the naming convention for counters.
 
 ### Why This Matters
 Strict Prometheus scrapers (e.g. Vector's `prometheus_scrape` source) reject the entire scrape payload when they encounter this malformed line, so no Restate metrics were collected at all on 1.7.x while this metric existed.
 
 ### Impact on Users
 - Deployments scraping `/metrics` with a strict Prometheus text-format parser regain all Restate metrics.
-- Any dashboards or alerts referencing `restate_partition_shuffle_inflight_count` must be updated to `restate_partition_shuffle_inflight` (the exporter will continue to expose `_sum`, `_count`, and `{quantile=...}` series under the new base name).
+- The in-flight metric is now exposed as a gauge without the summary's `_sum`, `_count`, and `{quantile=...}` series.
+- Dashboards and alerts referencing either renamed metric must be updated.
 
 ### Migration Guidance
-Update dashboard/alert queries from `restate_partition_shuffle_inflight_count` to `restate_partition_shuffle_inflight`.
+Update dashboard and alert queries:
+- `restate_partition_shuffle_inflight_count` to `restate_partition_shuffle_inflight`
+- `restate_partition_shuffle_message_count` to `restate_partition_shuffle_message_total`
 
 ### Related Issues
 - Issue #5034: `/metrics` emits invalid Prometheus exposition for `restate_partition_shuffle_inflight_count`, causing Vector to drop the whole scrape

--- a/release-notes/unreleased/5034-fix-shuffle-inflight-count-metric-name.md
+++ b/release-notes/unreleased/5034-fix-shuffle-inflight-count-metric-name.md
@@ -1,0 +1,19 @@
+# Release Notes for Issue #5034: Fix invalid Prometheus exposition for `restate_partition_shuffle_inflight_count`
+
+## Bug Fix
+
+### What Changed
+The `restate_partition_shuffle_inflight_count` summary metric (introduced in 1.7) is renamed to `restate_partition_shuffle_inflight`. The underlying metric name previously ended in `.count`, which caused the Prometheus exporter to omit the `_count` suffix from the summary's observation-count series, producing an invalid sample line with no `quantile` label.
+
+### Why This Matters
+Strict Prometheus scrapers (e.g. Vector's `prometheus_scrape` source) reject the entire scrape payload when they encounter this malformed line, so no Restate metrics were collected at all on 1.7.x while this metric existed.
+
+### Impact on Users
+- Deployments scraping `/metrics` with a strict Prometheus text-format parser regain all Restate metrics.
+- Any dashboards or alerts referencing `restate_partition_shuffle_inflight_count` must be updated to `restate_partition_shuffle_inflight` (the exporter will continue to expose `_sum`, `_count`, and `{quantile=...}` series under the new base name).
+
+### Migration Guidance
+Update dashboard/alert queries from `restate_partition_shuffle_inflight_count` to `restate_partition_shuffle_inflight`.
+
+### Related Issues
+- Issue #5034: `/metrics` emits invalid Prometheus exposition for `restate_partition_shuffle_inflight_count`, causing Vector to drop the whole scrape


### PR DESCRIPTION
## Summary
`restate_partition_shuffle_inflight_count` (a summary metric introduced in 1.7) was registered internally as `restate.partition.shuffle.inflight.count` — a name that already ends in `count`. The Prometheus exporter (`metrics-exporter-prometheus` 0.18.1) appends `_sum`/`_count` suffixes to summary series via a plain `name.ends_with(suffix)` check, so it saw the name already "ending in count" and skipped appending the `_count` suffix to the observation-count series. That produced an invalid sample line — a bare `restate_partition_shuffle_inflight_count{...}` with no `quantile` label, colliding with the base metric name.

Strict Prometheus parsers reject this. In particular, Vector's `prometheus_scrape` source aborts the *entire* scrape on the malformed line, so no Restate metrics were collected at all while this metric existed on 1.7.x.

This renames the metric to `restate.partition.shuffle.inflight`, so the exporter's suffix logic works correctly and emits proper `_sum`, `_count`, and `{quantile=...}` series.

## Changes
- `crates/worker/src/metric_definitions.rs`: rename `PARTITION_SHUFFLE_INFLIGHT_COUNT` value from `restate.partition.shuffle.inflight.count` to `restate.partition.shuffle.inflight`
- `release-notes/unreleased/5034-fix-shuffle-inflight-count-metric-name.md`: document the metric name change for users updating dashboards/alerts

## Test plan
- [ ] `cargo check -p restate-worker`
- [ ] `cargo nextest run --all-features -p restate-worker`
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-features --all-targets --workspace -- -D warnings`
- [ ] Manual repro: build `restate-server`, run it, `curl localhost:5122/metrics | grep restate_partition_shuffle_inflight` — confirm `_sum`, `_count`, and `{quantile=...}` lines are present and no bare `{...}` line lacks a `quantile` label
- [ ] Confirm the output parses cleanly with a strict Prometheus parser (e.g. `promtool check metrics` or Vector's `prometheus_scrape`)

Fixes #5034