### PR TITLE
[PartitionStore] Simplify and harden range scans

### DIFF
--- a/crates/partition-store/src/inbox_table/mod.rs
+++ b/crates/partition-store/src/inbox_table/mod.rs
@@ -43,10 +43,9 @@ define_table_key!(
 );
 
 fn any_inbox_entry_in_range<S: StorageAccess>(storage: &mut S, range: KeyRange) -> Result<bool> {
-    storage.get_first_blocking(
-        TableScan::FullScanPartitionKeyRange::<InboxKey>(range),
-        |kv| Ok(kv.is_some()),
-    )
+    storage.get_first_blocking(TableScan::ScanPartitionKeyRange::<InboxKey>(range), |kv| {
+        Ok(kv.is_some())
+    })
 }
 
 fn peek_inbox<S: StorageAccess>(
@@ -58,16 +57,13 @@ fn peek_inbox<S: StorageAccess>(
         .service_name(service_id.service_name.clone())
         .service_key(service_id.key.clone());
 
-    storage.get_first_blocking(
-        TableScan::SinglePartitionKeyPrefix(service_id.partition_key(), key),
-        |kv| match kv {
-            Some((k, v)) => {
-                let entry = decode_inbox_key_value(k, v)?;
-                Ok(Some(entry))
-            }
-            None => Ok(None),
-        },
-    )
+    storage.get_first_blocking(TableScan::Prefix(key), |kv| match kv {
+        Some((k, v)) => {
+            let entry = decode_inbox_key_value(k, v)?;
+            Ok(Some(entry))
+        }
+        None => Ok(None),
+    })
 }
 
 fn inbox<S: StorageAccess>(
@@ -80,7 +76,7 @@ fn inbox<S: StorageAccess>(
         .service_key(service_id.key.clone());
 
     Ok(stream::iter(storage.for_each_key_value_in_place(
-        TableScan::SinglePartitionKeyPrefix(service_id.partition_key(), key),
+        TableScan::Prefix(key),
         |k, v| {
             let inbox_entry = decode_inbox_key_value(k, v);
             TableScanIterationDecision::Emit(inbox_entry)
@@ -121,7 +117,7 @@ impl ScanInboxTable for PartitionStore {
         self.iterator_for_each(
             "df-inbox",
             Priority::Low,
-            TableScan::FullScanPartitionKeyRange::<InboxKey>(range),
+            TableScan::ScanPartitionKeyRange::<InboxKey>(range),
             move |(mut key, mut value)| {
                 let key = break_on_err(InboxKey::deserialize_from(&mut key))?;
                 let inbox_entry = break_on_err(InboxEntry::decode(&mut value))?;

--- a/crates/partition-store/src/invocation_status_table/mod.rs
+++ b/crates/partition-store/src/invocation_status_table/mod.rs
@@ -25,7 +25,7 @@ use restate_types::identifiers::{InvocationId, InvocationUuid, PartitionKey, Wit
 use restate_types::sharding::KeyRange;
 use restate_util_string::format_restring;
 
-use crate::TableScan::FullScanPartitionKeyRange;
+use crate::TableScan::ScanPartitionKeyRange;
 use crate::keys::{DecodeTableKey, KeyKind, define_table_key};
 use crate::scan::TableScan;
 use crate::{PartitionStore, PartitionStoreTransaction, StorageAccess, TableKind, break_on_err};
@@ -95,7 +95,7 @@ fn any_non_completed_invocation_in_range<S: StorageAccess>(
     storage: &S,
     range: KeyRange,
 ) -> Result<bool> {
-    let mut iterator = storage.iterator_from(TableScan::FullScanPartitionKeyRange::<
+    let mut iterator = storage.iterator_from(TableScan::ScanPartitionKeyRange::<
         InvocationStatusKey,
     >(range))?;
 
@@ -155,7 +155,7 @@ impl ScanInvocationStatusTable for PartitionStore {
         self.iterator_filter_map(
             "scan-all-invoked",
             Priority::High,
-            FullScanPartitionKeyRange::<InvocationStatusKey>(self.partition_key_range()),
+            ScanPartitionKeyRange::<InvocationStatusKey>(self.partition_key_range()),
             read_invoked_full_invocation_id,
         )
         .map_err(|_| StorageError::OperationalError)
@@ -176,7 +176,7 @@ impl ScanInvocationStatusTable for PartitionStore {
     ) -> Result<impl Future<Output = Result<()>> + Send> {
         let scan = match range {
             ScanInvocationStatusTableRange::PartitionKey(partition_key) => {
-                TableScan::FullScanPartitionKeyRange::<InvocationStatusKeyBuilder>(partition_key)
+                TableScan::ScanPartitionKeyRange::<InvocationStatusKeyBuilder>(partition_key)
             }
             ScanInvocationStatusTableRange::InvocationId(invocation_id) => {
                 let start = InvocationStatusKey::builder()
@@ -187,7 +187,7 @@ impl ScanInvocationStatusTable for PartitionStore {
                     .partition_key(invocation_id.end().partition_key())
                     .invocation_uuid(invocation_id.end().invocation_uuid());
 
-                TableScan::KeyRangeInclusiveInSinglePartition(self.partition_id(), start, end)
+                TableScan::RangeInclusive(start, end)
             }
         };
 
@@ -254,7 +254,7 @@ impl ScanInvocationStatusTable for PartitionStore {
             .iterator_filter_map(
                 "df-filter-map-invocation-status",
                 Priority::Low,
-                TableScan::FullScanPartitionKeyRange::<InvocationStatusKey>(
+                TableScan::ScanPartitionKeyRange::<InvocationStatusKey>(
                     self.partition_key_range(),
                 ),
                 {

--- a/crates/partition-store/src/journal_events/mod.rs
+++ b/crates/partition-store/src/journal_events/mod.rs
@@ -106,34 +106,31 @@ fn get_journal_events<S: StorageAccess>(
         .partition_key(invocation_id.partition_key())
         .invocation_uuid(invocation_id.invocation_uuid());
 
-    storage.for_each_key_value_in_place(
-        TableScan::SinglePartitionKeyPrefix(invocation_id.partition_key(), key),
-        move |mut k, mut v| {
-            TableScanIterationDecision::Emit(
-                JournalEventKey::deserialize_from(&mut k)
-                    .map(|k| k.split())
-                    .and_then(|k_elements| {
-                        EventWrapper::decode(&mut v).map(|value| (k_elements, value.0))
-                    })
-                    .map(
-                        |(
-                            (_, _, event_type, timestamp, _),
-                            PbEvent {
-                                content,
-                                after_journal_entry_index,
-                            },
-                        )| EventView {
-                            event: RawEvent::new(
-                                EventType::from_repr(event_type).unwrap_or(EventType::Unknown),
-                                content,
-                            ),
+    storage.for_each_key_value_in_place(TableScan::Prefix(key), move |mut k, mut v| {
+        TableScanIterationDecision::Emit(
+            JournalEventKey::deserialize_from(&mut k)
+                .map(|k| k.split())
+                .and_then(|k_elements| {
+                    EventWrapper::decode(&mut v).map(|value| (k_elements, value.0))
+                })
+                .map(
+                    |(
+                        (_, _, event_type, timestamp, _),
+                        PbEvent {
+                            content,
                             after_journal_entry_index,
-                            append_time: MillisSinceEpoch::new(timestamp),
                         },
-                    ),
-            )
-        },
-    )
+                    )| EventView {
+                        event: RawEvent::new(
+                            EventType::from_repr(event_type).unwrap_or(EventType::Unknown),
+                            content,
+                        ),
+                        after_journal_entry_index,
+                        append_time: MillisSinceEpoch::new(timestamp),
+                    },
+                ),
+        )
+    })
 }
 
 fn delete_journal_events<S: StorageAccess>(
@@ -146,10 +143,9 @@ fn delete_journal_events<S: StorageAccess>(
         .partition_key(invocation_id.partition_key())
         .invocation_uuid(invocation_id.invocation_uuid());
 
-    let keys = storage.for_each_key_value_in_place(
-        TableScan::SinglePartitionKeyPrefix(invocation_id.partition_key(), prefix_key),
-        |k, _| TableScanIterationDecision::Emit(Ok(Box::from(k))),
-    )?;
+    let keys = storage.for_each_key_value_in_place(TableScan::Prefix(prefix_key), |k, _| {
+        TableScanIterationDecision::Emit(Ok(Box::from(k)))
+    })?;
 
     for k in keys {
         let key = k?;
@@ -178,7 +174,7 @@ impl ScanJournalEventsTable for PartitionStore {
     ) -> Result<impl Future<Output = Result<()>> + Send> {
         let scan = match range {
             ScanJournalEventsTableRange::PartitionKey(partition_key) => {
-                TableScan::FullScanPartitionKeyRange::<JournalEventKeyBuilder>(partition_key)
+                TableScan::ScanPartitionKeyRange::<JournalEventKeyBuilder>(partition_key)
             }
             ScanJournalEventsTableRange::InvocationId(invocation_id) => {
                 let start = JournalEventKey::builder()
@@ -189,7 +185,7 @@ impl ScanJournalEventsTable for PartitionStore {
                     .partition_key(invocation_id.end().partition_key())
                     .invocation_uuid(invocation_id.end().invocation_uuid());
 
-                TableScan::KeyRangeInclusiveInSinglePartition(self.partition_id(), start, end)
+                TableScan::RangeInclusive(start, end)
             }
         };
 

--- a/crates/partition-store/src/journal_table/mod.rs
+++ b/crates/partition-store/src/journal_table/mod.rs
@@ -205,10 +205,7 @@ fn get_journal<'a, S: StorageAccess>(
         .partition_key(invocation_id.partition_key())
         .invocation_uuid(invocation_id.invocation_uuid());
 
-    let iter = storage.iterator_from(TableScan::SinglePartitionKeyPrefix(
-        invocation_id.partition_key(),
-        key,
-    ))?;
+    let iter = storage.iterator_from(TableScan::Prefix(key))?;
 
     Ok(JournalEntryIter::new(iter, journal_length))
 }
@@ -291,18 +288,20 @@ impl ScanJournalTable for PartitionStore {
     ) -> Result<impl Future<Output = Result<()>> + Send> {
         let scan = match range {
             ScanJournalTableRange::PartitionKey(partition_key) => {
-                TableScan::FullScanPartitionKeyRange::<JournalKeyBuilder>(partition_key)
+                TableScan::ScanPartitionKeyRange::<JournalKeyBuilder>(partition_key)
             }
             ScanJournalTableRange::InvocationId(invocation_id) => {
+                let start_partition_key = invocation_id.start().partition_key();
+                let end_partition_key = invocation_id.end().partition_key();
                 let start = JournalKey::builder()
-                    .partition_key(invocation_id.start().partition_key())
+                    .partition_key(start_partition_key)
                     .invocation_uuid(invocation_id.start().invocation_uuid());
 
                 let end = JournalKey::builder()
-                    .partition_key(invocation_id.end().partition_key())
+                    .partition_key(end_partition_key)
                     .invocation_uuid(invocation_id.end().invocation_uuid());
 
-                TableScan::KeyRangeInclusiveInSinglePartition(self.partition_id(), start, end)
+                TableScan::RangeInclusive(start, end)
             }
         };
 

--- a/crates/partition-store/src/journal_table_v2/mod.rs
+++ b/crates/partition-store/src/journal_table_v2/mod.rs
@@ -253,10 +253,7 @@ fn get_journal<'a, S: StorageAccess>(
         .partition_key(invocation_id.partition_key())
         .invocation_uuid(invocation_id.invocation_uuid());
 
-    let iter = storage.iterator_from(TableScan::SinglePartitionKeyPrefix(
-        invocation_id.partition_key(),
-        key,
-    ))?;
+    let iter = storage.iterator_from(TableScan::Prefix(key))?;
 
     Ok(JournalEntryIter::new(iter, journal_length))
 }
@@ -280,12 +277,9 @@ fn delete_journal<S: StorageAccess>(
         JournalNotificationIdToNotificationIndexKey::builder()
             .partition_key(invocation_id.partition_key())
             .invocation_uuid(invocation_id.invocation_uuid());
-    let notification_id_index = OwnedIterator::new(storage.iterator_from(
-        TableScan::SinglePartitionKeyPrefix(
-            invocation_id.partition_key(),
-            notification_id_to_notification_index.clone(),
-        ),
-    )?)
+    let notification_id_index = OwnedIterator::new(storage.iterator_from(TableScan::Prefix(
+        notification_id_to_notification_index.clone(),
+    ))?)
     .map(|(mut key, _)| {
         let journal_key = JournalNotificationIdToNotificationIndexKey::deserialize_from(&mut key)?;
         let (_, _, notification_id) = journal_key.split();
@@ -306,17 +300,15 @@ fn delete_journal<S: StorageAccess>(
     let completion_id_to_command_index = JournalCompletionIdToCommandIndexKey::builder()
         .partition_key(invocation_id.partition_key())
         .invocation_uuid(invocation_id.invocation_uuid());
-    let completion_id_index =
-        OwnedIterator::new(storage.iterator_from(TableScan::SinglePartitionKeyPrefix(
-            invocation_id.partition_key(),
-            completion_id_to_command_index.clone(),
-        ))?)
-        .map(|(mut key, _)| {
-            let journal_key = JournalCompletionIdToCommandIndexKey::deserialize_from(&mut key)?;
-            let (_, _, completion_id) = journal_key.split();
-            Ok(completion_id)
-        })
-        .collect::<Result<Vec<_>>>()?;
+    let completion_id_index = OwnedIterator::new(
+        storage.iterator_from(TableScan::Prefix(completion_id_to_command_index.clone()))?,
+    )
+    .map(|(mut key, _)| {
+        let journal_key = JournalCompletionIdToCommandIndexKey::deserialize_from(&mut key)?;
+        let (_, _, completion_id) = journal_key.split();
+        Ok(completion_id)
+    })
+    .collect::<Result<Vec<_>>>()?;
     for completion_id in completion_id_index {
         storage.delete_key(
             &completion_id_to_command_index
@@ -353,7 +345,7 @@ pub fn cleanup_orphaned_completion_id_index_entries(
 
     let scan_store = storage.clone();
     let partition_key_range = scan_store.partition_key_range();
-    let scan = TableScan::FullScanPartitionKeyRange::<JournalCompletionIdToCommandIndexKeyBuilder>(
+    let scan = TableScan::ScanPartitionKeyRange::<JournalCompletionIdToCommandIndexKeyBuilder>(
         partition_key_range,
     );
     let iter = OwnedIterator::new(scan_store.iterator_from(scan)?);
@@ -415,7 +407,7 @@ fn has_journal_entries(
     let prefix = JournalKey::builder()
         .partition_key(partition_key)
         .invocation_uuid(invocation_uuid);
-    let iter = storage.iterator_from(TableScan::SinglePartitionKeyPrefix(partition_key, prefix))?;
+    let iter = storage.iterator_from(TableScan::Prefix(prefix))?;
     Ok(iter.item().is_some())
 }
 
@@ -426,10 +418,7 @@ fn get_notifications_index<S: StorageAccess>(
     let key = JournalNotificationIdToNotificationIndexKey::builder()
         .partition_key(invocation_id.partition_key())
         .invocation_uuid(invocation_id.invocation_uuid());
-    let iter = storage.iterator_from(TableScan::SinglePartitionKeyPrefix(
-        invocation_id.partition_key(),
-        key,
-    ))?;
+    let iter = storage.iterator_from(TableScan::Prefix(key))?;
     OwnedIterator::new(iter)
         .map(|(mut key, mut value)| {
             let journal_key =
@@ -591,18 +580,20 @@ impl ScanJournalTable for PartitionStore {
     ) -> Result<impl Future<Output = Result<()>> + Send> {
         let scan = match range {
             ScanJournalTableRange::PartitionKey(partition_key) => {
-                TableScan::FullScanPartitionKeyRange::<JournalKeyBuilder>(partition_key)
+                TableScan::ScanPartitionKeyRange::<JournalKeyBuilder>(partition_key)
             }
             ScanJournalTableRange::InvocationId(invocation_id) => {
+                let start_partition_key = invocation_id.start().partition_key();
+                let end_partition_key = invocation_id.end().partition_key();
                 let start = JournalKey::builder()
-                    .partition_key(invocation_id.start().partition_key())
+                    .partition_key(start_partition_key)
                     .invocation_uuid(invocation_id.start().invocation_uuid());
 
                 let end = JournalKey::builder()
-                    .partition_key(invocation_id.end().partition_key())
+                    .partition_key(end_partition_key)
                     .invocation_uuid(invocation_id.end().invocation_uuid());
 
-                TableScan::KeyRangeInclusiveInSinglePartition(self.partition_id(), start, end)
+                TableScan::RangeInclusive(start, end)
             }
         };
 

--- a/crates/partition-store/src/lib.rs
+++ b/crates/partition-store/src/lib.rs
@@ -49,6 +49,33 @@ pub use restate_rocksdb::Priority;
 
 use crate::scan::TableScan;
 
+// FixedPrefixTransform requires seek keys to be at least as long as its configured prefix.
+// Shorter prefixes must bypass prefix seeking and its bloom filters.
+fn configure_prefix_iterator_opts<B: Into<Vec<u8>>>(opts: &mut rocksdb::ReadOptions, prefix: B) {
+    let prefix = prefix.into();
+    if prefix.len() >= DB_PREFIX_LENGTH {
+        opts.set_prefix_same_as_start(true);
+        opts.set_total_order_seek(false);
+    } else {
+        opts.set_prefix_same_as_start(false);
+        opts.set_total_order_seek(true);
+    }
+    opts.set_iterate_range(rocksdb::PrefixRange(prefix));
+}
+
+fn configure_range_iterator_opts<S, E>(
+    opts: &mut rocksdb::ReadOptions,
+    scan_mode: ScanMode,
+    start: S,
+    end: E,
+) where
+    S: Into<Vec<u8>>,
+    E: Into<Vec<u8>>,
+{
+    opts.set_total_order_seek(scan_mode == ScanMode::TotalOrder);
+    opts.set_iterate_range(start.into()..end.into());
+}
+
 // Optimized for modern CPU branch predictors
 #[inline]
 fn convert_to_upper_bound(bytes: &mut [u8]) -> bool {

--- a/crates/partition-store/src/locks_table/mod.rs
+++ b/crates/partition-store/src/locks_table/mod.rs
@@ -228,7 +228,7 @@ impl ScanLocksTable for PartitionStore {
         self.iterator_for_each(
             "df-locks",
             Priority::Low,
-            TableScan::FullScanPartitionKeyRange::<LockKey>(range),
+            TableScan::ScanPartitionKeyRange::<LockKey>(range),
             move |(mut key, mut value)| {
                 let lock_key = break_on_err(LockKey::deserialize_from(&mut key))?;
                 let lock_state = break_on_err(

--- a/crates/partition-store/src/migrations/migrate_to_scoped_promise_table.rs
+++ b/crates/partition-store/src/migrations/migrate_to_scoped_promise_table.rs
@@ -37,10 +37,13 @@ pub fn migrate_to_scoped_promise_table(
     let key_range = ctx.key_range;
     let mut counter = 0;
 
-    let mut iterator = ctx.partition_db.scan(PhysicalScan::from(
-        TableScan::FullScanPartitionKeyRange::<PromiseKey>(key_range),
-        &mut ctx.arena,
-    ))?;
+    let mut iterator = ctx.partition_db.scan(
+        PhysicalScan::from(
+            TableScan::ScanPartitionKeyRange::<PromiseKey>(key_range),
+            &mut ctx.arena,
+        ),
+        rocksdb::ReadOptions::default(),
+    )?;
     iterator.seek_to_first();
 
     // 1 MiB batches

--- a/crates/partition-store/src/migrations/migrate_to_scoped_state_table.rs
+++ b/crates/partition-store/src/migrations/migrate_to_scoped_state_table.rs
@@ -34,10 +34,13 @@ pub fn migrate_to_scoped_state_table(ctx: &mut MigrationContext<'_>) -> Result<(
     let key_range = ctx.key_range;
     let mut counter = 0;
 
-    let mut iterator = ctx.partition_db.scan(PhysicalScan::from(
-        TableScan::FullScanPartitionKeyRange::<StateKey>(key_range),
-        &mut ctx.arena,
-    ))?;
+    let mut iterator = ctx.partition_db.scan(
+        PhysicalScan::from(
+            TableScan::ScanPartitionKeyRange::<StateKey>(key_range),
+            &mut ctx.arena,
+        ),
+        rocksdb::ReadOptions::default(),
+    )?;
     iterator.seek_to_first();
 
     // 1 MiB batches

--- a/crates/partition-store/src/outbox_table/mod.rs
+++ b/crates/partition-store/src/outbox_table/mod.rs
@@ -53,17 +53,14 @@ fn get_outbox_head_seq_number<S: StorageAccess>(
         .partition_id(partition_id.into())
         .message_index(u64::MAX);
 
-    storage.get_first_blocking(
-        TableScan::KeyRangeInclusiveInSinglePartition(partition_id, start, end),
-        |kv| {
-            if let Some((mut k, _)) = kv {
-                let key = OutboxKey::deserialize_from(&mut k)?;
-                Ok(Some(key.message_index))
-            } else {
-                Ok(None)
-            }
-        },
-    )
+    storage.get_first_blocking(TableScan::RangeInclusive(start, end), |kv| {
+        if let Some((mut k, _)) = kv {
+            let key = OutboxKey::deserialize_from(&mut k)?;
+            Ok(Some(key.message_index))
+        } else {
+            Ok(None)
+        }
+    })
 }
 
 fn get_next_outbox_message<S: StorageAccess>(
@@ -80,17 +77,14 @@ fn get_next_outbox_message<S: StorageAccess>(
         .partition_id(partition_id.into())
         .message_index(u64::MAX);
 
-    storage.get_first_blocking(
-        TableScan::KeyRangeInclusiveInSinglePartition(partition_id, start, end),
-        |kv| {
-            if let Some((k, v)) = kv {
-                let t = decode_key_value(k, v)?;
-                Ok(Some(t))
-            } else {
-                Ok(None)
-            }
-        },
-    )
+    storage.get_first_blocking(TableScan::RangeInclusive(start, end), |kv| {
+        if let Some((k, v)) = kv {
+            let t = decode_key_value(k, v)?;
+            Ok(Some(t))
+        } else {
+            Ok(None)
+        }
+    })
 }
 
 fn get_outbox_message<S: StorageAccess>(

--- a/crates/partition-store/src/partition_db.rs
+++ b/crates/partition-store/src/partition_db.rs
@@ -14,7 +14,6 @@ use std::ops::DerefMut;
 use std::sync::Arc;
 use std::time::Duration;
 
-use bytes::BytesMut;
 use parking_lot::RwLock;
 use rocksdb::table_properties::TablePropertiesExt;
 use rocksdb::{
@@ -38,7 +37,7 @@ use crate::keys::KeyKind;
 use crate::memory::{MemoryBudget, PartitionDbMemoryConfig};
 use crate::scan::PhysicalScan;
 use crate::snapshots::LocalPartitionSnapshot;
-use crate::{DB_PREFIX_LENGTH, ScanMode, TableKind};
+use crate::{TableKind, configure_prefix_iterator_opts, configure_range_iterator_opts};
 
 use restate_util_string::{ReString, ToReString};
 
@@ -179,15 +178,18 @@ impl PartitionDb {
     }
 
     #[track_caller]
-    pub(super) fn scan(
+    pub(super) fn scan<B>(
         &self,
-        scan: PhysicalScan,
-    ) -> Result<DBRawIteratorWithThreadMode<'_, rocksdb::DB>, StorageError> {
+        scan: PhysicalScan<B>,
+        mut opts: ReadOptions,
+    ) -> Result<DBRawIteratorWithThreadMode<'_, rocksdb::DB>, StorageError>
+    where
+        B: AsRef<[u8]>,
+    {
         match scan {
-            PhysicalScan::Prefix(table, _key_kind, prefix) => {
-                debug_assert!(table.has_key_kind(&prefix));
-                let prefix = prefix.freeze();
-                let opts = new_prefix_iterator_opts(prefix.as_ref());
+            PhysicalScan::Prefix(table, prefix) => {
+                debug_assert!(table.has_key_kind(prefix.as_ref()));
+                configure_prefix_iterator_opts(&mut opts, prefix.as_ref());
                 let table = self.table_cf_handle(table);
                 let mut it = self
                     .rocksdb
@@ -197,35 +199,9 @@ impl PartitionDb {
                 it.seek(prefix);
                 Ok(it)
             }
-            PhysicalScan::RangeExclusive(table, _key_kind, scan_mode, start, end) => {
-                debug_assert!(table.has_key_kind(&start));
-                let opts = new_range_iterator_opts(scan_mode, start.as_ref(), end.as_ref());
-                let table = self.table_cf_handle(table);
-                let mut it = self
-                    .rocksdb
-                    .inner()
-                    .as_raw_db()
-                    .raw_iterator_cf_opt(table, opts);
-                it.seek(start);
-                Ok(it)
-            }
-            PhysicalScan::RangeOpen(table, key_kind, start) => {
-                debug_assert!(table.has_key_kind(&start));
-                // We delayed the generate the synthetic iterator upper bound until this point
-                // because we might have different prefix length requirements based on the
-                // table+key_kind combination and we should keep this knowledge as low-level as
-                // possible.
-                //
-                // make the end has the same length as all prefixes to ensure rocksdb key
-                // comparator can leverage bloom filters when applicable
-                // (if auto_prefix_mode is enabled)
-                let mut end = BytesMut::zeroed(DB_PREFIX_LENGTH);
-                // We want to ensure that Range scans fall within the same key kind.
-                // So, we limit the iterator to the upper bound of this prefix
-                let kind_upper_bound = key_kind.exclusive_upper_bound();
-                end[..kind_upper_bound.len()].copy_from_slice(&kind_upper_bound);
-                let opts =
-                    new_range_iterator_opts(ScanMode::TotalOrder, start.as_ref(), end.as_ref());
+            PhysicalScan::RangeExclusive(table, scan_mode, start, end) => {
+                debug_assert!(table.has_key_kind(start.as_ref()));
+                configure_range_iterator_opts(&mut opts, scan_mode, start.as_ref(), end.as_ref());
                 let table = self.table_cf_handle(table);
                 let mut it = self
                     .rocksdb
@@ -237,23 +213,6 @@ impl PartitionDb {
             }
         }
     }
-}
-
-fn new_prefix_iterator_opts<B: Into<Vec<u8>>>(prefix: B) -> ReadOptions {
-    let mut opts = ReadOptions::default();
-    opts.set_prefix_same_as_start(true);
-    opts.set_iterate_range(rocksdb::PrefixRange(prefix));
-    opts.set_async_io(true);
-    opts.set_total_order_seek(false);
-    opts
-}
-
-fn new_range_iterator_opts<B: Into<Vec<u8>>>(scan_mode: ScanMode, from: B, to: B) -> ReadOptions {
-    let mut opts = ReadOptions::default();
-    opts.set_total_order_seek(scan_mode == ScanMode::TotalOrder);
-    opts.set_iterate_range(from..to);
-    opts.set_async_io(true);
-    opts
 }
 
 #[derive(Clone)]

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -18,7 +18,7 @@ use bytes::Bytes;
 use bytes::BytesMut;
 use enum_map::Enum;
 use rocksdb::{
-    BoundColumnFamily, DBPinnableSlice, DBRawIteratorWithThreadMode, PrefixRange, ReadOptions,
+    BoundColumnFamily, DBPinnableSlice, DBRawIteratorWithThreadMode, ReadOptions,
     SnapshotWithThreadMode,
 };
 use static_assertions::const_assert_eq;
@@ -57,11 +57,9 @@ use crate::partition_db::PartitionDb;
 use crate::scan::PhysicalScan;
 use crate::scan::TableScan;
 use crate::snapshots::{LocalPartitionSnapshot, SnapshotDir};
+use crate::{configure_prefix_iterator_opts, configure_range_iterator_opts};
 
 pub type DB = rocksdb::DB;
-
-pub type DBIterator<'b> = DBRawIteratorWithThreadMode<'b, DB>;
-pub type DBIteratorTransaction<'b> = DBRawIteratorWithThreadMode<'b, rocksdb::Transaction<'b, DB>>;
 
 // Key prefix is 10 bytes (KeyKind(2) + PartitionKey/Id(8))
 pub(crate) const DB_PREFIX_LENGTH: usize =
@@ -293,34 +291,6 @@ impl PartitionStore {
         self.db.table_cf_handle(table_kind)
     }
 
-    fn new_prefix_iterator_opts(&self, _key_kind: KeyKind, prefix: Bytes) -> ReadOptions {
-        let mut opts = ReadOptions::default();
-        opts.set_prefix_same_as_start(true);
-        opts.set_iterate_range(PrefixRange(prefix));
-        opts.set_async_io(true);
-        opts.set_total_order_seek(false);
-        opts
-    }
-
-    fn new_range_iterator_opts(&self, scan_mode: ScanMode, from: Bytes, to: Bytes) -> ReadOptions {
-        let mut opts = ReadOptions::default();
-        // todo: use auto_prefix_mode, at the moment, rocksdb doesn't expose this through the C
-        // binding.
-        opts.set_total_order_seek(scan_mode == ScanMode::TotalOrder);
-        opts.set_iterate_range(from..to);
-        opts.set_async_io(true);
-        opts
-    }
-
-    #[track_caller]
-    pub(super) fn iterator_from<K: EncodeTableKeyPrefix>(
-        &self,
-        scan: TableScan<K>,
-    ) -> Result<DBRawIteratorWithThreadMode<'_, DB>> {
-        let scan: PhysicalScan = scan.into();
-        self.db.scan(scan)
-    }
-
     #[allow(clippy::type_complexity)]
     fn iterator_step_map<O: Send + 'static>(
         tx: mpsc::Sender<Result<O>>,
@@ -435,7 +405,9 @@ impl PartitionStore {
     ) -> Result<impl Future<Output = Result<()>>, ShutdownError> {
         let (tx, rx) = oneshot::channel();
         let on_iter = Self::iterator_step_for_each(tx, f);
-        self.run_iterator_internal(name, priority, scan, on_iter)?;
+        let mut opts = ReadOptions::default();
+        opts.set_async_io(true);
+        self.run_iterator_internal(name, priority, opts, scan, on_iter)?;
         Ok(async {
             match rx.await {
                 Ok(storage_err) => Err(storage_err),
@@ -456,7 +428,9 @@ impl PartitionStore {
     ) -> Result<ReceiverStream<Result<O>>, ShutdownError> {
         let (tx, rx) = mpsc::channel(8);
         let on_iter = Self::iterator_step_map(tx, f);
-        self.run_iterator_internal(name, priority, scan, on_iter)?;
+        let mut opts = ReadOptions::default();
+        opts.set_async_io(true);
+        self.run_iterator_internal(name, priority, opts, scan, on_iter)?;
         Ok(ReceiverStream::new(rx))
     }
 
@@ -469,7 +443,9 @@ impl PartitionStore {
     ) -> Result<ReceiverStream<Result<O>>, ShutdownError> {
         let (tx, rx) = mpsc::channel(8);
         let on_iter = Self::iterator_step_filter_map(tx, f);
-        self.run_iterator_internal(name, priority, scan, on_iter)?;
+        let mut opts = ReadOptions::default();
+        opts.set_async_io(true);
+        self.run_iterator_internal(name, priority, opts, scan, on_iter)?;
         Ok(ReceiverStream::new(rx))
     }
 
@@ -477,15 +453,15 @@ impl PartitionStore {
         &self,
         name: &'static str,
         priority: Priority,
+        mut opts: ReadOptions,
         scan: TableScan<K>,
         on_iter: impl FnMut(Result<(&[u8], &[u8]), RocksError>) -> IterAction + Send + 'static,
     ) -> Result<(), ShutdownError> {
-        let scan: PhysicalScan = scan.into();
+        let scan: PhysicalScan<Bytes> = scan.into();
         match scan {
-            PhysicalScan::Prefix(table, key_kind, prefix) => {
+            PhysicalScan::Prefix(table, prefix) => {
                 assert!(table.has_key_kind(&prefix));
-                let prefix = prefix.freeze();
-                let opts = self.new_prefix_iterator_opts(key_kind, prefix.clone());
+                configure_prefix_iterator_opts(&mut opts, prefix.as_ref());
                 self.db.rocksdb().clone().run_background_iterator(
                     // todo(asoli): Pass an owned cf handle instead of name
                     self.db.partition().cf_name().into(),
@@ -496,39 +472,11 @@ impl PartitionStore {
                     on_iter,
                 )?;
             }
-            PhysicalScan::RangeExclusive(table, _key_kind, scan_mode, start, end) => {
+            PhysicalScan::RangeExclusive(table, scan_mode, start, end) => {
                 assert!(table.has_key_kind(&start));
-                let start = start.freeze();
-                let end = end.freeze();
-                let opts = self.new_range_iterator_opts(scan_mode, start.clone(), end);
+                configure_range_iterator_opts(&mut opts, scan_mode, start.clone(), end);
                 self.db.rocksdb().clone().run_background_iterator(
                     self.db.partition().cf_name().as_ref().into(),
-                    name,
-                    priority,
-                    IterAction::Seek(start),
-                    opts,
-                    on_iter,
-                )?;
-            }
-            PhysicalScan::RangeOpen(_table, _key_kind, start) => {
-                // We delayed the generate the synthetic iterator upper bound until this point
-                // because we might have different prefix length requirements based on the
-                // table+key_kind combination and we should keep this knowledge as low-level as
-                // possible.
-                //
-                // make the end has the same length as all prefixes to ensure rocksdb key
-                // comparator can leverage bloom filters when applicable
-                // (if auto_prefix_mode is enabled)
-                let mut end = BytesMut::zeroed(DB_PREFIX_LENGTH);
-                // We want to ensure that Range scans fall within the same key kind.
-                // So, we limit the iterator to the upper bound of this prefix
-                let kind_upper_bound = K::KEY_KIND.exclusive_upper_bound();
-                end[..kind_upper_bound.len()].copy_from_slice(&kind_upper_bound);
-                let start = start.freeze();
-                let end = end.freeze();
-                let opts = self.new_range_iterator_opts(ScanMode::TotalOrder, start.clone(), end);
-                self.db.rocksdb().clone().run_background_iterator(
-                    self.db.partition().cf_name().into(),
                     name,
                     priority,
                     IterAction::Seek(start),
@@ -756,7 +704,9 @@ impl StorageAccess for PartitionStore {
         &self,
         scan: TableScan<K>,
     ) -> Result<DBRawIteratorWithThreadMode<'_, Self::DBAccess<'_>>> {
-        self.iterator_from(scan)
+        let mut opts = ReadOptions::default();
+        opts.set_async_io(true);
+        self.db.scan(scan.into(), opts)
     }
 
     #[inline]
@@ -839,6 +789,24 @@ pub enum ScanMode {
     TotalOrder,
 }
 
+impl ScanMode {
+    // Deduces the scan mode from whether the start and end keys share a prefix.
+    pub(crate) fn from_range<S, E>(start: S, end: E) -> Self
+    where
+        S: AsRef<[u8]>,
+        E: AsRef<[u8]>,
+    {
+        let start_prefix = start.as_ref().first_chunk::<DB_PREFIX_LENGTH>();
+        let end_prefix = end.as_ref().first_chunk::<DB_PREFIX_LENGTH>();
+
+        if start_prefix.is_some() && start_prefix == end_prefix {
+            ScanMode::WithinPrefix
+        } else {
+            ScanMode::TotalOrder
+        }
+    }
+}
+
 pub struct PartitionStoreTransaction<'a> {
     meta: &'a Arc<Partition>,
     write_batch_with_index: Option<rocksdb::WriteBatchWithIndex>,
@@ -910,61 +878,6 @@ impl PartitionStoreTransaction<'_> {
             .as_mut()
             .expect("transaction valid")
             .single_delete_cf(self.data_cf_handle, key);
-    }
-
-    pub(crate) fn prefix_iterator(
-        &self,
-        table: TableKind,
-        _key_kind: KeyKind,
-        prefix: Bytes,
-    ) -> Result<DBIterator<'_>> {
-        let table = self.table_handle(table);
-        let mut opts = self.read_options();
-        opts.set_iterate_range(PrefixRange(prefix.clone()));
-        opts.set_prefix_same_as_start(true);
-        opts.set_total_order_seek(false);
-
-        let it = self
-            .rocksdb
-            .inner()
-            .as_raw_db()
-            .raw_iterator_cf_opt(table, opts);
-        let mut it = self
-            .write_batch_with_index
-            .as_ref()
-            .expect("transaction valid")
-            .iterator_with_base_cf(it, table);
-        it.seek(prefix);
-        Ok(it)
-    }
-
-    pub(crate) fn range_iterator(
-        &self,
-        table: TableKind,
-        _key_kind: KeyKind,
-        scan_mode: ScanMode,
-        from: Bytes,
-        to: Bytes,
-    ) -> Result<DBIterator<'_>> {
-        let table = self.table_handle(table);
-        let mut opts = self.read_options();
-        // todo: use auto_prefix_mode, at the moment, rocksdb doesn't expose this through the C
-        // binding.
-        opts.set_total_order_seek(scan_mode == ScanMode::TotalOrder);
-        opts.set_iterate_range(from.clone()..to);
-
-        let it = self
-            .rocksdb
-            .inner()
-            .as_raw_db()
-            .raw_iterator_cf_opt(table, opts);
-        let mut it = self
-            .write_batch_with_index
-            .as_ref()
-            .expect("transaction valid")
-            .iterator_with_base_cf(it, table);
-        it.seek(from);
-        Ok(it)
     }
 
     pub(crate) fn table_handle(&self, _table_kind: TableKind) -> &Arc<BoundColumnFamily<'_>> {
@@ -1056,37 +969,33 @@ impl StorageAccess for PartitionStoreTransaction<'_> {
         &self,
         scan: TableScan<K>,
     ) -> Result<DBRawIteratorWithThreadMode<'_, Self::DBAccess<'_>>> {
-        let scan: PhysicalScan = scan.into();
-        match scan {
-            PhysicalScan::Prefix(table, key_kind, prefix) => {
-                self.prefix_iterator(table, key_kind, prefix.freeze())
+        let scan: PhysicalScan<Bytes> = scan.into();
+        let (table, start, opts) = match scan {
+            PhysicalScan::Prefix(table, prefix) => {
+                let mut opts = self.read_options();
+                configure_prefix_iterator_opts(&mut opts, prefix.as_ref());
+                (table, prefix, opts)
             }
-            PhysicalScan::RangeExclusive(table, key_kind, scan_mode, start, end) => {
-                self.range_iterator(table, key_kind, scan_mode, start.freeze(), end.freeze())
+            PhysicalScan::RangeExclusive(table, scan_mode, start, end) => {
+                let mut opts = self.read_options();
+                configure_range_iterator_opts(&mut opts, scan_mode, start.as_ref(), end);
+                (table, start, opts)
             }
-            PhysicalScan::RangeOpen(table, key_kind, start) => {
-                // We delayed the generate the synthetic iterator upper bound until this point
-                // because we might have different prefix length requirements based on the
-                // table+key_kind combination and we should keep this knowledge as low-level as
-                // possible.
-                //
-                // make the end has the same length as all prefixes to ensure rocksdb key
-                // comparator can leverage bloom filters when applicable
-                // (if auto_prefix_mode is enabled)
-                let mut end = BytesMut::zeroed(DB_PREFIX_LENGTH);
-                // We want to ensure that Range scans fall within the same key kind.
-                // So, we limit the iterator to the upper bound of this prefix
-                let kind_upper_bound = K::KEY_KIND.exclusive_upper_bound();
-                end[..kind_upper_bound.len()].copy_from_slice(&kind_upper_bound);
-                self.range_iterator(
-                    table,
-                    key_kind,
-                    ScanMode::TotalOrder,
-                    start.freeze(),
-                    end.freeze(),
-                )
-            }
-        }
+        };
+
+        let table = self.table_handle(table);
+        let base = self
+            .rocksdb
+            .inner()
+            .as_raw_db()
+            .raw_iterator_cf_opt(table, opts);
+        let mut iterator = self
+            .write_batch_with_index
+            .as_ref()
+            .expect("transaction valid")
+            .iterator_with_base_cf(base, table);
+        iterator.seek(start);
+        Ok(iterator)
     }
 
     #[inline]

--- a/crates/partition-store/src/promise_table/mod.rs
+++ b/crates/partition-store/src/promise_table/mod.rs
@@ -148,10 +148,9 @@ fn delete_all_promises<S: StorageAccess>(
 
         // Right now the WBWI does not support range deletions :-(
         // That's why we need to iterate over the individual promises.
-        let keys = storage.for_each_key_value_in_place(
-            TableScan::SinglePartitionKeyPrefix(service_id.partition_key(), prefix_key),
-            |k, _| TableScanIterationDecision::Emit(Ok(Box::from(k))),
-        )?;
+        let keys = storage.for_each_key_value_in_place(TableScan::Prefix(prefix_key), |k, _| {
+            TableScanIterationDecision::Emit(Ok(Box::from(k)))
+        })?;
 
         for k in keys {
             let key = k?;
@@ -164,10 +163,9 @@ fn delete_all_promises<S: StorageAccess>(
             .service_name(&service_id.service_name)
             .service_key(service_id.key.as_bytes());
 
-        let keys = storage.for_each_key_value_in_place(
-            TableScan::SinglePartitionKeyPrefix(service_id.partition_key(), prefix_key),
-            |k, _| TableScanIterationDecision::Emit(Ok(Box::from(k))),
-        )?;
+        let keys = storage.for_each_key_value_in_place(TableScan::Prefix(prefix_key), |k, _| {
+            TableScanIterationDecision::Emit(Ok(Box::from(k)))
+        })?;
 
         for k in keys {
             let key = k?;
@@ -211,7 +209,7 @@ impl ScanPromiseTable for PartitionStore {
                 self.iterator_for_each(
                     "df-promise",
                     Priority::Low,
-                    TableScan::FullScanPartitionKeyRange::<PromiseKey>(range),
+                    TableScan::ScanPartitionKeyRange::<PromiseKey>(range),
                     move |(mut k, mut v)| {
                         let key = break_on_err(PromiseKey::deserialize_from(&mut k))?;
                         let metadata = break_on_err(Promise::decode(&mut v))?;
@@ -242,7 +240,7 @@ impl ScanPromiseTable for PartitionStore {
             .iterator_for_each(
                 "df-promise-scoped",
                 Priority::Low,
-                TableScan::FullScanPartitionKeyRange::<ScopedPromiseKey>(range),
+                TableScan::ScanPartitionKeyRange::<ScopedPromiseKey>(range),
                 move |(mut k, mut v)| {
                     let key = break_on_err(ScopedPromiseKey::deserialize_from(&mut k))?;
                     let metadata = break_on_err(Promise::decode(&mut v))?;

--- a/crates/partition-store/src/scan.rs
+++ b/crates/partition-store/src/scan.rs
@@ -8,159 +8,141 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use bytes::BytesMut;
+use bytes::{Bytes, BytesMut};
 
-use restate_types::identifiers::{PartitionId, PartitionKey};
 use restate_types::sharding::KeyRange;
 
-use crate::keys::{EncodeTableKey, EncodeTableKeyPrefix, KeyEncode, KeyKind};
-use crate::scan::TableScan::{
-    FullScanPartitionKeyRange, KeyRangeInclusiveInSinglePartition, SinglePartition,
-    SinglePartitionKeyPrefix,
-};
-use crate::{PaddedPartitionId, ScanMode, TableKind};
+use crate::keys::{EncodeTableKeyPrefix, KeyEncode, KeyKind};
+use crate::scan::TableScan::{Prefix, RangeInclusive, ScanPartitionKeyRange};
+use crate::{ScanMode, TableKind, convert_to_upper_bound};
 
-// Note: we take extra arguments like (PartitionId or PartitionKey) only to make sure that
-// call-sites know what they are opting to. Those values might not actually be used to perform the
-// query, albeit this might change at any time.
 #[derive(Debug)]
 pub enum TableScan<K> {
-    /// Scan an entire partition of a given table.
-    SinglePartition(PartitionId),
-    /// Scan an inclusive key-range potentially across partitions.
-    /// Requires total seek order
-    FullScanPartitionKeyRange(KeyRange),
-    /// Scan within a single partition key
-    SinglePartitionKeyPrefix(PartitionKey, K),
-    /// Inclusive Key Range in a single partition.
-    KeyRangeInclusiveInSinglePartition(PartitionId, K, K),
+    /// Scan an inclusive partition key-range.
+    ScanPartitionKeyRange(KeyRange),
+    /// Scan within the same prefix.
+    Prefix(K),
+    /// Inclusive key range.
+    RangeInclusive(K, K),
 }
 
-pub(crate) enum PhysicalScan {
-    Prefix(TableKind, KeyKind, BytesMut),
-    RangeExclusive(TableKind, KeyKind, ScanMode, BytesMut, BytesMut),
-    // Exclusively used for cross-partition full-scan queries.
-    RangeOpen(TableKind, KeyKind, BytesMut),
+pub(crate) enum PhysicalScan<B> {
+    Prefix(TableKind, B),
+    RangeExclusive(TableKind, ScanMode, B, B),
 }
 
-impl PhysicalScan {
+impl PhysicalScan<Bytes> {
     pub fn from<K: EncodeTableKeyPrefix>(scan: TableScan<K>, arena: &mut BytesMut) -> Self {
         match scan {
-            SinglePartitionKeyPrefix(_partition_key, key) => {
+            Prefix(key) => {
                 key.serialize_to(arena);
-                PhysicalScan::Prefix(K::TABLE, K::KEY_KIND, arena.split())
+                PhysicalScan::Prefix(K::TABLE, arena.split().freeze())
             }
-            KeyRangeInclusiveInSinglePartition(_partition_id, start, end) => {
+            RangeInclusive(start, end) => {
+                arena.reserve(start.serialized_length() + end.serialized_length());
                 start.serialize_to(arena);
-                let start = arena.split();
+                let start = arena.split().freeze();
                 end.serialize_to(arena);
                 let mut end = arena.split();
-                if try_increment(&mut end) {
-                    PhysicalScan::RangeExclusive(
-                        K::TABLE,
-                        K::KEY_KIND,
-                        ScanMode::WithinPrefix,
-                        start,
-                        end,
-                    )
-                } else {
-                    // not allowed to happen since we guarantee that KeyKind is
+                if start == end {
+                    return PhysicalScan::Prefix(K::TABLE, start);
+                }
+
+                if !convert_to_upper_bound(&mut end) {
+                    // Not allowed to happen since we guarantee that KeyKind is
                     // always incrementable.
+                    std::hint::cold_path();
                     panic!("Key range end overflowed, start key {:x?}", &start);
                 }
+                let end = end.freeze();
+                // RocksDB requires the exclusive upper bound to share the seek prefix when
+                // total-order seek is disabled.
+                let scan_mode = ScanMode::from_range(&start, &end);
+
+                PhysicalScan::RangeExclusive(K::TABLE, scan_mode, start, end)
             }
-            SinglePartition(partition_id) => {
-                let partition_id = PaddedPartitionId::from(partition_id);
-                arena.reserve(partition_id.serialized_length() + KeyKind::SERIALIZED_LENGTH);
-                K::serialize_key_kind(arena);
-                partition_id.encode(arena);
-                let prefix_start = arena.split();
-                PhysicalScan::Prefix(K::TABLE, K::KEY_KIND, prefix_start)
-            }
-            FullScanPartitionKeyRange(range) => {
+            ScanPartitionKeyRange(range) => {
                 let start = range.start();
                 let end = range.end();
-                arena.reserve(start.serialized_length() + KeyKind::SERIALIZED_LENGTH);
+                // A single partition key can use a prefix scan over the start key.
+                if start == end {
+                    arena.reserve(start.serialized_length() + KeyKind::SERIALIZED_LENGTH);
+                    K::serialize_key_kind(arena);
+                    start.encode(arena);
+                    return PhysicalScan::Prefix(K::TABLE, arena.split().freeze());
+                }
+
+                arena.reserve(2 * (start.serialized_length() + KeyKind::SERIALIZED_LENGTH));
                 K::serialize_key_kind(arena);
                 start.encode(arena);
-                let start_bytes = arena.split();
-                match end.checked_add(1) {
-                    None => PhysicalScan::RangeOpen(K::TABLE, K::KEY_KIND, start_bytes),
-                    Some(end) => {
-                        arena.reserve(end.serialized_length() + KeyKind::SERIALIZED_LENGTH);
-                        K::serialize_key_kind(arena);
-                        end.encode(arena);
-                        let end_bytes = arena.split();
-                        PhysicalScan::RangeExclusive(
-                            K::TABLE,
-                            K::KEY_KIND,
-                            ScanMode::TotalOrder,
-                            start_bytes,
-                            end_bytes,
-                        )
-                    }
+                let start_bytes = arena.split().freeze();
+
+                K::serialize_key_kind(arena);
+                end.encode(arena);
+                let mut end_bytes = arena.split();
+                if !convert_to_upper_bound(&mut end_bytes) {
+                    // not allowed to happen since we guarantee that KeyKind is
+                    // always incrementable.
+                    std::hint::cold_path();
+                    panic!("Key range end overflowed, start key {:x?}", &start);
                 }
+                let end_bytes = end_bytes.freeze();
+                PhysicalScan::RangeExclusive(K::TABLE, ScanMode::TotalOrder, start_bytes, end_bytes)
             }
         }
     }
 }
 
-impl<K: EncodeTableKeyPrefix> From<TableScan<K>> for PhysicalScan {
+impl<K: EncodeTableKeyPrefix> From<TableScan<K>> for PhysicalScan<Bytes> {
     fn from(scan: TableScan<K>) -> Self {
         let mut arena = BytesMut::new();
         PhysicalScan::from(scan, &mut arena)
     }
 }
 
-impl<K: EncodeTableKey> TableScan<K> {
-    pub fn table(&self) -> TableKind {
-        K::TABLE
-    }
-}
-
-/// Binary increment the number represented by the given bytes.
-/// This function computes the next lexicographical byte string
-/// that comes after this string.
-///
-/// RocksDB ranges are exclusive, yet in restate we treat the partition
-/// ranges as inclusive.
-///
-/// RocksDB rows can be considered as sorted, big, unsigned
-/// integers stored as big endian byte strings.
-/// To compute the successor of a key, we do a binary increment of
-/// the number represented by the input bytes.
-///
-///```ignore
-/// [aBytes, bBytes] = [aBytes, successor(bBytes) ) =
-///     [aBytes, (BigUint(bBytes)+1).to_big_endian_bytes() )
-///```
-/// returns true iff the successor doesn't generate a carry.
-#[inline]
-fn try_increment(bytes: &mut BytesMut) -> bool {
-    for byte in bytes.iter_mut().rev() {
-        if let Some(incremented) = byte.checked_add(1) {
-            *byte = incremented;
-            return true;
-        } else {
-            *byte = 0;
-        }
-    }
-    false
-}
-
 #[cfg(test)]
 mod tests {
-    use crate::scan::try_increment;
-    use bytes::{BufMut, BytesMut};
-    use num_bigint::BigUint;
     use std::collections::BTreeMap;
     use std::ops::Add;
+
+    use bytes::{BufMut, Bytes, BytesMut};
+    use num_bigint::BigUint;
+
+    use restate_types::sharding::KeyRange;
+
+    use crate::keys::{EncodeTableKey, KeyKind};
+    use crate::scan::{PhysicalScan, TableScan};
+    use crate::{DB_PREFIX_LENGTH, ScanMode, TableKind, convert_to_upper_bound};
+
+    struct TestKey(u64, u64);
+
+    impl EncodeTableKey for TestKey {
+        const TABLE: TableKind = TableKind::InvocationStatus;
+        const KEY_KIND: KeyKind = KeyKind::InvocationStatus;
+
+        fn serialize_to<B: BufMut>(&self, bytes: &mut B) {
+            Self::KEY_KIND.serialize(bytes);
+            bytes.put_u64(self.0);
+            bytes.put_u64(self.1);
+        }
+
+        fn serialized_length(&self) -> usize {
+            KeyKind::SERIALIZED_LENGTH + std::mem::size_of::<u64>() * 2
+        }
+    }
+
+    fn scan_mode(scan: TableScan<TestKey>) -> ScanMode {
+        let PhysicalScan::RangeExclusive(_, scan_mode, _, _) = scan.into() else {
+            panic!("expected range scan");
+        };
+        scan_mode
+    }
 
     fn verify_binary_increment(bytes: &mut BytesMut) {
         let as_number = BigUint::from_bytes_be(bytes);
         let expected_successor = as_number.add(1u64);
 
-        try_increment(bytes);
+        assert!(convert_to_upper_bound(bytes));
         let got_successor = BigUint::from_bytes_be(bytes);
 
         assert_eq!(got_successor, expected_successor);
@@ -207,7 +189,7 @@ mod tests {
         upper_bound_inclusive.put_u64(partition_id);
         upper_bound_inclusive.put_u64(u64::MAX);
 
-        assert!(try_increment(&mut upper_bound_inclusive));
+        assert!(convert_to_upper_bound(&mut upper_bound_inclusive));
 
         let mut seen_values = 0;
         for (_, &value) in db.range(lower_bound..upper_bound_inclusive) {
@@ -227,6 +209,71 @@ mod tests {
         verify_partition_covers_exactly(32 * 1024);
         verify_partition_covers_exactly(u32::MAX as u64);
         verify_partition_covers_exactly(u64::MAX - 1);
+    }
+
+    #[test]
+    fn inclusive_key_ranges_crossing_prefix_use_total_order() {
+        assert_eq!(
+            scan_mode(TableScan::RangeInclusive(TestKey(1, 0), TestKey(2, 0))),
+            ScanMode::TotalOrder
+        );
+        assert_eq!(
+            scan_mode(TableScan::RangeInclusive(
+                TestKey(1, 0),
+                TestKey(1, u64::MAX),
+            )),
+            ScanMode::TotalOrder
+        );
+    }
+
+    #[test]
+    fn single_partition_inclusive_key_range_stays_within_prefix() {
+        assert_eq!(
+            scan_mode(TableScan::RangeInclusive(TestKey(1, 0), TestKey(1, 9))),
+            ScanMode::WithinPrefix
+        );
+    }
+
+    #[test]
+    fn equal_inclusive_key_range_uses_prefix_scan() {
+        let scan = TableScan::RangeInclusive(TestKey(1, 9), TestKey(1, 9));
+        let physical_scan: PhysicalScan<Bytes> = scan.into();
+
+        let PhysicalScan::Prefix(_, prefix) = physical_scan else {
+            panic!("expected prefix scan");
+        };
+
+        let mut expected_prefix = BytesMut::new();
+        TestKey(1, 9).serialize_to(&mut expected_prefix);
+        assert_eq!(prefix, expected_prefix);
+    }
+
+    #[test]
+    fn full_scan_ranges_use_prefix_or_total_order_as_appropriate() {
+        let singleton_scan = TableScan::<TestKey>::ScanPartitionKeyRange(KeyRange::new(42, 42));
+        let singleton_physical_scan: PhysicalScan<Bytes> = singleton_scan.into();
+
+        let PhysicalScan::Prefix(_, singleton_prefix) = singleton_physical_scan else {
+            panic!("expected prefix scan");
+        };
+
+        let mut expected_prefix = BytesMut::from(&KeyKind::InvocationStatus.as_bytes()[..]);
+        expected_prefix.put_u64(42);
+        assert_eq!(singleton_prefix, expected_prefix);
+
+        let scan = TableScan::<TestKey>::ScanPartitionKeyRange(KeyRange::FULL);
+        let physical_scan: PhysicalScan<Bytes> = scan.into();
+
+        let PhysicalScan::RangeExclusive(_, scan_mode, _, end) = physical_scan else {
+            panic!("expected range scan");
+        };
+
+        let mut expected_end =
+            BytesMut::from(&KeyKind::InvocationStatus.exclusive_upper_bound()[..]);
+        expected_end.resize(DB_PREFIX_LENGTH, 0);
+
+        assert_eq!(scan_mode, ScanMode::TotalOrder);
+        assert_eq!(end, expected_end);
     }
 
     #[test]

--- a/crates/partition-store/src/service_status_table/mod.rs
+++ b/crates/partition-store/src/service_status_table/mod.rs
@@ -100,7 +100,7 @@ impl ScanVirtualObjectStatusTable for PartitionStore {
         self.iterator_for_each(
             "df-vo-status",
             Priority::Low,
-            TableScan::FullScanPartitionKeyRange::<ServiceStatusKey>(range),
+            TableScan::ScanPartitionKeyRange::<ServiceStatusKey>(range),
             move |(mut key, mut value)| {
                 let state_key = break_on_err(ServiceStatusKey::deserialize_from(&mut key))?;
                 let state_value = break_on_err(VirtualObjectStatus::decode(&mut value))?;

--- a/crates/partition-store/src/state_table/mod.rs
+++ b/crates/partition-store/src/state_table/mod.rs
@@ -213,10 +213,9 @@ fn delete_all_user_state<S: StorageAccess>(
 
         // Right now the WBWI does not support range deletions :-(
         // That's why we need to iterate over the individual state entries.
-        let keys = storage.for_each_key_value_in_place(
-            TableScan::SinglePartitionKeyPrefix(service_id.partition_key(), prefix_key),
-            |k, _| TableScanIterationDecision::Emit(Ok(Bytes::copy_from_slice(k))),
-        )?;
+        let keys = storage.for_each_key_value_in_place(TableScan::Prefix(prefix_key), |k, _| {
+            TableScanIterationDecision::Emit(Ok(Bytes::copy_from_slice(k)))
+        })?;
 
         for k in keys {
             let key = k?;
@@ -228,10 +227,9 @@ fn delete_all_user_state<S: StorageAccess>(
             .service_name(service_id.service_name.clone())
             .service_key(service_id.key.clone());
 
-        let keys = storage.for_each_key_value_in_place(
-            TableScan::SinglePartitionKeyPrefix(service_id.partition_key(), prefix_key),
-            |k, _| TableScanIterationDecision::Emit(Ok(Bytes::copy_from_slice(k))),
-        )?;
+        let keys = storage.for_each_key_value_in_place(TableScan::Prefix(prefix_key), |k, _| {
+            TableScanIterationDecision::Emit(Ok(Bytes::copy_from_slice(k)))
+        })?;
 
         for k in keys {
             let key = k?;
@@ -290,10 +288,7 @@ fn get_all_user_states_for_service<'a, S: StorageAccess>(
             .service_name(&service_name)
             .service_key(&service_key);
 
-        let iter = storage.iterator_from(TableScan::SinglePartitionKeyPrefix(
-            service_id.partition_key(),
-            key,
-        ))?;
+        let iter = storage.iterator_from(TableScan::Prefix(key))?;
         Ok(StateEntryIter::new(iter))
     } else {
         let key = StateKey::builder()
@@ -301,10 +296,7 @@ fn get_all_user_states_for_service<'a, S: StorageAccess>(
             .service_name(service_id.service_name.clone())
             .service_key(service_id.key.clone());
 
-        let iter = storage.iterator_from(TableScan::SinglePartitionKeyPrefix(
-            service_id.partition_key(),
-            key,
-        ))?;
+        let iter = storage.iterator_from(TableScan::Prefix(key))?;
         Ok(StateEntryIter::new(iter))
     }
 }
@@ -370,7 +362,7 @@ impl ScanStateTable for PartitionStore {
                 self.iterator_for_each(
                     "df-user-state",
                     Priority::Low,
-                    TableScan::FullScanPartitionKeyRange::<StateKey>(range),
+                    TableScan::ScanPartitionKeyRange::<StateKey>(range),
                     move |(mut key, value)| {
                         let row_key = break_on_err(StateKey::deserialize_from(&mut key))?;
                         let (partition_key, service_name, service_key, state_key) = row_key.split();
@@ -388,7 +380,7 @@ impl ScanStateTable for PartitionStore {
             .iterator_for_each(
                 "df-user-state-scoped",
                 Priority::Low,
-                TableScan::FullScanPartitionKeyRange::<ScopedStateKey>(range),
+                TableScan::ScanPartitionKeyRange::<ScopedStateKey>(range),
                 move |(mut key, value)| {
                     let row_key = break_on_err(ScopedStateKey::deserialize_from(&mut key))?;
                     let (_partition_key, scope, service_name, service_key, state_key) =

--- a/crates/partition-store/src/tests/migrations_test/migrate_to_scoped_promise_table.rs
+++ b/crates/partition-store/src/tests/migrations_test/migrate_to_scoped_promise_table.rs
@@ -108,10 +108,13 @@ async fn migrate_to_scoped_promise_table_moves_unscoped_promises_to_scoped_table
     let mut arena = BytesMut::new();
     let mut unscoped_iter = rocksdb
         .partition_db()
-        .scan(PhysicalScan::from(
-            TableScan::FullScanPartitionKeyRange::<PromiseKey>(rocksdb.partition_key_range()),
-            &mut arena,
-        ))
+        .scan(
+            PhysicalScan::from(
+                TableScan::ScanPartitionKeyRange::<PromiseKey>(rocksdb.partition_key_range()),
+                &mut arena,
+            ),
+            rocksdb::ReadOptions::default(),
+        )
         .expect("scan should start");
     unscoped_iter.seek_to_first();
     assert!(
@@ -128,10 +131,13 @@ async fn migrate_to_scoped_promise_table_moves_unscoped_promises_to_scoped_table
     let mut observed: HashMap<(PartitionKey, String, String, String), Promise> = HashMap::new();
     let mut scoped_iter = rocksdb
         .partition_db()
-        .scan(PhysicalScan::from(
-            TableScan::FullScanPartitionKeyRange::<ScopedPromiseKey>(rocksdb.partition_key_range()),
-            &mut arena,
-        ))
+        .scan(
+            PhysicalScan::from(
+                TableScan::ScanPartitionKeyRange::<ScopedPromiseKey>(rocksdb.partition_key_range()),
+                &mut arena,
+            ),
+            rocksdb::ReadOptions::default(),
+        )
         .expect("scan should start");
     scoped_iter.seek_to_first();
     while scoped_iter.valid() {

--- a/crates/partition-store/src/tests/migrations_test/migrate_to_scoped_state_table.rs
+++ b/crates/partition-store/src/tests/migrations_test/migrate_to_scoped_state_table.rs
@@ -96,10 +96,13 @@ async fn migrate_to_scoped_state_table_moves_unscoped_state_to_scoped_table() {
     let mut arena = BytesMut::new();
     let mut unscoped_iter = rocksdb
         .partition_db()
-        .scan(PhysicalScan::from(
-            TableScan::FullScanPartitionKeyRange::<StateKey>(rocksdb.partition_key_range()),
-            &mut arena,
-        ))
+        .scan(
+            PhysicalScan::from(
+                TableScan::ScanPartitionKeyRange::<StateKey>(rocksdb.partition_key_range()),
+                &mut arena,
+            ),
+            rocksdb::ReadOptions::default(),
+        )
         .expect("scan should start");
     unscoped_iter.seek_to_first();
     assert!(
@@ -116,10 +119,13 @@ async fn migrate_to_scoped_state_table_moves_unscoped_state_to_scoped_table() {
     let mut observed: HashMap<(PartitionKey, String, String, Bytes), Bytes> = HashMap::new();
     let mut scoped_iter = rocksdb
         .partition_db()
-        .scan(PhysicalScan::from(
-            TableScan::FullScanPartitionKeyRange::<ScopedStateKey>(rocksdb.partition_key_range()),
-            &mut arena,
-        ))
+        .scan(
+            PhysicalScan::from(
+                TableScan::ScanPartitionKeyRange::<ScopedStateKey>(rocksdb.partition_key_range()),
+                &mut arena,
+            ),
+            rocksdb::ReadOptions::default(),
+        )
         .expect("scan should start");
     scoped_iter.seek_to_first();
     while scoped_iter.valid() {

--- a/crates/partition-store/src/tests/migrations_test/verify_and_run_migrations.rs
+++ b/crates/partition-store/src/tests/migrations_test/verify_and_run_migrations.rs
@@ -79,10 +79,13 @@ fn count_legacy_state(store: &crate::PartitionStore) -> usize {
     let mut arena = BytesMut::new();
     let mut it = store
         .partition_db()
-        .scan(PhysicalScan::from(
-            TableScan::FullScanPartitionKeyRange::<StateKey>(store.partition_key_range()),
-            &mut arena,
-        ))
+        .scan(
+            PhysicalScan::from(
+                TableScan::ScanPartitionKeyRange::<StateKey>(store.partition_key_range()),
+                &mut arena,
+            ),
+            rocksdb::ReadOptions::default(),
+        )
         .expect("scan legacy state");
     it.seek_to_first();
     let mut n = 0;
@@ -97,10 +100,13 @@ fn count_legacy_promise(store: &crate::PartitionStore) -> usize {
     let mut arena = BytesMut::new();
     let mut it = store
         .partition_db()
-        .scan(PhysicalScan::from(
-            TableScan::FullScanPartitionKeyRange::<PromiseKey>(store.partition_key_range()),
-            &mut arena,
-        ))
+        .scan(
+            PhysicalScan::from(
+                TableScan::ScanPartitionKeyRange::<PromiseKey>(store.partition_key_range()),
+                &mut arena,
+            ),
+            rocksdb::ReadOptions::default(),
+        )
         .expect("scan legacy promise");
     it.seek_to_first();
     let mut n = 0;
@@ -115,10 +121,13 @@ fn count_scoped_state(store: &crate::PartitionStore) -> usize {
     let mut arena = BytesMut::new();
     let mut it = store
         .partition_db()
-        .scan(PhysicalScan::from(
-            TableScan::FullScanPartitionKeyRange::<ScopedStateKey>(store.partition_key_range()),
-            &mut arena,
-        ))
+        .scan(
+            PhysicalScan::from(
+                TableScan::ScanPartitionKeyRange::<ScopedStateKey>(store.partition_key_range()),
+                &mut arena,
+            ),
+            rocksdb::ReadOptions::default(),
+        )
         .expect("scan scoped state");
     it.seek_to_first();
     let mut n = 0;
@@ -137,10 +146,13 @@ fn count_scoped_promise(store: &crate::PartitionStore) -> usize {
     let mut arena = BytesMut::new();
     let mut it = store
         .partition_db()
-        .scan(PhysicalScan::from(
-            TableScan::FullScanPartitionKeyRange::<ScopedPromiseKey>(store.partition_key_range()),
-            &mut arena,
-        ))
+        .scan(
+            PhysicalScan::from(
+                TableScan::ScanPartitionKeyRange::<ScopedPromiseKey>(store.partition_key_range()),
+                &mut arena,
+            ),
+            rocksdb::ReadOptions::default(),
+        )
         .expect("scan scoped promise");
     it.seek_to_first();
     let mut n = 0;

--- a/crates/partition-store/src/timer_table/mod.rs
+++ b/crates/partition-store/src/timer_table/mod.rs
@@ -116,13 +116,9 @@ fn exclusive_start_key_range(
             .partition_id(partition_id.into())
             .timestamp(u64::MAX);
 
-        TableScan::KeyRangeInclusiveInSinglePartition(
-            partition_id,
-            lower_bound.into_builder(),
-            upper_bound,
-        )
+        TableScan::RangeInclusive(lower_bound.into_builder(), upper_bound)
     } else {
-        TableScan::SinglePartition(partition_id)
+        TableScan::Prefix(TimersKey::builder().partition_id(partition_id.into()))
     }
 }
 
@@ -452,7 +448,7 @@ mod tests {
         assert!(less_than(&key_a_bytes, &key_b_bytes));
 
         let (low, high) = match exclusive_start_key_range(PartitionId::from(1), Some(key_a)) {
-            TableScan::KeyRangeInclusiveInSinglePartition(p, low, high) if *p == 1 => (low, high),
+            TableScan::RangeInclusive(low, high) => (low, high),
             _ => panic!(""),
         };
         let low = low.serialize();

--- a/crates/partition-store/src/vqueue_table/mod.rs
+++ b/crates/partition-store/src/vqueue_table/mod.rs
@@ -459,7 +459,7 @@ impl ScanVQueueMetaTable for PartitionStore {
         self.iterator_for_each(
             "df-vqueue-meta",
             Priority::Low,
-            TableScan::FullScanPartitionKeyRange::<MetaKey>(range),
+            TableScan::ScanPartitionKeyRange::<MetaKey>(range),
             move |(mut key, value)| {
                 let meta_key = break_on_err(MetaKey::deserialize_from(&mut key))?;
                 let meta = break_on_err(
@@ -489,7 +489,7 @@ impl ScanVQueueEntryStatusTable for PartitionStore {
         self.iterator_for_each(
             "df-vqueue-entry-status",
             Priority::Low,
-            TableScan::FullScanPartitionKeyRange::<EntryStatusKey>(range),
+            TableScan::ScanPartitionKeyRange::<EntryStatusKey>(range),
             move |(mut key, mut value)| {
                 let status_key = break_on_err(EntryStatusKey::deserialize_from(&mut key))?;
                 let (_, entry_id) = status_key.split();
@@ -545,7 +545,7 @@ where
         .iterator_for_each(
             scanner_name,
             Priority::Low,
-            TableScan::FullScanPartitionKeyRange::<K>(range),
+            TableScan::ScanPartitionKeyRange::<K>(range),
             move |(mut key, mut value)| {
                 // Skip the key-kind byte; the iterator was opened with a stage-specific
                 // prefix so every row belongs to `stage`.


### PR DESCRIPTION

Replace the specialized partition and key-range scan variants with a compact TableScan API that lowers encoded bounds to prefix or exclusive range scans. Use prefix seeking only when the encoded bounds remain within RocksDB's fixed prefix, fall back to total-order seeking for cross-prefix ranges, and turn singleton ranges into prefix scans.

Centralize iterator-bound configuration across direct, background, and transactional readers. Let callers supply ReadOptions so async I/O and transaction snapshots remain caller policy, while short prefixes safely bypass the fixed-prefix extractor and its bloom filters.

Remove the iterator wrapper plumbing, share encoded Bytes bounds across RocksDB paths, and migrate table and storage-migration callers to the consolidated API. Cover inclusive upper bounds, singleton partition ranges, and prefix-versus-total-order selection.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/5052).
* #5056
* #5053
* #5048
* #5047
* #5046
* __->__ #5052