### PR TITLE
Observe chain prefix-trim in Bifrost LogReadStream Reading state

### DIFF
--- a/crates/bifrost/src/read_stream.rs
+++ b/crates/bifrost/src/read_stream.rs
@@ -119,6 +119,13 @@ enum State {
         safe_known_tail: Option<Lsn>,
         #[pin]
         tail_watch: Option<BoxStream<'static, TailState>>,
+        /// Logs-metadata version at which we last confirmed our `read_pointer` is still
+        /// covered by a live segment. A chain prefix-trim always bumps the logs version, so
+        /// we only need to re-scan the chain for a trim gap when this lags the current
+        /// version. Reset to [`Version::INVALID`] on every entry into `Reading` so the check
+        /// runs at least once per substream (catching a trim observed during substream
+        /// creation).
+        trim_checked_version: Version,
     },
     /// Chain reconfiguration has been detected, we'll update our view of the chain.
     AwaitingReconfiguration,
@@ -155,6 +162,7 @@ impl State {
         Self::Reading {
             safe_known_tail: Some(tail_lsn),
             tail_watch: None,
+            trim_checked_version: Version::INVALID,
         }
     }
 }
@@ -354,6 +362,7 @@ impl Stream for LogReadStream {
                     this.state.set(State::Reading {
                         safe_known_tail,
                         tail_watch,
+                        trim_checked_version: Version::INVALID,
                     });
                 }
 
