### PR TITLE
[VQueues] Optimize sys_vqueue_entry_status point lookups

### DIFF
--- a/crates/partition-store/src/tests/vqueue_table_test/mod.rs
+++ b/crates/partition-store/src/tests/vqueue_table_test/mod.rs
@@ -25,17 +25,20 @@
 //!   cursor is created are NOT visible to that cursor — callers must create
 //!   a fresh cursor to observe them.
 
+use std::collections::BTreeSet;
+
 use restate_clock::time::MillisSinceEpoch;
 use restate_storage_api::Transaction;
-use restate_storage_api::vqueue_table::ScanVQueueEntries;
+use restate_storage_api::vqueue_table::filters::ScanEntryIdFilter;
 use restate_storage_api::vqueue_table::{
     EntryKey, EntryMetadata, EntryValue, Options, Stage, Status, VQueueCursor, VQueueRunningCursor,
     VQueueStore, WriteVQueueTable, stats::EntryStatistics,
 };
+use restate_storage_api::vqueue_table::{ScanVQueueEntries, ScanVQueueEntryStatusTable};
 use restate_types::clock::UniqueTimestamp;
 use restate_types::identifiers::PartitionKey;
 use restate_types::sharding::KeyRange;
-use restate_types::vqueues::{EntryId, EntryKind, VQueueId};
+use restate_types::vqueues::{EntryId, EntryKind, VQueueEntryId, VQueueId};
 
 use crate::PartitionStore;
 
@@ -45,6 +48,12 @@ fn test_qid() -> VQueueId {
 
 fn entry_id(id: u8) -> EntryId {
     EntryId::new(EntryKind::Invocation, [id; 16])
+}
+
+fn entry_id_from_u64(id: u64) -> EntryId {
+    let mut remainder = [0; EntryId::REMAINDER_LEN];
+    remainder[8..].copy_from_slice(&id.to_be_bytes());
+    EntryId::new(EntryKind::Invocation, remainder)
 }
 
 const TEST_BASE_RUN_AT: u64 = 1_744_000_000_000;
@@ -590,6 +599,82 @@ async fn stage_scan_is_filtered_by_stage(rocksdb: &mut PartitionStore) {
     }
 }
 
