### PR TITLE
[InvocationStatus] Add exact ID selection and batched multi-get point reads

### DIFF
--- a/crates/partition-store/src/invocation_status_table/mod.rs
+++ b/crates/partition-store/src/invocation_status_table/mod.rs
@@ -8,11 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::BTreeSet;
 use std::ops::ControlFlow;
 
-use futures::Stream;
+use bytes::BytesMut;
+use futures::{FutureExt, Stream};
+use rocksdb::ReadOptions;
 
-use restate_rocksdb::{Priority, RocksDbReadPerfGuard};
+use restate_rocksdb::{Priority, RocksDbReadPerfGuard, StorageTaskKind};
 use restate_storage_api::invocation_status_table::{
     InvocationLite, InvocationStatus, InvocationStatusDiscriminants, InvokedInvocationStatusLite,
     ReadInvocationStatusTable, ScanInvocationStatusTable, ScanInvocationStatusTableRange,
@@ -26,7 +29,7 @@ use restate_types::sharding::KeyRange;
 use restate_util_string::format_restring;
 
 use crate::TableScan::ScanPartitionKeyRange;
-use crate::keys::{DecodeTableKey, KeyKind, define_table_key};
+use crate::keys::{DecodeTableKey, EncodeTableKey, KeyKind, define_table_key};
 use crate::scan::TableScan;
 use crate::{PartitionStore, PartitionStoreTransaction, StorageAccess, TableKind, break_on_err};
 
@@ -38,6 +41,20 @@ define_table_key!(
         invocation_uuid: InvocationUuid
     )
 );
+
+impl InvocationStatusKey {
+    pub const fn serialized_length_fixed() -> usize {
+        KeyKind::SERIALIZED_LENGTH
+            + std::mem::size_of::<PartitionKey>()
+            + InvocationUuid::RAW_BYTES_LEN
+    }
+}
+
+/// Maximum number of invocation-status keys passed to one RocksDB multi-get call.
+/// This one is set to a low value due to the possibility of loading a large value from rocksdb
+/// when the invocation holds a large output payload. This is an unfortunate side effect of storing
+/// the output payload into invocation-status!
+const INVOCATION_STATUS_MULTI_GET_BATCH_SIZE: usize = 25;
 
 #[inline]
 fn create_invocation_status_key(invocation_id: &InvocationId) -> InvocationStatusKey {
@@ -54,6 +71,133 @@ fn invocation_id_from_key_bytes<B: bytes::Buf>(bytes: &mut B) -> crate::Result<I
         key.partition_key,
         key.invocation_uuid,
     ))
