### PR TITLE
[VQueues] Optimize sys_vqueues point lookups

### DIFF
--- a/crates/storage-query-datafusion/src/filter.rs
+++ b/crates/storage-query-datafusion/src/filter.rs
@@ -479,23 +479,27 @@ fn extract_column_literal<'a>(
 pub struct VQueueFilter {
     pub partition_keys: KeyRange,
     pub stages: Option<BTreeSet<Stage>>,
+    pub entry_ids: Option<IdSelection<VQueueEntryId>>,
 }
 
 impl ScanLocalPartitionFilter for VQueueFilter {
     fn new(range: KeyRange, predicate: Option<Arc<dyn PhysicalExpr>>) -> Self {
         let mut stages: Option<BTreeSet<Stage>> = None;
+        let mut entry_ids = None;
 
         if let Some(predicate) = predicate
             && let Ok(predicate) = snapshot_physical_expr(predicate)
         {
             for conjunct in split_conjunction(&predicate) {
-                let Some(conjunct_stages) = parse_vqueue_stages("stage", conjunct) else {
-                    continue;
-                };
+                if let Some(conjunct_stages) = parse_vqueue_stages("stage", conjunct) {
+                    stages = Some(match stages {
+                        Some(current) => current.intersection(&conjunct_stages).copied().collect(),
+                        None => conjunct_stages,
+                    });
+                }
 
-                stages = Some(match stages {
-                    Some(current) => current.intersection(&conjunct_stages).copied().collect(),
-                    None => conjunct_stages,
+                entry_ids = entry_ids.or_else(|| {
+                    parse_id_selection("entry_id", range, conjunct, VQueueEntryId::partition_key)
                 });
             }
         }
@@ -503,6 +507,7 @@ impl ScanLocalPartitionFilter for VQueueFilter {
         Self {
             partition_keys: range,
             stages,
+            entry_ids,
         }
     }
 }
@@ -1385,7 +1390,39 @@ mod tests {
         let filter = VQueueFilter::new(FULL_RANGE, None);
 
         assert!(filter.stages.is_none());
+        assert!(filter.entry_ids.is_none());
         assert_eq!(filter.partition_keys, FULL_RANGE);
+    }
+
+    #[test]
+    fn vqueue_filter_extracts_entry_ids_and_rejects_negated_list() {
+        let id1 = make_invocation_id("key-1");
+        let id2 = make_invocation_id("key-2");
+        let filter = VQueueFilter::new(
+            FULL_RANGE,
+            Some(and(
+                in_list(
+                    "entry_id",
+                    vec![utf8_lit(id1.to_string()), utf8_lit(id2.to_string())],
+                ),
+                eq(col("stage"), utf8_lit("running")),
+            )),
+        );
+
+        assert_eq!(
+            filter.entry_ids.expect("should extract entry ids").ids,
+            BTreeSet::from([
+                VQueueEntryId::from_str(&id1.to_string()).unwrap(),
+                VQueueEntryId::from_str(&id2.to_string()).unwrap(),
+            ])
+        );
+        assert_eq!(filter.stages, Some(BTreeSet::from([Stage::Running])));
+
+        let filter = VQueueFilter::new(
+            FULL_RANGE,
+            Some(not_in_list("entry_id", vec![utf8_lit(id1.to_string())])),
+        );
+        assert!(filter.entry_ids.is_none());
     }
 
     #[test]

--- a/crates/storage-query-datafusion/src/vqueues/row.rs
+++ b/crates/storage-query-datafusion/src/vqueues/row.rs
@@ -8,8 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use restate_storage_api::vqueue_table::{EntryKey, EntryValue, Stage};
-use restate_types::vqueues::VQueueId;
+use std::fmt::Display;
+
+use restate_sharding::PartitionKey;
+use restate_storage_api::vqueue_table::stats::EntryStatistics;
+use restate_storage_api::vqueue_table::{
+    EntryId, EntryKey, EntryValue, RawStatusHeaderRef, Stage, Status,
+};
+use restate_types::vqueues::{Seq, VQueueId};
 
 use super::schema::SysVqueuesBuilder;
 
@@ -21,9 +27,60 @@ pub(crate) fn append_vqueues_row<'a>(
     entry_key: &'a EntryKey,
     entry: &'a EntryValue,
 ) {
+    append_vqueues_row_inner(
+        builder,
+        qid.partition_key(),
+        qid,
+        stage,
+        entry.status,
+        entry_key.has_lock(),
+        entry_key.run_at().as_unix_millis().as_u64() as i64,
+        entry_key.seq(),
+        entry_key.entry_id(),
+        &entry.stats,
+        entry.metadata.deployment.as_deref(),
+    );
+}
+
+#[inline]
+pub(crate) fn append_vqueues_status_row(
+    builder: &mut SysVqueuesBuilder,
+    partition_key: PartitionKey,
+    entry_id: &EntryId,
+    header: &RawStatusHeaderRef<'_>,
+) {
+    append_vqueues_row_inner(
+        builder,
+        partition_key,
+        &header.qid,
+        header.stage,
+        header.status,
+        header.has_lock,
+        header.next_run_at.as_unix_millis().as_u64() as i64,
+        header.seq,
+        entry_id,
+        &header.stats,
+        header.metadata.deployment,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn append_vqueues_row_inner(
+    builder: &mut SysVqueuesBuilder,
+    partition_key: PartitionKey,
+    qid: impl Display,
+    stage: Stage,
+    status: Status,
+    has_lock: bool,
+    run_at: i64,
+    seq: Seq,
+    entry_id: &EntryId,
+    stats: &EntryStatistics,
+    deployment: Option<&str>,
+) {
     let mut row = builder.row();
 
-    row.partition_key(qid.partition_key());
+    row.partition_key(partition_key);
     if row.is_id_defined() {
         row.fmt_id(qid);
     }
@@ -31,73 +88,73 @@ pub(crate) fn append_vqueues_row<'a>(
         row.fmt_stage(stage);
     }
     if row.is_status_defined() {
-        row.fmt_status(entry.status);
+        row.fmt_status(status);
     }
 
     if row.is_has_lock_defined() {
-        row.has_lock(entry_key.has_lock());
+        row.has_lock(has_lock);
     }
     if matches!(stage, Stage::Inbox) && row.is_run_at_defined() {
-        row.run_at(entry_key.run_at().as_unix_millis().as_u64() as i64);
+        row.run_at(run_at);
     }
     if row.is_sequence_number_defined() {
-        row.sequence_number(entry_key.seq().as_u64());
+        row.sequence_number(seq.as_u64());
     }
 
     if row.is_entry_id_defined() {
-        row.fmt_entry_id(entry_key.entry_id().display(qid.partition_key()));
+        row.fmt_entry_id(entry_id.display(partition_key));
     }
 
     if row.is_entry_kind_defined() {
-        row.fmt_entry_kind(entry_key.kind());
+        row.fmt_entry_kind(entry_id.kind());
     }
 
     if row.is_created_at_defined() {
-        row.created_at(entry.stats.created_at.to_unix_millis().as_u64() as i64);
+        row.created_at(stats.created_at.to_unix_millis().as_u64() as i64);
     }
 
     if row.is_transitioned_at_defined() {
-        row.transitioned_at(entry.stats.transitioned_at.to_unix_millis().as_u64() as i64);
+        row.transitioned_at(stats.transitioned_at.to_unix_millis().as_u64() as i64);
     }
 
     if row.is_num_attempts_defined() {
-        row.num_attempts(entry.stats.num_attempts);
+        row.num_attempts(stats.num_attempts);
     }
 
     if row.is_num_errors_defined() {
-        row.num_errors(entry.stats.num_errors);
+        row.num_errors(stats.num_errors);
     }
 
     if row.is_num_pauses_defined() {
-        row.num_pauses(entry.stats.num_paused);
+        row.num_pauses(stats.num_paused);
     }
 
     if row.is_num_suspensions_defined() {
-        row.num_suspensions(entry.stats.num_suspensions);
+        row.num_suspensions(stats.num_suspensions);
     }
 
     if row.is_num_yields_defined() {
-        row.num_yields(entry.stats.num_yields);
+        row.num_yields(stats.num_yields);
     }
 
     if row.is_first_attempt_at_defined()
-        && let Some(first_attempt_at) = entry.stats.first_attempt_at
+        && let Some(first_attempt_at) = stats.first_attempt_at
     {
         row.first_attempt_at(first_attempt_at.to_unix_millis().as_u64() as i64);
     }
 
     if row.is_latest_attempt_at_defined()
-        && let Some(latest_attempt_at) = entry.stats.latest_attempt_at
+        && let Some(latest_attempt_at) = stats.latest_attempt_at
     {
         row.latest_attempt_at(latest_attempt_at.to_unix_millis().as_u64() as i64);
     }
 
     if row.is_first_runnable_at_defined() {
-        row.first_runnable_at(entry.stats.first_runnable_at.as_u64() as i64);
+        row.first_runnable_at(stats.first_runnable_at.as_u64() as i64);
     }
 
     if row.is_deployment_defined()
-        && let Some(deployment) = &entry.metadata.deployment
+        && let Some(deployment) = deployment
     {
         row.fmt_deployment(deployment);
     }

--- a/crates/storage-query-datafusion/src/vqueues/table.rs
+++ b/crates/storage-query-datafusion/src/vqueues/table.rs
@@ -12,17 +12,25 @@ use std::fmt::Debug;
 use std::ops::ControlFlow;
 use std::sync::Arc;
 
+use futures::FutureExt;
+
 use restate_partition_store::{PartitionStore, PartitionStoreManager};
+use restate_sharding::PartitionKey;
 use restate_storage_api::StorageError;
-use restate_storage_api::vqueue_table::{EntryKey, EntryValue, ScanVQueueEntries, Stage};
+use restate_storage_api::vqueue_table::filters::ScanEntryIdFilter;
+use restate_storage_api::vqueue_table::{
+    EntryId, EntryKey, EntryValue, RawStatusHeaderRef, ScanVQueueEntries,
+    ScanVQueueEntryStatusTable, Stage,
+};
 use restate_types::vqueues::VQueueId;
 
 use crate::context::{QueryContext, SelectPartitions};
 use crate::filter::{FirstMatchingPartitionKeyExtractor, VQueueFilter};
 use crate::partition_store_scanner::{LocalPartitionsScanner, ScanLocalPartition};
 use crate::remote_query_scanner_manager::RemoteScannerManager;
+use crate::statistics::{DEPLOYMENT_ROW_ESTIMATE, RowEstimate, TableStatisticsBuilder};
 use crate::table_providers::{PartitionedTableProvider, ScanPartition};
-use crate::vqueues::row::append_vqueues_row;
+use crate::vqueues::row::{append_vqueues_row, append_vqueues_status_row};
 use crate::vqueues::schema::{SysVqueuesBuilder, sys_vqueues_sort_order};
 
 const NAME: &str = "sys_vqueues";
@@ -38,15 +46,24 @@ pub(crate) fn register_self(
         VQueuesScanner,
     )) as Arc<dyn ScanPartition>;
 
+    let schema = SysVqueuesBuilder::schema();
+    let statistics = TableStatisticsBuilder::new(schema.clone())
+        .with_num_rows_estimate(RowEstimate::Large)
+        .with_partition_key()
+        .with_primary_key("entry_id")
+        .with_foreign_key("deployment", DEPLOYMENT_ROW_ESTIMATE)
+        .with_foreign_key("id", RowEstimate::Small);
+
     let table = PartitionedTableProvider::new(
         partition_selector,
-        SysVqueuesBuilder::schema(),
+        schema,
         sys_vqueues_sort_order(),
         remote_scanner_manager.create_distributed_scanner(NAME, local_scanner),
         FirstMatchingPartitionKeyExtractor::default()
-            .with_partitioned_resource_id::<VQueueId>("id")
-            .with_vqueue_entry_id("entry_id"),
-    );
+            .with_grouped_vqueue_entry_id("entry_id")
+            .with_partitioned_resource_id::<VQueueId>("id"),
+    )
+    .with_statistics(statistics.build());
 
     ctx.register_partitioned_table(NAME, Arc::new(table))
 }
@@ -54,9 +71,14 @@ pub(crate) fn register_self(
 #[derive(Debug, Clone)]
 struct VQueuesScanner;
 
+enum VQueueRow<'a> {
+    Stage(&'a VQueueId, Stage, &'a EntryKey, &'a EntryValue),
+    Status(PartitionKey, &'a EntryId, &'a RawStatusHeaderRef<'a>),
+}
+
 impl ScanLocalPartition for VQueuesScanner {
     type Builder = SysVqueuesBuilder;
-    type Item<'a> = (&'a VQueueId, Stage, &'a EntryKey, &'a EntryValue);
+    type Item<'a> = VQueueRow<'a>;
     type ConversionError = std::convert::Infallible;
     type Filter = VQueueFilter;
 
@@ -70,19 +92,49 @@ impl ScanLocalPartition for VQueuesScanner {
         filter: VQueueFilter,
         mut f: F,
     ) -> Result<impl Future<Output = restate_storage_api::Result<()>> + Send, StorageError> {
-        partition_store.for_each_vqueue_entry(
-            filter.partition_keys,
-            filter.stages.unwrap_or_default(),
-            move |item| f(item).map_break(Result::unwrap),
-        )
+        if let Some(entry_ids) = filter.entry_ids {
+            let stages = filter.stages;
+            return partition_store
+                .for_each_vqueue_entry_status(
+                    ScanEntryIdFilter::EntryIdSet(entry_ids.ids),
+                    move |partition_key, entry_id, header| {
+                        if stages
+                            .as_ref()
+                            .is_some_and(|stages| !stages.contains(&header.stage))
+                        {
+                            return ControlFlow::Continue(());
+                        }
+
+                        f(VQueueRow::Status(partition_key, entry_id, header))
+                            .map_break(Result::unwrap)
+                    },
+                )
+                .map(FutureExt::boxed);
+        }
+
+        partition_store
+            .for_each_vqueue_entry(
+                filter.partition_keys,
+                filter.stages.unwrap_or_default(),
+                move |(qid, stage, entry_key, entry)| {
+                    f(VQueueRow::Stage(qid, stage, entry_key, entry)).map_break(Result::unwrap)
+                },
+            )
+            .map(FutureExt::boxed)
     }
 
     fn append_row<'a>(
         row_builder: &mut Self::Builder,
         value: Self::Item<'a>,
     ) -> Result<(), Self::ConversionError> {
-        let (qid, stage, entry_key, entry) = value;
-        append_vqueues_row(row_builder, qid, stage, entry_key, entry);
+        match value {
+            VQueueRow::Stage(qid, stage, entry_key, entry) => {
+                append_vqueues_row(row_builder, qid, stage, entry_key, entry);
+            }
+            VQueueRow::Status(partition_key, entry_id, header) => {
+                append_vqueues_status_row(row_builder, partition_key, entry_id, header);
+            }
+        }
         Ok(())
     }
 }

--- a/crates/storage-query-datafusion/src/vqueues/tests.rs
+++ b/crates/storage-query-datafusion/src/vqueues/tests.rs
@@ -27,6 +27,31 @@ use restate_types::time::MillisSinceEpoch;
 use restate_types::vqueues::VQueueId;
 use restate_util_string::ToReString;
 
+async fn select_entry_ids(engine: &mut MockQueryEngine, query: &str) -> Vec<String> {
+    let records = engine
+        .execute(query.to_owned())
+        .await
+        .unwrap()
+        .stream
+        .collect::<Vec<datafusion::common::Result<RecordBatch>>>()
+        .await
+        .remove(0)
+        .unwrap();
+
+    let mut ids = records
+        .column_by_name("entry_id")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<LargeStringArray>()
+        .unwrap()
+        .iter()
+        .flatten()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    ids.sort();
+    ids
+}
+
 #[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_vqueue_entry_value_fields() {
     let mut engine = MockQueryEngine::create().await;
@@ -193,4 +218,90 @@ async fn vqueue_stage_filter_and_unfiltered_scan() {
             row!(1, { "stage" => LargeStringArray: eq("running") })
         )
     );