+/// Test: Entry-status exact-ID scans stay exact when they cross the multi-get batch size.
+async fn entry_status_scan_batches_large_id_set(rocksdb: &mut PartitionStore) {
+    const NUM_PRESENT_IDS: u64 = 501;
+
+    let partition_key = PartitionKey::from(9_400u64);
+    let qid = VQueueId::custom(partition_key, "status-multi-get-batch");
+    let mut requested_ids = BTreeSet::new();
+    let mut expected_ids = Vec::with_capacity(NUM_PRESENT_IDS as usize);
+
+    {
+        let mut txn = rocksdb.transaction();
+        for index in 0..NUM_PRESENT_IDS {
+            let entry_id = entry_id_from_u64(index);
+            let entry_key = EntryKey::new(false, test_run_at(index), index, entry_id);
+            let stats = EntryStatistics::new(
+                UniqueTimestamp::try_from(10_000u64 + index).unwrap(),
+                entry_key.run_at(),
+            );
+
+            txn.put_vqueue_entry_status(
+                &qid,
+                Stage::Running,
+                &entry_key,
+                &EntryMetadata::default(),
+                stats,
+                Status::Started,
+            );
+
+            requested_ids.insert(VQueueEntryId::Invocation(
+                partition_key,
+                entry_id.to_remainder_bytes(),
+            ));
+            expected_ids.push(entry_id);
+        }
+        txn.commit().await.expect("commit should succeed");
+    }
+
+    let missing_entry_id = entry_id_from_u64(10_000);
+    requested_ids.insert(VQueueEntryId::Invocation(
+        partition_key,
+        missing_entry_id.to_remainder_bytes(),
+    ));
+
+    let rows = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let rows_for_scan = rows.clone();
+    rocksdb
+        .for_each_vqueue_entry_status(
+            ScanEntryIdFilter::EntryIdSet(requested_ids),
+            move |partition_key, entry_id, header| {
+                rows_for_scan
+                    .lock()
+                    .expect("entry-status scan lock should not be poisoned")
+                    .push((partition_key, *entry_id, header.stage, header.status));
+                std::ops::ControlFlow::Continue(())
+            },
+        )
+        .expect("entry-status scan setup should succeed")
+        .await
+        .expect("entry-status scan should succeed");
+
+    let rows = rows
+        .lock()
+        .expect("entry-status scan lock should not be poisoned")
+        .clone();
+    let got_ids = rows
+        .iter()
+        .map(|(_, entry_id, _, _)| *entry_id)
+        .collect::<Vec<_>>();
+
+    assert_eq!(got_ids, expected_ids);
+    assert_eq!(rows.len(), NUM_PRESENT_IDS as usize);
+    assert!(rows.iter().all(|(pk, _, stage, status)| {
+        *pk == partition_key && *stage == Stage::Running && *status == Status::Started
+    }));
+}
+
 pub(crate) async fn run_tests(mut rocksdb: PartitionStore) {
     let mut txn = rocksdb.transaction();
 
@@ -618,6 +703,7 @@ pub(crate) async fn run_tests(mut rocksdb: PartitionStore) {
     verify_waiting_cursor_partition_prefix_boundary_is_respected(db);
 
     stage_scan_is_filtered_by_stage(&mut rocksdb).await;
+    entry_status_scan_batches_large_id_set(&mut rocksdb).await;
     // Snapshot-iterator tests — exercise the contract that a fresh reader
     // sees current storage and that an existing reader holds a fixed view.
     fresh_reader_sees_current_state(&mut rocksdb).await;

--- a/crates/partition-store/src/vqueue_table/entry.rs
+++ b/crates/partition-store/src/vqueue_table/entry.rs
@@ -8,18 +8,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::io::Cursor;
-
-use rocksdb::DBPinnableSlice;
-
-use restate_clock::RoughTimestamp;
-use restate_storage_api::vqueue_table::Status;
-use restate_storage_api::vqueue_table::{
-    EntryKey, EntryMetadata, EntryMetadataRef, EntryStatusHeader, LazyEntryStatus,
-    OwnedEntryStatusHeader, Stage, stats::EntryStatistics,
-};
+use restate_storage_api::vqueue_table::RawStatusHeader;
+use restate_storage_api::vqueue_table::{EntryKey, OwnedEntryStatusHeader};
 use restate_types::identifiers::{InvocationId, PartitionKey, WithPartitionKey};
-use restate_types::vqueues::{EntryId, EntryKind, Seq, VQueueId, VQueueIdRef};
+use restate_types::vqueues::EntryId;
 
 use crate::TableKind;
 use crate::keys::{KeyKind, define_table_key};
@@ -52,55 +44,9 @@ impl From<&InvocationId> for EntryStatusKey {
     }
 }
 
-/// Borrowing version of [`StatusHeaderRaw`].
-///
-/// NOTE: keep in-sync with [`StatusHeaderRaw`]
-#[derive(Clone, bilrost::Message)]
-pub struct StatusHeaderRawRef<'a> {
-    #[bilrost(tag(1))]
-    pub(super) qid: VQueueIdRef<'a>,
-    #[bilrost(tag(2))]
-    pub(super) stage: Stage,
-    #[bilrost(tag(3))]
-    pub(super) has_lock: bool,
-    #[bilrost(tag(4))]
-    pub(super) next_run_at: RoughTimestamp,
-    #[bilrost(tag(5))]
-    pub(super) seq: Seq,
-    #[bilrost(tag(6))]
-    pub(super) metadata: EntryMetadataRef<'a>,
-    // Not borrowed because it's full of numeric values
-    #[bilrost(tag(7))]
-    pub(super) stats: EntryStatistics,
-    #[bilrost(tag(8))]
-    pub(super) status: Status,
-}
-
-#[derive(Debug, Clone, bilrost::Message)]
-pub struct StatusHeaderRaw {
-    #[bilrost(tag(1))]
-    qid: VQueueId,
-    #[bilrost(tag(2))]
-    stage: Stage,
-    #[bilrost(tag(3))]
-    has_lock: bool,
-    #[bilrost(tag(4))]
-    next_run_at: RoughTimestamp,
-    #[bilrost(tag(5))]
-    seq: Seq,
-    /// Entry metadata is lightweight metadata and/or resource information that
-    /// is copied from entry state to the vqueue's inbox entry on each transition.
-    #[bilrost(tag(6))]
-    metadata: EntryMetadata,
-    #[bilrost(tag(7))]
-    stats: EntryStatistics,
-    #[bilrost(tag(8))]
-    status: Status,
-}
-
 pub(super) fn entry_status_header_from_raw(
     entry_id: EntryId,
-    header: StatusHeaderRaw,
+    header: RawStatusHeader,
 ) -> OwnedEntryStatusHeader {
     OwnedEntryStatusHeader::new(
         header.qid,
@@ -112,110 +58,92 @@ pub(super) fn entry_status_header_from_raw(
     )
 }
 
-#[derive(derive_more::Debug)]
-pub struct LazyEntryStatusHolder<'a> {
-    header: OwnedEntryStatusHeader,
-    #[debug(skip)]
-    state_bytes: Cursor<DBPinnableSlice<'a>>,
-}
+#[cfg(test)]
+mod tests {
+    use bytes::BytesMut;
 
-impl<'a> LazyEntryStatusHolder<'a> {
-    pub(crate) fn new(
-        entry_id: EntryId,
-        header: StatusHeaderRaw,
-        state_bytes: Cursor<DBPinnableSlice<'a>>,
-    ) -> Self {
-        Self {
-            header: entry_status_header_from_raw(entry_id, header),
-            state_bytes,
+    use restate_types::vqueues::VQueueEntryId;
+
+    use crate::keys::EncodeTableKeyPrefix;
+
+    use super::*;
+
+    /// Encodes a `VQueueEntryId` exactly the way its `EntryStatusKey` lands on disk:
+    /// `qs | partition_key (u64 BE) | kind (u8) | remainder (16B)`.
+    fn encode(id: VQueueEntryId) -> BytesMut {
+        EntryStatusKey {
+            partition_key: id.partition_key(),
+            id: EntryId::from(id),
+        }
+        .serialize()
+    }
+
+    /// A spread of ids exercising every tier of the comparison:
+    /// - partition keys whose relative order flips under little- vs big-endian,
+    /// - both entry kinds (Invocation = 0x69 < StateMutation = 0x73),
+    /// - remainders differing only in the first vs last byte (bytewise order).
+    fn sample_ids() -> Vec<VQueueEntryId> {
+        let r0 = [0u8; 16];
+        let mut r_first = [0u8; 16];
+        r_first[0] = 1;
+        let mut r_last = [0u8; 16];
+        r_last[15] = 1;
+        let r_max = [0xffu8; 16];
+
+        vec![
+            VQueueEntryId::Invocation(0, r0),
+            VQueueEntryId::StateMutation(0, r0),
+            VQueueEntryId::Invocation(0, r_first),
+            VQueueEntryId::Invocation(0, r_last),
+            VQueueEntryId::Invocation(0, r_max),
+            // partition keys that catch a little-endian mistake:
+            // 0x0000_0000_0000_00ff must sort before 0x0000_0000_0000_ff00.
+            VQueueEntryId::Invocation(0x0000_0000_0000_00ff, r0),
+            VQueueEntryId::Invocation(0x0000_0000_0000_ff00, r0),
+            VQueueEntryId::StateMutation(0x0000_0000_0000_00ff, r_max),
+            VQueueEntryId::Invocation(0xff00_0000_0000_0000, r0),
+            VQueueEntryId::StateMutation(u64::MAX, r0),
+            VQueueEntryId::Invocation(u64::MAX, r_max),
+        ]
+    }
+
+    /// The hand-written `Ord`/`PartialOrd` on `VQueueEntryId` must agree with the
+    /// lexicographic byte ordering of its encoded `EntryStatusKey` for every pair.
+    /// The `qs` kind prefix is identical for all entries, so it doesn't affect the
+    /// relative ordering.
+    #[test]
+    fn ord_matches_encoded_entry_status_key_bytes() {
+        let ids = sample_ids();
+
+        for a in &ids {
+            for b in &ids {
+                let logical = a.cmp(b);
+                let bytewise = encode(*a).as_ref().cmp(encode(*b).as_ref());
+                assert_eq!(
+                    logical, bytewise,
+                    "ordering mismatch between {a:?} and {b:?}: \
+                     VQueueEntryId::cmp = {logical:?} but encoded bytes compare = {bytewise:?}"
+                );
+
+                // PartialOrd must delegate to Ord.
+                assert_eq!(a.partial_cmp(b), Some(logical));
+            }
         }
     }
-}
 
-impl<'a> EntryStatusHeader for LazyEntryStatusHolder<'a> {
-    #[inline]
-    fn vqueue_id(&self) -> &VQueueId {
-        self.header.vqueue_id()
-    }
+    /// Sorting a collection by `VQueueEntryId::Ord` yields the same sequence as
+    /// sorting by the encoded key bytes (RocksDB's on-disk order).
+    #[test]
+    fn sort_order_agrees_with_encoded_bytes() {
+        let mut by_logical = sample_ids();
+        by_logical.sort();
 
-    #[inline]
-    fn entry_id(&self) -> &EntryId {
-        self.header.entry_id()
-    }
+        let mut by_bytes = sample_ids();
+        by_bytes.sort_by(|a, b| encode(*a).as_ref().cmp(encode(*b).as_ref()));
 
-    #[inline]
-    fn entry_key(&self) -> &EntryKey {
-        self.header.entry_key()
-    }
-
-    #[inline]
-    fn kind(&self) -> EntryKind {
-        self.header.kind()
-    }
-
-    #[inline]
-    fn stage(&self) -> Stage {
-        self.header.stage()
-    }
-
-    #[inline]
-    fn seq(&self) -> Seq {
-        self.header.seq()
-    }
-
-    #[inline]
-    fn has_lock(&self) -> bool {
-        self.header.has_lock()
-    }
-
-    #[inline]
-    fn next_run_at(&self) -> RoughTimestamp {
-        self.header.next_run_at()
-    }
-
-    #[inline]
-    fn stats(&self) -> &EntryStatistics {
-        self.header.stats()
-    }
-
-    #[inline]
-    fn metadata(&self) -> &EntryMetadata {
-        self.header.metadata()
-    }
-
-    #[inline]
-    fn status(&self) -> Status {
-        self.header.status()
-    }
-
-    #[inline]
-    fn display_entry_id(&self) -> impl std::fmt::Display + '_ {
-        self.header.display_entry_id()
-    }
-}
-
-impl<'a> LazyEntryStatus for LazyEntryStatusHolder<'a> {
-    fn header(&self) -> &impl EntryStatusHeader {
-        &self.header
-    }
-
-    fn into_header(self) -> impl EntryStatusHeader + Send + Sync + 'static {
-        self.header
-    }
-
-    fn decode_state_owned<E>(&self) -> Option<E>
-    where
-        E: bilrost::OwnedMessage + Send + Sized + 'static,
-    {
-        let buf = self.state_bytes.get_ref();
-        E::decode_length_delimited(&mut buf.as_ref()).ok()
-    }
-
-    fn decode_state_borrowed<'b, E>(&'b self) -> Option<E>
-    where
-        E: bilrost::BorrowedMessage<'b> + Send,
-    {
-        let buf = self.state_bytes.get_ref();
-        E::decode_borrowed_length_delimited(&mut buf.as_ref()).ok()
+        assert_eq!(
+            by_logical, by_bytes,
+            "sorting by VQueueEntryId::Ord disagrees with sorting by encoded key bytes"
+        );
     }
 }

--- a/crates/partition-store/src/vqueue_table/mod.rs
+++ b/crates/partition-store/src/vqueue_table/mod.rs
@@ -17,10 +17,10 @@ mod metadata;
 mod reader;
 mod running_reader;
 
-use std::io::Cursor;
+use std::collections::BTreeSet;
 use std::pin::Pin;
 
-pub use entry::{EntryStatusKey, EntryStatusKeyRef, StatusHeaderRaw};
+pub use entry::{EntryStatusKey, EntryStatusKeyRef};
 pub use inbox::InboxKey;
 pub use input::InputPayloadKey;
 pub use metadata::*;
@@ -28,24 +28,27 @@ pub use metadata::*;
 use anyhow::Context;
 use bilrost::{BorrowedMessage, Message, OwnedMessage};
 use bytes::BytesMut;
+use futures::FutureExt;
 use rocksdb::{DBRawIteratorWithThreadMode, ReadOptions};
 use strum::EnumCount;
 use tracing::error;
 
-use restate_rocksdb::Priority;
+use restate_rocksdb::{Priority, StorageTaskKind};
 use restate_storage_api::StorageError;
+use restate_storage_api::vqueue_table::filters::ScanEntryIdFilter;
 use restate_storage_api::vqueue_table::metadata::{VQueueMeta, VQueueMetaRef};
 use restate_storage_api::vqueue_table::{
-    EntryKey, EntryMetadata, EntryStatusHeader, EntryValue, LazyEntryStatus, ReadVQueueTable,
-    ScanVQueueTable, Stage, Status, WriteVQueueTable, stats::EntryStatistics,
+    EntryKey, EntryMetadata, EntryStatusHeader, EntryValue, ReadVQueueTable, ScanVQueueTable,
+    Stage, Status, WriteVQueueTable, stats::EntryStatistics,
 };
 use restate_storage_api::vqueue_table::{
-    OwnedEntryStatusHeader, ScanVQueueEntries, ScanVQueueEntryStatusTable, ScanVQueueMetaTable,
+    RawStatusHeader, RawStatusHeaderRef, ScanVQueueEntries, ScanVQueueEntryStatusTable,
+    ScanVQueueMetaTable,
 };
 use restate_types::sharding::{KeyRange, PartitionKey};
-use restate_types::vqueues::{EntryId, Seq, VQueueId};
+use restate_types::vqueues::{EntryId, Seq, VQueueEntryId, VQueueId};
 
-use self::entry::{LazyEntryStatusHolder, StatusHeaderRawRef, entry_status_header_from_raw};
+use self::entry::{EntryStatusKeyBuilder, entry_status_header_from_raw};
 use crate::keys::{DecodeTableKey, EncodeTableKey, EncodeTableKeyPrefix, KeyKind};
 use crate::scan::TableScan;
 use crate::vqueue_table::input::InputPayloadKeyRef;
@@ -262,7 +265,7 @@ impl WriteVQueueTable for PartitionStoreTransaction<'_> {
             .id(entry_key.entry_id())
             .serialize_to(&mut key_buffer.as_mut());
 
-        let header = StatusHeaderRawRef {
+        let header = RawStatusHeaderRef {
             qid: qid.into(),
             stage,
             has_lock: entry_key.has_lock(),
@@ -364,61 +367,10 @@ impl ReadVQueueTable for PartitionStoreTransaction<'_> {
             return Ok(None);
         };
 
-        let header = StatusHeaderRaw::decode_length_delimited(&mut raw_value.as_ref())?;
+        let header = RawStatusHeader::decode_length_delimited(&mut raw_value.as_ref())?;
 
         Ok(Some(entry_status_header_from_raw(*id, header)))
     }
-
-    // Currently unused but left for future use
-    async fn get_vqueue_entry_status_lazy<'a>(
-        &'a self,
-        partition_key: PartitionKey,
-        entry_id: &EntryId,
-    ) -> Result<Option<impl LazyEntryStatus + 'a>> {
-        let mut key_buffer = [0u8; EntryStatusKey::serialized_length_fixed()];
-        EntryStatusKeyRef::builder()
-            .partition_key(&partition_key)
-            .id(entry_id)
-            .serialize_to(&mut key_buffer.as_mut());
-
-        let Some(raw_value) = self.get(TableKind::VQueue, key_buffer)? else {
-            return Ok(None);
-        };
-
-        let mut cursor = Cursor::new(raw_value);
-        // The cursor will be advanced by the header size so LazyEntryState
-        // will be positioned to read the state next.
-        let header = StatusHeaderRaw::decode_length_delimited(&mut cursor)?;
-
-        Ok(Some(LazyEntryStatusHolder::new(*entry_id, header, cursor)))
-    }
-
-    // Left intentionally for future reference
-    // async fn get_entry_state<I>(
-    //     &self,
-    //     id: I,
-    // ) -> Result<Option<(impl EntryStatusHeader + 'static, I::State)>>
-    // where
-    //     I: IdentifiesEntry,
-    //     I::State: EntryStatus + bilrost::OwnedMessage + Send + Sized + 'static,
-    // {
-    //     let mut key_buffer = [0u8; EntryStatusKey::serialized_length_fixed()];
-    //     let entry_id = id.to_entry_id();
-    //     EntryStatusKey::builder_ref()
-    //         .partition_key(&id.partition_key())
-    //         .id(&entry_id)
-    //         .serialize_to(&mut key_buffer.as_mut());
-    //
-    //     let Some(raw_value) = self.get(TableKind::VQueue, key_buffer)? else {
-    //         return Ok(None);
-    //     };
-    //
-    //     let mut slice = raw_value.as_ref();
-    //     let header = StatusHeaderRaw::decode_length_delimited(&mut slice)?;
-    //     let state = I::State::decode_length_delimited(&mut slice)?;
-    //
-    //     Ok(Some((OwnedEntryStatusHeader::new(entry_id, header), state)))
-    // }
 
     async fn get_vqueue_input_payload<E>(
         &self,
@@ -477,32 +429,167 @@ impl ScanVQueueMetaTable for PartitionStore {
 impl ScanVQueueEntryStatusTable for PartitionStore {
     fn for_each_vqueue_entry_status<F>(
         &self,
-        range: KeyRange,
+        filter: ScanEntryIdFilter,
         mut f: F,
     ) -> Result<impl Future<Output = Result<()>> + Send>
     where
-        F: for<'a> FnMut(&'a OwnedEntryStatusHeader) -> std::ops::ControlFlow<()>
+        F: for<'a> FnMut(
+                PartitionKey,
+                &'a EntryId,
+                &'a RawStatusHeaderRef<'a>,
+            ) -> std::ops::ControlFlow<()>
             + Send
             + Sync
             + 'static,
     {
-        self.iterator_for_each(
-            "df-vqueue-entry-status",
-            Priority::Low,
-            TableScan::ScanPartitionKeyRange::<EntryStatusKey>(range),
-            move |(mut key, mut value)| {
-                let status_key = break_on_err(EntryStatusKey::deserialize_from(&mut key))?;
-                let (_, entry_id) = status_key.split();
-                let header = break_on_err(
-                    StatusHeaderRaw::decode_length_delimited(&mut value)
-                        .map_err(StorageError::BilrostDecode),
-                )?;
-                let header = entry_status_header_from_raw(entry_id, header);
+        if let ScanEntryIdFilter::EntryIdSet(ids) = filter {
+            return Ok(multi_get_vqueue_entry_status(self, ids, f).boxed());
+        }
 
-                f(&header).map_break(Ok)
-            },
-        )
-        .map_err(|_| StorageError::OperationalError)
+        let scan = match filter {
+            ScanEntryIdFilter::PartitionKey(range) => {
+                TableScan::ScanPartitionKeyRange::<EntryStatusKeyBuilder>(range)
+            }
+            ScanEntryIdFilter::EntryIdRange(range) => {
+                let start_partition_key = range.start.partition_key();
+                let end_partition_key = range.last.partition_key();
+                let start = EntryStatusKey::builder()
+                    .partition_key(start_partition_key)
+                    .id(range.start.into());
+
+                let end = EntryStatusKey::builder()
+                    .partition_key(end_partition_key)
+                    .id(range.last.into());
+
+                TableScan::RangeInclusive(start, end)
+            }
+            ScanEntryIdFilter::EntryIdSet(_) => unreachable!("handled above"),
+        };
+
+        let scan_fut = self
+            .iterator_for_each(
+                "df-vqueue-entry-status",
+                Priority::Low,
+                scan,
+                move |(mut key, mut value)| {
+                    let status_key = break_on_err(EntryStatusKey::deserialize_from(&mut key))?;
+                    let (partition_key, entry_id) = status_key.split();
+                    let header = break_on_err(
+                        RawStatusHeaderRef::decode_borrowed_length_delimited(&mut value)
+                            .map_err(StorageError::BilrostDecode),
+                    )?;
+
+                    f(partition_key, &entry_id, &header).map_break(Ok)
+                },
+            )
+            .map_err(|_| StorageError::OperationalError)?;
+
+        Ok(scan_fut.boxed())
+    }
+}
+
+/// Maximum number of entry-status keys passed to one RocksDB multi-get call.
+const ENTRY_STATUS_MULTI_GET_BATCH_SIZE: usize = 500;
+
+fn multi_get_vqueue_entry_status<F>(
+    store: &PartitionStore,
+    ids: BTreeSet<VQueueEntryId>,
+    mut f: F,
+) -> impl Future<Output = Result<()>> + Send
+where
+    F: for<'a> FnMut(
+            PartitionKey,
+            &'a EntryId,
+            &'a RawStatusHeaderRef<'a>,
+        ) -> std::ops::ControlFlow<()>
+        + Send
+        + Sync
+        + 'static,
+{
+    const KEY_LEN: usize = EntryStatusKey::serialized_length_fixed();
+
+    let rocksdb = store.partition_db().rocksdb().clone();
+    let cf_name: restate_rocksdb::CfName = store.partition_db().partition().cf_name().into();
+
+    async move {
+        rocksdb
+            .run_background_read_op(
+                "df-vqueue-entry-status",
+                StorageTaskKind::MultiGet,
+                Priority::Low,
+                move |raw_db| -> Result<()> {
+                    let Some(cf) = raw_db.cf_handle(cf_name.as_str()) else {
+                        return Err(StorageError::Generic(anyhow::anyhow!(
+                            "column family {cf_name} not found for vqueue entry-status multi-get"
+                        )));
+                    };
+
+                    let batch_capacity = ids.len().min(ENTRY_STATUS_MULTI_GET_BATCH_SIZE);
+                    let mut key_buf = BytesMut::with_capacity(batch_capacity * KEY_LEN);
+                    let mut batch_ids = Vec::with_capacity(batch_capacity);
+
+                    let mut readopts = ReadOptions::default();
+                    // future proofing to make use of parallel L0 reads and async-io
+                    // if/when we build rocksdb with COROUTINES=1 and IO-URING support.
+                    // by default, this will not do anything.
+                    readopts.set_async_io(true);
+                    readopts.set_optimize_multiget_for_io(true);
+
+                    let mut ids = ids.into_iter();
+                    loop {
+                        key_buf.clear();
+                        batch_ids.clear();
+
+                        for id in ids.by_ref().take(ENTRY_STATUS_MULTI_GET_BATCH_SIZE) {
+                            EncodeTableKey::serialize_to(
+                                &EntryStatusKey {
+                                    partition_key: id.partition_key(),
+                                    id: EntryId::from(id),
+                                },
+                                &mut key_buf,
+                            );
+                            batch_ids.push(id);
+                        }
+
+                        if batch_ids.is_empty() {
+                            break;
+                        }
+
+                        let results = raw_db.batched_multi_get_cf_opt(
+                            &cf,
+                            key_buf.chunks_exact(KEY_LEN),
+                            true,
+                            &readopts,
+                        );
+
+                        for (id, result) in batch_ids.iter().zip(results) {
+                            let Some(value) =
+                                result.map_err(|e| StorageError::Generic(e.into()))?
+                            else {
+                                continue;
+                            };
+
+                            let entry_id = EntryId::from(*id);
+                            let mut value = value.as_ref();
+                            let header =
+                                RawStatusHeaderRef::decode_borrowed_length_delimited(&mut value)
+                                    .map_err(StorageError::BilrostDecode)?;
+
+                            if f(id.partition_key(), &entry_id, &header).is_break() {
+                                return Ok(());
+                            }
+                        }
+
+                        if batch_ids.len() < ENTRY_STATUS_MULTI_GET_BATCH_SIZE {
+                            break;
+                        }
+                    }
+
+                    Ok(())
+                },
+            )
+            .await
+            .map_err(|_| StorageError::OperationalError)?
     }
 }
 