+}
+
+fn multi_get_invocation_status_lazy<E, F>(
+    store: &PartitionStore,
+    ids: BTreeSet<InvocationId>,
+    mut f: F,
+) -> impl Future<Output = Result<()>> + Send
+where
+    E: Into<anyhow::Error> + 'static,
+    F: for<'a> FnMut(
+            (InvocationId, &'a InvocationStatusV2Lazy<'a>),
+        ) -> ControlFlow<std::result::Result<(), E>>
+        + Send
+        + Sync
+        + 'static,
+{
+    const KEY_LEN: usize = InvocationStatusKey::serialized_length_fixed();
+
+    let rocksdb = store.partition_db().rocksdb().clone();
+    let cf_name: restate_rocksdb::CfName = store.partition_db().partition().cf_name().into();
+
+    async move {
+        rocksdb
+            .run_background_read_op(
+                "df-for-each-invocation-status",
+                StorageTaskKind::MultiGet,
+                Priority::Low,
+                move |raw_db| -> Result<()> {
+                    let Some(cf) = raw_db.cf_handle(cf_name.as_str()) else {
+                        return Err(StorageError::Generic(anyhow::anyhow!(
+                            "column family {cf_name} not found for invocation-status multi-get"
+                        )));
+                    };
+
+                    let batch_capacity = ids.len().min(INVOCATION_STATUS_MULTI_GET_BATCH_SIZE);
+                    let mut key_buf = BytesMut::with_capacity(batch_capacity * KEY_LEN);
+                    let mut batch_ids = Vec::with_capacity(batch_capacity);
+
+                    let mut readopts = ReadOptions::default();
+                    // future proofing to make use of parallel L0 reads and async-io
+                    // if/when we build rocksdb with COROUTINES=1 and IO-URING support.
+                    // by default, this will not do anything.
+                    readopts.set_async_io(true);
+                    readopts.set_optimize_multiget_for_io(true);
+
+                    let mut ids = ids.into_iter();
+                    loop {
+                        key_buf.clear();
+                        batch_ids.clear();
+
+                        for id in ids.by_ref().take(INVOCATION_STATUS_MULTI_GET_BATCH_SIZE) {
+                            EncodeTableKey::serialize_to(
+                                &create_invocation_status_key(&id),
+                                &mut key_buf,
+                            );
+                            batch_ids.push(id);
+                        }
+
+                        if batch_ids.is_empty() {
+                            break;
+                        }
+
+                        let results = raw_db.batched_multi_get_cf_opt(
+                            &cf,
+                            key_buf.chunks_exact(KEY_LEN),
+                            true,
+                            &readopts,
+                        );
+
+                        for (id, result) in batch_ids.iter().zip(results) {
+                            let Some(value) = result.map_err(|e| StorageError::Generic(e.into()))?
+                            else {
+                                continue;
+                            };
+                            let mut value = value.as_ref();
+
+                            if value.len() < std::mem::size_of::<u8>() {
+                                return Err(StorageError::Conversion(
+                                    restate_types::storage::StorageDecodeError::ReadingCodec(
+                                        format_restring!(
+                                            "remaining bytes in buf '{}' < version bytes '{}'",
+                                            value.len(),
+                                            std::mem::size_of::<u8>()
+                                        ),
+                                    )
+                                    .into(),
+                                ));
+                            }
+
+                            let codec = restate_types::storage::StorageCodecKind::try_from(
+                                bytes::Buf::get_u8(&mut value),
+                            )
+                            .map_err(|e| StorageError::Conversion(e.into()))?;
+                            let restate_types::storage::StorageCodecKind::Protobuf = codec else {
+                                return Err(StorageError::Conversion(
+                                    restate_types::storage::StorageDecodeError::UnsupportedCodecKind(
+                                        codec,
+                                    )
+                                    .into(),
+                                ));
+                            };
+
+                            let mut inv_status_v2_lazy = InvocationStatusV2Lazy::default();
+                            inv_status_v2_lazy
+                                .merge(value)
+                                .map_err(|e| StorageError::Conversion(e.into()))?;
+
+                            match f((*id, &inv_status_v2_lazy)) {
+                                ControlFlow::Continue(()) => {}
+                                ControlFlow::Break(Ok(())) => return Ok(()),
+                                ControlFlow::Break(Err(e)) => {
+                                    return Err(StorageError::Conversion(e.into()));
+                                }
+                            }
+                        }
+
+                        if batch_ids.len() < INVOCATION_STATUS_MULTI_GET_BATCH_SIZE {
+                            break;
+                        }
+                    }
+
+                    Ok(())
+                },
+            )
+            .await
+            .map_err(|_| StorageError::OperationalError)?
+    }
 }
 
 fn put_invocation_status<S: StorageAccess>(
@@ -162,7 +306,7 @@ impl ScanInvocationStatusTable for PartitionStore {
     }
 
     fn for_each_invocation_status_lazy<
-        E: Into<anyhow::Error>,
+        E: Into<anyhow::Error> + 'static,
         F: for<'a> FnMut(
                 (InvocationId, &'a InvocationStatusV2Lazy<'a>),
             ) -> ControlFlow<std::result::Result<(), E>>