@@ -361,6 +370,7 @@ impl Stream for LogReadStream {
                 StateProj::Reading {
                     safe_known_tail,
                     tail_watch,
+                    trim_checked_version,
                 } => {
                     // Continue driving the substream
                     //
@@ -377,14 +387,22 @@ impl Stream for LogReadStream {
                     // whole segment, so we must consult the chain here — the same check the
                     // FindingLoglet / AwaitingReconfiguration / AwaitingOrSealChain states
                     // already perform via `check_chain`.
-                    let trimmed_to = match chain.find_segment_for_lsn(*this.read_pointer) {
-                        MaybeSegment::Trim { next_base_lsn } => Some(next_base_lsn),
-                        MaybeSegment::Some(_) => None,
-                    };
-                    if let Some(next_base_lsn) = trimmed_to {
-                        let gap = deliver_trim_gap(&mut this, next_base_lsn, bifrost_inner);
-                        update_shared_state(&this);
-                        return Poll::Ready(Some(Ok(gap)));
+                    //
+                    // `find_segment_for_lsn` is a linear scan of the retained chain, and this
+                    // runs on the hot per-record path, so we skip it while the logs version is
+                    // unchanged: a trim can only reach us via a version bump we haven't checked
+                    // yet.
+                    if *trim_checked_version != logs.version() {
+                        match chain.find_segment_for_lsn(*this.read_pointer) {
+                            MaybeSegment::Trim { next_base_lsn } => {
+                                let gap = deliver_trim_gap(&mut this, next_base_lsn, bifrost_inner);
+                                update_shared_state(&this);
+                                return Poll::Ready(Some(Ok(gap)));
+                            }
+                            MaybeSegment::Some(_) => {
+                                *trim_checked_version = logs.version();
+                            }
+                        }
                     }
 
                     // If the loglet's `tail_lsn` is known, this is the tail we should always respect.

--- a/crates/bifrost/src/read_stream.rs
+++ b/crates/bifrost/src/read_stream.rs
@@ -119,12 +119,9 @@ enum State {
         safe_known_tail: Option<Lsn>,
         #[pin]
         tail_watch: Option<BoxStream<'static, TailState>>,
-        /// Logs-metadata version at which we last confirmed our `read_pointer` is still
-        /// covered by a live segment. A chain prefix-trim always bumps the logs version, so
-        /// we only need to re-scan the chain for a trim gap when this lags the current
-        /// version. Reset to [`Version::INVALID`] on every entry into `Reading` so the check
-        /// runs at least once per substream (catching a trim observed during substream
-        /// creation).
+        /// Logs version at which we last confirmed `read_pointer` still falls in a live
+        /// segment. A prefix-trim always bumps the version, so we only re-scan the chain when
+        /// this lags. Reset to [`Version::INVALID`] on entry so the check runs once per substream.
         trim_checked_version: Version,
     },
     /// Chain reconfiguration has been detected, we'll update our view of the chain.
@@ -380,18 +377,10 @@ impl Stream for LogReadStream {
                         panic!("substream must be set at this point");
                     };
 
-                    // A prefix-trim may have clipped the chain at or below our read_pointer
-                    // while we were parked in Reading (e.g. the segment under us was dropped
-                    // from the chain). A substream sitting on a known sealed tail only observes
-                    // trims of its own loglet, not a chain-level prefix-trim that drops the
-                    // whole segment, so we must consult the chain here — the same check the
-                    // FindingLoglet / AwaitingReconfiguration / AwaitingOrSealChain states
-                    // already perform via `check_chain`.
-                    //
-                    // `find_segment_for_lsn` is a linear scan of the retained chain, and this
-                    // runs on the hot per-record path, so we skip it while the logs version is
-                    // unchanged: a trim can only reach us via a version bump we haven't checked
-                    // yet.
+                    // A prefix-trim may have dropped the segment under our read_pointer from
+                    // the chain while we were parked here; a substream on a sealed tail won't
+                    // surface that, so we consult the chain directly, as the other stalled
+                    // states do via `check_chain`.
                     if *trim_checked_version != logs.version() {
                         match chain.find_segment_for_lsn(*this.read_pointer) {
                             MaybeSegment::Trim { next_base_lsn } => {

--- a/crates/bifrost/src/read_stream.rs
+++ b/crates/bifrost/src/read_stream.rs
@@ -370,6 +370,23 @@ impl Stream for LogReadStream {
                         panic!("substream must be set at this point");
                     };
 
+                    // A prefix-trim may have clipped the chain at or below our read_pointer
+                    // while we were parked in Reading (e.g. the segment under us was dropped
+                    // from the chain). A substream sitting on a known sealed tail only observes
+                    // trims of its own loglet, not a chain-level prefix-trim that drops the
+                    // whole segment, so we must consult the chain here — the same check the
+                    // FindingLoglet / AwaitingReconfiguration / AwaitingOrSealChain states
+                    // already perform via `check_chain`.
+                    let trimmed_to = match chain.find_segment_for_lsn(*this.read_pointer) {
+                        MaybeSegment::Trim { next_base_lsn } => Some(next_base_lsn),
+                        MaybeSegment::Some(_) => None,
+                    };
+                    if let Some(next_base_lsn) = trimmed_to {
+                        let gap = deliver_trim_gap(&mut this, next_base_lsn, bifrost_inner);
+                        update_shared_state(&this);
+                        return Poll::Ready(Some(Ok(gap)));
+                    }
+
                     // If the loglet's `tail_lsn` is known, this is the tail we should always respect.
                     match substream.tail_lsn() {
                         // Next LSN is beyond the boundaries of this substream

--- a/crates/bifrost/src/read_stream.rs
+++ b/crates/bifrost/src/read_stream.rs
@@ -1433,4 +1433,78 @@ mod tests {
 
         Ok(())
     }
+
+    #[restate_core::test(start_paused = true)]
+    async fn readstream_reading_state_observes_chain_trim() -> anyhow::Result<()> {
+        const LOG_ID: LogId = LogId::new(0);
+
+        let node_env = TestCoreEnvBuilder::with_incoming_only_connector()
+            .set_provider_kind(ProviderKind::Local)
+            .build()
+            .await;
+        let config = Constant::new(LocalLogletOptions::default()).boxed();
+        RocksDbManager::init();
+        let svc = BifrostService::new(node_env.metadata_writer.clone())
+            .enable_local_loglet(config)
+            .enable_in_memory_loglet();
+        let bifrost = svc.handle();
+        svc.start().await.expect("loglet must start");
+
+        let mut appender = bifrost.create_appender(LOG_ID, ErrorRecoveryStrategy::Wait)?;
+        for i in 1..=10 {
+            let lsn = appender.append(format!("record-{i}")).await?;
+            assert_eq!(Lsn::from(i), lsn);
+        }
+
+        let new_segment_params = new_single_node_loglet_params(ProviderKind::InMemory);
+        bifrost
+            .admin()
+            .seal_and_extend_chain(
+                LOG_ID,
+                None,
+                Version::MIN,
+                ProviderKind::InMemory,
+                new_segment_params,
+            )
+            .await?;
+
+        let mut reader = bifrost.create_reader(LOG_ID, KeyFilter::Any, Lsn::OLDEST, Lsn::MAX)?;
+        for i in 1..=5 {
+            let record = reader.next().await.expect("to stay alive")?;
+            assert_that!(record.sequence_number(), eq(Lsn::new(i)));
+        }
+        assert_eq!(Lsn::from(6), reader.read_pointer());
+
+        // Trim only the chain (not the loglet) so records 6..=10 remain physically
+        // present in the substream. This isolates the Reading-state bug: the substream
+        // still has a known sealed tail > read_pointer, so it never re-checks the chain
+        // for a trim before polling for the next record.
+        let metadata = Metadata::current();
+        let old_version = metadata.logs_version();
+        let mut builder = metadata
+            .logs_ref()
+            .clone()
+            .try_into_builder()
+            .expect("can create builder");
+        let mut chain_builder = builder.chain(LOG_ID).unwrap();
+        chain_builder.trim_prefix(Lsn::new(11));
+        let new_metadata = builder.build();
+        let new_version = new_metadata.version();
+        assert_eq!(new_version, old_version.next());
+        node_env
+            .metadata_writer
+            .global_metadata()
+            .put(
+                new_metadata.into(),
+                Precondition::MatchesVersion(old_version),
+            )
+            .await?;
+
+        let record = reader.next().await.expect("reader must not hang")?;
+        assert_that!(record.sequence_number(), eq(Lsn::new(6)));
+        assert_that!(record.trim_gap_to_sequence_number(), eq(Some(Lsn::new(10))));
+        assert_eq!(Lsn::from(11), reader.read_pointer());
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Problem

A Bifrost read stream can wait **forever** on a log prefix-trim that sweeps over its read pointer, instead of surfacing the trim gap. If a reader is parked on a known sealed tail and a prefix-trim later clips the chain at/below its read pointer, the reader never notices — it stays parked until the process is restarted.

## Root cause

In `LogReadStream`, the `State::Reading` arm — reached when the substream sits on a *known sealed tail* and `read_pointer < tail` — polls the substream and re-parks **without ever consulting the chain's trim point**.

The other states that can hold a stalled reader (`FindingLoglet` / `AwaitingReconfiguration` / `AwaitingOrSealChain`) all re-check the chain via `check_chain` and will emit a trim gap if the chain has moved past the read pointer. `Reading` was the one gap: a substream sitting on a sealed tail only observes trims *of its own loglet*, not a **chain-level prefix-trim that drops the whole segment** out from under it. So a reader parked there when a prefix-trim later sweeps over its read pointer never observes the trim gap and waits indefinitely until restarted.

## Fix

The final commit adds a chain-trim check at the top of the `Reading` arm, mirroring the sibling states: `find_segment_for_lsn(read_pointer)` → on `MaybeSegment::Trim` → `deliver_trim_gap` → emit the gap. It is a pure no-op when the read pointer is still covered by a live segment (`MaybeSegment::Some`).

Effect: the permanent hang becomes automatic recovery. A parked reader wakes on the chain-version bump it already subscribes to, sees the trim, and emits the gap → the partition processor encounters a `TrimGapEncountered` and fast-forwards from a snapshot. Residual exposure is bounded by trim-propagation latency rather than being unbounded.

## Reproducer

The first commit adds `readstream_reading_state_observes_chain_trim` in `crates/bifrost/src/read_stream.rs`. It:

1. Drives a reader into the vulnerable `Reading` / `Some(tail)` state at LSN 6.
2. Performs a **chain-only** `trim_prefix(11)` over the parked read pointer (`read_pointer == 11`).
3. Asserts a trim gap `[6..10]` followed by a fast-forward to LSN 11.

On the unfixed code the reader returns the data record at LSN 6 with `trim_gap == None` — it never sees the trim. The test is red without the fix and green with it, so it cannot pass by accident.

## Verification

- Reproducer flips **RED → GREEN** across the two commits.
- `read_stream` module: 8/8 pass. Whole `restate-bifrost` crate: 53/53 (incl. replicated-loglet + reconfiguration tests).
- `clippy -D warnings` clean.

## Follow-up (separate)

There is a second, deeper issue this PR intentionally does **not** address: the sealed-tail-watch can freeze the reader so it is stranded in `Reading` in the first place. Preventing that (rather than recovering from it) needs the heavier replicated-loglet test harness and is tracked as a follow-up. This PR is the minimal, proven recovery fix.