--- a/crates/storage-api/src/vqueue_table/entry.rs
+++ b/crates/storage-api/src/vqueue_table/entry.rs
@@ -187,9 +187,10 @@ impl EntryValue {
 }
 
 #[derive(Debug, Clone, Eq, Default, PartialEq, bilrost::Message)]
+#[non_exhaustive]
 pub struct EntryMetadataRef<'a> {
     #[bilrost(tag(1))]
-    deployment: Option<&'a str>,
+    pub deployment: Option<&'a str>,
     // If set, this is the amount of memory the invocation seems to require to
     // run on the invoker side.
     #[bilrost(tag(2), encoding(fixed))]

--- a/crates/storage-api/src/vqueue_table/entry_status.rs
+++ b/crates/storage-api/src/vqueue_table/entry_status.rs
@@ -9,10 +9,10 @@
 // by the Apache License, Version 2.0.
 
 use restate_clock::RoughTimestamp;
-use restate_types::vqueues::{EntryId, EntryKind, Seq, VQueueId};
+use restate_types::vqueues::{EntryId, EntryKind, Seq, VQueueId, VQueueIdRef};
 
 use super::stats::EntryStatistics;
-use super::{EntryKey, EntryMetadata, Stage};
+use super::{EntryKey, EntryMetadata, EntryMetadataRef, Stage};
 
 #[derive(Debug, strum::Display, Clone, Copy, Eq, PartialEq, bilrost::Enumeration)]
 #[strum(serialize_all = "kebab-case")]
