### PR TITLE
[DataFusion] Fix declared ordering of SQL ID columns

### DIFF
--- a/crates/storage-query-datafusion/src/inbox/row.rs
+++ b/crates/storage-query-datafusion/src/inbox/row.rs
@@ -17,14 +17,13 @@ pub(crate) fn append_inbox_row(
     builder: &mut SysInboxBuilder,
     inbox_entry: SequenceNumberInboxEntry,
 ) {
-    let mut row = builder.row();
-
     let SequenceNumberInboxEntry {
         inbox_sequence_number,
         inbox_entry,
     } = inbox_entry;
 
     if let InboxEntry::Invocation(service_id, invocation_id) = inbox_entry {
+        let mut row = builder.row();
         row.partition_key(invocation_id.partition_key());
         row.service_name(&service_id.service_name);
         row.service_key(&service_id.key);

--- a/crates/storage-query-datafusion/src/inbox/schema.rs
+++ b/crates/storage-query-datafusion/src/inbox/schema.rs
@@ -12,7 +12,7 @@ use crate::table_macro::*;
 
 use datafusion::arrow::datatypes::DataType;
 
-define_sort_order!(sys_inbox(partition_key, id));
+define_sort_order!(sys_inbox(partition_key));
 
 define_table!(sys_inbox(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.

--- a/crates/storage-query-datafusion/src/inbox/tests.rs
+++ b/crates/storage-query-datafusion/src/inbox/tests.rs
@@ -19,6 +19,7 @@ use restate_storage_api::Transaction;
 use restate_storage_api::inbox_table::{InboxEntry, WriteInboxTable};
 use restate_types::identifiers::InvocationId;
 use restate_types::invocation::InvocationTarget;
+use restate_types::state_mut::ExternalStateMutation;
 
 #[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_inbox() {
@@ -33,9 +34,18 @@ async fn get_inbox() {
         &InboxEntry::Invocation(service_id.clone(), invocation_id_1),
     )
     .unwrap();
-    let invocation_id_2 = InvocationId::mock_generate(&invocation_target);
     tx.put_inbox_entry(
         1,
+        &InboxEntry::StateMutation(ExternalStateMutation {
+            service_id: service_id.clone(),
+            version: None,
+            state: Default::default(),
+        }),
+    )
+    .unwrap();
+    let invocation_id_2 = InvocationId::mock_generate(&invocation_target);
+    tx.put_inbox_entry(
+        2,
         &InboxEntry::Invocation(service_id.clone(), invocation_id_2),
     )
     .unwrap();
@@ -68,7 +78,7 @@ async fn get_inbox() {
                 1,
                 {
                     "id" => LargeStringArray: eq(invocation_id_2.to_string()),
-                    "sequence_number" => UInt64Array: eq(1),
+                    "sequence_number" => UInt64Array: eq(2),
                     "service_name" => LargeStringArray: eq(service_id.service_name.to_string()),
                     "service_key" => LargeStringArray: eq(service_id.key.to_string()),
                 }

--- a/crates/storage-query-datafusion/src/invocation_state/schema.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/schema.rs
@@ -12,7 +12,7 @@ use crate::table_macro::*;
 
 use datafusion::arrow::datatypes::DataType;
 
-define_sort_order!(sys_invocation_state(partition_key, id));
+define_sort_order!(sys_invocation_state(partition_key));
 
 define_table!(sys_invocation_state(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.

--- a/crates/storage-query-datafusion/src/invocation_status/schema.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/schema.rs
@@ -12,7 +12,7 @@ use crate::table_macro::*;
 
 use datafusion::arrow::datatypes::DataType;
 
-define_sort_order!(sys_invocation_status(partition_key, id));
+define_sort_order!(sys_invocation_status(partition_key));
 
 define_table!(sys_invocation_status(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.

--- a/crates/storage-query-datafusion/src/journal/schema.rs
+++ b/crates/storage-query-datafusion/src/journal/schema.rs
@@ -12,7 +12,9 @@ use crate::table_macro::*;
 
 use datafusion::arrow::datatypes::DataType;
 
-define_sort_order!(sys_journal(partition_key, id));
+// Mixed V1/V2 journals can violate this ordering because the two scans are concatenated rather
+// than merged. We accept this compromise while the deprecated V1 journal is phased out.
+define_sort_order!(sys_journal(partition_key));
 
 define_table!(sys_journal (
     /// Internal column that is used for partitioning the services invocations. Can be ignored.

--- a/crates/storage-query-datafusion/src/journal_events/schema.rs
+++ b/crates/storage-query-datafusion/src/journal_events/schema.rs
@@ -12,7 +12,7 @@ use crate::table_macro::*;
 
 use datafusion::arrow::datatypes::DataType;
 
-define_sort_order!(sys_journal_events(partition_key, id));
+define_sort_order!(sys_journal_events(partition_key));
 
 define_table!(sys_journal_events (
     /// Internal column that is used for partitioning the services invocations. Can be ignored.

--- a/crates/storage-query-datafusion/src/scheduler_status/schema.rs
+++ b/crates/storage-query-datafusion/src/scheduler_status/schema.rs
@@ -12,7 +12,7 @@ use datafusion::arrow::datatypes::DataType;
 
 use crate::table_macro::*;
 
-define_sort_order!(sys_scheduler(partition_key, id));
+define_sort_order!(sys_scheduler(partition_key));
 
 define_table!(sys_scheduler(
     /// Internal column that is used for partitioning. Can be ignored.

--- a/crates/storage-query-datafusion/src/tests.rs
+++ b/crates/storage-query-datafusion/src/tests.rs
@@ -541,6 +541,73 @@ async fn query_sys_invocation_status_not_in() {
     assert_eq!(got, expected);
 }
 
+/// Regression: `id` must not be declared as a sorted column. The rocksdb scan emits rows in
+/// big-endian key order, but the base62 string encoding of `InvocationId` is not monotonic with
+/// it, so DataFusion would elide sorts that match the declared ordering (notably the
+/// `NULLS FIRST` form, which matches the default `SortOptions` used by `make_ordering`) and
+/// return misordered rows.
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_sys_invocation_status_order_by_id() {
+    let invocation_target = InvocationTarget::mock_service();
+    let mut engine = MockQueryEngine::create().await;
+
+    // uuids whose storage (numeric) order differs from the string order of the encoded id
+    let uuids: [u128; 5] = [1, 255, 256, 1 << 64, u128::MAX / 7];
+    let mut ids = Vec::new();
+    let mut tx = engine.partition_store().transaction();
+    for uuid in uuids {
+        let id = InvocationId::from_parts(1, InvocationUuid::from_u128(uuid));
+        tx.put_invocation_status(
+            &id,
+            &InvocationStatus::Completed(CompletedInvocation {
+                invocation_target: invocation_target.clone(),
+                ..CompletedInvocation::mock_neo()
+            }),
+        )
+        .unwrap();
+        ids.push(id.to_string());
+    }
+    tx.commit().await.unwrap();
+    drop(tx);
+
+    let mut expected = ids.clone();
+    expected.sort();
+    // `ids` is in storage order; the test is vacuous unless the string order diverges from it
+    assert_ne!(expected, ids);
+
+    for sql in [
+        "SELECT id FROM sys_invocation_status ORDER BY partition_key, id",
+        // matches the declared ordering's SortOptions, so this form is eligible for sort elision
+        "SELECT id FROM sys_invocation_status ORDER BY partition_key NULLS FIRST, id NULLS FIRST",
+    ] {
+        let batches = engine
+            .execute(sql)
+            .await
+            .unwrap()
+            .stream
+            .collect::<Vec<datafusion::common::Result<RecordBatch>>>()
+            .await;
+
+        let mut got = Vec::new();
+        for batch in batches {
+            let batch = batch.unwrap();
+            got.extend(
+                batch
+                    .column_by_name("id")
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<LargeStringArray>()
+                    .unwrap()
+                    .iter()
+                    .flatten()
+                    .map(str::to_string),
+            );
+        }
+
+        assert_eq!(got, expected, "misordered result for: {sql}");
+    }
+}
+
 /// Exercises the exact-id fast path: `id IN (...)` on `sys_invocation_status`
 /// must return exactly the requested rows.
 #[restate_core::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/storage-query-datafusion/src/vqueue_meta/schema.rs
+++ b/crates/storage-query-datafusion/src/vqueue_meta/schema.rs
@@ -12,7 +12,7 @@ use crate::table_macro::*;
 
 use datafusion::arrow::datatypes::DataType;
 
-define_sort_order!(sys_vqueue_meta(partition_key, id));
+define_sort_order!(sys_vqueue_meta(partition_key));
 
 define_table!(sys_vqueue_meta(
     /// Internal column that is used for partitioning. Can be ignored.

--- a/crates/storage-query-datafusion/src/vqueues/schema.rs
+++ b/crates/storage-query-datafusion/src/vqueues/schema.rs
@@ -12,10 +12,6 @@ use crate::table_macro::*;
 
 use datafusion::arrow::datatypes::DataType;
 
-// Stage scans run concurrently and merge into a shared builder, so only
-// `partition_key` is monotone within a single partition's output stream.
-define_sort_order!(sys_vqueues(partition_key));
-
 define_table!(sys_vqueues(
     /// Internal column that is used for partitioning. Can be ignored.
     partition_key: DataType::UInt64,

--- a/crates/storage-query-datafusion/src/vqueues/table.rs
+++ b/crates/storage-query-datafusion/src/vqueues/table.rs
@@ -31,7 +31,7 @@ use crate::remote_query_scanner_manager::RemoteScannerManager;
 use crate::statistics::{DEPLOYMENT_ROW_ESTIMATE, RowEstimate, TableStatisticsBuilder};
 use crate::table_providers::{PartitionedTableProvider, ScanPartition};
 use crate::vqueues::row::{append_vqueues_row, append_vqueues_status_row};
-use crate::vqueues::schema::{SysVqueuesBuilder, sys_vqueues_sort_order};
+use crate::vqueues::schema::SysVqueuesBuilder;
 
 const NAME: &str = "sys_vqueues";
 
@@ -57,7 +57,7 @@ pub(crate) fn register_self(
     let table = PartitionedTableProvider::new(
         partition_selector,
         schema,
-        sys_vqueues_sort_order(),
+        Vec::new(),
         remote_scanner_manager.create_distributed_scanner(NAME, local_scanner),
         FirstMatchingPartitionKeyExtractor::default()
             .with_grouped_vqueue_entry_id("entry_id")

--- a/release-notes/unreleased/fix-sql-id-sort-order.md
+++ b/release-notes/unreleased/fix-sql-id-sort-order.md
@@ -1,0 +1,16 @@
+# Release Notes: Fix incorrect row ordering for `ORDER BY id` SQL queries
+
+## Bug Fix
+
+### What Changed
+The SQL tables `sys_invocation_status`, `sys_invocation_state`, `sys_journal`, `sys_journal_events`, `sys_inbox`, `sys_vqueue_meta`, and `sys_scheduler` no longer declare the `id` column as pre-sorted to the query engine. The underlying storage orders rows by the binary key encoding, which does not match the lexicographic order of the string-encoded `id` column. DataFusion trusted the declared ordering and skipped sorting for queries whose requested order matched it (e.g. `ORDER BY partition_key NULLS FIRST, id NULLS FIRST`), returning rows in storage order instead of the requested order.
+
+`partition_key` remains declared as sorted; its numeric order genuinely matches the storage order.
+
+### Why This Matters
+Queries ordering by `id` could silently return misordered rows. Queries that group or deduplicate on `(partition_key, id)` relied on the same false ordering through sort-based aggregation.
+
+### Impact on Users
+- `ORDER BY ... id` queries on the affected tables now always return correctly ordered rows.
+- Such queries now include an explicit sort step. Common query forms (the default `ASC`/`DESC` orderings, the CLI's invocation listing, and the `sys_invocation` view join) were already planned with a sort and are unaffected.
+- No configuration or code changes are required.


### PR DESCRIPTION

System-table scans do not emit rows in the lexicographic order of their
string-encoded id columns. Declaring (partition_key, id) as sorted allowed
DataFusion to omit required sorts for matching NULLS FIRST queries and return
incorrectly ordered results.

Remove invalid id orderings from the affected tables and the invalid
partition_key ordering from sys_vqueues, whose independent stage scans are not
globally ordered. Cover the failure with a regression test, and omit unsupported
inbox state-mutation entries instead of emitting all-NULL rows.

`sys_journal` retains the partition-key declaration as a pragmatic compromise:
mixed V1/V2 scans can violate it, but V1 journals are deprecated.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/5056).
* __->__ #5056
* #5053
* #5048
* #5047
* #5046
* #5052