### PR TITLE
[Restate UI] Update to v1.0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9070,8 +9070,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "1.0.12"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v1.0.12#1296268085b68791fd8b24c7444f195eb519582c"
+version = "1.0.13"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v1.0.13#37ab9a7cea2d61da2d6234a95c9e8c75c5bae10f"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -39,7 +39,7 @@ restate-util-time = { workspace = true }
 restate-types = { workspace = true }
 restate-util-string = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "1.0.12", tag = "v1.0.12" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "1.0.13", tag = "v1.0.13" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v1.0.13
published at https://github.com/restatedev/restate-web-ui/releases/download/v1.0.13/ui-v1.0.13.zip