@@ -47,6 +47,52 @@ pub enum Status {
     Failed,
     #[bilrost(9)]
     Succeeded,
+}
+
+/// Borrowing version of [`RawStatusHeader`].
+///
+/// NOTE: keep in-sync with [`RawStatusHeader`]
+#[derive(Clone, bilrost::Message)]
+pub struct RawStatusHeaderRef<'a> {
+    #[bilrost(tag(1))]
+    pub qid: VQueueIdRef<'a>,
+    #[bilrost(tag(2))]
+    pub stage: Stage,
+    #[bilrost(tag(3))]
+    pub has_lock: bool,
+    #[bilrost(tag(4))]
+    pub next_run_at: RoughTimestamp,
+    #[bilrost(tag(5))]
+    pub seq: Seq,
+    #[bilrost(tag(6))]
+    pub metadata: EntryMetadataRef<'a>,
+    // Not borrowed because it's full of numeric values
+    #[bilrost(tag(7))]
+    pub stats: EntryStatistics,
+    #[bilrost(tag(8))]
+    pub status: Status,
+}
+
+#[derive(Debug, Clone, bilrost::Message)]
+pub struct RawStatusHeader {
+    #[bilrost(tag(1))]
+    pub qid: VQueueId,
+    #[bilrost(tag(2))]
+    pub stage: Stage,
+    #[bilrost(tag(3))]
+    pub has_lock: bool,
+    #[bilrost(tag(4))]
+    pub next_run_at: RoughTimestamp,
+    #[bilrost(tag(5))]
+    pub seq: Seq,
+    /// Entry metadata is lightweight metadata and/or resource information that
+    /// is copied from entry state to the vqueue's inbox entry on each transition.
+    #[bilrost(tag(6))]
+    pub metadata: EntryMetadata,
+    #[bilrost(tag(7))]
+    pub stats: EntryStatistics,
+    #[bilrost(tag(8))]
+    pub status: Status,
 }
 
 /// Owned vqueue entry status header.

--- a/crates/storage-api/src/vqueue_table/filters.rs
+++ b/crates/storage-api/src/vqueue_table/filters.rs
@@ -1,0 +1,25 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeSet;
+use std::range::RangeInclusive;
+
+use restate_sharding::KeyRange;
+use restate_types::vqueues::VQueueEntryId;
+
+/// Filter vqueue entries by partition keys, entry ID range, or an exact set of entry IDs.
+#[derive(Debug, Clone)]
+pub enum ScanEntryIdFilter {
+    PartitionKey(KeyRange),
+    EntryIdRange(RangeInclusive<VQueueEntryId>),
+    /// A known set of entry IDs served via batched multi-get calls instead of a
+    /// range scan. The set is sorted in on-disk key order.
+    EntryIdSet(BTreeSet<VQueueEntryId>),
+}

--- a/crates/storage-api/src/vqueue_table/mod.rs
+++ b/crates/storage-api/src/vqueue_table/mod.rs
@@ -10,6 +10,7 @@
 
 mod entry;
 mod entry_status;
+pub mod filters;
 pub mod metadata;
 pub mod scheduler;
 pub mod stats;

--- a/crates/storage-api/src/vqueue_table/tables.rs
+++ b/crates/storage-api/src/vqueue_table/tables.rs
@@ -11,12 +11,12 @@
 use restate_sharding::{KeyRange, PartitionKey};
 use restate_types::vqueues::{Seq, VQueueId};
 
-use super::Status;
+use super::filters::ScanEntryIdFilter;
 use super::metadata::{VQueueMeta, VQueueMetaRef};
 use super::{
-    EntryId, EntryKey, EntryMetadata, EntryStatusHeader, EntryValue, LazyEntryStatus,
-    OwnedEntryStatusHeader, stats::EntryStatistics,
+    EntryId, EntryKey, EntryMetadata, EntryStatusHeader, EntryValue, stats::EntryStatistics,
 };
+use super::{RawStatusHeaderRef, Status};
 use crate::Result;
 
 /// Stages in the inbox/vqueue
@@ -205,12 +205,12 @@ pub trait ReadVQueueTable {
         id: &EntryId,
     ) -> impl Future<Output = Result<Option<impl EntryStatusHeader + 'static>>>;
 
-    /// Get the entry state for a vqueue entry by id
-    fn get_vqueue_entry_status_lazy<'a>(
-        &'a self,
-        partition_key: PartitionKey,
-        entry_id: &EntryId,
-    ) -> impl Future<Output = Result<Option<impl LazyEntryStatus + 'a>>>;
+    // /// Get the entry state for a vqueue entry by id
+    // fn get_vqueue_entry_status_lazy<'a>(
+    //     &'a self,
+    //     partition_key: PartitionKey,
+    //     entry_id: &EntryId,
+    // ) -> impl Future<Output = Result<Option<impl LazyEntryStatus + 'a>>>;
 
     // Left intentionally for future reference
     // fn get_entry_state<I>(
@@ -290,11 +290,15 @@ pub trait ScanVQueueEntryStatusTable {
     /// Used for data-fusion queries.
     fn for_each_vqueue_entry_status<F>(
         &self,
-        range: KeyRange,
+        filter: ScanEntryIdFilter,
         f: F,
     ) -> Result<impl Future<Output = Result<()>> + Send>
     where
-        F: for<'a> FnMut(&'a OwnedEntryStatusHeader) -> std::ops::ControlFlow<()>
+        F: for<'a> FnMut(
+                PartitionKey,
+                &'a EntryId,
+                &'a RawStatusHeaderRef<'a>,
+            ) -> std::ops::ControlFlow<()>
             + Send
             + Sync
             + 'static;

--- a/crates/storage-query-datafusion/src/filter.rs
+++ b/crates/storage-query-datafusion/src/filter.rs
@@ -26,10 +26,9 @@ use strum::EnumCount;
 use restate_storage_api::vqueue_table::Stage;
 use restate_types::PartitionedResourceId;
 use restate_types::identifiers::partitioner::HashPartitioner;
-use restate_types::identifiers::{
-    InvocationId, PartitionKey, ResourceId, StateMutationId, WithPartitionKey,
-};
+use restate_types::identifiers::{InvocationId, PartitionKey, ResourceId, WithPartitionKey};
 use restate_types::sharding::KeyRange;
+use restate_types::vqueues::VQueueEntryId;
 
 use crate::partition_store_scanner::ScanLocalPartitionFilter;
 