@@ -174,6 +318,10 @@ impl ScanInvocationStatusTable for PartitionStore {
         range: ScanInvocationStatusTableRange,
         mut f: F,
     ) -> Result<impl Future<Output = Result<()>> + Send> {
+        if let ScanInvocationStatusTableRange::InvocationIdSet(ids) = range {
+            return Ok(multi_get_invocation_status_lazy(self, ids, f).boxed());
+        }
+
         let scan = match range {
             ScanInvocationStatusTableRange::PartitionKey(partition_key) => {
                 TableScan::ScanPartitionKeyRange::<InvocationStatusKeyBuilder>(partition_key)
@@ -189,6 +337,7 @@ impl ScanInvocationStatusTable for PartitionStore {
 
                 TableScan::RangeInclusive(start, end)
             }
+            ScanInvocationStatusTableRange::InvocationIdSet(_) => unreachable!("handled above"),
         };
 
         let new_status_keys = self
@@ -234,7 +383,7 @@ impl ScanInvocationStatusTable for PartitionStore {
             )
             .map_err(|_| StorageError::OperationalError)?;
 
-        Ok(new_status_keys)
+        Ok(new_status_keys.boxed())
     }
 
     fn filter_map_invocation_status_lazy<

--- a/crates/rocksdb/src/background.rs
+++ b/crates/rocksdb/src/background.rs
@@ -30,6 +30,7 @@ pub enum StorageTaskKind {
     Shutdown,
     OpenDb,
     BackgroundIterator,
+    MultiGet,
 }
 
 impl StorageTaskKind {

--- a/crates/rocksdb/src/lib.rs
+++ b/crates/rocksdb/src/lib.rs
@@ -38,6 +38,7 @@ use restate_core::ShutdownError;
 use restate_types::protobuf::common::DatabaseKind;
 
 // re-exports
+pub use self::background::StorageTaskKind;
 pub use self::db_manager::RocksDbManager;
 pub use self::db_spec::*;
 pub use self::error::*;
@@ -47,7 +48,6 @@ pub use self::perf::{RocksDbReadPerfGuard, RocksDbWritePerfGuard};
 pub use self::rock_access::RocksAccess;
 
 use self::background::StorageTask;
-use self::background::StorageTaskKind;
 use self::metric_definitions::*;
 
 pub type RawRocksDb = rocksdb::DBWithThreadMode<rocksdb::MultiThreaded>;
@@ -394,6 +394,39 @@ impl RocksDb {
             .unwrap();
 
         manager.spawn(task)
+    }
+
+    /// Runs a blocking read operation on the storage background thread-pool and
+    /// awaits its result.
+    ///
+    /// Unlike [`Self::run_background_iterator`], this is for bounded operations
+    /// that run to completion and produce a single value, rather than streaming
+    /// rows. The op receives the raw RocksDB handle and must not let borrowed
+    /// database values escape its own scope.
+    #[tracing::instrument(skip_all, fields(db = %self.name()))]
+    pub async fn run_background_read_op<OP, R>(
+        self: Arc<Self>,
+        name: &'static str,
+        kind: StorageTaskKind,
+        priority: Priority,
+        op: OP,
+    ) -> Result<R, ShutdownError>
+    where
+        OP: FnOnce(&RawRocksDb) -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        let manager = self.manager;
+        let task = StorageTask::default()
+            .kind(kind)
+            .priority(priority)
+            .op(move || {
+                let _x = RocksDbReadPerfGuard::new(name);
+                op(self.db.as_raw_db())
+            })
+            .build()
+            .unwrap();
+
+        manager.async_spawn(task).await
     }
 
     #[tracing::instrument(skip_all, fields(db = %self.name()))]

--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 use std::future::Future;
 use std::ops::{ControlFlow, RangeInclusive};
 use std::time::Duration;
@@ -817,11 +817,12 @@ pub trait ReadInvocationStatusTable {
 pub enum ScanInvocationStatusTableRange {
     PartitionKey(KeyRange),
     InvocationId(RangeInclusive<InvocationId>),
+    InvocationIdSet(BTreeSet<InvocationId>),
 }
 
 pub trait ScanInvocationStatusTable {
     fn for_each_invocation_status_lazy<
-        E: Into<anyhow::Error>,
+        E: Into<anyhow::Error> + 'static,
         F: for<'a> FnMut(
                 (InvocationId, &'a InvocationStatusV2Lazy<'a>),
             ) -> ControlFlow<std::result::Result<(), E>>

--- a/crates/storage-query-datafusion/src/filter.rs
+++ b/crates/storage-query-datafusion/src/filter.rs
@@ -10,7 +10,7 @@
 
 use std::collections::{BTreeSet, HashSet};
 use std::fmt::{Debug, Formatter};
-use std::ops::{RangeBounds, RangeInclusive};
+use std::ops::RangeBounds;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -42,18 +42,43 @@ pub trait PartitionKeyExtractor: Send + Sync + 'static + Debug {
 
 #[derive(Debug)]
 pub struct FirstMatchingPartitionKeyExtractor {
-    extractors: Vec<Box<dyn PartitionKeyExtractor>>,
+    extractors: Vec<PartitionKeyExtractorEntry>,
+}
+
+#[derive(Debug)]
+struct PartitionKeyExtractorEntry {
+    extractor: Box<dyn PartitionKeyExtractor>,
+    fanout: PointReadFanout,
+}
+
+/// Controls how selected partition keys are mapped to physical scans.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PointReadFanout {
+    /// Creates one scan per selected partition key.
+    PerKey,
+    /// Groups selected keys into one scan per Restate partition.
+    PerPartition,
+}
+
+/// The partition keys and fanout produced by the first matching extractor.
+#[derive(Debug)]
+pub(crate) struct PartitionKeySelection {
+    pub(crate) keys: BTreeSet<PartitionKey>,
+    pub(crate) fanout: PointReadFanout,
 }
 
 impl Default for FirstMatchingPartitionKeyExtractor {
     fn default() -> Self {
-        let extractors = vec![Box::new(MatchingColumnExtractor::new(
-            "partition_key",
-            |value: &ScalarValue| match value {
-                ScalarValue::UInt64(Some(v)) => Ok(*v),
-                _ => anyhow::bail!("expected UInt64 partition key"),
-            },
-        )) as Box<dyn PartitionKeyExtractor>];
+        let extractors = vec![PartitionKeyExtractorEntry {
+            extractor: Box::new(MatchingColumnExtractor::new(
+                "partition_key",
+                |value: &ScalarValue| match value {
+                    ScalarValue::UInt64(Some(v)) => Ok(*v),
+                    _ => anyhow::bail!("expected UInt64 partition key"),
+                },
+            )),
+            fanout: PointReadFanout::PerKey,
+        }];
         Self { extractors }
     }
 }
@@ -131,15 +156,34 @@ impl FirstMatchingPartitionKeyExtractor {
     }
 
     pub fn with_invocation_id(self, column_name: impl Into<String>) -> Self {
-        let e = MatchingColumnExtractor::new(column_name, |value: &ScalarValue| {
+        self.append(Self::create_invocation_id_partition_key_extractor(
+            column_name,
+        ))
+    }
+
+    /// Adds an invocation-id extractor whose matches are grouped into a single
+    /// scan per Restate partition.
+    ///
+    /// Only use this when the table's scanner re-fetches each id exactly via an
+    /// exact-id filter; range-scanning tables would read every intermediate key.
+    pub fn with_grouped_invocation_id(self, column_name: impl Into<String>) -> Self {
+        self.append_with_fanout(
+            Self::create_invocation_id_partition_key_extractor(column_name),
+            PointReadFanout::PerPartition,
+        )
+    }
+
+    fn create_invocation_id_partition_key_extractor(
+        column_name: impl Into<String>,
+    ) -> MatchingColumnExtractor<fn(&ScalarValue) -> anyhow::Result<PartitionKey>> {
+        MatchingColumnExtractor::new(column_name, |value: &ScalarValue| {
             let value = value
                 .try_as_str()
                 .context("expected string invocation id")?
                 .context("unexpected null invocation id")?;
             let invocation_id = InvocationId::from_str(value).context("non valid invocation id")?;
             Ok(invocation_id.partition_key())
-        });
-        self.append(e)
+        })
     }
 
     pub fn with_vqueue_entry_id(self, column_name: impl Into<String>) -> Self {
@@ -162,9 +206,36 @@ impl FirstMatchingPartitionKeyExtractor {
         self.append(e)
     }
 
-    pub fn append(mut self, extractor: impl PartitionKeyExtractor) -> Self {
-        self.extractors.push(Box::new(extractor));
+    pub fn append(self, extractor: impl PartitionKeyExtractor) -> Self {
+        self.append_with_fanout(extractor, PointReadFanout::PerKey)
+    }
+
+    fn append_with_fanout(
+        mut self,
+        extractor: impl PartitionKeyExtractor,
+        fanout: PointReadFanout,
+    ) -> Self {
+        self.extractors.push(PartitionKeyExtractorEntry {
+            extractor: Box::new(extractor),
+            fanout,
+        });
         self
+    }
+
+    pub(crate) fn try_extract_selection(
+        &self,
+        filters: &[Arc<dyn PhysicalExpr>],
+    ) -> anyhow::Result<Option<PartitionKeySelection>> {
+        for entry in &self.extractors {
+            if let Some(keys) = entry.extractor.try_extract(filters)? {
+                return Ok(Some(PartitionKeySelection {
+                    keys,
+                    fanout: entry.fanout,
+                }));
+            }
+        }
+
+        Ok(None)
     }
 }
 
@@ -173,13 +244,9 @@ impl PartitionKeyExtractor for FirstMatchingPartitionKeyExtractor {
         &self,
         filters: &[Arc<dyn PhysicalExpr>],
     ) -> anyhow::Result<Option<BTreeSet<PartitionKey>>> {
-        for extractor in &self.extractors {
-            if let Some(partition_keys) = extractor.try_extract(filters)? {
-                return Ok(Some(partition_keys));
-            }
-        }
-
-        Ok(None)
+        Ok(self
+            .try_extract_selection(filters)?
+            .map(|selection| selection.keys))
     }
 }
 
@@ -449,9 +516,25 @@ fn parse_stage_literal(value: &str) -> Option<Stage> {
 }
 
 #[derive(Debug, Clone)]
+pub struct IdSelection<T> {
+    pub ids: BTreeSet<T>,
+}
+
+impl<T: Ord + Clone> IdSelection<T> {
+    /// The inclusive `[min, max]` span the selected IDs cover. Used by consumers
+    /// that can only range-scan, while point-lookup tables consume the exact set.
+    pub fn bounds(&self) -> (T, T) {
+        (
+            self.ids.first().expect("selection is never empty").clone(),
+            self.ids.last().expect("selection is never empty").clone(),
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct InvocationIdFilter {
     pub partition_keys: KeyRange,
-    pub invocation_ids: Option<RangeInclusive<InvocationId>>,
+    pub invocation_ids: Option<IdSelection<InvocationId>>,
 }
 
 impl ScanLocalPartitionFilter for InvocationIdFilter {
@@ -460,7 +543,11 @@ impl ScanLocalPartitionFilter for InvocationIdFilter {
             && let Ok(predicate) = snapshot_physical_expr(predicate)
         {
             for conjunct in split_conjunction(&predicate) {
-                if let Some(invocation_ids) = parse_invocation_id_range("id", range, conjunct) {
+                if let Some(invocation_ids) =
+                    parse_id_selection("id", range, conjunct, |id: &InvocationId| {
+                        id.partition_key()
+                    })
+                {
                     return Self {
                         partition_keys: range,
                         invocation_ids: Some(invocation_ids),
@@ -476,39 +563,43 @@ impl ScanLocalPartitionFilter for InvocationIdFilter {
     }
 }
 
-fn parse_invocation_id_range(
+fn parse_id_selection<T>(
     column_name: &str,
     range: KeyRange,
     predicate: &Arc<dyn PhysicalExpr>,
-) -> Option<RangeInclusive<InvocationId>> {
+    partition_key_of: impl Fn(&T) -> PartitionKey,
+) -> Option<IdSelection<T>>
+where
+    T: FromStr + Ord,
+{
     let in_list = InList::parse(predicate, 5)?;
 
     // A negated list (`NOT IN`/`!=`) enumerates excluded IDs; using it to build
-    // a lookup range would fetch exactly the rows that must be filtered out.
+    // a lookup set would fetch exactly the rows that must be filtered out.
     if in_list.col.name() != column_name || in_list.negated {
         return None;
     }
 
-    let mut invocation_ids: Option<RangeInclusive<InvocationId>> = None;
+    let mut ids = BTreeSet::new();
     for literal in in_list.list {
         let str = literal.try_as_str()??;
-        let invocation_id = InvocationId::from_str(str).ok()?;
+        let id = T::from_str(str).ok()?;
 
-        if range.contains(&invocation_id.partition_key()) {
-            if let Some(invocation_ids) = &mut invocation_ids {
-                *invocation_ids = (*invocation_ids.start()).min(invocation_id)
-                    ..=(*invocation_ids.end()).max(invocation_id);
-            } else {
-                invocation_ids = Some(invocation_id..=invocation_id)
-            }
+        if range.contains(&partition_key_of(&id)) {
+            ids.insert(id);
         }
     }
 
-    invocation_ids
+    if ids.is_empty() {
+        None
+    } else {
+        Some(IdSelection { ids })
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
     use std::sync::Arc;
 
     use datafusion::common::ScalarValue;
@@ -927,9 +1018,8 @@ mod tests {
 
         let filter = InvocationIdFilter::new(FULL_RANGE, Some(predicate));
 
-        let range = filter.invocation_ids.expect("should extract range");
-        assert_eq!(*range.start(), id);
-        assert_eq!(*range.end(), id);
+        let selection = filter.invocation_ids.expect("should extract selection");
+        assert_eq!(selection.ids, BTreeSet::from([id]));
     }
 
     #[test]
@@ -943,9 +1033,30 @@ mod tests {
 
         let filter = InvocationIdFilter::new(FULL_RANGE, Some(predicate));
 
-        let range = filter.invocation_ids.expect("should extract range");
-        assert_eq!(*range.start(), id1.min(id2));
-        assert_eq!(*range.end(), id1.max(id2));
+        let selection = filter.invocation_ids.expect("should extract selection");
+        assert_eq!(selection.ids, BTreeSet::from([id1, id2]));
+    }
+
+    #[test]
+    fn invocation_id_filter_keeps_large_in_list_as_set() {
+        let invocation_ids = (0..501)
+            .map(|id| make_invocation_id(&format!("key-{id}")))
+            .collect::<Vec<_>>();
+        let predicate = in_list(
+            "id",
+            invocation_ids
+                .iter()
+                .map(|id| utf8_lit(id.to_string()))
+                .collect(),
+        );
+
+        let filter = InvocationIdFilter::new(FULL_RANGE, Some(predicate));
+
+        let selection = filter.invocation_ids.expect("should extract selection");
+        assert_eq!(selection.ids.len(), invocation_ids.len());
+        for invocation_id in invocation_ids {
+            assert!(selection.ids.contains(&invocation_id));
+        }
     }
 
     #[test]
@@ -975,11 +1086,10 @@ mod tests {
 
         let filter = InvocationIdFilter::new(FULL_RANGE, Some(predicate));
 
-        let range = filter
+        let selection = filter
             .invocation_ids
             .expect("should extract from conjunction");
-        assert_eq!(*range.start(), id);
-        assert_eq!(*range.end(), id);
+        assert_eq!(selection.ids, BTreeSet::from([id]));
     }
 
     #[test]

--- a/crates/storage-query-datafusion/src/invocation_status/table.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/table.rs
@@ -22,8 +22,7 @@ use restate_types::errors::ConversionError;
 use restate_types::identifiers::InvocationId;
 
 use crate::context::{QueryContext, SelectPartitions};
-use crate::filter::FirstMatchingPartitionKeyExtractor;
-use crate::filter::InvocationIdFilter;
+use crate::filter::{FirstMatchingPartitionKeyExtractor, InvocationIdFilter};
 use crate::invocation_status::row::append_invocation_status_row;
 use crate::invocation_status::schema::{
     SysInvocationStatusBuilder, sys_invocation_status_sort_order,
@@ -63,7 +62,7 @@ pub(crate) fn register_self(
         remote_scanner_manager.create_distributed_scanner(NAME, local_scanner),
         FirstMatchingPartitionKeyExtractor::default()
             .with_service_key("target_service_key")
-            .with_invocation_id("id"),
+            .with_grouped_invocation_id("id"),
     )
     .with_statistics(statistics.build());
     ctx.register_partitioned_table(NAME, Arc::new(status_table))
@@ -101,10 +100,9 @@ impl ScanLocalPartition for StatusScanner {
 
 impl From<InvocationIdFilter> for ScanInvocationStatusTableRange {
     fn from(value: InvocationIdFilter) -> Self {
-        if let Some(invocation_ids) = value.invocation_ids {
-            ScanInvocationStatusTableRange::InvocationId(invocation_ids)
-        } else {
-            ScanInvocationStatusTableRange::PartitionKey(value.partition_keys)
+        match value.invocation_ids {
+            Some(selection) => ScanInvocationStatusTableRange::InvocationIdSet(selection.ids),
+            None => ScanInvocationStatusTableRange::PartitionKey(value.partition_keys),
         }
     }
 }

--- a/crates/storage-query-datafusion/src/journal/table.rs
+++ b/crates/storage-query-datafusion/src/journal/table.rs
@@ -143,8 +143,9 @@ impl ScanLocalPartition for JournalScanner {
 
 impl From<InvocationIdFilter> for ScanJournalTableRange {
     fn from(value: InvocationIdFilter) -> Self {
-        if let Some(invocation_ids) = value.invocation_ids {
-            ScanJournalTableRange::InvocationId(invocation_ids)
+        if let Some(selection) = value.invocation_ids {
+            let (start, last) = selection.bounds();
+            ScanJournalTableRange::InvocationId(start..=last)
         } else {
             ScanJournalTableRange::PartitionKey(value.partition_keys)
         }
@@ -153,8 +154,9 @@ impl From<InvocationIdFilter> for ScanJournalTableRange {
 
 impl From<InvocationIdFilter> for ScanJournalTableRangeV2 {
     fn from(value: InvocationIdFilter) -> Self {
-        if let Some(invocation_ids) = value.invocation_ids {
-            ScanJournalTableRangeV2::InvocationId(invocation_ids)
+        if let Some(selection) = value.invocation_ids {
+            let (start, last) = selection.bounds();
+            ScanJournalTableRangeV2::InvocationId(start..=last)
         } else {
             ScanJournalTableRangeV2::PartitionKey(value.partition_keys)
         }

--- a/crates/storage-query-datafusion/src/journal_events/table.rs
+++ b/crates/storage-query-datafusion/src/journal_events/table.rs
@@ -86,8 +86,9 @@ impl ScanLocalPartition for JournalEventsScanner {
 
 impl From<InvocationIdFilter> for ScanJournalEventsTableRange {
     fn from(value: InvocationIdFilter) -> Self {
-        if let Some(invocation_ids) = value.invocation_ids {
-            ScanJournalEventsTableRange::InvocationId(invocation_ids)
+        if let Some(selection) = value.invocation_ids {
+            let (start, last) = selection.bounds();
+            ScanJournalEventsTableRange::InvocationId(start..=last)
         } else {
             ScanJournalEventsTableRange::PartitionKey(value.partition_keys)
         }

--- a/crates/storage-query-datafusion/src/table_providers.rs
+++ b/crates/storage-query-datafusion/src/table_providers.rs
@@ -38,7 +38,7 @@ use restate_types::partition_table::Partition;
 use restate_types::sharding::KeyRange;
 
 use crate::context::SelectPartitions;
-use crate::filter::{FirstMatchingPartitionKeyExtractor, PartitionKeyExtractor};
+use crate::filter::{FirstMatchingPartitionKeyExtractor, PointReadFanout};
 use crate::table_util::{find_sort_columns, make_ordering};
 
 pub trait ScanPartition: Send + Sync + Debug + 'static {
@@ -167,9 +167,9 @@ where
             })
             .collect::<datafusion::common::Result<_>>()?;
 
-        let partition_keys = self
+        let partition_key_selection = self
             .partition_key_extractor
-            .try_extract(&filters)
+            .try_extract_selection(&filters)
             .map_err(|e| DataFusionError::External(e.into()))?;
 
         let predicate = datafusion::physical_expr::conjunction_opt(filters);
@@ -181,17 +181,30 @@ where
             .map_err(DataFusionError::External)?
             .into_iter()
             .flat_map(|(partition_id, partition)| {
-                match &partition_keys {
+                match &partition_key_selection {
                     // User requested a full scan of all partitions, return one physical partition per restate partition
-                    None => itertools::Either::Left([(partition_id, partition)].into_iter()),
+                    None => itertools::Either::Left(Some((partition_id, partition)).into_iter()),
                     // User requested too many point reads; for safety reasons we will ignore them
-                    Some(partition_keys) if partition_keys.len() > 4096 => {
-                        itertools::Either::Left([(partition_id, partition)].into_iter())
+                    Some(selection) if selection.keys.len() > 4096 => {
+                        itertools::Either::Left(Some((partition_id, partition)).into_iter())
+                    }
+                    // Group selected keys into one physical scan per Restate partition.
+                    Some(selection) if selection.fanout == PointReadFanout::PerPartition => {
+                        let mut keys = selection.keys.range(partition.key_range).copied();
+                        let selected = keys.next().map(|first| {
+                            let last = keys.next_back().unwrap_or(first);
+                            (
+                                partition_id,
+                                Partition::new(partition_id, KeyRange::new(first, last)),
+                            )
+                        });
+                        itertools::Either::Left(selected.into_iter())
                     }
                     // User requested a list of point reads
-                    Some(partition_keys) => {
+                    Some(selection) => {
                         itertools::Either::Right(
-                            partition_keys
+                            selection
+                                .keys
                                 // Find requested partition keys that are in this partition
                                 .range(partition.key_range)
                                 .cloned()

--- a/crates/storage-query-datafusion/src/tests.rs
+++ b/crates/storage-query-datafusion/src/tests.rs
@@ -541,6 +541,63 @@ async fn query_sys_invocation_status_not_in() {
     assert_eq!(got, expected);
 }
 
+/// Exercises the exact-id fast path: `id IN (...)` on `sys_invocation_status`
+/// must return exactly the requested rows.
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_sys_invocation_status_in_list() {
+    use datafusion::arrow::array::Array;
+
+    let invocation_target = InvocationTarget::mock_service();
+    let mut engine = MockQueryEngine::create().await;
+
+    let mut ids = Vec::new();
+    let mut tx = engine.partition_store().transaction();
+    for i in 1..=4u128 {
+        let id = InvocationId::from_parts(0, InvocationUuid::from_u128(i));
+        tx.put_invocation_status(
+            &id,
+            &InvocationStatus::Completed(CompletedInvocation {
+                invocation_target: invocation_target.clone(),
+                ..CompletedInvocation::mock_neo()
+            }),
+        )
+        .unwrap();
+        ids.push(id.to_string());
+    }
+    tx.commit().await.unwrap();
+    drop(tx);
+
+    let wanted = format!("'{}', '{}'", ids[0], ids[2]);
+    let records = engine
+        .execute(format!(
+            "SELECT id FROM sys_invocation_status WHERE id IN ({wanted})"
+        ))
+        .await
+        .unwrap()
+        .stream
+        .collect::<Vec<datafusion::common::Result<RecordBatch>>>()
+        .await
+        .remove(0)
+        .unwrap();
+
+    let mut got: Vec<String> = records
+        .column_by_name("id")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<LargeStringArray>()
+        .unwrap()
+        .iter()
+        .flatten()
+        .map(str::to_string)
+        .collect();
+    got.sort();
+
+    let mut expected = vec![ids[0].clone(), ids[2].clone()];
+    expected.sort();
+
+    assert_eq!(got, expected);
+}
+
 #[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
 async fn query_sys_invocation_suspended_waiting() {
     let invocation_id = InvocationId::mock_random();

--- a/crates/worker/src/partition/cleaner.rs
+++ b/crates/worker/src/partition/cleaner.rs
@@ -226,7 +226,7 @@ mod tests {
 
     impl ScanInvocationStatusTable for MockInvocationStatusReader {
         fn for_each_invocation_status_lazy<
-            E: Into<anyhow::Error>,
+            E: Into<anyhow::Error> + 'static,
             F: for<'a> FnMut(
                     (InvocationId, &'a InvocationStatusV2Lazy<'a>),
                 ) -> std::ops::ControlFlow<std::result::Result<(), E>>


### PR DESCRIPTION

Keep equality and IN predicates as exact ID selections in the DataFusion filter layer instead of collapsing large sets into scan ranges. This lets point-lookup tables preserve the user's requested IDs while range-scan tables can still convert the same selection back to bounds.

Teach the partitioned table provider to group exact point reads by Restate partition when the scanner can re-fetch the exact IDs itself. Use that for sys_invocation_status by adding an InvocationIdSet scan path backed by bounded RocksDB multi-get batches.

Split partition-store inclusive key-range scans into single-prefix and total-order variants, and use total-order scans when invocation-status, journal, or journal-events ID bounds span multiple partition keys. This preserves correctness for range-scan consumers of exact ID selections.

Adapt the worker cleaner to the fallible stream shape used by the new invocation-status scan path, and add scan-mode coverage for the new total-order range variant.


This design delivers 5-10x better performance for point-lookups than the concurrent iterator-per-entry approach that was previously used. This pays more dividends on slower disks and will allow us to leverage async I/O better when we build rocksdb with folly.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/5046).
* #5056
* #5053
* #5048
* #5047
* __->__ #5046
* #5052