+}
+
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
+async fn vqueue_entry_id_point_query_and_not_in_fallback() {
+    let mut engine = MockQueryEngine::create().await;
+    let qid = VQueueId::custom(3337, "df-vqueue-point-lookup");
+    let mut keys = Vec::new();
+
+    let mut tx = engine.partition_store().transaction();
+    for index in 0..6u8 {
+        let key = EntryKey::new(
+            false,
+            MillisSinceEpoch::new(1_744_002_000_000 + u64::from(index)),
+            u64::from(index),
+            EntryId::new(EntryKind::Invocation, [index + 1; 16]),
+        );
+        let stage = if index == 2 {
+            Stage::Paused
+        } else {
+            Stage::Inbox
+        };
+        let stats = EntryStatistics::new(
+            UniqueTimestamp::try_from_unix_millis(MillisSinceEpoch::new(
+                1_744_002_000_100 + u64::from(index),
+            ))
+            .unwrap(),
+            key.run_at(),
+        );
+        let value = EntryValue {
+            status: Status::Started,
+            metadata: EntryMetadata::default(),
+            stats,
+        };
+
+        if index < 4 {
+            // Point lookups must use the status index; these rows are absent
+            // from the stage table so a stage scan cannot satisfy the query.
+            tx.put_vqueue_entry_status(
+                &qid,
+                stage,
+                &key,
+                &value.metadata,
+                value.stats,
+                value.status,
+            );
+        } else {
+            // NOT IN must retain the stage-scan path; these rows are absent
+            // from the status index so an exact lookup cannot return them.
+            tx.put_vqueue_inbox(&qid, stage, &key, &value);
+        }
+        keys.push(key);
+    }
+    tx.commit().await.unwrap();
+    drop(tx);
+
+    let entry_ids = keys
+        .iter()
+        .map(|key| key.entry_id().display(qid.partition_key()).to_string())
+        .collect::<Vec<_>>();
+    let got = select_entry_ids(
+        &mut engine,
+        &format!(
+            "SELECT entry_id FROM sys_vqueues WHERE entry_id IN ('{}', '{}', '{}') AND stage = 'inbox'",
+            entry_ids[0], entry_ids[1], entry_ids[2]
+        ),
+    )
+    .await;
+
+    let mut expected = vec![entry_ids[0].clone(), entry_ids[1].clone()];
+    expected.sort();
+    assert_eq!(got, expected);
+
+    let excluded = entry_ids[0..4]
+        .iter()
+        .map(|entry_id| format!("'{entry_id}'"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let got = select_entry_ids(
+        &mut engine,
+        &format!("SELECT entry_id FROM sys_vqueues WHERE entry_id NOT IN ({excluded})"),
+    )
+    .await;
+
+    let mut expected = vec![entry_ids[4].clone(), entry_ids[5].clone()];
+    expected.sort();
+    assert_eq!(got, expected);
 }


### PR DESCRIPTION

Extract exact entry_id equality and IN predicates and group them by Restate partition. Instead of scanning the stage-oriented vqueue records, serve those lookups from the entry-status index using its existing batched multi-get path; the status header already contains every field needed to construct a sys_vqueues row.

Keep stage scans for unfiltered, non-point, and negated predicates, and apply any stage restriction to point-read results before building rows.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/5053).
* #5056
* __->__ #5053
* #5048
* #5047
* #5046
* #5052