@@ -187,23 +186,36 @@ impl FirstMatchingPartitionKeyExtractor {
     }
 
     pub fn with_vqueue_entry_id(self, column_name: impl Into<String>) -> Self {
-        let e = MatchingColumnExtractor::new(column_name, |value: &ScalarValue| {
+        self.append(Self::create_vqueue_entry_id_partition_key_extractor(
+            column_name,
+        ))
+    }
+
+    /// Adds a vqueue-entry-id extractor whose matches are grouped into a single
+    /// scan per Restate partition.
+    ///
+    /// Only use this when the table's scanner re-fetches each entry id exactly
+    /// via an exact-id filter; range-scanning tables would read every
+    /// intermediate key.
+    pub fn with_grouped_vqueue_entry_id(self, column_name: impl Into<String>) -> Self {
+        self.append_with_fanout(
+            Self::create_vqueue_entry_id_partition_key_extractor(column_name),
+            PointReadFanout::PerPartition,
+        )
+    }
+
+    fn create_vqueue_entry_id_partition_key_extractor(
+        column_name: impl Into<String>,
+    ) -> MatchingColumnExtractor<fn(&ScalarValue) -> anyhow::Result<PartitionKey>> {
+        MatchingColumnExtractor::new(column_name, |value: &ScalarValue| {
             let value = value
                 .try_as_str()
                 .context("expected string entry id")?
                 .context("unexpected null entry id")?;
 
-            if let Ok(invocation_id) = InvocationId::from_str(value) {
-                return Ok(invocation_id.partition_key());
-            }
-
-            if let Ok(state_mutation_id) = StateMutationId::from_str(value) {
-                return Ok(WithPartitionKey::partition_key(&state_mutation_id));
-            }
-
-            anyhow::bail!("non valid entry id")
-        });
-        self.append(e)
+            VQueueEntryId::extract_partition_key(value)
+                .map_err(|_| anyhow::anyhow!("non valid entry id"))
+        })
     }
 
     pub fn append(self, extractor: impl PartitionKeyExtractor) -> Self {
@@ -597,9 +609,40 @@ where
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct VQueueEntryIdFilter {
+    pub partition_keys: KeyRange,
+    pub entry_ids: Option<IdSelection<VQueueEntryId>>,
+}
+
+impl ScanLocalPartitionFilter for VQueueEntryIdFilter {
+    fn new(range: KeyRange, predicate: Option<Arc<dyn PhysicalExpr>>) -> Self {
+        if let Some(predicate) = predicate
+            && let Ok(predicate) = snapshot_physical_expr(predicate)
+        {
+            for conjunct in split_conjunction(&predicate) {
+                if let Some(entry_ids) =
+                    parse_id_selection("entry_id", range, conjunct, VQueueEntryId::partition_key)
+                {
+                    return Self {
+                        partition_keys: range,
+                        entry_ids: Some(entry_ids),
+                    };
+                }
+            }
+        }
+
+        Self {
+            partition_keys: range,
+            entry_ids: None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
+    use std::str::FromStr;
     use std::sync::Arc;
 
     use datafusion::common::ScalarValue;
@@ -612,9 +655,11 @@ mod tests {
     use restate_types::identifiers::{InvocationId, ServiceId, StateMutationId, WithPartitionKey};
     use restate_types::invocation::{InvocationTarget, VirtualObjectHandlerType};
     use restate_types::sharding::KeyRange;
+    use restate_types::vqueues::VQueueEntryId;
 
     use crate::filter::{
-        FirstMatchingPartitionKeyExtractor, InvocationIdFilter, PartitionKeyExtractor, VQueueFilter,
+        FirstMatchingPartitionKeyExtractor, InvocationIdFilter, PartitionKeyExtractor,
+        VQueueEntryIdFilter, VQueueFilter,
     };
     use crate::partition_store_scanner::ScanLocalPartitionFilter;
 
@@ -1138,6 +1183,76 @@ mod tests {
         );
 
         assert!(filter.invocation_ids.is_none());
+    }
+
+    #[test]
+    fn vqueue_entry_id_filter_set_from_in_list() {
+        let id1 = make_invocation_id("key-1");
+        let id2 = make_invocation_id("key-2");
+        let predicate = in_list(
+            "entry_id",
+            vec![utf8_lit(id1.to_string()), utf8_lit(id2.to_string())],
+        );
+
+        let filter = VQueueEntryIdFilter::new(FULL_RANGE, Some(predicate));
+
+        let expected1 = VQueueEntryId::from_str(&id1.to_string()).unwrap();
+        let expected2 = VQueueEntryId::from_str(&id2.to_string()).unwrap();
+        let selection = filter.entry_ids.expect("should extract entry-id set");
+        assert_eq!(selection.ids.len(), 2);
+        assert!(selection.ids.contains(&expected1));
+        assert!(selection.ids.contains(&expected2));
+    }
+
+    #[test]
+    fn vqueue_entry_id_filter_keeps_large_in_list_as_set() {
+        let invocation_ids = (0..501)
+            .map(|id| make_invocation_id(&format!("key-{id}")))
+            .collect::<Vec<_>>();
+        let predicate = in_list(
+            "entry_id",
+            invocation_ids
+                .iter()
+                .map(|id| utf8_lit(id.to_string()))
+                .collect(),
+        );
+
+        let filter = VQueueEntryIdFilter::new(FULL_RANGE, Some(predicate));
+
+        let selection = filter.entry_ids.expect("should extract entry-id set");
+        assert_eq!(selection.ids.len(), invocation_ids.len());
+        for invocation_id in invocation_ids {
+            let expected = VQueueEntryId::from_str(&invocation_id.to_string()).unwrap();
+            assert!(selection.ids.contains(&expected));
+        }
+    }
+
+    #[test]
+    fn vqueue_entry_id_filter_excludes_out_of_range() {
+        let id = make_invocation_id("key-1");
+        let entry_id = VQueueEntryId::from_str(&id.to_string()).unwrap();
+        let pk = entry_id.partition_key();
+        let narrow_range = if pk > 0 {
+            KeyRange::new(0, pk - 1)
+        } else {
+            KeyRange::new(1, 1)
+        };
+
+        let predicate = eq(col("entry_id"), utf8_lit(id.to_string()));
+        let filter = VQueueEntryIdFilter::new(narrow_range, Some(predicate));
+
+        assert!(filter.entry_ids.is_none());
+    }
+
+    #[test]
+    fn vqueue_entry_id_filter_rejects_negated_in_list() {
+        let id = make_invocation_id("key-1");
+        let filter = VQueueEntryIdFilter::new(
+            FULL_RANGE,
+            Some(not_in_list("entry_id", vec![utf8_lit(id.to_string())])),
+        );
+
+        assert!(filter.entry_ids.is_none());
     }
 
     #[test]

--- a/crates/storage-query-datafusion/src/vqueue_entry_status/row.rs
+++ b/crates/storage-query-datafusion/src/vqueue_entry_status/row.rs
@@ -8,46 +8,52 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use restate_storage_api::vqueue_table::EntryStatusHeader;
+use restate_sharding::PartitionKey;
+use restate_storage_api::vqueue_table::RawStatusHeaderRef;
+use restate_types::vqueues::EntryId;
 
 use super::schema::SysVqueueEntryStatusBuilder;
 
 #[inline]
 pub(crate) fn append_vqueue_entry_status_row(
     builder: &mut SysVqueueEntryStatusBuilder,
-    header: &impl EntryStatusHeader,
+    partition_key: PartitionKey,
+    entry_id: &EntryId,
+    header: &RawStatusHeaderRef<'_>,
 ) {
+    let stats = &header.stats;
+    let metadata = &header.metadata;
+
     let mut row = builder.row();
 
-    let qid = header.vqueue_id();
-    let stats = header.stats();
-    let metadata = header.metadata();
+    if row.is_partition_key_defined() {
+        row.partition_key(partition_key);
+    }
 
-    row.partition_key(qid.partition_key());
     if row.is_entry_id_defined() {
-        row.fmt_entry_id(header.display_entry_id());
+        row.fmt_entry_id(entry_id.display(partition_key));
     }
     if row.is_vqueue_id_defined() {
-        row.fmt_vqueue_id(qid);
+        row.fmt_vqueue_id(&header.qid);
     }
     if row.is_stage_defined() {
-        row.fmt_stage(header.stage());
+        row.fmt_stage(header.stage);
     }
     if row.is_status_defined() {
-        row.fmt_status(header.status());
+        row.fmt_status(header.status);
     }
     if row.is_has_lock_defined() {
-        row.has_lock(header.has_lock());
+        row.has_lock(header.has_lock);
     }
     if row.is_next_at_defined() {
-        row.next_at(header.next_run_at().as_unix_millis().as_u64() as i64);
+        row.next_at(header.next_run_at.as_unix_millis().as_u64() as i64);
     }
     if row.is_sequence_number_defined() {
-        row.sequence_number(header.seq().as_u64());
+        row.sequence_number(header.seq.as_u64());
     }
 
     if row.is_entry_kind_defined() {
-        row.fmt_entry_kind(header.kind());
+        row.fmt_entry_kind(entry_id.kind());
     }
 
     if row.is_created_at_defined() {
@@ -95,7 +101,7 @@ pub(crate) fn append_vqueue_entry_status_row(
     }
 
     if row.is_deployment_defined()
-        && let Some(deployment) = &metadata.deployment
+        && let Some(deployment) = metadata.deployment
     {
         row.fmt_deployment(deployment);
     }

--- a/crates/storage-query-datafusion/src/vqueue_entry_status/schema.rs
+++ b/crates/storage-query-datafusion/src/vqueue_entry_status/schema.rs
@@ -8,9 +8,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::table_macro::*;
-
 use datafusion::arrow::datatypes::DataType;
+
+use crate::table_macro::*;
 
 define_sort_order!(sys_vqueue_entry_status(partition_key));
 

--- a/crates/storage-query-datafusion/src/vqueue_entry_status/table.rs
+++ b/crates/storage-query-datafusion/src/vqueue_entry_status/table.rs
@@ -13,15 +13,17 @@ use std::ops::ControlFlow;
 use std::sync::Arc;
 
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
-use restate_sharding::KeyRange;
+use restate_sharding::PartitionKey;
 use restate_storage_api::StorageError;
-use restate_storage_api::vqueue_table::{OwnedEntryStatusHeader, ScanVQueueEntryStatusTable};
-use restate_types::vqueues::VQueueId;
+use restate_storage_api::vqueue_table::filters::ScanEntryIdFilter;
+use restate_storage_api::vqueue_table::{RawStatusHeaderRef, ScanVQueueEntryStatusTable};
+use restate_types::vqueues::{EntryId, VQueueId};
 
 use crate::context::{QueryContext, SelectPartitions};
-use crate::filter::FirstMatchingPartitionKeyExtractor;
+use crate::filter::{FirstMatchingPartitionKeyExtractor, VQueueEntryIdFilter};
 use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
 use crate::remote_query_scanner_manager::RemoteScannerManager;
+use crate::statistics::{DEPLOYMENT_ROW_ESTIMATE, RowEstimate, TableStatisticsBuilder};
 use crate::table_providers::{PartitionedTableProvider, ScanPartition};
 use crate::vqueue_entry_status::row::append_vqueue_entry_status_row;
 use crate::vqueue_entry_status::schema::{
@@ -41,15 +43,27 @@ pub(crate) fn register_self(
         VQueueEntryStatusScanner,
     )) as Arc<dyn ScanPartition>;
 
+    let schema = SysVqueueEntryStatusBuilder::schema();
+
+    let statistics = TableStatisticsBuilder::new(schema.clone())
+        .with_num_rows_estimate(RowEstimate::Large)
+        .with_partition_key()
+        .with_primary_key("entry_id")
+        .with_foreign_key("deployment", DEPLOYMENT_ROW_ESTIMATE)
+        // This can be wrong in some rare cases, but the assumption is that
+        // the number of vqueue entries is bigger than the number of vqueues
+        .with_foreign_key("vqueue_id", RowEstimate::Small);
+
     let table = PartitionedTableProvider::new(
         partition_selector,
-        SysVqueueEntryStatusBuilder::schema(),
+        schema,
         sys_vqueue_entry_status_sort_order(),
         remote_scanner_manager.create_distributed_scanner(NAME, local_scanner),
         FirstMatchingPartitionKeyExtractor::default()
-            .with_vqueue_entry_id("entry_id")
+            .with_grouped_vqueue_entry_id("entry_id")
             .with_partitioned_resource_id::<VQueueId>("vqueue_id"),
-    );
+    )
+    .with_statistics(statistics.build());
 
     ctx.register_partitioned_table(NAME, Arc::new(table))
 }
@@ -59,9 +73,9 @@ struct VQueueEntryStatusScanner;
 
 impl ScanLocalPartition for VQueueEntryStatusScanner {
     type Builder = SysVqueueEntryStatusBuilder;
-    type Item<'a> = &'a OwnedEntryStatusHeader;
+    type Item<'a> = (PartitionKey, &'a EntryId, &'a RawStatusHeaderRef<'a>);
     type ConversionError = std::convert::Infallible;
-    type Filter = KeyRange;
+    type Filter = VQueueEntryIdFilter;
 
     fn for_each_row<
         F: for<'a> FnMut(Self::Item<'a>) -> ControlFlow<Result<(), Self::ConversionError>>
@@ -70,18 +84,31 @@ impl ScanLocalPartition for VQueueEntryStatusScanner {
             + 'static,
     >(
         partition_store: &PartitionStore,
-        range: KeyRange,
+        filter: VQueueEntryIdFilter,
         mut f: F,
     ) -> Result<impl Future<Output = restate_storage_api::Result<()>> + Send, StorageError> {
-        partition_store
-            .for_each_vqueue_entry_status(range, move |item| f(item).map_break(Result::unwrap))
+        partition_store.for_each_vqueue_entry_status(
+            filter.into(),
+            move |partition_key, entry_id, header| {
+                f((partition_key, entry_id, header)).map_break(Result::unwrap)
+            },
+        )
     }
 
     fn append_row<'a>(
         row_builder: &mut Self::Builder,
-        header: Self::Item<'a>,
+        (partition_key, entry_id, header): Self::Item<'a>,
     ) -> Result<(), Self::ConversionError> {
-        append_vqueue_entry_status_row(row_builder, header);
+        append_vqueue_entry_status_row(row_builder, partition_key, entry_id, header);
         Ok(())
+    }
+}
+
+impl From<VQueueEntryIdFilter> for ScanEntryIdFilter {
+    fn from(value: VQueueEntryIdFilter) -> Self {
+        match value.entry_ids {
+            Some(selection) => ScanEntryIdFilter::EntryIdSet(selection.ids),
+            None => ScanEntryIdFilter::PartitionKey(value.partition_keys),
+        }
     }
 }

--- a/crates/storage-query-datafusion/src/vqueue_entry_status/tests.rs
+++ b/crates/storage-query-datafusion/src/vqueue_entry_status/tests.rs
@@ -33,6 +33,82 @@ use crate::mocks::*;
 use crate::row;
 
 #[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
+async fn vqueue_entry_status_not_in_returns_non_excluded_rows() {
+    use datafusion::arrow::array::Array;
+
+    let mut engine = MockQueryEngine::create().await;
+    let qid = VQueueId::custom(3337, "df-vqueue-not-in");
+
+    let created_at =
+        UniqueTimestamp::try_from_unix_millis(MillisSinceEpoch::new(1_744_010_000_000)).unwrap();
+    let metadata = EntryMetadata {
+        deployment: None,
+        needed_memory: None,
+        retry_attempts: 0,
+        retry_count_since_last_stored_command: 0,
+    };
+
+    let mut ids = Vec::new();
+    let mut tx = engine.partition_store().transaction();
+    for i in 1..=6u8 {
+        let entry_id = EntryId::new(EntryKind::Invocation, [i; 16]);
+        let key = EntryKey::new(
+            false,
+            MillisSinceEpoch::new(1_744_010_000_000),
+            i as u64,
+            entry_id,
+        );
+        let stats = EntryStatistics::new(created_at, key.run_at());
+        tx.put_vqueue_entry_status(
+            &qid,
+            Stage::Running,
+            &key,
+            &metadata,
+            stats,
+            Status::Started,
+        );
+        ids.push(key.entry_id().display(qid.partition_key()).to_string());
+    }
+    tx.commit().await.unwrap();
+    drop(tx);
+
+    let excluded = ids[0..4]
+        .iter()
+        .map(|id| format!("'{id}'"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let records = engine
+        .execute(format!(
+            "SELECT entry_id FROM sys_vqueue_entry_status \
+             WHERE entry_id NOT IN ({excluded})"
+        ))
+        .await
+        .unwrap()
+        .stream
+        .collect::<Vec<datafusion::common::Result<RecordBatch>>>()
+        .await
+        .remove(0)
+        .unwrap();
+
+    let mut got: Vec<String> = records
+        .column_by_name("entry_id")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<LargeStringArray>()
+        .unwrap()
+        .iter()
+        .flatten()
+        .map(str::to_string)
+        .collect();
+    got.sort();
+
+    let mut expected = vec![ids[4].clone(), ids[5].clone()];
+    expected.sort();
+
+    assert_eq!(got, expected);
+}
+
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_vqueue_entry_status_header_fields() {
     let mut engine = MockQueryEngine::create().await;
 

--- a/crates/types/src/identifiers.rs
+++ b/crates/types/src/identifiers.rs
@@ -385,6 +385,11 @@ impl FromStr for InvocationUuid {
 
         // ulid (u128)
         let raw_ulid: u128 = decoder.cursor.decode_next()?;
+
+        if decoder.cursor.remaining() != 0 {
+            return Err(IdDecodeError::Length);
+        }
+
         Ok(Self::from(raw_ulid))
     }
 }
@@ -743,6 +748,11 @@ impl FromStr for InvocationId {
         // ulid (u128)
         let raw_ulid: u128 = decoder.cursor.decode_next()?;
         let inner = InvocationUuid::from(raw_ulid);
+
+        if decoder.cursor.remaining() != 0 {
+            return Err(IdDecodeError::Length);
+        }
+
         Ok(Self {
             partition_key,
             inner,

--- a/crates/types/src/vqueues.rs
+++ b/crates/types/src/vqueues.rs
@@ -12,7 +12,7 @@ mod entry_id;
 mod seq;
 mod vqueue_id;
 
-pub use entry_id::{EntryId, EntryIdDisplay, EntryKind};
+pub use entry_id::{EntryId, EntryIdDisplay, EntryKind, VQueueEntryId};
 pub use seq::Seq;
 pub use vqueue_id::{VQueueId, VQueueIdRef};
 

--- a/crates/types/src/vqueues/entry_id.rs
+++ b/crates/types/src/vqueues/entry_id.rs
@@ -8,12 +8,135 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::identifiers::{InvocationId, InvocationUuid, PartitionKey, StateMutationId};
+use std::str::FromStr;
+
+use crate::errors::IdDecodeError;
+use crate::id_util::{IdDecoder, IdEncoder};
+use crate::identifiers::{InvocationId, InvocationUuid, PartitionKey, ResourceId, StateMutationId};
 
 use super::ParseError;
 
 /// The length of the remainder bytes of an entry id.
 const REMAINDER_LEN: usize = 16;
+
+/// Identifiers that can be used as entry ids in vqueues.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub enum VQueueEntryId {
+    Invocation(PartitionKey, [u8; REMAINDER_LEN]),
+    StateMutation(PartitionKey, [u8; REMAINDER_LEN]),
+}
+
+impl VQueueEntryId {
+    pub fn partition_key(&self) -> PartitionKey {
+        match self {
+            Self::Invocation(partition_key, _) => *partition_key,
+            Self::StateMutation(partition_key, _) => *partition_key,
+        }
+    }
+
+    pub fn kind(&self) -> EntryKind {
+        match self {
+            Self::Invocation(_, _) => EntryKind::Invocation,
+            Self::StateMutation(_, _) => EntryKind::StateMutation,
+        }
+    }
+
+    pub fn remainder(&self) -> &[u8; REMAINDER_LEN] {
+        match self {
+            Self::Invocation(_, remainder) => remainder,
+            Self::StateMutation(_, remainder) => remainder,
+        }
+    }
+
+    pub fn into_remainder(self) -> [u8; REMAINDER_LEN] {
+        match self {
+            Self::Invocation(_, remainder) => remainder,
+            Self::StateMutation(_, remainder) => remainder,
+        }
+    }
+
+    /// Extracts the partition key if the entry ids are of a valid type
+    pub fn extract_partition_key(encoded: &str) -> Result<PartitionKey, IdDecodeError> {
+        let mut decoder = IdDecoder::new(encoded)?;
+        match decoder.resource_type {
+            InvocationId::RESOURCE_TYPE | StateMutationId::RESOURCE_TYPE => {
+                decoder.cursor.decode_next::<u64>()
+            }
+            _ => Err(IdDecodeError::TypeMismatch),
+        }
+    }
+}
+
+// It's critical that this matches the memory ordering of the EntryStatusKey
+// That is, the partition key is matched first, then the entry kind (as u8)
+// then the remainder (bytewise)
+impl PartialOrd for VQueueEntryId {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for VQueueEntryId {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.partition_key()
+            .cmp(&other.partition_key())
+            .then_with(|| self.kind().cmp(&other.kind()))
+            .then_with(|| self.remainder().cmp(other.remainder()))
+    }
+}
+
+impl FromStr for VQueueEntryId {
+    type Err = IdDecodeError;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let mut decoder = IdDecoder::new(input)?;
+        // Ensure we are decoding the right type
+        match decoder.resource_type {
+            InvocationId::RESOURCE_TYPE => {
+                let partition_key: PartitionKey = decoder.cursor.decode_next()?;
+                let raw: [u8; REMAINDER_LEN] = decoder.cursor.decode_next::<u128>()?.to_be_bytes();
+                Ok(Self::Invocation(partition_key, raw))
+            }
+            StateMutationId::RESOURCE_TYPE => {
+                let partition_key: PartitionKey = decoder.cursor.decode_next()?;
+                let raw: [u8; REMAINDER_LEN] = decoder.cursor.decode_next::<u128>()?.to_be_bytes();
+                Ok(Self::StateMutation(partition_key, raw))
+            }
+            _ => Err(IdDecodeError::TypeMismatch),
+        }
+    }
+}
+
+impl std::fmt::Display for VQueueEntryId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Invocation(partition_key, remainder) => {
+                let mut encoder = IdEncoder::<InvocationId>::new();
+                encoder.push_u64(*partition_key);
+                encoder.push_u128(u128::from_be_bytes(*remainder));
+                f.write_str(encoder.as_str())
+            }
+            Self::StateMutation(partition_key, remainder) => {
+                let mut encoder = IdEncoder::<StateMutationId>::new();
+                encoder.push_u64(*partition_key);
+                encoder.push_u128(u128::from_be_bytes(*remainder));
+                f.write_str(encoder.as_str())
+            }
+        }
+    }
+}
+
+impl std::fmt::Debug for VQueueEntryId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, f)
+    }
+}
+
+impl From<VQueueEntryId> for EntryId {
+    fn from(value: VQueueEntryId) -> Self {
+        EntryId::new(value.kind(), value.into_remainder())
+    }
+}
 
 #[derive(
     Debug,
@@ -254,6 +377,8 @@ impl std::fmt::Display for EntryIdDisplay<'_> {
 mod tests {
     use bilrost::{Message, OwnedMessage};
 
+    use crate::identifiers::WithPartitionKey;
+
     use super::*;
 
     #[test]
@@ -280,5 +405,84 @@ mod tests {
 
         assert_eq!(encoded.len(), 23);
         assert_eq!(EntryId::decode(encoded).unwrap(), value);
+    }
+
+    /// `Display` then `FromStr` must round-trip both variants, including edge
+    /// remainders. `Debug` delegates to `Display`, so it must match too.
+    #[test]
+    fn display_from_str_round_trips() {
+        let mut r_first = [0u8; REMAINDER_LEN];
+        r_first[0] = 0xff;
+        let mut r_last = [0u8; REMAINDER_LEN];
+        r_last[REMAINDER_LEN - 1] = 0xff;
+
+        let cases = [
+            VQueueEntryId::Invocation(0, [0u8; REMAINDER_LEN]),
+            VQueueEntryId::Invocation(42, r_first),
+            VQueueEntryId::Invocation(u64::MAX, [0xffu8; REMAINDER_LEN]),
+            VQueueEntryId::StateMutation(0, r_last),
+            VQueueEntryId::StateMutation(7, [0xabu8; REMAINDER_LEN]),
+            VQueueEntryId::StateMutation(u64::MAX, [0xffu8; REMAINDER_LEN]),
+        ];
+
+        for id in cases {
+            let encoded = id.to_string();
+            assert_eq!(
+                encoded,
+                format!("{id:?}"),
+                "Debug must delegate to Display for {id:?}"
+            );
+            let parsed: VQueueEntryId = encoded.parse().expect("must parse its own Display output");
+            assert_eq!(parsed, id, "round-trip mismatch for {encoded}");
+            // The encoded prefix identifies the kind.
+            let expected_prefix = match id.kind() {
+                EntryKind::Invocation => "inv_",
+                EntryKind::StateMutation => "mut_",
+                EntryKind::Unknown => unreachable!(),
+            };
+            assert!(
+                encoded.starts_with(expected_prefix),
+                "expected {encoded} to start with {expected_prefix}"
+            );
+            assert_eq!(
+                VQueueEntryId::extract_partition_key(&encoded).unwrap(),
+                id.partition_key(),
+            );
+        }
+    }
+
+    /// A `VQueueEntryId` built from a real resource id must produce the exact same
+    /// string as that resource id, and parsing it back must reproduce the parts.
+    #[test]
+    fn display_matches_underlying_resource_id() {
+        let inv = InvocationId::mock_random();
+        let inv_entry =
+            VQueueEntryId::Invocation(inv.partition_key(), inv.invocation_uuid().to_bytes());
+        assert_eq!(inv_entry.to_string(), inv.to_string());
+        assert_eq!(inv.to_string().parse::<VQueueEntryId>().unwrap(), inv_entry,);
+
+        let sm = StateMutationId::generate(1234);
+        let sm_entry = VQueueEntryId::StateMutation(sm.partition_key(), sm.to_remainder_bytes());
+        assert_eq!(sm_entry.to_string(), sm.to_string());
+        assert_eq!(sm.to_string().parse::<VQueueEntryId>().unwrap(), sm_entry,);
+    }
+
+    /// Malformed strings, and well-formed ids of an unrelated resource type, must
+    /// be rejected rather than silently mis-parsed.
+    #[test]
+    fn from_str_rejects_invalid_input() {
+        for bad in ["", "not-an-id", "inv_", "xyz_1abc"] {
+            assert!(
+                bad.parse::<VQueueEntryId>().is_err(),
+                "expected {bad:?} to fail parsing"
+            );
+        }
+
+        // A valid id of a different resource type must be rejected (TypeMismatch),
+        // not decoded as an entry id.
+        let service_id = InvocationId::mock_random()
+            .to_string()
+            .replace("inv_", "svc_");
+        assert!(service_id.parse::<VQueueEntryId>().is_err());
     }
 }

--- a/crates/types/src/vqueues/entry_id.rs
+++ b/crates/types/src/vqueues/entry_id.rs
@@ -95,11 +95,21 @@ impl FromStr for VQueueEntryId {
             InvocationId::RESOURCE_TYPE => {
                 let partition_key: PartitionKey = decoder.cursor.decode_next()?;
                 let raw: [u8; REMAINDER_LEN] = decoder.cursor.decode_next::<u128>()?.to_be_bytes();
+
+                if decoder.cursor.remaining() != 0 {
+                    return Err(IdDecodeError::Length);
+                }
+
                 Ok(Self::Invocation(partition_key, raw))
             }
             StateMutationId::RESOURCE_TYPE => {
                 let partition_key: PartitionKey = decoder.cursor.decode_next()?;
                 let raw: [u8; REMAINDER_LEN] = decoder.cursor.decode_next::<u128>()?.to_be_bytes();
+
+                if decoder.cursor.remaining() != 0 {
+                    return Err(IdDecodeError::Length);
+                }
+
                 Ok(Self::StateMutation(partition_key, raw))
             }
             _ => Err(IdDecodeError::TypeMismatch),

--- a/crates/types/src/vqueues/vqueue_id.rs
+++ b/crates/types/src/vqueues/vqueue_id.rs
@@ -39,6 +39,38 @@ impl<'a> From<&'a VQueueId> for VQueueIdRef<'a> {
     }
 }
 
+impl VQueueIdRef<'_> {
+    #[inline(always)]
+    pub fn partition_key(&self) -> crate::PartitionKey {
+        u64::from_be_bytes(self.0[0..size_of::<PartitionKey>()].try_into().unwrap())
+    }
+
+    /// The key is encoded as follows:
+    /// - PartitionKey (u64) (big-endian)
+    /// - u8 For the size of the rest of the bytes (to support future evolution) with max 255
+    ///   bytes. and 0 being a special marker to indicate format change.
+    /// - [u8; SIZE]
+    pub fn encode_raw_bytes<B: BufMut>(&self, target: &mut B) {
+        target.put_slice(self.0);
+    }
+
+    /// The dual of `from_raw_bytes`
+    ///
+    /// The key is encoded as follows:
+    /// - PartitionKey (u64) (big-endian)
+    /// - u8 For the size of the rest of the bytes (to support future evolution) with max 255
+    ///   bytes. and 0 being a special marker to indicate format change.
+    /// - [u8; SIZE]
+    pub fn as_raw_bytes(&self) -> &[u8] {
+        self.0
+    }
+
+    // 25 bytes
+    pub const fn serialized_length_fixed() -> usize {
+        std::mem::size_of::<PartitionKey>() + 1 + DIGEST_LEN
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, bilrost::Message)]
 pub struct VQueueId(#[bilrost(encoding(plainbytes))] [u8; RAW_VQUEUE_ID_LEN]);
 
@@ -77,7 +109,7 @@ impl VQueueId {
 
     #[inline]
     pub fn partition_key(&self) -> PartitionKey {
-        u64::from_be_bytes(self.0[0..size_of::<PartitionKey>()].try_into().unwrap())
+        VQueueIdRef(&self.0).partition_key()
     }
 
     /// The key is encoded as follows:
@@ -86,7 +118,7 @@ impl VQueueId {
     ///   bytes. and 0 being a special marker to indicate format change.
     /// - [u8; SIZE]
     pub fn encode_raw_bytes<B: BufMut>(&self, target: &mut B) {
-        target.put_slice(&self.0);
+        VQueueIdRef(&self.0).encode_raw_bytes(target)
     }
 
     pub fn from_raw_bytes<B: Buf>(source: &mut B) -> Self {
@@ -108,7 +140,7 @@ impl VQueueId {
 
     // 25 bytes
     pub const fn serialized_length_fixed() -> usize {
-        std::mem::size_of::<PartitionKey>() + 1 + DIGEST_LEN
+        VQueueIdRef::serialized_length_fixed()
     }
 }
 
@@ -150,6 +182,21 @@ impl PartitionedResourceId for VQueueId {
 impl From<&VQueueId> for VQueueId {
     fn from(value: &VQueueId) -> Self {
         value.clone()
+    }
+}
+
+impl ResourceId for VQueueIdRef<'_> {
+    const RAW_BYTES_LEN: usize = RAW_VQUEUE_ID_LEN;
+    const RESOURCE_TYPE: IdResourceType = IdResourceType::VQueue;
+
+    type StrEncodedLen = <VQueueId as ResourceId>::StrEncodedLen;
+
+    fn push_to_encoder(&self, encoder: &mut IdEncoder<Self>) {
+        // v1 vqueue ID is 37c long
+        encoder.push_u64(self.partition_key());
+        let rest_bytes: [u8; DIGEST_LEN] =
+            self.0[size_of::<PartitionKey>() + 1..].try_into().unwrap();
+        encoder.push_u128(u128::from_be_bytes(rest_bytes));
     }
 }
 
@@ -223,6 +270,21 @@ impl std::fmt::Debug for VQueueId {
 }
 
 impl std::fmt::Display for VQueueId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut encoder = IdEncoder::new();
+        self.push_to_encoder(&mut encoder);
+        f.write_str(encoder.as_str())
+    }
+}
+
+impl std::fmt::Debug for VQueueIdRef<'_> {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, f)
+    }
+}
+
+impl std::fmt::Display for VQueueIdRef<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut encoder = IdEncoder::new();
         self.push_to_encoder(&mut encoder);

--- a/crates/types/src/vqueues/vqueue_id.rs
+++ b/crates/types/src/vqueues/vqueue_id.rs
@@ -256,6 +256,10 @@ impl FromStr for VQueueId {
             // the version of the encoded string.
             let rest: u128 = decoder.cursor.decode_next()?;
             buf.put_u128(rest);
+
+            if decoder.cursor.remaining() != 0 {
+                return Err(IdDecodeError::Length);
+            }
         }
 
         Ok(Self(buf))

--- a/tools/restate-doctor/src/util/decode_value.rs
+++ b/tools/restate-doctor/src/util/decode_value.rs
@@ -18,7 +18,7 @@ use bilrost::OwnedMessage;
 use restate_limiter::RuleBook;
 use restate_partition_store::fsm_table::PartitionStateMachineKey;
 use restate_partition_store::keys::{DecodeTableKey, KeyKind};
-use restate_partition_store::vqueue_table::{EntryStatusKey, InputPayloadKey, StatusHeaderRaw};
+use restate_partition_store::vqueue_table::{EntryStatusKey, InputPayloadKey};
 use restate_storage_api::deduplication_table::DedupSequenceNumber;
 use restate_storage_api::fsm_table::{CachedEpochMetadata, PartitionDurability, SequenceNumber};
 use restate_storage_api::inbox_table::InboxEntry;
@@ -31,8 +31,8 @@ use restate_storage_api::promise_table::Promise;
 use restate_storage_api::protobuf_types::PartitionStoreProtobufValue;
 use restate_storage_api::service_status_table::VirtualObjectStatus;
 use restate_storage_api::timer_table::Timer;
-use restate_storage_api::vqueue_table::EntryValue;
 use restate_storage_api::vqueue_table::metadata::VQueueMeta;
+use restate_storage_api::vqueue_table::{EntryValue, RawStatusHeader};
 use restate_types::SemanticRestateVersion;
 use restate_types::partitions::features::PersistedFeatures;
 use restate_types::state_mut::ExternalStateMutation;
@@ -232,7 +232,7 @@ fn decode_vqueue_entry_status(value: &[u8], key: &[u8]) -> DecodedValue {
     };
 
     let mut buf = value;
-    let header = match StatusHeaderRaw::decode_length_delimited(&mut buf) {
+    let header = match RawStatusHeader::decode_length_delimited(&mut buf) {
         Ok(header) => header,
         Err(e) => {
             return DecodedValue::error(


### PR DESCRIPTION

Make sys_vqueue_entry_status understand exact entry_id predicates so equality and IN filters can be planned as targeted reads rather than broad partition scans. Entry IDs are parsed back to their partition keys for routing and displayed consistently from the stored EntryId representation.

Add the partition-store support needed to read selected entry-status records through bounded batched multi-get calls while preserving range scans for non-point predicates. Entry-id range scans now use total-order iteration when the bounds span multiple partition keys.

Only advertise partition_key ordering for sys_vqueue_entry_status, because the exposed entry_id string ordering does not match the raw on-disk entry-id ordering.

Cover both the DataFusion point-query path and multi-get batching behavior, including a NOT IN regression so excluded IDs are not treated as an exact lookup set.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/5047).
* #5056
* #5053
* #5048
* __->__ #5047
* #5046
* #5052