### PR TITLE
Detect stalled partition processors, self-bail, and quarantine them from leadership

### DIFF
--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -370,12 +370,7 @@ impl<T: TransportConnect> Scheduler<T> {
         let Some(partition) = self.partitions.get(&partition_id) else {
             return;
         };
-
-        let mut relevant_nodes: HashSet<PlainNodeId> =
-            partition.current.replica_set().iter().copied().collect();
-        if let Some(next) = partition.next.as_ref() {
-            relevant_nodes.extend(next.replica_set().iter().copied());
-        }
+        let relevant_nodes = Self::relevant_nodes(partition);
 
         update_quarantine_memory(
             partition_id,
@@ -384,6 +379,17 @@ impl<T: TransportConnect> Scheduler<T> {
             legacy_cluster_state,
             &mut self.quarantine_memory,
         );
+    }
+
+    /// The set of plain node ids `quarantine_memory` must track for `partition` (current + next
+    /// replica set, if any).
+    fn relevant_nodes(partition: &PartitionState) -> HashSet<PlainNodeId> {
+        let mut relevant_nodes: HashSet<PlainNodeId> =
+            partition.current.replica_set().iter().copied().collect();
+        if let Some(next) = partition.next.as_ref() {
+            relevant_nodes.extend(next.replica_set().iter().copied());
+        }
+        relevant_nodes
     }
 
     async fn ensure_valid_partition_configuration(
@@ -477,6 +483,20 @@ impl<T: TransportConnect> Scheduler<T> {
                 }
             };
 
+            // Finding 5 (DEFECTB review): re-refresh right before the completion predicate,
+            // *after* any reconfiguration above may have changed `current`/`next` -- a node newly
+            // added to `next` by this same pass must have its quarantine status known before
+            // `should_complete_reconfiguration` looks at it, not the pre-change memory from
+            // `ensure_valid_leaders`.
+            let relevant_nodes = Self::relevant_nodes(occupied_entry.get());
+            update_quarantine_memory(
+                partition_id,
+                &relevant_nodes,
+                cluster_state,
+                legacy_cluster_state,
+                &mut self.quarantine_memory,
+            );
+
             let partition_state = occupied_entry.get();
 
             if Self::should_complete_reconfiguration(
@@ -551,12 +571,25 @@ impl<T: TransportConnect> Scheduler<T> {
         // configuration, which is possible as soon as a single non-quarantined partition
         // processor from the next configuration has become active
         let any_next_pp_active = next.replica_set().iter().any(|node_id| {
-            legacy_cluster_state.is_partition_processor_active(&partition_id, node_id)
-                && !cluster_state
-                    .get_node_state_and_generation(*node_id)
-                    .is_some_and(|(generational_node_id, _)| {
-                        quarantine_memory.contains_key(&(partition_id, generational_node_id))
-                    })
+            if !legacy_cluster_state.is_partition_processor_active(&partition_id, node_id) {
+                return false;
+            }
+            let quarantined = match cluster_state.get_node_state_and_generation(*node_id) {
+                Some((generational_node_id, _)) => {
+                    quarantine_memory.contains_key(&(partition_id, generational_node_id))
+                }
+                // Finding 6 (DEFECTB review): no generation info available for this node in the
+                // live `ClusterState` -- fail *closed* rather than assuming not-quarantined. If
+                // `quarantine_memory` retains a memo for this (partition, plain node) under *any*
+                // generation, treat it as quarantined; only a total absence of any retained memo
+                // is read as "no reason to believe it's stalled".
+                None => quarantine_memory
+                    .keys()
+                    .any(|(memo_partition_id, memo_node_id)| {
+                        *memo_partition_id == partition_id && memo_node_id.as_plain() == *node_id
+                    }),
+            };
+            !quarantined
         });
 
         all_current_workers_disabled || any_next_pp_active
@@ -1516,6 +1549,106 @@ mod tests {
                 &legacy_state,
                 &quarantine_memory,
             )
+        );
+    }
+
+    #[test]
+    fn quarantine_memory_catches_newly_added_next_replica_before_reconfiguration_completes() {
+        // Finding 5 (DEFECTB review): a plain node added to `next` by *this same*
+        // `ensure_valid_partition_configuration` pass, and already reporting
+        // `apply_stalled_since` on its very first heartbeat, must be visible to
+        // `should_complete_reconfiguration` immediately -- a refresh against the
+        // pre-reconfiguration relevant-node set (as `ensure_valid_leaders` took earlier this
+        // tick) does not know about it yet.
+        let partition_id = PartitionId::MIN;
+        let current_node = GenerationalNodeId::new(1, 1);
+        let next_node = GenerationalNodeId::new(2, 1);
+
+        let cluster_state = cluster_state_with(&[
+            (current_node, LiveNodeState::Alive),
+            (next_node, LiveNodeState::Alive),
+        ]);
+
+        let mut legacy_state =
+            legacy_state_with(partition_id, &[(current_node.as_plain(), Some(None))]);
+        legacy_state.nodes.insert(
+            next_node.as_plain(),
+            LegacyNodeState::Alive(AliveNode {
+                last_heartbeat_at: MillisSinceEpoch::now(),
+                generational_node_id: next_node,
+                partitions: [(
+                    partition_id,
+                    PartitionProcessorStatus {
+                        replay_status: ReplayStatus::Active,
+                        apply_stalled_since: Some(MillisSinceEpoch::now()),
+                        ..PartitionProcessorStatus::default()
+                    },
+                )]
+                .into_iter()
+                .collect(),
+                uptime: Duration::ZERO,
+            }),
+        );
+
+        let mut quarantine_memory = HashMap::default();
+
+        // Before this pass's reconfiguration, `next_node` isn't part of the replica set yet, so
+        // a refresh against the narrower relevant-node set must not track it.
+        let relevant_before = HashSet::from_iter([current_node.as_plain()]);
+        update_quarantine_memory(
+            partition_id,
+            &relevant_before,
+            &cluster_state,
+            &legacy_state,
+            &mut quarantine_memory,
+        );
+        assert!(!quarantine_memory.contains_key(&(partition_id, next_node)));
+
+        // This pass reconfigures, adding `next_node` to `next`.
+        let mut current_replica_set = NodeSet::new();
+        current_replica_set.insert(current_node.as_plain());
+        let current = PartitionConfiguration::new(
+            ReplicationProperty::new_unchecked(1),
+            current_replica_set,
+            Default::default(),
+        );
+        let mut next_replica_set = NodeSet::new();
+        next_replica_set.insert(next_node.as_plain());
+        let next = PartitionConfiguration::new(
+            ReplicationProperty::new_unchecked(1),
+            next_replica_set,
+            Default::default(),
+        );
+        let partition_state = PartitionState::new(current, Some(next), LeadershipPolicy::default());
+
+        // Finding 5's fix: refresh again with the post-reconfiguration relevant-node set, right
+        // before the completion predicate -- this must catch `next_node`'s stall immediately.
+        let relevant_after =
+            Scheduler::<restate_core::network::FailingConnector>::relevant_nodes(&partition_state);
+        update_quarantine_memory(
+            partition_id,
+            &relevant_after,
+            &cluster_state,
+            &legacy_state,
+            &mut quarantine_memory,
+        );
+        assert!(
+            quarantine_memory.contains_key(&(partition_id, next_node)),
+            "a newly-added next replica already reporting a stall must be quarantined \
+             before reconfiguration can complete"
+        );
+
+        let nodes_config = NodesConfiguration::new_for_testing();
+        assert!(
+            !Scheduler::<restate_core::network::FailingConnector>::should_complete_reconfiguration(
+                partition_id,
+                &cluster_state,
+                &nodes_config,
+                &partition_state,
+                &legacy_state,
+                &quarantine_memory,
+            ),
+            "reconfiguration must not complete while the newly-added next replica is quarantined"
         );
     }
 }

--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -1651,4 +1651,93 @@ mod tests {
             "reconfiguration must not complete while the newly-added next replica is quarantined"
         );
     }
+
+    /// Finding 6 (DEFECTB review): when the live `ClusterState` has no generation info for a
+    /// next-replica node (e.g. a gossip gap), and `quarantine_memory` still retains a memo for
+    /// that (partition, plain node) under *some* generation, the missing generation must not be
+    /// read as "not quarantined" -- fail closed.
+    #[test]
+    fn should_complete_reconfiguration_fails_closed_on_missing_generation_with_quarantine_memo() {
+        let partition_id = PartitionId::MIN;
+        let next_node = GenerationalNodeId::new(2, 1);
+
+        let mut current_replica_set = NodeSet::new();
+        current_replica_set.insert(PlainNodeId::new(1));
+        let current = PartitionConfiguration::new(
+            ReplicationProperty::new_unchecked(1),
+            current_replica_set,
+            Default::default(),
+        );
+        let mut next_replica_set = NodeSet::new();
+        next_replica_set.insert(next_node.as_plain());
+        let next = PartitionConfiguration::new(
+            ReplicationProperty::new_unchecked(1),
+            next_replica_set,
+            Default::default(),
+        );
+        let partition_state = PartitionState::new(current, Some(next), LeadershipPolicy::default());
+
+        let nodes_config = NodesConfiguration::new_for_testing();
+        // Deliberately omit `next_node` from `cluster_state`, so
+        // `get_node_state_and_generation(next_node.as_plain())` returns `None` -- the "no
+        // generation info available" case this finding addresses.
+        let cluster_state = cluster_state_with(&[]);
+
+        let mut legacy_state = LegacyClusterState::empty();
+        legacy_state.nodes.insert(
+            next_node.as_plain(),
+            LegacyNodeState::Alive(AliveNode {
+                last_heartbeat_at: MillisSinceEpoch::now(),
+                generational_node_id: next_node,
+                partitions: [(
+                    partition_id,
+                    PartitionProcessorStatus {
+                        replay_status: ReplayStatus::Active,
+                        ..PartitionProcessorStatus::default()
+                    },
+                )]
+                .into_iter()
+                .collect(),
+                uptime: Duration::ZERO,
+            }),
+        );
+
+        // A retained memo under an *older* generation of the same plain node -- the live
+        // `ClusterState` doesn't know this node's current generation, but `quarantine_memory`
+        // still has a reason to distrust it.
+        let mut quarantine_memory = HashMap::default();
+        quarantine_memory.insert(
+            (partition_id, GenerationalNodeId::new(2, 0)),
+            QuarantineMemo {
+                since: MillisSinceEpoch::now(),
+            },
+        );
+
+        assert!(
+            !Scheduler::<restate_core::network::FailingConnector>::should_complete_reconfiguration(
+                partition_id,
+                &cluster_state,
+                &nodes_config,
+                &partition_state,
+                &legacy_state,
+                &quarantine_memory,
+            ),
+            "missing generation info must fail closed when a quarantine memo exists for this node"
+        );
+
+        // With no retained memo for this plain node under any generation, the missing generation
+        // info is read as "no reason to believe it's stalled" -- reconfiguration may complete.
+        quarantine_memory.clear();
+        assert!(
+            Scheduler::<restate_core::network::FailingConnector>::should_complete_reconfiguration(
+                partition_id,
+                &cluster_state,
+                &nodes_config,
+                &partition_state,
+                &legacy_state,
+                &quarantine_memory,
+            ),
+            "missing generation info with no retained memo must not block reconfiguration"
+        );
+    }
 }

--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -12,7 +12,7 @@ use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::collections::hash_map::Entry;
 
-use ahash::HashMap;
+use ahash::{HashMap, HashSet};
 use futures::{StreamExt, TryStreamExt};
 use tracing::{debug, info, trace};
 
@@ -40,7 +40,8 @@ use restate_types::replication::balanced_spread_selector::{
     BalancedSpreadSelector, SelectorOptions,
 };
 use restate_types::replication::{NodeSet, ReplicationProperty};
-use restate_types::{NodeId, PlainNodeId, Version, Versioned};
+use restate_types::time::MillisSinceEpoch;
+use restate_types::{GenerationalNodeId, PlainNodeId, Version, Versioned};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -158,12 +159,29 @@ struct PartitionConfigurationUpdate {
     leadership_policy: LeadershipPolicy,
 }
 
+/// A cached, in-memory derivation of the worker's durably-synthesized `apply_stalled_since`
+/// signal (see `restate-worker`'s `apply_progress_tracker` module) -- not itself a source of
+/// truth. Rebuilt from scratch from the first cluster-state refresh after any controller leader
+/// transition (a fresh `Scheduler` starts with an empty map), so there is nothing to persist.
+///
+/// Keyed by `(PartitionId, GenerationalNodeId)` rather than a plain node id and never expired on
+/// a time TTL: an entry is retained for the current generation until the worker affirmatively
+/// reports non-stalled, and is only ever removed on generation replacement or replica-set
+/// removal. A single missed/erroring refresh (the node reports `Dead`, or is simply missing from
+/// this partition's status) must never be read as "not stalled" -- see
+/// `LegacyClusterState::apply_stalled_since`.
+#[derive(Debug, Clone, Copy)]
+struct QuarantineMemo {
+    since: MillisSinceEpoch,
+}
+
 pub struct Scheduler<T> {
     metadata_writer: MetadataWriter,
     networking: Networking<T>,
     partitions: HashMap<PartitionId, PartitionState>,
     replica_set_states: PartitionReplicaSetStates,
     cluster_state: ClusterState,
+    quarantine_memory: HashMap<(PartitionId, GenerationalNodeId), QuarantineMemo>,
 }
 
 /// The scheduler is responsible for assigning partition processors to nodes and to electing
@@ -182,6 +200,7 @@ impl<T: TransportConnect> Scheduler<T> {
             partitions: HashMap::default(),
             replica_set_states,
             cluster_state: TaskCenter::with_current(|h| h.cluster_state().clone()),
+            quarantine_memory: HashMap::default(),
         }
     }
 
@@ -325,15 +344,46 @@ impl<T: TransportConnect> Scheduler<T> {
         nodes_config: &NodesConfiguration,
         partition_table: &PartitionTable,
     ) {
-        for partition_id in partition_table.iter_ids() {
+        for partition_id in partition_table.iter_ids().copied() {
+            self.refresh_quarantine_memory(partition_id, cluster_state, legacy_cluster_state);
+
             // select the leader based on the observed cluster state
             self.select_leader(
-                partition_id,
+                &partition_id,
                 cluster_state,
                 legacy_cluster_state,
                 nodes_config,
             );
         }
+    }
+
+    /// A1: rebuilds this controller's cached view of the durable `apply_stalled_since` signal for
+    /// `partition_id`'s replica set (current + next, if any). See [`QuarantineMemo`]'s doc for the
+    /// update/retention rules. The actual decision logic lives in the pure, independently
+    /// unit-tested [`update_quarantine_memory`] -- this method only assembles its inputs.
+    fn refresh_quarantine_memory(
+        &mut self,
+        partition_id: PartitionId,
+        cluster_state: &ClusterState,
+        legacy_cluster_state: &LegacyClusterState,
+    ) {
+        let Some(partition) = self.partitions.get(&partition_id) else {
+            return;
+        };
+
+        let mut relevant_nodes: HashSet<PlainNodeId> =
+            partition.current.replica_set().iter().copied().collect();
+        if let Some(next) = partition.next.as_ref() {
+            relevant_nodes.extend(next.replica_set().iter().copied());
+        }
+
+        update_quarantine_memory(
+            partition_id,
+            &relevant_nodes,
+            cluster_state,
+            legacy_cluster_state,
+            &mut self.quarantine_memory,
+        );
     }
 
     async fn ensure_valid_partition_configuration(
@@ -431,9 +481,11 @@ impl<T: TransportConnect> Scheduler<T> {
 
             if Self::should_complete_reconfiguration(
                 partition_id,
+                cluster_state,
                 nodes_config,
                 partition_state,
                 legacy_cluster_state,
+                &self.quarantine_memory,
             ) {
                 let partition_configuration_update = Self::complete_reconfiguration(
                     self.metadata_writer.raw_metadata_store_client(),
@@ -470,16 +522,19 @@ impl<T: TransportConnect> Scheduler<T> {
     /// Checks whether a pending reconfiguration should be completed. Conditions for doing this are:
     ///
     /// * All workers in the current configuration are disabled
-    /// * Any of the partition processors in the next configuration is active (== caught up)
+    /// * Any of the partition processors in the next configuration is active (== caught up) and
+    ///   not quarantined for an apply stall
     ///
     /// Note: We don't complete the reconfiguration if all current nodes are dead for some time,
     /// because we might need any of them to send a partition store snapshot to the next nodes once
     /// we support in-band snapshot exchanges and trimming based on durable lsns.
     fn should_complete_reconfiguration(
         partition_id: PartitionId,
+        cluster_state: &ClusterState,
         nodes_config: &NodesConfiguration,
         partition_state: &PartitionState,
         legacy_cluster_state: &LegacyClusterState,
+        quarantine_memory: &HashMap<(PartitionId, GenerationalNodeId), QuarantineMemo>,
     ) -> bool {
         // we can only complete the reconfiguration if a next configuration has been set
         let Some(next) = partition_state.next.as_ref() else {
@@ -493,10 +548,15 @@ impl<T: TransportConnect> Scheduler<T> {
             .all(|node_id| nodes_config.get_worker_state(node_id) == WorkerState::Disabled);
 
         // check whether we can transition from the current configuration to the next
-        // configuration, which is possible as soon as a single partition processor from the
-        // next configuration has become active
+        // configuration, which is possible as soon as a single non-quarantined partition
+        // processor from the next configuration has become active
         let any_next_pp_active = next.replica_set().iter().any(|node_id| {
             legacy_cluster_state.is_partition_processor_active(&partition_id, node_id)
+                && !cluster_state
+                    .get_node_state_and_generation(*node_id)
+                    .is_some_and(|(generational_node_id, _)| {
+                        quarantine_memory.contains_key(&(partition_id, generational_node_id))
+                    })
         });
 
         all_current_workers_disabled || any_next_pp_active
@@ -760,13 +820,9 @@ impl<T: TransportConnect> Scheduler<T> {
             .ok()
     }
 
-    /// Selects a leader based on the leadership policy, observed cluster state and replica set.
-    ///
-    /// Scores each alive replica in a single pass. Higher score wins:
-    /// - 3: matches affinity + caught up
-    /// - 2: caught up (no affinity match)
-    /// - 1: matches affinity + alive (not caught up)
-    /// - 0: alive only (baseline)
+    /// Selects a leader based on the leadership policy, observed cluster state, replica set, and
+    /// quarantine memory. Delegates the actual decision to the pure, independently unit-tested
+    /// [`choose_target_leader`] -- this method's job is only to assemble the [`CandidateView`]s.
     ///
     /// If `freeze` is set, the current target leader is kept unchanged.
     fn select_leader(
@@ -776,6 +832,7 @@ impl<T: TransportConnect> Scheduler<T> {
         legacy_cluster_state: &LegacyClusterState,
         nodes_config: &NodesConfiguration,
     ) {
+        let quarantine_memory = &self.quarantine_memory;
         let Some(partition) = self.partitions.get_mut(partition_id) else {
             return;
         };
@@ -787,36 +844,42 @@ impl<T: TransportConnect> Scheduler<T> {
 
         let affinity = partition.leadership_policy.affinity.as_ref();
 
-        let best = partition
-            .current
-            .replica_set()
-            .iter()
-            .copied()
-            .filter(|node_id| cluster_state.is_alive(NodeId::from(*node_id)))
-            .max_by_key(|node_id| {
-                let has_affinity =
-                    affinity.is_some_and(|a| matches_affinity(*node_id, a, nodes_config));
-                let is_caught_up =
-                    legacy_cluster_state.is_partition_processor_active(partition_id, node_id);
-                match (has_affinity, is_caught_up) {
-                    (true, true) => 3u8,
-                    (false, true) => 2,
-                    (true, false) => 1,
-                    (false, false) => 0,
-                }
-            });
+        let candidates =
+            partition
+                .current
+                .replica_set()
+                .iter()
+                .copied()
+                .filter_map(|plain_node_id| {
+                    let (node, state) =
+                        cluster_state.get_node_state_and_generation(plain_node_id)?;
+                    Some(CandidateView {
+                        node,
+                        alive: state.is_alive(),
+                        active: legacy_cluster_state
+                            .is_partition_processor_active(partition_id, &plain_node_id),
+                        quarantined: quarantine_memory.contains_key(&(*partition_id, node)),
+                        matches_affinity: affinity
+                            .is_some_and(|a| matches_affinity(plain_node_id, a, nodes_config)),
+                    })
+                });
 
-        if let Some(best) = best
-            && partition.target_leader != Some(best)
-        {
-            debug!(
-                "Selecting node {} as partition processor leader for partition {partition_id}",
-                best
-            );
-            partition.target_leader = Some(best);
+        match choose_target_leader(partition.target_leader, candidates) {
+            TargetDecision::Keep => {}
+            TargetDecision::Set(best) => {
+                debug!(
+                    "Selecting node {} as partition processor leader for partition {partition_id}",
+                    best
+                );
+                partition.target_leader = Some(best);
+            }
+            TargetDecision::Clear => {
+                debug!(
+                    "Clearing target leader for partition {partition_id}: every alive replica is quarantined for an apply stall"
+                );
+                partition.target_leader = None;
+            }
         }
-
-        // keep the current target leader as we couldn't find any suitable substitute
     }
 
     fn instruct_nodes(&self, legacy_cluster_state: &LegacyClusterState) -> Result<(), Error> {
@@ -926,6 +989,141 @@ impl<T: TransportConnect> Scheduler<T> {
     }
 }
 
+/// A1: applies one refresh's worth of updates to `quarantine_memory` for `partition_id`'s
+/// `relevant_nodes` (current + next replica set). Pure aside from the `quarantine_memory`
+/// out-parameter, so it's unit-testable with plain `ClusterState`/`LegacyClusterState` fixtures
+/// and no `Scheduler` at all -- see [`QuarantineMemo`]'s doc for the exact rules being applied.
+fn update_quarantine_memory(
+    partition_id: PartitionId,
+    relevant_nodes: &HashSet<PlainNodeId>,
+    cluster_state: &ClusterState,
+    legacy_cluster_state: &LegacyClusterState,
+    quarantine_memory: &mut HashMap<(PartitionId, GenerationalNodeId), QuarantineMemo>,
+) {
+    for &plain_node_id in relevant_nodes {
+        // No generation info at all -- can't form a key either way; leave any existing memory
+        // for this node untouched rather than guessing.
+        let Some((generational_node_id, _state)) =
+            cluster_state.get_node_state_and_generation(plain_node_id)
+        else {
+            continue;
+        };
+
+        match legacy_cluster_state.apply_stalled_since(&partition_id, &plain_node_id) {
+            // Status absent (Dead in legacy, or no entry for this partition): never clears --
+            // the worker is authoritative for clearing, not its absence.
+            None => {}
+            Some(None) => {
+                quarantine_memory.remove(&(partition_id, generational_node_id));
+            }
+            Some(Some(since)) => {
+                let key = (partition_id, generational_node_id);
+                if quarantine_memory
+                    .insert(key, QuarantineMemo { since })
+                    .is_none()
+                {
+                    let memo = quarantine_memory.get(&key).expect("just inserted");
+                    debug!(
+                        %partition_id, node = %generational_node_id, since = %memo.since,
+                        "Quarantining node for partition leadership: apply stall reported"
+                    );
+                }
+            }
+        }
+    }
+
+    quarantine_memory.retain(|(memo_partition_id, generational_node_id), _| {
+        if *memo_partition_id != partition_id {
+            return true;
+        }
+        let plain_node_id = generational_node_id.as_plain();
+        if !relevant_nodes.contains(&plain_node_id) {
+            return false; // no longer part of this partition's replica set
+        }
+        match cluster_state.get_node_state_and_generation(plain_node_id) {
+            // A newer generation of this node is now observed: the quarantined generation is
+            // gone for good, so the memo for it can't be affirmed non-stalled by that node
+            // ever again -- drop it.
+            Some((current, _)) => current.generation() <= generational_node_id.generation(),
+            // No generation info to disprove the stored one; keep conservatively.
+            None => true,
+        }
+    });
+}
+
+/// One replica's view for the [`choose_target_leader`] decision.
+#[derive(Debug, Clone, Copy)]
+struct CandidateView {
+    node: GenerationalNodeId,
+    alive: bool,
+    /// Caught up (`replay_status == Active`).
+    active: bool,
+    /// Quarantined for an apply stall, per the scheduler's `quarantine_memory`.
+    quarantined: bool,
+    matches_affinity: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TargetDecision {
+    Keep,
+    Set(PlainNodeId),
+    Clear,
+}
+
+/// The pure leader-selection decision, extracted from [`Scheduler::select_leader`] so it can be
+/// unit tested without a `Scheduler`/cluster-state harness.
+///
+/// Scores each alive, non-quarantined replica in a single pass. Higher score wins:
+/// - 3: matches affinity + caught up
+/// - 2: caught up (no affinity match)
+/// - 1: matches affinity + alive (not caught up)
+/// - 0: alive only (baseline)
+///
+/// A quarantined replica is never eligible to win, but a progressing, non-quarantined
+/// `CatchingUp` peer is (it simply scores lower than an `Active` one). If every alive replica is
+/// quarantined, `target_leader` is cleared (stops instruction generation) only when `current`
+/// itself is one of the quarantined replicas; otherwise (e.g. no alive replicas were observed at
+/// all) the existing target is left unchanged, as before this feature existed.
+fn choose_target_leader(
+    current: Option<PlainNodeId>,
+    candidates: impl Iterator<Item = CandidateView>,
+) -> TargetDecision {
+    let candidates: Vec<CandidateView> = candidates.collect();
+
+    let best = candidates
+        .iter()
+        .filter(|candidate| candidate.alive && !candidate.quarantined)
+        .max_by_key(
+            |candidate| match (candidate.matches_affinity, candidate.active) {
+                (true, true) => 3u8,
+                (false, true) => 2,
+                (true, false) => 1,
+                (false, false) => 0,
+            },
+        );
+
+    if let Some(best) = best {
+        let best_node = best.node.as_plain();
+        return if current == Some(best_node) {
+            TargetDecision::Keep
+        } else {
+            TargetDecision::Set(best_node)
+        };
+    }
+
+    let current_is_quarantined = current.is_some_and(|current_node| {
+        candidates
+            .iter()
+            .any(|candidate| candidate.node.as_plain() == current_node && candidate.quarantined)
+    });
+
+    if current_is_quarantined {
+        TargetDecision::Clear
+    } else {
+        TargetDecision::Keep
+    }
+}
+
 /// Returns `true` if the given node matches the leader affinity expression.
 fn matches_affinity(
     node_id: PlainNodeId,
@@ -942,5 +1140,382 @@ fn matches_affinity(
                     .shares_domain_with(location, location.smallest_defined_scope())
             })
             .unwrap_or(false),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use restate_types::cluster::cluster_state::{
+        AliveNode, DeadNode, NodeState as LegacyNodeState, PartitionProcessorStatus, ReplayStatus,
+    };
+    use restate_types::cluster_state::NodeState as LiveNodeState;
+    use restate_types::time::MillisSinceEpoch;
+    use std::time::Duration;
+
+    fn candidate(
+        node: GenerationalNodeId,
+        alive: bool,
+        active: bool,
+        quarantined: bool,
+    ) -> CandidateView {
+        CandidateView {
+            node,
+            alive,
+            active,
+            quarantined,
+            matches_affinity: false,
+        }
+    }
+
+    #[test]
+    fn choose_target_leader_moves_off_quarantined_target_with_active_peer() {
+        let target = GenerationalNodeId::new(1, 1);
+        let peer = GenerationalNodeId::new(2, 1);
+        let candidates = vec![
+            candidate(target, true, true, true),
+            candidate(peer, true, true, false),
+        ];
+
+        let decision = choose_target_leader(Some(target.as_plain()), candidates.into_iter());
+        assert_eq!(decision, TargetDecision::Set(peer.as_plain()));
+    }
+
+    #[test]
+    fn choose_target_leader_moves_to_progressing_catching_up_peer() {
+        let target = GenerationalNodeId::new(1, 1);
+        let peer = GenerationalNodeId::new(2, 1);
+        // Peer is alive, not quarantined, but not yet caught up (CatchingUp) -- still eligible
+        // and must be elected since it's the only non-quarantined alive replica.
+        let candidates = vec![
+            candidate(target, true, true, true),
+            candidate(peer, true, false, false),
+        ];
+
+        let decision = choose_target_leader(Some(target.as_plain()), candidates.into_iter());
+        assert_eq!(decision, TargetDecision::Set(peer.as_plain()));
+    }
+
+    #[test]
+    fn choose_target_leader_clears_when_all_alive_replicas_quarantined() {
+        let target = GenerationalNodeId::new(1, 1);
+        let peer = GenerationalNodeId::new(2, 1);
+        let candidates = vec![
+            candidate(target, true, true, true),
+            candidate(peer, true, false, true),
+        ];
+
+        let decision = choose_target_leader(Some(target.as_plain()), candidates.into_iter());
+        assert_eq!(decision, TargetDecision::Clear);
+    }
+
+    #[test]
+    fn choose_target_leader_does_not_repick_once_cleared() {
+        // With no current target and every alive replica quarantined, there is nothing to elect
+        // and nothing to clear -- stays Keep (a no-op).
+        let target = GenerationalNodeId::new(1, 1);
+        let candidates = vec![candidate(target, true, false, true)];
+
+        let decision = choose_target_leader(None, candidates.into_iter());
+        assert_eq!(decision, TargetDecision::Keep);
+    }
+
+    #[test]
+    fn choose_target_leader_keeps_target_when_no_alive_replicas_observed() {
+        // No alive replicas at all (e.g. a transient gossip gap) is different from "all
+        // quarantined": we don't know enough to clear, so the existing target is left alone.
+        let target = GenerationalNodeId::new(1, 1);
+        let candidates = vec![candidate(target, false, false, false)];
+
+        let decision = choose_target_leader(Some(target.as_plain()), candidates.into_iter());
+        assert_eq!(decision, TargetDecision::Keep);
+    }
+
+    #[test]
+    fn choose_target_leader_affirmative_non_stalled_peer_is_eligible() {
+        let target = GenerationalNodeId::new(1, 1);
+        let peer = GenerationalNodeId::new(2, 1);
+        // Both alive, active, and non-quarantined -- an affirmatively-non-stalled peer must be a
+        // real candidate for the top spot, not merely tolerated: give it the higher-scoring
+        // affinity match so the decision is unambiguous.
+        let mut peer_candidate = candidate(peer, true, true, false);
+        peer_candidate.matches_affinity = true;
+        let candidates = vec![candidate(target, true, true, false), peer_candidate];
+
+        let decision = choose_target_leader(Some(target.as_plain()), candidates.into_iter());
+        assert_eq!(decision, TargetDecision::Set(peer.as_plain()));
+    }
+
+    #[test]
+    fn choose_target_leader_keeps_current_target_when_it_is_the_unambiguous_best() {
+        let target = GenerationalNodeId::new(1, 1);
+        let peer = GenerationalNodeId::new(2, 1);
+        let mut target_candidate = candidate(target, true, true, false);
+        target_candidate.matches_affinity = true;
+        let candidates = vec![target_candidate, candidate(peer, true, true, false)];
+
+        let decision = choose_target_leader(Some(target.as_plain()), candidates.into_iter());
+        assert_eq!(decision, TargetDecision::Keep);
+    }
+
+    fn cluster_state_with(nodes: &[(GenerationalNodeId, LiveNodeState)]) -> ClusterState {
+        let mut updater = ClusterState::default().updater();
+        for &(node_id, state) in nodes {
+            updater.upsert_node_state(node_id, state);
+        }
+        updater.into_cluster_state()
+    }
+
+    fn legacy_state_with(
+        partition_id: PartitionId,
+        nodes: &[(PlainNodeId, Option<Option<MillisSinceEpoch>>)],
+    ) -> LegacyClusterState {
+        let mut state = LegacyClusterState::empty();
+        for &(node_id, apply_stalled_since) in nodes {
+            let legacy_node = match apply_stalled_since {
+                None => LegacyNodeState::Dead(DeadNode {
+                    last_seen_alive: None,
+                }),
+                Some(apply_stalled_since) => LegacyNodeState::Alive(AliveNode {
+                    last_heartbeat_at: MillisSinceEpoch::now(),
+                    generational_node_id: node_id.with_generation(1),
+                    partitions: [(
+                        partition_id,
+                        PartitionProcessorStatus {
+                            apply_stalled_since,
+                            ..PartitionProcessorStatus::default()
+                        },
+                    )]
+                    .into_iter()
+                    .collect(),
+                    uptime: Duration::ZERO,
+                }),
+            };
+            state.nodes.insert(node_id, legacy_node);
+        }
+        state
+    }
+
+    #[test]
+    fn quarantine_rebuilt_after_controller_failover() {
+        // A1: a fresh Scheduler (empty quarantine_memory, as after a controller failover) must
+        // quarantine a node purely from the first refresh that carries `apply_stalled_since`,
+        // without needing any prior persisted state.
+        let partition_id = PartitionId::MIN;
+        let node = GenerationalNodeId::new(1, 1);
+        let relevant = HashSet::from_iter([node.as_plain()]);
+        let cluster_state = cluster_state_with(&[(node, LiveNodeState::Alive)]);
+        let legacy_state = legacy_state_with(
+            partition_id,
+            &[(node.as_plain(), Some(Some(MillisSinceEpoch::now())))],
+        );
+        let mut memory = HashMap::default();
+
+        update_quarantine_memory(
+            partition_id,
+            &relevant,
+            &cluster_state,
+            &legacy_state,
+            &mut memory,
+        );
+
+        assert!(memory.contains_key(&(partition_id, node)));
+    }
+
+    #[test]
+    fn quarantine_memory_absence_of_status_retains_entry() {
+        // Node reported Dead in the legacy view (or missing a partition entry) must never be
+        // read as "not stalled" -- the existing memo must survive untouched.
+        let partition_id = PartitionId::MIN;
+        let node = GenerationalNodeId::new(1, 1);
+        let relevant = HashSet::from_iter([node.as_plain()]);
+        let cluster_state = cluster_state_with(&[(node, LiveNodeState::Alive)]);
+        let mut memory = HashMap::default();
+        memory.insert(
+            (partition_id, node),
+            QuarantineMemo {
+                since: MillisSinceEpoch::now(),
+            },
+        );
+
+        // Node reported Dead this refresh.
+        let legacy_state = legacy_state_with(partition_id, &[(node.as_plain(), None)]);
+        update_quarantine_memory(
+            partition_id,
+            &relevant,
+            &cluster_state,
+            &legacy_state,
+            &mut memory,
+        );
+
+        assert!(
+            memory.contains_key(&(partition_id, node)),
+            "absence of status must not clear the memo"
+        );
+    }
+
+    #[test]
+    fn quarantine_memory_affirmative_non_stalled_clears_entry() {
+        let partition_id = PartitionId::MIN;
+        let node = GenerationalNodeId::new(1, 1);
+        let relevant = HashSet::from_iter([node.as_plain()]);
+        let cluster_state = cluster_state_with(&[(node, LiveNodeState::Alive)]);
+        let mut memory = HashMap::default();
+        memory.insert(
+            (partition_id, node),
+            QuarantineMemo {
+                since: MillisSinceEpoch::now(),
+            },
+        );
+
+        let legacy_state = legacy_state_with(partition_id, &[(node.as_plain(), Some(None))]);
+        update_quarantine_memory(
+            partition_id,
+            &relevant,
+            &cluster_state,
+            &legacy_state,
+            &mut memory,
+        );
+
+        assert!(!memory.contains_key(&(partition_id, node)));
+    }
+
+    #[test]
+    fn quarantine_memory_generation_replacement_drops_entry() {
+        let partition_id = PartitionId::MIN;
+        let old_generation = GenerationalNodeId::new(1, 1);
+        let new_generation = GenerationalNodeId::new(1, 2);
+        let relevant = HashSet::from_iter([old_generation.as_plain()]);
+        let mut memory = HashMap::default();
+        memory.insert(
+            (partition_id, old_generation),
+            QuarantineMemo {
+                since: MillisSinceEpoch::now(),
+            },
+        );
+
+        // The plain node id is now observed at a newer generation.
+        let cluster_state = cluster_state_with(&[(new_generation, LiveNodeState::Alive)]);
+        let legacy_state = legacy_state_with(partition_id, &[]);
+        update_quarantine_memory(
+            partition_id,
+            &relevant,
+            &cluster_state,
+            &legacy_state,
+            &mut memory,
+        );
+
+        assert!(
+            !memory.contains_key(&(partition_id, old_generation)),
+            "a superseded generation's memo must be dropped"
+        );
+    }
+
+    #[test]
+    fn quarantine_memory_replica_set_removal_drops_entry() {
+        let partition_id = PartitionId::MIN;
+        let node = GenerationalNodeId::new(1, 1);
+        let mut memory = HashMap::default();
+        memory.insert(
+            (partition_id, node),
+            QuarantineMemo {
+                since: MillisSinceEpoch::now(),
+            },
+        );
+
+        // Node is no longer part of the replica set this refresh.
+        let relevant = HashSet::default();
+        let cluster_state = cluster_state_with(&[(node, LiveNodeState::Alive)]);
+        let legacy_state = legacy_state_with(partition_id, &[]);
+        update_quarantine_memory(
+            partition_id,
+            &relevant,
+            &cluster_state,
+            &legacy_state,
+            &mut memory,
+        );
+
+        assert!(!memory.contains_key(&(partition_id, node)));
+    }
+
+    #[test]
+    fn should_complete_reconfiguration_blocked_by_quarantined_next_replica() {
+        let partition_id = PartitionId::MIN;
+        let next_node = GenerationalNodeId::new(2, 1);
+
+        let mut current_replica_set = NodeSet::new();
+        current_replica_set.insert(PlainNodeId::new(1));
+        let current = PartitionConfiguration::new(
+            ReplicationProperty::new_unchecked(1),
+            current_replica_set,
+            Default::default(),
+        );
+
+        let mut next_replica_set = NodeSet::new();
+        next_replica_set.insert(next_node.as_plain());
+        let next = PartitionConfiguration::new(
+            ReplicationProperty::new_unchecked(1),
+            next_replica_set,
+            Default::default(),
+        );
+
+        let partition_state = PartitionState::new(current, Some(next), LeadershipPolicy::default());
+
+        let nodes_config = NodesConfiguration::new_for_testing();
+        let cluster_state = cluster_state_with(&[(next_node, LiveNodeState::Alive)]);
+
+        // The next replica is Active (caught up) but quarantined.
+        let mut legacy_state = LegacyClusterState::empty();
+        legacy_state.nodes.insert(
+            next_node.as_plain(),
+            LegacyNodeState::Alive(AliveNode {
+                last_heartbeat_at: MillisSinceEpoch::now(),
+                generational_node_id: next_node,
+                partitions: [(
+                    partition_id,
+                    PartitionProcessorStatus {
+                        replay_status: ReplayStatus::Active,
+                        apply_stalled_since: Some(MillisSinceEpoch::now()),
+                        ..PartitionProcessorStatus::default()
+                    },
+                )]
+                .into_iter()
+                .collect(),
+                uptime: Duration::ZERO,
+            }),
+        );
+
+        let mut quarantine_memory = HashMap::default();
+        quarantine_memory.insert(
+            (partition_id, next_node),
+            QuarantineMemo {
+                since: MillisSinceEpoch::now(),
+            },
+        );
+
+        assert!(
+            !Scheduler::<restate_core::network::FailingConnector>::should_complete_reconfiguration(
+                partition_id,
+                &cluster_state,
+                &nodes_config,
+                &partition_state,
+                &legacy_state,
+                &quarantine_memory,
+            ),
+            "a quarantined next-replica must not be treated as ready to complete reconfiguration"
+        );
+
+        // Once un-quarantined, reconfiguration should be able to complete.
+        quarantine_memory.clear();
+        assert!(
+            Scheduler::<restate_core::network::FailingConnector>::should_complete_reconfiguration(
+                partition_id,
+                &cluster_state,
+                &nodes_config,
+                &partition_state,
+                &legacy_state,
+                &quarantine_memory,
+            )
+        );
     }
 }

--- a/crates/storage-query-datafusion/src/partition_state/row.rs
+++ b/crates/storage-query-datafusion/src/partition_state/row.rs
@@ -72,4 +72,8 @@ pub(crate) fn append_partition_row(
     if let Some(version) = state.storage_version {
         row.storage_version(version as u32);
     }
+
+    if let Some(ts) = state.apply_stalled_since {
+        row.apply_stalled_since(ts.as_u64() as i64);
+    }
 }

--- a/crates/storage-query-datafusion/src/partition_state/schema.rs
+++ b/crates/storage-query-datafusion/src/partition_state/schema.rs
@@ -70,5 +70,11 @@ define_table!(
         /// Partition-store on-disk storage version (StorageVersion discriminant).
         /// Set once on partition open.
         storage_version: DataType::UInt32,
+
+        /// Set while the partition processor is quarantined for an apply stall (its apply loop
+        /// is lagging with work available, or a candidate's committed AnnounceLeader marker never
+        /// applied). Sticky until real progress is observed past the LSN recorded at quarantine
+        /// time.
+        apply_stalled_since: TimestampMillisecond,
     )
 );

--- a/crates/types/protobuf/restate/cluster.proto
+++ b/crates/types/protobuf/restate/cluster.proto
@@ -93,6 +93,9 @@ message PartitionProcessorStatus {
   // Partition-store on-disk storage version (StorageVersion discriminant).
   optional uint32 storage_version = 16;
   DetailedRunMode detailed_effective_mode = 17;
+  // Set while the partition processor manager has quarantined this partition processor for an
+  // apply stall. Sticky until the worker observes real progress.
+  optional google.protobuf.Timestamp apply_stalled_since = 18;
 }
 
 message ReplicationProperty { string replication_property = 1; }

--- a/crates/types/src/cluster/cluster_state.rs
+++ b/crates/types/src/cluster/cluster_state.rs
@@ -83,6 +83,28 @@ impl LegacyClusterState {
             .unwrap_or_default()
     }
 
+    /// Returns true if the given node's partition processor is quarantined for an apply stall
+    /// (`apply_stalled_since` is set). Absence of a status entry (e.g. the node is reported
+    /// `Dead`) is never treated as "not stalled" by callers of this method -- see the
+    /// scheduler's `quarantine_memory`, which retains its own record independently of this
+    /// instantaneous view.
+    pub fn is_partition_processor_stalled(
+        &self,
+        partition_id: &PartitionId,
+        node_id: &PlainNodeId,
+    ) -> bool {
+        self.nodes
+            .get(node_id)
+            .and_then(|node| match node {
+                NodeState::Alive(alive) => alive
+                    .partitions
+                    .get(partition_id)
+                    .map(|partition_state| partition_state.apply_stalled_since.is_some()),
+                NodeState::Dead(_) => None,
+            })
+            .unwrap_or_default()
+    }
+
     /// Returns true if the given node runs the partition processor leader for the given partition
     /// id. The decision is based on the partition processor reporting as their effective_mode
     /// `RunMode::Leader`.
@@ -211,6 +233,15 @@ pub struct PartitionProcessorStatus {
     /// Since v1.7.3 (if Unknown, use effective_mode)
     #[bilrost(17)]
     pub detailed_effective_mode: DetailedRunMode,
+
+    /// Set while the partition processor manager has quarantined this partition processor
+    /// because its apply loop is stalled with work available (or, for a candidate, a committed
+    /// `AnnounceLeader` marker that never got applied). Sticky: synthesized into the reported
+    /// status across `Starting`/`Started`/`Stopping` until the worker observes real progress
+    /// past the applied LSN recorded at quarantine time.
+    /// *Since v1.8.0*
+    #[bilrost(18)]
+    pub apply_stalled_since: Option<MillisSinceEpoch>,
 }
 
 impl PartitionProcessorStatus {
@@ -269,6 +300,7 @@ impl Default for PartitionProcessorStatus {
             last_applied_schema_version: None,
             enabled_features: PersistedFeatures::default(),
             storage_version: None,
+            apply_stalled_since: None,
         }
     }
 }

--- a/crates/types/src/cluster/cluster_state.rs
+++ b/crates/types/src/cluster/cluster_state.rs
@@ -93,16 +93,32 @@ impl LegacyClusterState {
         partition_id: &PartitionId,
         node_id: &PlainNodeId,
     ) -> bool {
-        self.nodes
-            .get(node_id)
-            .and_then(|node| match node {
-                NodeState::Alive(alive) => alive
-                    .partitions
-                    .get(partition_id)
-                    .map(|partition_state| partition_state.apply_stalled_since.is_some()),
-                NodeState::Dead(_) => None,
-            })
-            .unwrap_or_default()
+        self.apply_stalled_since(partition_id, node_id)
+            .flatten()
+            .is_some()
+    }
+
+    /// The tri-state read behind [`Self::is_partition_processor_stalled`], distinguishing "no
+    /// status to consult" from "status present and affirmatively not stalled". Callers that need
+    /// to tell these apart (e.g. the scheduler's `quarantine_memory`, which must never clear on
+    /// mere status absence) should use this directly instead of the bool convenience method:
+    ///
+    /// - `None`: no status to consult -- the node is reported `Dead`, is entirely unknown, or has
+    ///   no entry for this partition. Must never be treated as "not stalled".
+    /// - `Some(None)`: status present; the worker affirmatively reports no stall.
+    /// - `Some(Some(since))`: status present; quarantined since `since`.
+    pub fn apply_stalled_since(
+        &self,
+        partition_id: &PartitionId,
+        node_id: &PlainNodeId,
+    ) -> Option<Option<MillisSinceEpoch>> {
+        match self.nodes.get(node_id)? {
+            NodeState::Dead(_) => None,
+            NodeState::Alive(alive) => alive
+                .partitions
+                .get(partition_id)
+                .map(|partition_state| partition_state.apply_stalled_since),
+        }
     }
 
     /// Returns true if the given node runs the partition processor leader for the given partition
@@ -312,5 +328,67 @@ impl PartitionProcessorStatus {
 
     pub fn new() -> Self {
         Self::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bilrost::{Message, OwnedMessage};
+
+    use super::*;
+
+    /// A stand-in for the pre-`apply_stalled_since` wire shape of [`PartitionProcessorStatus`]
+    /// (tags 1-17, 8 reserved) -- a handful of representative fields is enough to pin the wire
+    /// contract, since bilrost encodes/skips fields purely by tag number, independent of any
+    /// other field on the message.
+    #[derive(Debug, Clone, PartialEq, bilrost::Message)]
+    #[bilrost(reserved_tags(8))]
+    struct OldPartitionProcessorStatusV17 {
+        #[bilrost(1)]
+        updated_at: MillisSinceEpoch,
+        #[bilrost(6)]
+        last_applied_log_lsn: Option<Lsn>,
+        #[bilrost(9)]
+        replay_status: ReplayStatus,
+    }
+
+    #[test]
+    fn mixed_version_status_roundtrip() {
+        // New (with apply_stalled_since set) -> old: the old type must decode successfully,
+        // silently skipping the unknown tag 18, with the fields it does know about intact.
+        let new_status = PartitionProcessorStatus {
+            updated_at: MillisSinceEpoch::from(1234),
+            last_applied_log_lsn: Some(Lsn::new(42)),
+            replay_status: ReplayStatus::CatchingUp,
+            apply_stalled_since: Some(MillisSinceEpoch::from(5678)),
+            ..PartitionProcessorStatus::default()
+        };
+        let encoded = new_status.encode_to_bytes();
+        let decoded_as_old = OldPartitionProcessorStatusV17::decode(encoded)
+            .expect("old type must decode a message carrying the new field");
+        assert_eq!(decoded_as_old.updated_at, new_status.updated_at);
+        assert_eq!(
+            decoded_as_old.last_applied_log_lsn,
+            new_status.last_applied_log_lsn
+        );
+        assert_eq!(decoded_as_old.replay_status, new_status.replay_status);
+
+        // Old -> new: the new type must decode a message that never had tag 18, defaulting
+        // `apply_stalled_since` to `None`, with the rest of the fields intact.
+        let old_status = OldPartitionProcessorStatusV17 {
+            updated_at: MillisSinceEpoch::from(4321),
+            last_applied_log_lsn: Some(Lsn::new(7)),
+            replay_status: ReplayStatus::Active,
+        };
+        let encoded = old_status.encode_to_bytes();
+        let decoded_as_new = PartitionProcessorStatus::decode(encoded)
+            .expect("new type must decode a message missing the new field");
+        assert_eq!(decoded_as_new.updated_at, old_status.updated_at);
+        assert_eq!(
+            decoded_as_new.last_applied_log_lsn,
+            old_status.last_applied_log_lsn
+        );
+        assert_eq!(decoded_as_new.replay_status, old_status.replay_status);
+        assert_eq!(decoded_as_new.apply_stalled_since, None);
     }
 }

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -154,6 +154,15 @@ pub struct WorkerOptions {
     #[cfg_attr(feature = "schemars", schemars(skip))]
     #[serde(skip_serializing_if = "std::ops::Not::not", default)]
     pub use_multi_db_layout: bool,
+
+    /// # Partition apply-stall detection
+    ///
+    /// Detects a partition processor whose apply loop is stalled with work available (the log
+    /// has records past the last applied LSN but the processor isn't advancing), downgrades its
+    /// reported replay status, and safely restarts it if the stall persists.
+    /// *Since v1.8.0*
+    #[serde(default)]
+    pub stall_detection: StallDetectionOptions,
 }
 
 impl WorkerOptions {
@@ -217,7 +226,186 @@ impl Default for WorkerOptions {
             ),
             rule_book_poll_interval: NonZeroFriendlyDuration::from_secs_unchecked(30),
             use_multi_db_layout: false,
+            stall_detection: StallDetectionOptions::default(),
         }
+    }
+}
+
+/// # Apply-stall detection options
+///
+/// Tuning for the partition processor manager's apply-progress tracker: how quickly a lagging,
+/// reader-idle partition processor is suspected, confirmed via an authoritative tail check,
+/// downgraded in its reported status, and -- if the stall persists -- restarted.
+#[serde_as]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, derive_builder::Builder)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(
+    feature = "schemars",
+    schemars(rename = "StallDetectionOptions", default)
+)]
+#[serde(rename_all = "kebab-case")]
+#[builder(default)]
+pub struct StallDetectionOptions {
+    /// # Enable apply-stall detection
+    ///
+    /// When disabled, partition processors are never downgraded or restarted for an apply stall.
+    pub enabled: bool,
+
+    /// # Suspicion grace period
+    ///
+    /// How long a partition processor may sit reader-idle with the log tail ahead of its last
+    /// applied LSN before it is suspected of being stalled.
+    pub grace: FriendlyDuration,
+
+    /// # Heartbeat freshness
+    ///
+    /// How recently the apply loop must have beaten while parked in `select` (i.e. genuinely
+    /// reader-idle, not busy applying or handling a control operation) for a sample to count
+    /// towards suspicion.
+    pub heartbeat_fresh: FriendlyDuration,
+
+    /// # Tail observation freshness
+    ///
+    /// How old a tail observation (fast or consistent) may be and still be used to decide that
+    /// the log has records past the last applied LSN.
+    pub tail_ttl: FriendlyDuration,
+
+    /// # ConsistentRead sweep interval
+    ///
+    /// How often the manager issues one authoritative `ConsistentRead` tail probe, round-robined
+    /// across running partitions by longest-since-last-attempt. This is mandatory (in addition to
+    /// the existing 1s `Fast` tail poller) because a `Fast` tail can be a stale cached value that
+    /// looks fresh forever once its background refresher has exited.
+    pub sweep_interval: FriendlyDuration,
+
+    /// # Probe timeout
+    ///
+    /// Maximum time to wait for a `ConsistentRead` tail probe used to confirm suspected lag.
+    pub probe_timeout: FriendlyDuration,
+
+    /// # Probe retry backoff (base)
+    ///
+    /// Initial backoff before retrying a `ConsistentRead` confirmation probe after a failure or
+    /// timeout.
+    pub probe_backoff_base: FriendlyDuration,
+
+    /// # Probe retry backoff (cap)
+    ///
+    /// Maximum backoff between `ConsistentRead` confirmation probe retries within one suspicion
+    /// episode.
+    pub probe_backoff_cap: FriendlyDuration,
+
+    /// # Recovery window
+    ///
+    /// After a confirmation probe observes lag, how long the original reader is given to resume
+    /// on its own (a `ConsistentRead` probe can itself heal a wedged reader by sealing/repairing
+    /// the chain) before the processor is declared stalled.
+    pub recovery_window: FriendlyDuration,
+
+    /// # Bail grace period
+    ///
+    /// How long a partition processor may remain in the `Stalled` state (confirmed lag, no
+    /// progress, reader-idle) before it is cooperatively stopped and restarted.
+    pub bail_grace: FriendlyDuration,
+
+    /// # Bail restart backoff (base)
+    ///
+    /// Initial spacing between repeated self-bails of the same partition processor incarnation
+    /// history.
+    pub bail_backoff_base: FriendlyDuration,
+
+    /// # Bail restart backoff (cap)
+    ///
+    /// Maximum spacing between repeated self-bails.
+    pub bail_backoff_cap: FriendlyDuration,
+
+    /// # Loop-dead threshold
+    ///
+    /// How long the apply loop may sit in `InSelect` with no heartbeat at all before it is
+    /// considered dead (as opposed to merely reader-idle). Sound because the processor's status
+    /// timer guarantees a heartbeat well within this window whenever the loop can run at all.
+    pub hard_grace: FriendlyDuration,
+
+    /// # Stuck-stop flare timeout
+    ///
+    /// How long a partition processor may remain in `Stopping` after a self-bail before the
+    /// manager raises a flare for external supervision (it never spawns a second processor over
+    /// the same store, so this is observability only).
+    pub stop_stuck_timeout: FriendlyDuration,
+}
+
+impl Default for StallDetectionOptions {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            grace: FriendlyDuration::from_secs(30),
+            heartbeat_fresh: FriendlyDuration::from_secs(3),
+            tail_ttl: FriendlyDuration::from_secs(10),
+            sweep_interval: FriendlyDuration::from_secs(5),
+            probe_timeout: FriendlyDuration::from_secs(5),
+            probe_backoff_base: FriendlyDuration::from_secs(10),
+            probe_backoff_cap: FriendlyDuration::from_secs(60),
+            recovery_window: FriendlyDuration::from_secs(10),
+            bail_grace: FriendlyDuration::from_secs(60),
+            bail_backoff_base: FriendlyDuration::from_secs(60),
+            bail_backoff_cap: FriendlyDuration::from_secs(10 * 60),
+            hard_grace: FriendlyDuration::from_secs(120),
+            stop_stuck_timeout: FriendlyDuration::from_secs(5 * 60),
+        }
+    }
+}
+
+impl StallDetectionOptions {
+    pub fn grace(&self) -> Duration {
+        self.grace.into()
+    }
+
+    pub fn heartbeat_fresh(&self) -> Duration {
+        self.heartbeat_fresh.into()
+    }
+
+    pub fn tail_ttl(&self) -> Duration {
+        self.tail_ttl.into()
+    }
+
+    pub fn sweep_interval(&self) -> Duration {
+        self.sweep_interval.into()
+    }
+
+    pub fn probe_timeout(&self) -> Duration {
+        self.probe_timeout.into()
+    }
+
+    pub fn probe_backoff_base(&self) -> Duration {
+        self.probe_backoff_base.into()
+    }
+
+    pub fn probe_backoff_cap(&self) -> Duration {
+        self.probe_backoff_cap.into()
+    }
+
+    pub fn recovery_window(&self) -> Duration {
+        self.recovery_window.into()
+    }
+
+    pub fn bail_grace(&self) -> Duration {
+        self.bail_grace.into()
+    }
+
+    pub fn bail_backoff_base(&self) -> Duration {
+        self.bail_backoff_base.into()
+    }
+
+    pub fn bail_backoff_cap(&self) -> Duration {
+        self.bail_backoff_cap.into()
+    }
+
+    pub fn hard_grace(&self) -> Duration {
+        self.hard_grace.into()
+    }
+
+    pub fn stop_stuck_timeout(&self) -> Duration {
+        self.stop_stuck_timeout.into()
     }
 }
 

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -332,6 +332,13 @@ pub struct StallDetectionOptions {
     /// manager raises a flare for external supervision (it never spawns a second processor over
     /// the same store, so this is observability only).
     pub stop_stuck_timeout: FriendlyDuration,
+
+    /// # Candidate activation timeout
+    ///
+    /// How long a leader-elect may sit with its own committed `AnnounceLeader` marker unapplied
+    /// before it self-bails (Option D). The window is measured from commit, extended by any
+    /// further apply progress (a candidate catching up on backlog is not stuck).
+    pub candidate_activation_timeout: FriendlyDuration,
 }
 
 impl Default for StallDetectionOptions {
@@ -351,6 +358,7 @@ impl Default for StallDetectionOptions {
             bail_backoff_cap: FriendlyDuration::from_secs(10 * 60),
             hard_grace: FriendlyDuration::from_secs(120),
             stop_stuck_timeout: FriendlyDuration::from_secs(5 * 60),
+            candidate_activation_timeout: FriendlyDuration::from_secs(30),
         }
     }
 }
@@ -406,6 +414,10 @@ impl StallDetectionOptions {
 
     pub fn stop_stuck_timeout(&self) -> Duration {
         self.stop_stuck_timeout.into()
+    }
+
+    pub fn candidate_activation_timeout(&self) -> Duration {
+        self.candidate_activation_timeout.into()
     }
 }
 

--- a/crates/worker/src/metric_definitions.rs
+++ b/crates/worker/src/metric_definitions.rs
@@ -62,6 +62,14 @@ pub const PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS: &str =
 pub const PARTITION_SHUFFLE_MESSAGE_COUNT: &str = "restate.partition.shuffle.message.total";
 pub const PARTITION_SHUFFLE_INFLIGHT_RECORDS: &str = "restate.partition.shuffle.inflight";
 
+// contains `partition` label
+pub const PARTITION_APPLY_STALLED: &str = "restate.partition.apply_stalled";
+// contains `partition` and `phase` labels
+pub const PARTITION_APPLY_PHASE_STUCK: &str = "restate.partition.apply_phase_stuck";
+pub const PHASE_LABEL: &str = "phase";
+// contains `partition` label
+pub const PARTITION_STOP_STUCK: &str = "restate.partition.stop_stuck";
+
 pub(crate) fn describe_metrics() {
     describe_gauge!(
         PARTITION_BLOCKED_FLARE,
@@ -155,5 +163,23 @@ pub(crate) fn describe_metrics() {
         PARTITION_SHUFFLE_INFLIGHT_RECORDS,
         Unit::Count,
         "Number of inflight records by source partition"
+    );
+
+    describe_gauge!(
+        PARTITION_APPLY_STALLED,
+        Unit::Count,
+        "Set to 1 while the partition processor's apply loop is confirmed stalled with work available"
+    );
+
+    describe_gauge!(
+        PARTITION_APPLY_PHASE_STUCK,
+        Unit::Count,
+        "Set to 1 while the apply loop has been busy in a single phase (applying a batch or a control operation) for an unusually long time; observability only, never triggers a restart"
+    );
+
+    describe_gauge!(
+        PARTITION_STOP_STUCK,
+        Unit::Count,
+        "Set to 1 when a partition processor has remained in Stopping past the configured stop-stuck timeout after a self-bail"
     );
 }

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -21,11 +21,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use futures::{StreamExt, TryStreamExt};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tokio::time::Instant;
 use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, instrument, warn};
 
+use restate_bifrost::CommitToken;
 use restate_core::network::{Oneshot, Reciprocal, TransportConnect};
 use restate_core::{Metadata, ShutdownError, TaskCenter, TaskKind};
 use restate_errors::NotRunningError;
@@ -52,7 +53,7 @@ use restate_types::identifiers::{InvocationId, LeaderEpoch, PartitionId};
 use restate_types::identifiers::{PartitionKey, PartitionProcessorRpcRequestId};
 use restate_types::invocation::FencingToken;
 use restate_types::live::LiveLoadExt;
-use restate_types::logs::Keys;
+use restate_types::logs::{Keys, Lsn};
 use restate_types::message::MessageIndex;
 use restate_types::net::ingest::IngestRecord;
 use restate_types::net::partition_processor::{
@@ -119,6 +120,20 @@ pub(crate) enum Error {
         name: &'static str,
         cause: TaskTermination,
     },
+    /// Option D: the Candidate activation watchdog's deadline fired -- our own `AnnounceLeader`
+    /// marker committed to the log (the commit token resolved `Ok(())`) but was never applied
+    /// within `candidate_activation_timeout`. This is authoritative lag evidence (A2): the PPM's
+    /// `Stopped` handler quarantines this partition for an apply stall using `bail_lsn`, the exact
+    /// live FSM applied LSN captured at the deadline (A4).
+    #[error(
+        "committed AnnounceLeader marker for leader epoch {leader_epoch} was not applied within \
+         {committed_for:?} of commit; bailing (applied lsn at deadline: {bail_lsn})"
+    )]
+    AnnounceNotApplied {
+        leader_epoch: LeaderEpoch,
+        committed_for: Duration,
+        bail_lsn: Lsn,
+    },
 }
 
 impl Error {
@@ -158,11 +173,26 @@ pub(crate) enum ActionEffect {
     AwaitingRpcSelfProposeDone,
 }
 
+/// Option D: tracks the commit/apply lifecycle of a Candidate's self-proposed `AnnounceLeader`
+/// marker, driving the activation watchdog in [`LeadershipState::run`].
+enum CommitState {
+    /// Commit token outstanding; the marker has not yet committed to the log.
+    Pending(CommitToken),
+    /// The marker committed at this (monotonic) instant. The watchdog now sleeps until
+    /// `candidate_activation_timeout` past this (or later, if the FSM keeps catching up).
+    CommittedAt(Instant),
+    /// The commit notifier was dropped (`Err(RecvError)`) without ever resolving `Ok(())`. This
+    /// disarms the watchdog -- it never means the marker committed, and it must never transition
+    /// to `CommittedAt`. The appender's own death still surfaces separately via `join_on_err`.
+    NotifierLost,
+}
+
 enum State {
     Follower,
     Candidate {
         at: Instant,
         leader_epoch: LeaderEpoch,
+        commit: CommitState,
         // to be able to move out of it
         self_proposer: Option<SelfProposer>,
     },
@@ -289,13 +319,14 @@ where
             &node_ctx.bifrost,
         )?;
 
-        self_proposer
-            .self_propose(ctx.key_range().start(), announce_leader)
+        let commit_token = self_proposer
+            .self_propose_with_notification(ctx.key_range().start(), announce_leader)
             .await?;
 
         self.state = State::Candidate {
             at: Instant::now(),
             leader_epoch,
+            commit: CommitState::Pending(commit_token),
             self_proposer: Some(self_proposer),
         };
 
@@ -464,6 +495,7 @@ where
             at,
             leader_epoch,
             self_proposer,
+            ..
         }
         | State::BecomingLeader {
             at,
@@ -827,18 +859,94 @@ where
     /// * Leader: Await action effects and monitor appender task
     pub async fn run(
         &mut self,
-        ctx: impl Processor + HasVQueues,
+        ctx: impl Processor + HasVQueues + HasStatus,
+        candidate_activation_timeout: Duration,
     ) -> Result<Vec<ActionEffect>, Error> {
         match &mut self.state {
             State::Follower => Ok(futures::future::pending::<Vec<_>>().await),
-            State::Candidate { self_proposer, .. }
-            | State::BecomingLeader { self_proposer, .. } => Err(self_proposer
+            State::Candidate {
+                self_proposer,
+                commit,
+                leader_epoch,
+                ..
+            } => {
+                Self::run_candidate(
+                    self_proposer.as_mut().expect("must be present"),
+                    commit,
+                    *leader_epoch,
+                    ctx,
+                    candidate_activation_timeout,
+                )
+                .await
+            }
+            State::BecomingLeader { self_proposer, .. } => Err(self_proposer
                 .as_mut()
                 .expect("must be present")
                 .join_on_err()
                 .await
                 .expect_err("never should never be returned")),
             State::Leader(leader_state) => leader_state.run(ctx).await,
+        }
+    }
+
+    /// Option D: the Candidate activation watchdog. Cancellation-safe -- on token resolution it
+    /// only mutates `commit` and returns `Ok(vec![])`; the actual deadline transition happens on
+    /// the *next* call (the outer PP loop always re-enters `run()`), so this must never be called
+    /// from anywhere but the top of `run`'s `Candidate` arm. See the module doc / DEFECTB Stage 3
+    /// for the full design.
+    async fn run_candidate(
+        self_proposer: &mut SelfProposer,
+        commit: &mut CommitState,
+        leader_epoch: LeaderEpoch,
+        ctx: impl HasStatus + HasFsm,
+        candidate_activation_timeout: Duration,
+    ) -> Result<Vec<ActionEffect>, Error> {
+        match commit {
+            CommitState::Pending(commit_token) => {
+                tokio::select! {
+                    err = self_proposer.join_on_err() => Err(err.expect_err("never should never be returned")),
+                    result = commit_token => {
+                        *commit = Self::commit_state_after_token(result);
+                        Ok(Vec::new())
+                    }
+                }
+            }
+            CommitState::CommittedAt(committed_at) => {
+                let committed_at = *committed_at;
+                // The FSM catching up on backlog after commit keeps extending the deadline --
+                // only a candidate that's both committed *and* stopped applying entirely times out.
+                let deadline = committed_at.max(
+                    ctx.status()
+                        .last_applied_at_instant()
+                        .unwrap_or(committed_at),
+                ) + candidate_activation_timeout;
+                tokio::select! {
+                    err = self_proposer.join_on_err() => Err(err.expect_err("never should never be returned")),
+                    _ = tokio::time::sleep_until(deadline) => Err(Error::AnnounceNotApplied {
+                        leader_epoch,
+                        committed_for: committed_at.elapsed(),
+                        // A4: the exact live FSM applied LSN, not a possibly-stale tracker sample.
+                        bail_lsn: ctx.fsm().last_applied_lsn(),
+                    }),
+                }
+            }
+            CommitState::NotifierLost => Err(self_proposer
+                .join_on_err()
+                .await
+                .expect_err("never should never be returned")),
+        }
+    }
+
+    /// Only `Ok(())` means the marker committed. `Err(RecvError)` means the notifier channel was
+    /// dropped without ever confirming a commit -- never treat that as `CommittedAt`; the
+    /// appender's own death still surfaces separately via `join_on_err`. Split out from
+    /// [`Self::run_candidate`] so the transition is unit-testable without a live `CommitToken`
+    /// (`CommitToken`'s `Output` is exactly `Result<(), oneshot::error::RecvError>`, so a plain
+    /// `oneshot::channel` exercises the identical transition).
+    fn commit_state_after_token(result: Result<(), oneshot::error::RecvError>) -> CommitState {
+        match result {
+            Ok(()) => CommitState::CommittedAt(Instant::now()),
+            Err(_) => CommitState::NotifierLost,
         }
     }
 
@@ -1035,6 +1143,7 @@ impl shuffle::OutboxReader for OutboxReader {
 mod tests {
     use std::num::NonZeroUsize;
     use std::sync::Arc;
+    use std::time::Duration;
 
     use test_log::test;
     use tokio_stream::StreamExt;
@@ -1044,8 +1153,10 @@ mod tests {
     use restate_core::partitions::PartitionRouting;
     use restate_core::{TaskCenter, TestCoreEnv};
     use restate_ingestion_client::{IngestionClient, SessionOptions};
-    use restate_partition_store::PartitionStoreManager;
+    use restate_partition_store::{PartitionStore, PartitionStoreManager};
     use restate_rocksdb::RocksDbManager;
+    use restate_storage_api::Transaction;
+    use restate_storage_api::deduplication_table::{DedupSequenceNumber, EpochSequenceNumber};
     use restate_types::config::Configuration;
     use restate_types::identifiers::{LeaderEpoch, PartitionId};
     use restate_types::logs::{KeyFilter, Lsn, SequenceNumber};
@@ -1055,11 +1166,12 @@ mod tests {
     };
     use restate_types::sharding::KeyRange;
     use restate_types::{GenerationalNodeId, Version};
-    use restate_wal_protocol::Command;
-    use restate_wal_protocol::Envelope;
+    use restate_wal_protocol::control::UpdatePartitionDurabilityCommand;
+    use restate_wal_protocol::{Command, Destination, Envelope};
     use restate_worker_api::invoker::capacity::InvokerCapacity;
 
-    use crate::partition::leadership::{LeadershipState, State};
+    use crate::partition::leadership::self_proposer::SelfProposer;
+    use crate::partition::leadership::{CommitState, Error, LeadershipState, State};
     use crate::partition::processor::ProcessorRawContext;
     use crate::partition::{LeadershipInfo, NodeContext};
     use crate::partition_processor_manager::PartitionLeaderHandlesRegistry;
@@ -1183,5 +1295,294 @@ mod tests {
             .await;
         RocksDbManager::get().shutdown().await;
         Ok(())
+    }
+
+    /// Shared setup for the Candidate activation watchdog tests: builds a fresh in-memory
+    /// bifrost + node context and drives `LeadershipState` up to (but not through)
+    /// `run_for_leader`, mirroring `become_leader_then_step_down`'s preamble.
+    async fn setup_candidate() -> googletest::Result<(
+        NodeContext,
+        ProcessorRawContext,
+        LeadershipState<restate_core::network::FailingConnector>,
+        PartitionStore,
+    )> {
+        let env = TestCoreEnv::create_with_single_node(0, 0).await;
+
+        RocksDbManager::init();
+        let bifrost = Bifrost::init_in_memory(env.metadata_writer).await;
+        let replica_set_states = PartitionReplicaSetStates::default();
+
+        let partition_store_manager = PartitionStoreManager::create(true).await?;
+
+        let ingress = IngestionClient::new(
+            env.networking.clone(),
+            env.metadata.updateable_partition_table(),
+            PartitionRouting::new(replica_set_states.clone(), TaskCenter::current()),
+            NonZeroUsize::new(10 * 1024 * 1024).unwrap(),
+            SessionOptions::default(),
+        );
+
+        let node_ctx = NodeContext::new(
+            NODE_ID,
+            Configuration::live(),
+            replica_set_states.clone(),
+            RuleBookCacheHandle::detached(),
+            bifrost.clone(),
+            InvokerCapacity::new_unlimited(),
+            PartitionLeaderHandlesRegistry::default(),
+        );
+
+        let partition_store = partition_store_manager.open(&PARTITION, None).await?;
+        let ctx = ProcessorRawContext::new(Arc::new(PARTITION), PersistedFeatures::default());
+
+        let (leader_query_tx, _leader_query_rx) = restate_worker_api::channel();
+        let state = LeadershipState::new(PARTITION_ID, ingress, leader_query_tx);
+
+        Ok((node_ctx, ctx, state, partition_store))
+    }
+
+    async fn become_candidate(
+        state: &mut LeadershipState<restate_core::network::FailingConnector>,
+        node_ctx: &NodeContext,
+        ctx: &mut ProcessorRawContext,
+        leader_epoch: LeaderEpoch,
+    ) -> googletest::Result<()> {
+        let leadership_info = LeadershipInfo {
+            version: Version::MIN,
+            leader_epoch,
+            current_config: PartitionConfiguration::default().into(),
+            next_config: None,
+        };
+        state
+            .run_for_leader(ctx, node_ctx, Box::new(leadership_info))
+            .await?;
+        assert!(matches!(state.state, State::Candidate { .. }));
+        Ok(())
+    }
+
+    #[test(restate_core::test(start_paused = true))]
+    async fn candidate_watchdog_bails() -> googletest::Result<()> {
+        let (node_ctx, mut ctx, mut state, _partition_store) = setup_candidate().await?;
+        let leader_epoch = LeaderEpoch::from(1);
+        become_candidate(&mut state, &node_ctx, &mut ctx, leader_epoch).await?;
+
+        let candidate_activation_timeout = Duration::from_secs(30);
+
+        // Never deliver `on_announce_leader`. First poll drains the real (already-enqueued)
+        // commit notification: Pending -> CommittedAt.
+        let effects = state.run(&mut ctx, candidate_activation_timeout).await?;
+        assert!(effects.is_empty());
+        assert!(matches!(
+            state.state,
+            State::Candidate {
+                commit: CommitState::CommittedAt(_),
+                ..
+            }
+        ));
+
+        // Nothing else can make progress, so paused time auto-advances straight to the deadline.
+        let err = state
+            .run(&mut ctx, candidate_activation_timeout)
+            .await
+            .expect_err("must bail once the deadline elapses with the marker unapplied");
+        assert!(matches!(
+            err,
+            Error::AnnounceNotApplied { leader_epoch: e, .. } if e == leader_epoch
+        ));
+
+        TaskCenter::current()
+            .shutdown_node("test_completed", 0)
+            .await;
+        RocksDbManager::get().shutdown().await;
+        Ok(())
+    }
+
+    #[test(restate_core::test(start_paused = true))]
+    async fn candidate_watchdog_late_commit() -> googletest::Result<()> {
+        let (node_ctx, mut ctx, mut state, _partition_store) = setup_candidate().await?;
+        let leader_epoch = LeaderEpoch::from(1);
+        become_candidate(&mut state, &node_ctx, &mut ctx, leader_epoch).await?;
+
+        let candidate_activation_timeout = Duration::from_secs(30);
+
+        // Let a long time pass before ever polling the commit token -- simulating a commit
+        // that resolves long after the Candidate campaign started (`at`). The real append
+        // already completed in the background (it doesn't depend on virtual time), so the
+        // first poll below observes `Ok(())` immediately and stamps `CommittedAt` at *now*.
+        tokio::time::advance(candidate_activation_timeout + Duration::from_secs(10)).await;
+        state.run(&mut ctx, candidate_activation_timeout).await?;
+
+        // If the deadline were (wrongly) measured from Candidate `at` instead of the commit
+        // resolution, it would already be elapsed. Advancing by just under the full timeout
+        // from *now* must not bail yet.
+        tokio::time::advance(candidate_activation_timeout - Duration::from_secs(1)).await;
+        let result = tokio::time::timeout(
+            Duration::from_millis(1),
+            state.run(&mut ctx, candidate_activation_timeout),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "deadline must be measured from commit resolution, not from Candidate `at`"
+        );
+
+        // Advancing past the full timeout from the (late) commit must bail.
+        tokio::time::advance(Duration::from_secs(2)).await;
+        let err = state
+            .run(&mut ctx, candidate_activation_timeout)
+            .await
+            .expect_err("must bail once the full window has elapsed since the late commit");
+        assert!(matches!(err, Error::AnnounceNotApplied { .. }));
+
+        TaskCenter::current()
+            .shutdown_node("test_completed", 0)
+            .await;
+        RocksDbManager::get().shutdown().await;
+        Ok(())
+    }
+
+    #[test(restate_core::test(start_paused = true))]
+    async fn candidate_watchdog_catchup_extends() -> googletest::Result<()> {
+        let (node_ctx, mut ctx, mut state, mut partition_store) = setup_candidate().await?;
+        let leader_epoch = LeaderEpoch::from(1);
+        become_candidate(&mut state, &node_ctx, &mut ctx, leader_epoch).await?;
+
+        let candidate_activation_timeout = Duration::from_secs(30);
+        state.run(&mut ctx, candidate_activation_timeout).await?;
+
+        // Advance partway toward the deadline, then record real apply progress -- this must
+        // push the deadline out from the new instant, not the original commit time.
+        tokio::time::advance(candidate_activation_timeout / 2).await;
+        let mut txn = partition_store.transaction();
+        ctx.update_last_applied_lsn(&mut txn, Lsn::new(1))?;
+        txn.commit().await?;
+
+        // Advance past what would have been the *original* deadline (commit + timeout). Since
+        // the deadline now extends from the more recent apply progress, this must not bail.
+        tokio::time::advance(candidate_activation_timeout / 2 + Duration::from_millis(500)).await;
+        let result = tokio::time::timeout(
+            Duration::from_millis(1),
+            state.run(&mut ctx, candidate_activation_timeout),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "must not bail: catch-up progress must extend the deadline"
+        );
+
+        // Advance past the (extended) deadline and confirm it does bail.
+        tokio::time::advance(candidate_activation_timeout / 2 + Duration::from_secs(1)).await;
+        let err = state
+            .run(&mut ctx, candidate_activation_timeout)
+            .await
+            .expect_err("must eventually bail once apply progress also stops");
+        assert!(matches!(err, Error::AnnounceNotApplied { .. }));
+
+        TaskCenter::current()
+            .shutdown_node("test_completed", 0)
+            .await;
+        RocksDbManager::get().shutdown().await;
+        Ok(())
+    }
+
+    #[test(restate_core::test(start_paused = true))]
+    async fn candidate_activates_before_deadline() -> googletest::Result<()> {
+        let (mut node_ctx, mut ctx, mut state, mut partition_store) = setup_candidate().await?;
+        let leader_epoch = LeaderEpoch::from(1);
+        become_candidate(&mut state, &node_ctx, &mut ctx, leader_epoch).await?;
+
+        let candidate_activation_timeout = Duration::from_secs(30);
+        state.run(&mut ctx, candidate_activation_timeout).await?;
+
+        // Deliver the announce well before the deadline: the marker applied, so the campaign
+        // must win instead of the watchdog ever firing.
+        state
+            .on_announce_leader(&mut node_ctx, &mut ctx, &mut partition_store, leader_epoch)
+            .await?;
+        assert!(matches!(state.state, State::BecomingLeader { .. }));
+
+        TaskCenter::current()
+            .shutdown_node("test_completed", 0)
+            .await;
+        RocksDbManager::get().shutdown().await;
+        Ok(())
+    }
+
+    #[test(restate_core::test)]
+    async fn self_propose_with_notification_carries_dedup() -> googletest::Result<()> {
+        let env = TestCoreEnv::create_with_single_node(0, 0).await;
+        RocksDbManager::init();
+        let bifrost = Bifrost::init_in_memory(env.metadata_writer).await;
+
+        let leader_epoch = LeaderEpoch::from(1);
+        let mut self_proposer = SelfProposer::new(
+            PARTITION.log_id(),
+            EpochSequenceNumber::new(leader_epoch),
+            &bifrost,
+        )?;
+
+        let commit_token = self_proposer
+            .self_propose_with_notification(
+                PARTITION_KEY_RANGE.start(),
+                Command::UpdatePartitionDurability(UpdatePartitionDurabilityCommand {
+                    partition_id: PARTITION_ID,
+                    durable_point: Lsn::OLDEST,
+                    modification_time: restate_types::time::MillisSinceEpoch::now(),
+                }),
+            )
+            .await?;
+        commit_token.await.expect("commit token resolves");
+
+        let mut reader = bifrost
+            .create_reader(PARTITION_ID.into(), KeyFilter::Any, Lsn::OLDEST, Lsn::MAX)
+            .expect("valid reader");
+        let record = reader.next().await.unwrap()?;
+        let envelope = record.try_decode::<Envelope>().unwrap()?;
+
+        let_assert!(
+            Destination::Processor {
+                dedup: Some(dedup),
+                ..
+            } = envelope.header.dest
+        );
+        assert!(
+            matches!(dedup.sequence_number, DedupSequenceNumber::Esn(_)),
+            "self_propose_with_notification must carry ESN dedup, same as self_propose"
+        );
+
+        TaskCenter::current()
+            .shutdown_node("test_completed", 0)
+            .await;
+        RocksDbManager::get().shutdown().await;
+        Ok(())
+    }
+
+    #[test(tokio::test)]
+    async fn commit_token_err_disarms() {
+        // `CommitToken`'s `Output` is exactly `Result<(), oneshot::error::RecvError>` -- a plain
+        // `oneshot::channel` whose sender is dropped exercises the identical transition
+        // `run_candidate` applies to a real `CommitToken` (see `commit_state_after_token`'s doc:
+        // forcing a genuine dropped-notifier through the public bifrost API deterministically
+        // would require injecting a hard, unrecoverable append failure, which isn't reachable
+        // through `SelfProposer`/`AppenderHandle`'s graceful-only cancellation surface).
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        drop(tx);
+        let result = rx.await;
+        assert!(result.is_err());
+
+        let commit_state =
+            LeadershipState::<restate_core::network::FailingConnector>::commit_state_after_token(
+                result,
+            );
+        assert!(matches!(commit_state, CommitState::NotifierLost));
+
+        // The success path, for contrast: never transitions to NotifierLost.
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        tx.send(()).expect("receiver still alive");
+        let commit_state =
+            LeadershipState::<restate_core::network::FailingConnector>::commit_state_after_token(
+                rx.await,
+            );
+        assert!(matches!(commit_state, CommitState::CommittedAt(_)));
     }
 }

--- a/crates/worker/src/partition/leadership/self_proposer.rs
+++ b/crates/worker/src/partition/leadership/self_proposer.rs
@@ -134,6 +134,31 @@ impl SelfProposer {
         Ok(())
     }
 
+    /// Self-propose a single command to Bifrost, attaching ESN-based dedup information, and
+    /// return a [`CommitToken`] resolved once the record is committed.
+    ///
+    /// Unlike [`Self::append_with_notification`], this preserves the dedup information
+    /// `AnnounceLeader` fencing depends on (`announce_leader.rs:45-48`) -- callers that need a
+    /// commit notification for a self-proposed command (e.g. the Candidate activation watchdog)
+    /// must use this, not `append_with_notification`.
+    pub async fn self_propose_with_notification(
+        &mut self,
+        partition_key: PartitionKey,
+        cmd: Command,
+    ) -> Result<CommitToken, Error> {
+        let header = self.create_self_propose_header(partition_key);
+        let envelope = Envelope::new(header, cmd);
+
+        let commit_token = self
+            .bifrost_appender
+            .sender()
+            .enqueue_with_notification(Arc::new(envelope))
+            .await
+            .map_err(|e| Error::SelfProposer(e.to_string()))?;
+
+        Ok(commit_token)
+    }
+
     /// Append a command to Bifrost **without** dedup information, returning a [`CommitToken`].
     ///
     /// Unlike [`Self::self_propose`], this does not attach an epoch sequence number. Records

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -18,7 +18,7 @@
 
 mod cleaner;
 pub mod invoker_storage_reader;
-mod leadership;
+pub(crate) mod leadership;
 pub mod node;
 mod processor;
 mod rpc;
@@ -535,6 +535,8 @@ where
             let config = self.node_ctx.config.live_load();
             let max_batching_size = config.worker.max_command_batch_size();
             let bytes_limit = config.worker.max_command_batch_bytes.as_usize();
+            let candidate_activation_timeout =
+                config.worker.stall_detection.candidate_activation_timeout();
 
             // Marks the top of every loop iteration as "parked in select" for the apply-stall
             // detector. Every other branch below either beats a more specific phase on entry, or
@@ -640,7 +642,7 @@ where
                     self.ctx.release_applied_lsn();
                     self.leadership_state.handle_actions(&mut self.ctx, action_collector.drain(..))?;
                 },
-                result = self.leadership_state.run(&mut self.ctx) => {
+                result = self.leadership_state.run(&mut self.ctx, candidate_activation_timeout) => {
                     self.heartbeat.beat(LoopPhase::ControlOp);
                     let action_effects = result?;
                     // We process the action_effects not directly in the run future because it

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -315,6 +315,46 @@ enum OrderedOp {
     },
 }
 
+/// Test-only seam (DEFECTB): when set, the `record_stream.next()` branch is never selected, so the
+/// loop parks in `InSelect` forever regardless of records available on the log -- simulating a
+/// wedged reader for the apply-progress-tracker integration tests. Gated out of production builds
+/// entirely; read fresh on every poll so a test can reopen the gate mid-run (e.g. to simulate
+/// recovery). Named/exposed the same way as the existing
+/// `RESTATE_INTERNAL_STATE_MACHINE_FEATURES` internal-testing knob.
+#[cfg(any(test, feature = "test-util"))]
+pub(crate) const RESTATE_TEST_FREEZE_RECORD_STREAM: &str = "RESTATE_TEST_FREEZE_RECORD_STREAM";
+
+#[cfg(any(test, feature = "test-util"))]
+fn test_record_stream_gate_open() -> bool {
+    !std::env::var(RESTATE_TEST_FREEZE_RECORD_STREAM).is_ok_and(|v| v == "1")
+}
+
+#[cfg(not(any(test, feature = "test-util")))]
+#[inline(always)]
+fn test_record_stream_gate_open() -> bool {
+    true
+}
+
+/// Test-only seam (DEFECTB): an artificial per-entry apply delay, so a test can simulate a
+/// legitimately long (but eventually completing) apply -- the `long_apply_negative_control`
+/// scenario finding 1 needed a real reproduction of. Gated out of production builds entirely.
+#[cfg(any(test, feature = "test-util"))]
+pub(crate) const RESTATE_TEST_SLOW_APPLY_MILLIS: &str = "RESTATE_TEST_SLOW_APPLY_MILLIS";
+
+#[cfg(any(test, feature = "test-util"))]
+async fn test_only_slow_apply_delay() {
+    if let Some(millis) = std::env::var(RESTATE_TEST_SLOW_APPLY_MILLIS)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+    {
+        tokio::time::sleep(Duration::from_millis(millis)).await;
+    }
+}
+
+#[cfg(not(any(test, feature = "test-util")))]
+#[inline(always)]
+async fn test_only_slow_apply_delay() {}
+
 impl<T> PartitionProcessor<T>
 where
     T: TransportConnect,
@@ -539,9 +579,11 @@ where
                 config.worker.stall_detection.candidate_activation_timeout();
 
             // Marks the top of every loop iteration as "parked in select" for the apply-stall
-            // detector. Every other branch below either beats a more specific phase on entry, or
-            // (status timer, rpc, leader query) is expected to be quick enough not to need one --
-            // see `LoopHeartbeat`'s doc for why a beat here is a sound loop-liveness proof.
+            // detector. Every branch below that may await meaningful work (not just the status
+            // timer, which is a bounded, non-blocking watch send) beats a more specific phase on
+            // entry -- see `LoopHeartbeat`'s doc for why a beat here is a sound loop-liveness
+            // proof, and finding 3 (DEFECTB review) for why every such branch needs one, not just
+            // target-leader-state/leader-run.
             self.heartbeat.beat(LoopPhase::InSelect);
 
             tokio::select! {
@@ -552,12 +594,19 @@ where
                     self.refresh_status(&mut durable_lsn_watch)?;
                 }
                 Ok(()) = watch_leader_changes.changed() => {
+                    // Finding 3 (DEFECTB review): `maybe_step_down` can await a full leader
+                    // step-down (invoker/scheduler/cleaner teardown) -- beat before it so a long
+                    // teardown reads as ControlOp, not a stale InSelect that could trip LoopDead.
+                    self.heartbeat.beat(LoopPhase::ControlOp);
                     // cloning to avoid holding the underlying RwLock.
                     let new_state = *watch_leader_changes.borrow_and_update();
                     self.leadership_state.maybe_step_down(&mut self.ctx, new_state.current_leader_epoch, new_state.current_leader).await;
                     self.refresh_status(&mut durable_lsn_watch)?;
                 }
                 Some(msg) = self.network_leader_svc_rx.next(), if self.leadership_state.should_process_rpc() => {
+                    // Finding 3: an RPC/ingest request can do real storage/network work; beat
+                    // before dispatching it so a long one reads as ControlOp, not stale InSelect.
+                    self.heartbeat.beat(LoopPhase::ControlOp);
                     // todo: replace the live schema with the leader's consistent schema
                     self.on_rpc(msg, live_schemas.live_load(), &last_applied_lsn_watch).await;
                 }
@@ -569,7 +618,7 @@ where
                 // if this branch is dropped before a record is ready, nothing has been consumed.
                 // Subsequent records are drained synchronously below (`now_or_never`), so the
                 // applied-but-uncommitted records can never be lost to select cancellation.
-                maybe_first = record_stream.next() => {
+                maybe_first = record_stream.next(), if test_record_stream_gate_open() => {
                     self.heartbeat.beat(LoopPhase::ApplyingBatch);
                     let Some(first) = maybe_first else {
                         return Err(ProcessorError::LogReadStreamTerminated);
@@ -651,6 +700,9 @@ where
                     self.leadership_state.handle_action_effects(action_effects).await?;
                 }
                 Some(leader_query_cmd) = self.leader_query_rx.recv() => {
+                    // Finding 3: defensive -- handling is synchronous today, but beat before it
+                    // in case that ever changes, matching every other branch here.
+                    self.heartbeat.beat(LoopPhase::ControlOp);
                     self.on_leader_query(leader_query_cmd);
                 }
             }
@@ -886,6 +938,8 @@ where
         action_collector: &mut ActionCollector,
         leader_record_write_to_read_latency: &metrics::Histogram,
     ) -> Result<NextStep, ProcessorError> {
+        test_only_slow_apply_delay().await;
+
         trace!(
             "Processing {} record at lsn {}",
             entry.kind(),

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -88,6 +88,8 @@ use restate_wal_protocol::v2::CommandScope;
 use restate_wal_protocol::{Envelope, v2};
 use restate_worker_api::{LeaderQueryCommand, LeaderQueryReceiver};
 
+pub use self::processor::{LoopHeartbeat, LoopPhase};
+
 use self::processor::commands::{
     AnnounceLeaderContext, ApplyPartitionCommand, NextStep, TruncateOutboxContext,
     UpdateDurabilityContext, UpsertRuleBookContext, UpsertSchemaContext, VersionBarrierContext,
@@ -136,6 +138,7 @@ pub(super) struct PartitionProcessorBuilder {
     network_svc_rx: ServiceStream<PartitionLeaderService>,
     status_watch_tx: watch::Sender<PartitionProcessorStatus>,
     node_ctx: NodeContext,
+    heartbeat: Arc<LoopHeartbeat>,
 }
 
 impl PartitionProcessorBuilder {
@@ -144,12 +147,14 @@ impl PartitionProcessorBuilder {
         network_svc_rx: ServiceStream<PartitionLeaderService>,
         status_watch_tx: watch::Sender<PartitionProcessorStatus>,
         node_ctx: NodeContext,
+        heartbeat: Arc<LoopHeartbeat>,
     ) -> Self {
         Self {
             target_leader_state_rx,
             network_svc_rx,
             status_watch_tx,
             node_ctx,
+            heartbeat,
         }
     }
 
@@ -166,6 +171,7 @@ impl PartitionProcessorBuilder {
             network_svc_rx: rpc_rx,
             status_watch_tx,
             node_ctx,
+            heartbeat,
         } = self;
 
         let mut partition_store = PartitionStore::from(partition_db);
@@ -205,6 +211,7 @@ impl PartitionProcessorBuilder {
             network_leader_svc_rx: rpc_rx,
             status_watch_tx,
             leader_query_rx,
+            heartbeat,
         })
     }
 }
@@ -218,6 +225,7 @@ pub struct PartitionProcessor<T> {
     network_leader_svc_rx: ServiceStream<PartitionLeaderService>,
     status_watch_tx: watch::Sender<PartitionProcessorStatus>,
     leader_query_rx: LeaderQueryReceiver,
+    heartbeat: Arc<LoopHeartbeat>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -528,8 +536,15 @@ where
             let max_batching_size = config.worker.max_command_batch_size();
             let bytes_limit = config.worker.max_command_batch_bytes.as_usize();
 
+            // Marks the top of every loop iteration as "parked in select" for the apply-stall
+            // detector. Every other branch below either beats a more specific phase on entry, or
+            // (status timer, rpc, leader query) is expected to be quick enough not to need one --
+            // see `LoopHeartbeat`'s doc for why a beat here is a sound loop-liveness proof.
+            self.heartbeat.beat(LoopPhase::InSelect);
+
             tokio::select! {
                 _ = self.target_leader_state_rx.changed() => {
+                    self.heartbeat.beat(LoopPhase::ControlOp);
                     let target_leader_state = self.target_leader_state_rx.borrow_and_update().clone();
                     self.on_target_leader_state(target_leader_state).await.context("failed handling target leader state change")?;
                     self.refresh_status(&mut durable_lsn_watch)?;
@@ -553,6 +568,7 @@ where
                 // Subsequent records are drained synchronously below (`now_or_never`), so the
                 // applied-but-uncommitted records can never be lost to select cancellation.
                 maybe_first = record_stream.next() => {
+                    self.heartbeat.beat(LoopPhase::ApplyingBatch);
                     let Some(first) = maybe_first else {
                         return Err(ProcessorError::LogReadStreamTerminated);
                     };
@@ -625,6 +641,7 @@ where
                     self.leadership_state.handle_actions(&mut self.ctx, action_collector.drain(..))?;
                 },
                 result = self.leadership_state.run(&mut self.ctx) => {
+                    self.heartbeat.beat(LoopPhase::ControlOp);
                     let action_effects = result?;
                     // We process the action_effects not directly in the run future because it
                     // requires the run future to be cancellation safe. In the future this could be

--- a/crates/worker/src/partition/processor.rs
+++ b/crates/worker/src/partition/processor.rs
@@ -37,7 +37,7 @@ pub use dedup::{DedupAccess, DedupMut, HasDedup, HasDedupMut};
 pub use heartbeat::{LoopHeartbeat, LoopPhase};
 pub use restate_vqueues::context::{HasVQueues, HasVQueuesMut};
 pub use restate_worker_api::processor::*;
-pub use status::HasStatusMut;
+pub use status::{HasStatus, HasStatusMut};
 
 use self::fsm::Fsm;
 

--- a/crates/worker/src/partition/processor.rs
+++ b/crates/worker/src/partition/processor.rs
@@ -26,6 +26,7 @@ pub mod commands;
 mod context;
 mod dedup;
 mod fsm;
+pub mod heartbeat;
 pub mod leadership;
 mod outbox;
 mod status;
@@ -33,6 +34,7 @@ mod status;
 // Re-exports
 pub use context::ProcessorRawContext;
 pub use dedup::{DedupAccess, DedupMut, HasDedup, HasDedupMut};
+pub use heartbeat::{LoopHeartbeat, LoopPhase};
 pub use restate_vqueues::context::{HasVQueues, HasVQueuesMut};
 pub use restate_worker_api::processor::*;
 pub use status::HasStatusMut;

--- a/crates/worker/src/partition/processor/heartbeat.rs
+++ b/crates/worker/src/partition/processor/heartbeat.rs
@@ -1,0 +1,140 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A cheap, lock-free liveness signal for the partition processor's `run_inner` loop.
+//!
+//! The processor stores its current loop phase and a monotonically increasing counter in a
+//! single packed `AtomicU64`, written with `Release` ordering and read with `Acquire` ordering so
+//! that a reader always observes a coherent `(phase, counter)` pair -- never a phase from one
+//! write torn against the counter of another. The counter lets a reader detect "the phase
+//! changed since I last looked" without needing to compare phases (which repeat).
+//!
+//! Timestamps are deliberately kept out of the atomic: `Instant` cannot be packed into a `u64`,
+//! and the manager (not the processor) is the one that cares about elapsed time. The manager
+//! samples `(phase, counter)` and stamps its own `Instant` locally whenever the counter changes.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+const PHASE_BITS: u32 = 3;
+const PHASE_MASK: u64 = (1 << PHASE_BITS) - 1;
+
+/// Where the `run_inner` loop currently is. Written by the partition processor at well-defined
+/// points in its select loop; read by the `PartitionProcessorManager`'s apply-progress tracker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum LoopPhase {
+    /// Parked in `tokio::select!`, waiting for the next event (including the record stream).
+    /// This is the only phase whose staleness is a sound proof that the loop cannot run --
+    /// every other branch of the select is guaranteed to fire the ~500ms(+/-50%) status timer at
+    /// the latest, which always brings the loop back here.
+    InSelect = 0,
+    /// Applying a batch of records read from the log.
+    ApplyingBatch = 1,
+    /// Handling a target-leader-state change or running the leadership state machine.
+    ControlOp = 2,
+}
+
+impl LoopPhase {
+    fn from_bits(bits: u64) -> Self {
+        match bits {
+            0 => LoopPhase::InSelect,
+            1 => LoopPhase::ApplyingBatch,
+            2 => LoopPhase::ControlOp,
+            other => panic!("invalid packed LoopPhase bits: {other}"),
+        }
+    }
+}
+
+/// Packed `[phase: 3 bits | counter: 61 bits]` heartbeat. Cheap enough to write twice per loop
+/// iteration (relaxed load + released store); `sample()` is a single acquire load, so phase and
+/// counter are always observed together.
+#[derive(Debug, Default)]
+pub struct LoopHeartbeat(AtomicU64);
+
+impl LoopHeartbeat {
+    pub fn new() -> Self {
+        Self(AtomicU64::new(0))
+    }
+
+    /// Record that the loop has reached `phase`. Monotonically increments the counter so
+    /// repeated beats of the same phase are still distinguishable from a stale reading.
+    pub fn beat(&self, phase: LoopPhase) {
+        let counter = self.0.load(Ordering::Relaxed) >> PHASE_BITS;
+        let packed = (counter.wrapping_add(1) << PHASE_BITS) | (phase as u64);
+        self.0.store(packed, Ordering::Release);
+    }
+
+    /// A single coherent `(phase, counter)` snapshot.
+    pub fn sample(&self) -> (LoopPhase, u64) {
+        let packed = self.0.load(Ordering::Acquire);
+        (
+            LoopPhase::from_bits(packed & PHASE_MASK),
+            packed >> PHASE_BITS,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn heartbeat_coherence_unit() {
+        let hb = LoopHeartbeat::new();
+
+        // Initial sample: counter 0, phase InSelect (the packed zero value).
+        let (phase, counter) = hb.sample();
+        assert_eq!(phase, LoopPhase::InSelect);
+        assert_eq!(counter, 0);
+
+        hb.beat(LoopPhase::ApplyingBatch);
+        let (phase, counter1) = hb.sample();
+        assert_eq!(phase, LoopPhase::ApplyingBatch);
+        assert_eq!(counter1, 1);
+
+        hb.beat(LoopPhase::ControlOp);
+        let (phase, counter2) = hb.sample();
+        assert_eq!(phase, LoopPhase::ControlOp);
+        assert_eq!(counter2, 2);
+        assert!(
+            counter2 > counter1,
+            "counter must be monotonically increasing"
+        );
+
+        // Repeated beats of the same phase still bump the counter, so a reader can tell a fresh
+        // beat happened even though the phase read is identical to the last sample.
+        hb.beat(LoopPhase::InSelect);
+        hb.beat(LoopPhase::InSelect);
+        let (phase, counter3) = hb.sample();
+        assert_eq!(phase, LoopPhase::InSelect);
+        assert_eq!(counter3, 4);
+    }
+
+    #[test]
+    fn sample_never_tears_phase_and_counter() {
+        // Regression guard for the packed-atomic design: since beat() does a single store and
+        // sample() does a single load, there is no way to observe a phase from one beat combined
+        // with a counter from another -- verified structurally (single AtomicU64), exercised here
+        // by checking every phase transition keeps phase and counter in lock-step.
+        let hb = LoopHeartbeat::new();
+        let phases = [
+            LoopPhase::ApplyingBatch,
+            LoopPhase::ControlOp,
+            LoopPhase::InSelect,
+            LoopPhase::ApplyingBatch,
+        ];
+        for (i, phase) in phases.iter().enumerate() {
+            hb.beat(*phase);
+            let (sampled_phase, counter) = hb.sample();
+            assert_eq!(sampled_phase, *phase);
+            assert_eq!(counter, (i + 1) as u64);
+        }
+    }
+}

--- a/crates/worker/src/partition/processor/status.rs
+++ b/crates/worker/src/partition/processor/status.rs
@@ -36,6 +36,10 @@ pub struct Status {
     /// The time point when the processor is considered to have started
     started_at: Instant,
     last_lsn_applied_at: Option<MillisSinceEpoch>,
+    /// Monotonic counterpart of `last_lsn_applied_at`, set alongside it. Deadline math (e.g. the
+    /// Candidate activation watchdog) must use this, never the wall-clock stamp --
+    /// `MillisSinceEpoch::elapsed` is explicitly non-monotonic.
+    last_applied_at_instant: Option<Instant>,
     planned_run_mode: RunMode,
     replay_status: ReplayStatus,
     target_tail_lsn: Option<Lsn>,
@@ -48,6 +52,7 @@ impl Status {
         Self {
             started_at: Instant::now(),
             last_lsn_applied_at: None,
+            last_applied_at_instant: None,
             planned_run_mode: RunMode::Follower,
             replay_status: ReplayStatus::Starting,
             target_tail_lsn: None,
@@ -74,6 +79,10 @@ impl Status {
 
     pub fn last_lsn_applied_at(&self) -> Option<MillisSinceEpoch> {
         self.last_lsn_applied_at
+    }
+
+    pub fn last_applied_at_instant(&self) -> Option<Instant> {
+        self.last_applied_at_instant
     }
 
     pub fn set_planned_run_mode(&mut self, planned_run_mode: RunMode) {
@@ -116,6 +125,7 @@ impl Status {
     /// Returns true if we transitioned from CatchingUp to Active
     pub(super) fn update_last_applied_lsn(&mut self, lsn: Lsn) -> bool {
         self.last_lsn_applied_at = Some(MillisSinceEpoch::now());
+        self.last_applied_at_instant = Some(Instant::now());
         // Update replay status
         match self.replay_status {
             ReplayStatus::CatchingUp

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -1084,15 +1084,38 @@ where
         else {
             return;
         };
-        // A fresh phase read, independent of (and later than) the `HeartbeatView` sample the
-        // proposal was based on: confirms the loop is still parked in `select`, not busy having
-        // resumed real work.
-        let (phase, _counter) = started.heartbeat().sample();
-        let still_idle = phase == LoopPhase::InSelect;
+        // A fresh raw heartbeat read, independent of (and later than) the sample
+        // `evaluate_trackers` used to propose this bail.
+        let fresh_sample = started.heartbeat().sample();
+
+        let Some(sampled_at_proposal) = self
+            .heartbeat_views
+            .get(&partition_id)
+            .map(HeartbeatView::last_sample)
+        else {
+            return;
+        };
+        let fresh_last_applied_lsn = self
+            .processor_states
+            .get(&partition_id)
+            .and_then(ProcessorState::partition_processor_status)
+            .and_then(|status| status.last_applied_log_lsn);
 
         let Some(tracker) = self.trackers.get_mut(&partition_id) else {
             return;
         };
+
+        // Finding 4 (DEFECTB re-review): merely confirming the loop is *currently* `InSelect`
+        // isn't enough -- a loop that went `ApplyingBatch` and back to `InSelect` between the
+        // proposal and this revalidation looks identical to one that never moved. Requiring the
+        // raw `(phase, counter)` to be unchanged since the proposal's sample catches that, and
+        // re-reading `last_applied_lsn` catches progress that already landed but hasn't cycled
+        // the heartbeat again yet.
+        let still_idle = fresh_sample.0 == LoopPhase::InSelect;
+        let heartbeat_unchanged = fresh_sample == sampled_at_proposal;
+        let no_new_progress = tracker
+            .last_known_lsn()
+            .is_none_or(|known| fresh_last_applied_lsn.is_none_or(|fresh| fresh <= known));
 
         // A LoopDead episode's proof is "the loop still isn't scheduling", not lag -- an
         // ApplyStall episode (or none yet, e.g. a fresh Stalled->Bail transition) requires
@@ -1108,7 +1131,11 @@ where
                 .is_some_and(|obs| obs.lsn().prev() > known)
         });
 
-        if !still_idle || !(is_loop_dead_episode || still_lagging) {
+        if !still_idle
+            || !heartbeat_unchanged
+            || !no_new_progress
+            || !(is_loop_dead_episode || still_lagging)
+        {
             debug!(
                 %partition_id,
                 "Apply-stall bail aborted: the processor resumed before the manager could revalidate"
@@ -2382,6 +2409,298 @@ mod tests {
         Ok(())
     }
 
+    /// Shared rig for the `revalidate_and_commit_bail` regression tests below: a manager with one
+    /// `Started` processor (real `LoopHeartbeat`, real status watch channel) and a tracker already
+    /// quarantined (`LoopDead`) with a known `last_known_lsn`, i.e. exactly the state
+    /// `evaluate_trackers` would have left behind right after proposing a bail. Returns the
+    /// manager plus handles the test mutates to simulate what happens *after* that proposal and
+    /// *before* revalidation runs.
+    async fn bail_revalidation_rig() -> googletest::Result<(
+        PartitionProcessorManager<restate_core::network::FailingConnector>,
+        std::sync::Arc<crate::partition::LoopHeartbeat>,
+        tokio::sync::watch::Sender<restate_types::cluster::cluster_state::PartitionProcessorStatus>,
+    )> {
+        use std::sync::Arc;
+
+        use tokio::sync::watch;
+        use tokio::time::Instant;
+        use tokio_util::sync::CancellationToken;
+        use ulid::Ulid;
+
+        use crate::partition::{LoopHeartbeat, LoopPhase, TargetLeaderState};
+        use crate::partition_processor_manager::apply_progress_tracker::{
+            HeartbeatView, LoopState, QuarantineEpisode, TickInput, TrackerEffect, TrackerEntry,
+        };
+        use crate::partition_processor_manager::processor_state::{
+            LeaderState, ProcessorState, StartedProcessor,
+        };
+        use restate_core::network::ShardSender;
+        use restate_types::cluster::cluster_state::{PartitionProcessorStatus, ReplayStatus};
+        use restate_types::config::StallDetectionOptions;
+        use restate_types::identifiers::PartitionId;
+        use restate_types::logs::Lsn;
+        use restate_types::sharding::KeyRange;
+
+        let mut nodes_config = NodesConfiguration::new_for_testing();
+        let node_id = GenerationalNodeId::new(47, 47);
+        let node_config = NodeConfig::builder()
+            .name("47".to_owned())
+            .current_generation(node_id)
+            .address(AdvertisedAddress::default())
+            .roles(Role::Worker | Role::Admin)
+            .binary_version(RestateVersion::current())
+            .build();
+        nodes_config.upsert_node(node_config);
+
+        let mut env_builder = TestCoreEnvBuilder::with_incoming_only_connector()
+            .set_my_node_id(node_id)
+            .set_nodes_config(nodes_config);
+        let health_status = HealthStatus::default();
+
+        RocksDbManager::init();
+
+        let bifrost_svc = BifrostService::new(env_builder.metadata_writer.clone())
+            .with_factory(memory_loglet::Factory::default());
+        let bifrost = bifrost_svc.handle();
+
+        let replica_set_states = PartitionReplicaSetStates::default();
+        let partition_store_manager = PartitionStoreManager::create(true).await?;
+
+        let ingestion_client = IngestionClient::new(
+            env_builder.networking.clone(),
+            env_builder.metadata.updateable_partition_table(),
+            PartitionRouting::new(replica_set_states.clone(), TaskCenter::current()),
+            NonZeroUsize::new(10 * 1024 * 1024).unwrap(),
+            SessionOptions::default(),
+        );
+
+        let cfg = StallDetectionOptions::default();
+        let mut partition_processor_manager = PartitionProcessorManager::new(
+            health_status,
+            Live::from_value(Configuration::default()),
+            env_builder.metadata_writer.clone(),
+            partition_store_manager,
+            replica_set_states.clone(),
+            &mut env_builder.router_builder,
+            bifrost,
+            None,
+            ingestion_client,
+        );
+
+        let _env = env_builder.build().await;
+        bifrost_svc.start().await.into_test_result()?;
+
+        let heartbeat = Arc::new(LoopHeartbeat::new());
+        // Two beats: matches the manager having already sampled this loop once mid-incarnation
+        // (i.e. `has_observed_change` would be true), landing on `(InSelect, 2)`.
+        heartbeat.beat(LoopPhase::InSelect);
+        heartbeat.beat(LoopPhase::InSelect);
+
+        let (control_tx, _control_rx) = watch::channel(TargetLeaderState::Follower);
+        let (rpc_tx, _rpc_rx) = ShardSender::new();
+        let (status_tx, status_rx) = watch::channel(PartitionProcessorStatus {
+            replay_status: ReplayStatus::Active,
+            last_applied_log_lsn: Some(Lsn::new(10)),
+            ..PartitionProcessorStatus::default()
+        });
+        let started = StartedProcessor::new(
+            CancellationToken::new(),
+            KeyRange::FULL,
+            control_tx,
+            rpc_tx,
+            status_rx,
+            heartbeat.clone(),
+        );
+        partition_processor_manager.processor_states.insert(
+            PartitionId::MIN,
+            ProcessorState::Started {
+                processor: Some(started),
+                leader_state: LeaderState::Follower,
+                start_time: std::time::Instant::now(),
+                delay: None,
+            },
+        );
+
+        // The `HeartbeatView` reflects exactly the sample `evaluate_trackers` would have taken at
+        // proposal time: `(InSelect, 2)`, matching the live heartbeat above.
+        let now = Instant::now();
+        let mut heartbeat_view = HeartbeatView::new(now);
+        heartbeat_view.observe(heartbeat.sample(), now);
+        partition_processor_manager
+            .heartbeat_views
+            .insert(PartitionId::MIN, heartbeat_view);
+
+        // Drive the tracker to a quarantined, bail-eligible state with a known `last_known_lsn`:
+        // one progress sample to establish `last_known_lsn = Some(10)`, then a loop-dead sample
+        // (independent of lag) to quarantine and propose a bail.
+        let mut tracker = TrackerEntry::new(Ulid::new(), now, &cfg);
+        let progress_effect = tracker.on_sample(
+            now,
+            TickInput {
+                last_applied_lsn: Some(Lsn::new(10)),
+                replay_status: ReplayStatus::Active,
+                loop_state: LoopState::ReaderIdle,
+                fresh_tail: None,
+            },
+            &cfg,
+        );
+        assert!(matches!(progress_effect, TrackerEffect::None));
+
+        let bail_proposal = tracker.on_sample(
+            now,
+            TickInput {
+                last_applied_lsn: Some(Lsn::new(10)),
+                replay_status: ReplayStatus::Active,
+                loop_state: LoopState::LoopDead,
+                fresh_tail: None,
+            },
+            &cfg,
+        );
+        assert!(matches!(bail_proposal, TrackerEffect::Bail));
+        assert!(matches!(
+            tracker.quarantine(),
+            Some(QuarantineEpisode::LoopDead { bails: 0, .. })
+        ));
+
+        partition_processor_manager
+            .trackers
+            .insert(PartitionId::MIN, tracker);
+
+        Ok((partition_processor_manager, heartbeat, status_tx))
+    }
+
+    /// Finding 4 (DEFECTB re-review, BLOCKER 1): the pre-stop revalidation must reject a bail
+    /// whose heartbeat has moved since the sample that proposed it -- a loop that cycled through
+    /// `ApplyingBatch` and back to `InSelect` between the proposal and this revalidation looks
+    /// `InSelect` right now too, so checking only the current phase (the old, incomplete
+    /// revalidation) would miss it. No `stop()`, no `commit_bail` (quarantine's `bails` count
+    /// stays at 0).
+    #[test(restate_core::test)]
+    async fn bail_revalidation_rejects_on_heartbeat_change_since_proposal() -> googletest::Result<()>
+    {
+        use crate::partition::LoopPhase;
+        use crate::partition_processor_manager::apply_progress_tracker::QuarantineEpisode;
+        use crate::partition_processor_manager::processor_state::ProcessorState;
+        use restate_types::config::StallDetectionOptions;
+        use restate_types::identifiers::PartitionId;
+
+        let (mut manager, heartbeat, _status_tx) = bail_revalidation_rig().await?;
+
+        // The loop cycled through a phase and back to `InSelect` between the proposal and now --
+        // the counter moves even though the phase reported right now is unchanged.
+        heartbeat.beat(LoopPhase::ApplyingBatch);
+        heartbeat.beat(LoopPhase::InSelect);
+
+        let cfg = StallDetectionOptions::default();
+        manager.revalidate_and_commit_bail(PartitionId::MIN, &cfg);
+
+        let tracker = manager
+            .trackers
+            .get(&PartitionId::MIN)
+            .expect("tracker must still be present");
+        assert!(
+            matches!(
+                tracker.quarantine(),
+                Some(QuarantineEpisode::LoopDead { bails: 0, .. })
+            ),
+            "a rejected revalidation must not advance the bail count"
+        );
+        assert!(
+            matches!(
+                manager.processor_states.get(&PartitionId::MIN),
+                Some(ProcessorState::Started { .. })
+            ),
+            "a rejected revalidation must not stop the processor"
+        );
+
+        TaskCenter::shutdown_node("test completed", 0).await;
+        RocksDbManager::get().shutdown().await;
+        Ok(())
+    }
+
+    /// Finding 4 (DEFECTB re-review, BLOCKER 1): the pre-stop revalidation must reject a bail
+    /// whose `last_applied_lsn` has advanced since the sample that proposed it, even if the
+    /// heartbeat itself happens to read identically right now (e.g. the loop is `InSelect` again
+    /// on the *next* record, having not yet cycled a new counter value). No `stop()`, no
+    /// `commit_bail`.
+    #[test(restate_core::test)]
+    async fn bail_revalidation_rejects_on_progress_since_proposal() -> googletest::Result<()> {
+        use crate::partition_processor_manager::apply_progress_tracker::QuarantineEpisode;
+        use crate::partition_processor_manager::processor_state::ProcessorState;
+        use restate_types::config::StallDetectionOptions;
+        use restate_types::identifiers::PartitionId;
+        use restate_types::logs::Lsn;
+
+        let (mut manager, _heartbeat, status_tx) = bail_revalidation_rig().await?;
+
+        status_tx.send_modify(|status| status.last_applied_log_lsn = Some(Lsn::new(11)));
+
+        let cfg = StallDetectionOptions::default();
+        manager.revalidate_and_commit_bail(PartitionId::MIN, &cfg);
+
+        let tracker = manager
+            .trackers
+            .get(&PartitionId::MIN)
+            .expect("tracker must still be present");
+        assert!(
+            matches!(
+                tracker.quarantine(),
+                Some(QuarantineEpisode::LoopDead { bails: 0, .. })
+            ),
+            "a rejected revalidation must not advance the bail count"
+        );
+        assert!(
+            matches!(
+                manager.processor_states.get(&PartitionId::MIN),
+                Some(ProcessorState::Started { .. })
+            ),
+            "a rejected revalidation must not stop the processor"
+        );
+
+        TaskCenter::shutdown_node("test completed", 0).await;
+        RocksDbManager::get().shutdown().await;
+        Ok(())
+    }
+
+    /// Positive control for the two rejection tests above: an unchanged heartbeat and unchanged
+    /// `last_applied_lsn` must still let a `LoopDead` bail commit and stop the processor -- the
+    /// stricter finding-4 revalidation must not reject a genuinely-still-stalled bail.
+    #[test(restate_core::test)]
+    async fn bail_revalidation_commits_when_still_idle_and_unchanged() -> googletest::Result<()> {
+        use crate::partition_processor_manager::apply_progress_tracker::QuarantineEpisode;
+        use crate::partition_processor_manager::processor_state::ProcessorState;
+        use restate_types::config::StallDetectionOptions;
+        use restate_types::identifiers::PartitionId;
+
+        let (mut manager, _heartbeat, _status_tx) = bail_revalidation_rig().await?;
+
+        let cfg = StallDetectionOptions::default();
+        manager.revalidate_and_commit_bail(PartitionId::MIN, &cfg);
+
+        let tracker = manager
+            .trackers
+            .get(&PartitionId::MIN)
+            .expect("tracker must still be present");
+        assert!(
+            matches!(
+                tracker.quarantine(),
+                Some(QuarantineEpisode::LoopDead { bails: 1, .. })
+            ),
+            "a still-idle, still-unchanged bail must commit"
+        );
+        assert!(
+            matches!(
+                manager.processor_states.get(&PartitionId::MIN),
+                Some(ProcessorState::Stopping { .. })
+            ),
+            "a committed bail must stop the processor"
+        );
+
+        TaskCenter::shutdown_node("test completed", 0).await;
+        RocksDbManager::get().shutdown().await;
+        Ok(())
+    }
+
     /// Finding 1 negative control (DEFECTB review, merge-blocking integration coverage): a
     /// legitimately long apply (well past `grace`, with more records still sitting unapplied in
     /// the log the whole time) must never itself be reported as a stall. Uses the test-only
@@ -2390,6 +2709,13 @@ mod tests {
     /// proves that phase, not raw elapsed time since progress, gates suspicion (the exact
     /// distinction finding 1's fix restored; `tracker_state_machine_unit` pins the same invariant
     /// at the pure state-machine level with explicit RED->GREEN evidence for the fix).
+    ///
+    /// `NUM_RECORDS` exceeds `max_command_batch_size` (32, `config/worker.rs`) so the run crosses
+    /// at least one real batch boundary: after each batch, the loop briefly returns to `InSelect`
+    /// with the tail still ahead (the remaining, not-yet-read records) before starting the next
+    /// batch -- the same genuine idle+lagging transition finding 1's fix is about, now exercised
+    /// at the actual batch granularity the production loop uses, not just between individual
+    /// records.
     #[test(restate_core::test)]
     async fn long_apply_negative_control() -> googletest::Result<()> {
         use std::sync::Arc;
@@ -2408,8 +2734,8 @@ mod tests {
 
         use crate::partition::RESTATE_TEST_SLOW_APPLY_MILLIS;
 
-        const SLOW_APPLY_MILLIS: u64 = 300;
-        const NUM_RECORDS: u64 = 4;
+        const SLOW_APPLY_MILLIS: u64 = 50;
+        const NUM_RECORDS: u64 = 40;
 
         let mut nodes_config = NodesConfiguration::new_for_testing();
         let node_id = GenerationalNodeId::new(45, 45);
@@ -2587,6 +2913,267 @@ mod tests {
 
         unsafe {
             std::env::remove_var(RESTATE_TEST_SLOW_APPLY_MILLIS);
+        }
+
+        TaskCenter::shutdown_node("test completed", 0).await;
+        RocksDbManager::get().shutdown().await;
+        Ok(())
+    }
+
+    /// BLOCKER 2 (DEFECTB re-review): the positive end-to-end scenario proving
+    /// detect -> quarantine -> bail -> restart -> recovery through the real manager, a real
+    /// partition processor's `run_inner` loop, and real bifrost -- not a hand-crafted
+    /// `TrackerEntry`/`TickInput` sequence. Uses the frozen-reader test seam
+    /// (`RESTATE_TEST_FREEZE_RECORD_STREAM`, `partition/mod.rs`) so the log genuinely has
+    /// unconsumed records the whole time, without needing a slow apply.
+    ///
+    /// The freeze gate is re-checked on every `select!` iteration, so simply unfreezing it would
+    /// let recovery happen even if the bail/restart path were silently broken and the *original*
+    /// incarnation just kept running the whole time. `ProcessorsManagerHandle` only exposes
+    /// `get_state()`, so this test can't peek at the manager's `processor_states`/`trackers`
+    /// directly (the manager is moved into its spawned `run()` task); instead it stays frozen and
+    /// polls for a bounded window comfortably longer than one full detect->confirm->bail cycle,
+    /// asserting the quarantine never spuriously clears on its own during that window (only
+    /// unfreezing the reader can produce real progress) -- then unfreezes and asserts recovery.
+    #[test(restate_core::test)]
+    async fn frozen_reader_detects_quarantines_bails_restarts_and_recovers()
+    -> googletest::Result<()> {
+        use std::sync::Arc;
+
+        use restate_bifrost::ErrorRecoveryStrategy;
+        use restate_storage_api::deduplication_table::{DedupInformation, EpochSequenceNumber};
+        use restate_types::cluster::cluster_state::ReplayStatus;
+        use restate_types::config::StallDetectionOptions;
+        use restate_types::identifiers::LeaderEpoch;
+        use restate_types::partitions::Partition;
+        use restate_types::sharding::KeyRange;
+        use restate_types::time::MillisSinceEpoch;
+        use restate_util_time::FriendlyDuration;
+        use restate_wal_protocol::control::UpdatePartitionDurabilityCommand;
+        use restate_wal_protocol::{Command, Destination, Envelope, Header, Source};
+
+        use crate::partition::RESTATE_TEST_FREEZE_RECORD_STREAM;
+
+        const NUM_RECORDS: u64 = 3;
+
+        let mut nodes_config = NodesConfiguration::new_for_testing();
+        let node_id = GenerationalNodeId::new(48, 48);
+        let node_config = NodeConfig::builder()
+            .name("48".to_owned())
+            .current_generation(node_id)
+            .address(AdvertisedAddress::default())
+            .roles(Role::Worker | Role::Admin)
+            .binary_version(RestateVersion::current())
+            .build();
+        nodes_config.upsert_node(node_config);
+
+        let mut env_builder = TestCoreEnvBuilder::with_incoming_only_connector()
+            .set_my_node_id(node_id)
+            .set_nodes_config(nodes_config);
+        let health_status = HealthStatus::default();
+
+        RocksDbManager::init();
+
+        let bifrost_svc = BifrostService::new(env_builder.metadata_writer.clone())
+            .with_factory(memory_loglet::Factory::default());
+        let bifrost = bifrost_svc.handle();
+
+        let replica_set_states = PartitionReplicaSetStates::default();
+        let partition_store_manager = PartitionStoreManager::create(true).await?;
+
+        let ingestion_client = IngestionClient::new(
+            env_builder.networking.clone(),
+            env_builder.metadata.updateable_partition_table(),
+            PartitionRouting::new(replica_set_states.clone(), TaskCenter::current()),
+            NonZeroUsize::new(10 * 1024 * 1024).unwrap(),
+            SessionOptions::default(),
+        );
+
+        // Fast-but-real thresholds. `heartbeat_fresh`/`hard_grace` stay generously larger than
+        // the apply loop's own ~500ms(+/-50%) status-timer beat cadence so a frozen-but-otherwise-
+        // idle loop reads as genuinely `ReaderIdle` (not `Stale`/`LoopDead`) -- this scenario is
+        // about the `ApplyStall` detect->confirm->bail path, not loop-death.
+        let mut configuration = Configuration::default();
+        configuration.worker.stall_detection = StallDetectionOptions {
+            grace: FriendlyDuration::from_millis(300),
+            heartbeat_fresh: FriendlyDuration::from_secs(2),
+            tail_ttl: FriendlyDuration::from_secs(5),
+            sweep_interval: FriendlyDuration::from_secs(1),
+            probe_timeout: FriendlyDuration::from_secs(2),
+            probe_backoff_base: FriendlyDuration::from_millis(300),
+            probe_backoff_cap: FriendlyDuration::from_secs(1),
+            recovery_window: FriendlyDuration::from_millis(300),
+            bail_grace: FriendlyDuration::from_millis(300),
+            bail_backoff_base: FriendlyDuration::from_secs(2),
+            bail_backoff_cap: FriendlyDuration::from_secs(5),
+            hard_grace: FriendlyDuration::from_secs(10),
+            candidate_activation_timeout: FriendlyDuration::from_secs(60),
+            ..StallDetectionOptions::default()
+        };
+
+        let metadata_writer = env_builder.metadata_writer.clone();
+        let partition_processor_manager = PartitionProcessorManager::new(
+            health_status,
+            Live::from_value(configuration),
+            metadata_writer.clone(),
+            partition_store_manager,
+            replica_set_states.clone(),
+            &mut env_builder.router_builder,
+            bifrost.clone(),
+            None,
+            ingestion_client,
+        );
+
+        let _env = env_builder.build().await;
+
+        // See `long_apply_negative_control`'s identical workaround: `bootstrap_logs_metadata`
+        // leaves `Logs::configuration().default_provider` at `Replicated` even in in-memory test
+        // mode, which `ensure_log_exists` would otherwise choke on for every (re)spawn.
+        {
+            use restate_core::Metadata;
+            use restate_types::logs::metadata::{LogsConfiguration, ProviderConfiguration};
+
+            let logs = Metadata::with_current(|m| m.logs_snapshot());
+            let mut builder = (*logs).clone().try_into_builder().expect("valid logs");
+            builder.set_configuration(LogsConfiguration {
+                default_provider: ProviderConfiguration::InMemory,
+            });
+            metadata_writer.submit(Arc::new(builder.build()));
+        }
+
+        let processors_manager_handle = partition_processor_manager.handle();
+
+        bifrost_svc.start().await.into_test_result()?;
+        TaskCenter::spawn(
+            TaskKind::SystemService,
+            "partition-processor-manager",
+            partition_processor_manager.run(),
+        )?;
+
+        // Freeze the reader from the very start: with an empty log there is nothing to consume
+        // yet, so the processor still reaches `Active` immediately regardless.
+        unsafe {
+            std::env::set_var(RESTATE_TEST_FREEZE_RECORD_STREAM, "1");
+        }
+
+        let current_replica_set = ReplicaSetState {
+            version: Version::MIN,
+            members: vec![MemberState {
+                node_id: node_id.as_plain(),
+                durable_lsn: Lsn::INVALID,
+            }],
+        };
+        replica_set_states.note_observed_membership(
+            PartitionId::MIN,
+            Default::default(),
+            &current_replica_set,
+            &None,
+        );
+
+        loop {
+            let state = processors_manager_handle.get_state().await?;
+            if state
+                .get(&PartitionId::MIN)
+                .is_some_and(|s| s.replay_status == ReplayStatus::Active)
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        // Append records with the reader frozen: the tail is now ahead of the applied LSN, and
+        // will stay that way until the reader is unfrozen.
+        let log_id = Partition::new(PartitionId::MIN, KeyRange::FULL).log_id();
+        let mut appender =
+            bifrost.create_appender::<Envelope>(log_id, ErrorRecoveryStrategy::Wait)?;
+        let mut esn = EpochSequenceNumber::new(LeaderEpoch::INVALID);
+        for _ in 0..NUM_RECORDS {
+            let header = Header {
+                dest: Destination::Processor {
+                    partition_key: KeyRange::FULL.start(),
+                    dedup: Some(DedupInformation::self_proposal(esn)),
+                },
+                source: Source::Processor {
+                    partition_key: Some(KeyRange::FULL.start()),
+                    leader_epoch: LeaderEpoch::INVALID,
+                },
+            };
+            let envelope = Envelope::new(
+                header,
+                Command::UpdatePartitionDurability(UpdatePartitionDurabilityCommand {
+                    partition_id: PartitionId::MIN,
+                    durable_point: Lsn::OLDEST,
+                    modification_time: MillisSinceEpoch::now(),
+                }),
+            );
+            appender.append(Arc::new(envelope)).await?;
+            esn = esn.next();
+        }
+
+        // Wait for the overlay to report detect -> quarantine: `CatchingUp` (the manager's
+        // downgraded-replay-status overlay) plus a set `apply_stalled_since`.
+        loop {
+            let state = processors_manager_handle.get_state().await?;
+            let status = state
+                .get(&PartitionId::MIN)
+                .expect("partition must still be present while frozen");
+            if status.apply_stalled_since.is_some() {
+                assert_eq!(
+                    status.replay_status,
+                    ReplayStatus::CatchingUp,
+                    "a quarantined partition must report CatchingUp via the overlay"
+                );
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        // Still frozen: keep polling for a window comfortably longer than one full
+        // detect->confirm->bail cycle (grace + probe + recovery_window + bail_grace, plus the
+        // tracker-tick/tail-poller cadence), asserting the quarantine never spuriously clears.
+        // It can only clear via rule 1 (real progress past `bail_lsn`), which is impossible while
+        // frozen -- so persisting through this window is exactly what a working self-bail (stop
+        // the stuck incarnation, restart, remain quarantined since the new one is frozen too)
+        // looks like from the outside, and a hard failure otherwise would mean the reader somehow
+        // made progress without ever being unfrozen.
+        let watch_until = tokio::time::Instant::now() + Duration::from_secs(6);
+        while tokio::time::Instant::now() < watch_until {
+            let state = processors_manager_handle.get_state().await?;
+            let status = state
+                .get(&PartitionId::MIN)
+                .expect("partition must still be present across the self-bail restart cycle");
+
+            assert!(
+                status.apply_stalled_since.is_some(),
+                "apply_stalled_since cleared before the reader was ever unfrozen -- \
+                 the reader must have made progress without a bail/restart"
+            );
+
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        // Now let the (new, still-frozen-until-this-point) incarnation actually make progress.
+        unsafe {
+            std::env::remove_var(RESTATE_TEST_FREEZE_RECORD_STREAM);
+        }
+
+        let recovery_deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            if tokio::time::Instant::now() >= recovery_deadline {
+                panic!("never recovered to Active with a cleared quarantine after unfreezing");
+            }
+
+            let state = processors_manager_handle.get_state().await?;
+            let status = state
+                .get(&PartitionId::MIN)
+                .expect("partition must still be present after unfreezing");
+            if status.apply_stalled_since.is_none()
+                && status.replay_status == ReplayStatus::Active
+                && status.last_applied_log_lsn == Some(Lsn::new(NUM_RECORDS))
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
         }
 
         TaskCenter::shutdown_node("test completed", 0).await;

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -8,18 +8,24 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod apply_progress_tracker;
 mod introspection;
 mod processor_state;
 mod spawn_processor_task;
 
 pub use introspection::{LeaderQueryGuard, PartitionLeaderHandlesRegistry};
 
+use apply_progress_tracker::{
+    HeartbeatView, LoopState, ProbeResult, TailObservation, TickInput, TrackerEffect, TrackerEntry,
+    pick_next_consistent_read_sweep_target,
+};
+
 use std::collections::BTreeMap;
 use std::collections::hash_map::Entry;
 use std::ops::Add;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use ahash::{HashMap, HashSet};
 use anyhow::{Context, bail};
@@ -32,8 +38,9 @@ use rand::seq::SliceRandom;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::task::JoinSet;
-use tokio::time::MissedTickBehavior;
+use tokio::time::{Instant, MissedTickBehavior};
 use tracing::{debug, error, info, info_span, instrument, trace, warn};
+use ulid::Ulid;
 
 use restate_bifrost::Bifrost;
 use restate_bifrost::loglet::FindTailOptions;
@@ -58,7 +65,7 @@ use restate_partition_store::{SnapshotError, SnapshotErrorKind};
 use restate_types::GenerationalNodeId;
 use restate_types::cluster::cluster_state::ReplayStatus;
 use restate_types::cluster::cluster_state::{PartitionProcessorStatus, RunMode};
-use restate_types::config::Configuration;
+use restate_types::config::{Configuration, StallDetectionOptions};
 use restate_types::epoch::EpochMetadata;
 use restate_types::health::HealthStatus;
 use restate_types::identifiers::PartitionId;
@@ -78,12 +85,14 @@ use restate_types::partition_table::PartitionTable;
 use restate_types::partitions::Partition;
 use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::protobuf::common::WorkerStatus;
+use restate_types::time::MillisSinceEpoch;
 use restate_util_string::format_restring;
 use restate_util_time::DurationExt;
 use restate_wal_protocol::Envelope;
 use restate_worker_api::invoker::capacity::InvokerCapacity;
 use restate_worker_api::{ProcessorsManagerCommand, ProcessorsManagerHandle};
 
+use crate::metric_definitions::PARTITION_STOP_STUCK;
 use crate::metric_definitions::{
     ERROR_STOP, FLARE_REASON_MIGRATION_BARRIER, FLARE_REASON_SNAPSHOT_UNAVAILABLE,
     FLARE_REASON_VERSION_BARRIER, GAP_STOP, PARTITION_BLOCKED_FLARE, PARTITION_IS_EFFECTIVE_LEADER,
@@ -92,6 +101,9 @@ use crate::metric_definitions::{
 use crate::metric_definitions::{NORMAL_STOP, PARTITION_TIME_SINCE_LAST_STATUS_UPDATE};
 use crate::metric_definitions::{NUM_ACTIVE_PARTITIONS, PARTITION_APPLIED_LSN_LAG};
 use crate::metric_definitions::{NUM_PARTITIONS, SNAPSHOT_AGE};
+use crate::metric_definitions::{
+    PARTITION_APPLY_PHASE_STUCK, PARTITION_APPLY_STALLED, PHASE_LABEL,
+};
 use crate::metric_definitions::{PARTITION_LABEL, PARTITION_STOP};
 use crate::partition::{LeadershipInfo, NodeContext, ProcessorError};
 use crate::partition_processor_manager::processor_state::{
@@ -115,8 +127,20 @@ pub struct PartitionProcessorManager<T> {
     tx: mpsc::Sender<ProcessorsManagerCommand>,
 
     replica_set_states: PartitionReplicaSetStates,
-    target_tail_lsns: HashMap<PartitionId, Lsn>,
+    tail_observations: HashMap<PartitionId, TailObservation>,
     leader_handles_registry: PartitionLeaderHandlesRegistry,
+
+    /// Apply-stall detection (see `apply_progress_tracker`): per-partition tracker state, plus
+    /// the local view of each partition's `LoopHeartbeat`. Both are sticky across incarnations by
+    /// design and are only dropped once a partition both stops running here and leaves this
+    /// node's replica set (rule 9 in the design doc).
+    trackers: HashMap<PartitionId, TrackerEntry>,
+    heartbeat_views: HashMap<PartitionId, HeartbeatView>,
+    /// At most one `ConsistentRead` sweep probe in flight node-wide at a time.
+    consistent_read_sweep_inflight: bool,
+    /// When each currently-`Stopping` partition was first observed in that state, for the
+    /// `stop_stuck_timeout` flare. Never spawns a second processor -- observability only.
+    stopping_since: HashMap<PartitionId, Instant>,
 
     asynchronous_operations: JoinSet<AsynchronousEvent>,
 
@@ -151,7 +175,10 @@ enum RestartDelay {
     Immediate,
     Fixed,
     Exponential {
-        start_time: Instant,
+        // `ProcessorState::start_time` (processor_state.rs) is std::time::Instant; kept as such
+        // here too rather than the tokio::time::Instant used for the apply-stall tracker's
+        // paused-clock-aware deadline math below.
+        start_time: std::time::Instant,
         last_delay: Option<Duration>,
     },
     MaxBackoff,
@@ -260,8 +287,12 @@ where
             rx,
             tx,
             replica_set_states,
-            target_tail_lsns: HashMap::default(),
+            tail_observations: HashMap::default(),
             leader_handles_registry: PartitionLeaderHandlesRegistry::default(),
+            trackers: HashMap::default(),
+            heartbeat_views: HashMap::default(),
+            consistent_read_sweep_inflight: false,
+            stopping_since: HashMap::default(),
             asynchronous_operations: JoinSet::default(),
             pending_snapshots: HashMap::default(),
             latest_snapshots: HashMap::default(),
@@ -315,6 +346,24 @@ where
         let mut update_target_tail_lsns = tokio::time::interval(Duration::from_secs(1));
         update_target_tail_lsns.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
+        // Explicit deadline driver for the apply-progress tracker: fires all time-based
+        // transitions (grace, recovery window, bail, probe backoff) even if tail queries stop
+        // completing entirely -- the 1s Fast poller above only ever *launches* queries.
+        let mut tracker_tick = tokio::time::interval(Duration::from_millis(500));
+        tracker_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        // Mandatory ConsistentRead sweep (A5 fairness): the Fast poller above can be looking at
+        // a frozen cached tail forever once its background refresher exits, which would hide a
+        // stall from detection indefinitely -- see the apply_progress_tracker module doc.
+        let mut consistent_read_sweep = tokio::time::interval(
+            self.updateable_config
+                .live_load()
+                .worker
+                .stall_detection
+                .sweep_interval(),
+        );
+        consistent_read_sweep.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
         let mut ppm_svc_rx = self.ppm_svc_rx.take().start();
         let (mut pp_rpc_control, pp_rpc_shards) = self.pp_rpc_svc.take().start();
         self.pp_rpc_shards = Some(pp_rpc_shards);
@@ -339,6 +388,12 @@ where
                 }
                 _ = update_target_tail_lsns.tick() => {
                     self.update_target_tail_lsns();
+                }
+                _ = tracker_tick.tick(), if self.updateable_config.live_load().worker.stall_detection.enabled => {
+                    self.evaluate_trackers();
+                }
+                _ = consistent_read_sweep.tick(), if self.updateable_config.live_load().worker.stall_detection.enabled && !self.consistent_read_sweep_inflight => {
+                    self.spawn_consistent_read_sweep();
                 }
                 Some(op) = ppm_svc_rx.next() => {
                     self.handle_ppm_service_op(op);
@@ -536,6 +591,7 @@ where
                                     }
 
                                     *processor_state = new_state;
+                                    self.on_processor_incarnation_started(partition_id);
 
                                     self.await_runtime_task_result(partition_id, runtime_handle);
                                 }
@@ -571,10 +627,12 @@ where
                         // todo: metrics
                         info!(%partition_id, %err, "Partition processor failed to start");
                         self.processor_states.remove(&partition_id);
-                        self.restart_partition_processor_if_replica(
+                        if !self.restart_partition_processor_if_replica(
                             partition_id,
                             RestartDelay::Fixed,
-                        );
+                        ) {
+                            self.gc_tracker(partition_id);
+                        }
                     }
                 }
                 gauge!(NUM_ACTIVE_PARTITIONS).set(self.processor_states.len() as f64);
@@ -678,6 +736,9 @@ where
 
                 if !self.restart_partition_processor_if_replica(partition_id, delay) {
                     debug!("Partition processor stopped: {result:?}");
+                    // No longer a replica for this partition: safe to forget its apply-progress
+                    // tracker (rule 9 -- retained until both conditions hold).
+                    self.gc_tracker(partition_id);
                 }
 
                 gauge!(NUM_ACTIVE_PARTITIONS).set(self.processor_states.len() as f64);
@@ -709,19 +770,58 @@ where
             }
             EventKind::NewTargetTail { tail } => {
                 let Some(tail_lsn) = tail else {
-                    self.target_tail_lsns.remove(&partition_id);
+                    self.tail_observations.remove(&partition_id);
                     return;
                 };
 
-                match self.target_tail_lsns.entry(partition_id) {
-                    Entry::Occupied(mut o) => {
-                        if *o.get() < tail_lsn {
-                            o.insert(tail_lsn);
-                        }
-                    }
+                let now = Instant::now();
+                match self.tail_observations.entry(partition_id) {
+                    Entry::Occupied(mut o) => o.get_mut().observe_fast(tail_lsn, now),
                     Entry::Vacant(v) => {
-                        v.insert(tail_lsn);
+                        v.insert(TailObservation::new(tail_lsn, now));
                     }
+                }
+            }
+            EventKind::ConsistentReadSweepCompleted { probed, result } => {
+                self.consistent_read_sweep_inflight = false;
+                let now = Instant::now();
+                let Some(probed) = probed else {
+                    // Nothing running to sweep this round.
+                    return;
+                };
+                let Some(obs) = self.tail_observations.get_mut(&probed) else {
+                    return;
+                };
+                match result {
+                    Some(tail_lsn) => obs.observe_consistent(tail_lsn, now),
+                    None => obs.mark_consistent_attempt(now),
+                }
+            }
+            EventKind::ConsistentReadProbeCompleted {
+                incarnation,
+                nonce,
+                result,
+            } => {
+                let now = Instant::now();
+                if let Some(obs) = self.tail_observations.get_mut(&partition_id)
+                    && let Some(tail_lsn) = result.as_ref().and_then(|r| match r {
+                        ProbeResult::Confirmed { tail_lsn } => Some(*tail_lsn),
+                        _ => None,
+                    })
+                {
+                    obs.observe_consistent(tail_lsn, now);
+                } else if let Some(obs) = self.tail_observations.get_mut(&partition_id) {
+                    obs.mark_consistent_attempt(now);
+                }
+                if let Some(tracker) = self.trackers.get_mut(&partition_id) {
+                    let cfg = self.updateable_config.live_load().worker.stall_detection;
+                    tracker.on_probe_result(
+                        now,
+                        incarnation,
+                        nonce,
+                        result.unwrap_or(ProbeResult::Failed),
+                        &cfg,
+                    );
                 }
             }
             EventKind::SnapshotStatusUpdated { snapshot_status } => {
@@ -793,6 +893,256 @@ where
         }
     }
 
+    /// Rule 8: a fresh processor incarnation started running for `partition_id`. Creates a new
+    /// apply-progress tracker on first start, or resets live detection (retaining the sticky
+    /// quarantine and restart history) on every subsequent restart.
+    fn on_processor_incarnation_started(&mut self, partition_id: PartitionId) {
+        let now = Instant::now();
+        let cfg = self.updateable_config.live_load().worker.stall_detection;
+        let incarnation = Ulid::new();
+        match self.trackers.entry(partition_id) {
+            Entry::Occupied(mut e) => e.get_mut().on_incarnation_started(now, incarnation),
+            Entry::Vacant(v) => {
+                v.insert(TrackerEntry::new(incarnation, now, &cfg));
+            }
+        }
+        self.heartbeat_views
+            .insert(partition_id, HeartbeatView::new(now));
+    }
+
+    /// Rule 9 (GC): forget a partition's apply-progress tracker once it has both stopped running
+    /// here and left this node's replica set. Called only from that combined condition.
+    fn gc_tracker(&mut self, partition_id: PartitionId) {
+        self.trackers.remove(&partition_id);
+        self.heartbeat_views.remove(&partition_id);
+        self.tail_observations.remove(&partition_id);
+    }
+
+    /// The explicit deadline driver for the apply-progress tracker (`tracker_tick`): evaluates
+    /// every running partition's tracker against its current status, tail observation, and
+    /// heartbeat, and acts on the resulting effect (issue a confirmation probe, or bail).
+    fn evaluate_trackers(&mut self) {
+        let now = Instant::now();
+        let cfg = self.updateable_config.live_load().worker.stall_detection;
+
+        self.evaluate_stop_stuck(now, &cfg);
+
+        let partition_ids: Vec<PartitionId> = self.processor_states.keys().cloned().collect();
+        for partition_id in partition_ids {
+            let Some(ProcessorState::Started {
+                processor: Some(started),
+                ..
+            }) = self.processor_states.get(&partition_id)
+            else {
+                continue;
+            };
+
+            let Some(status) = self
+                .processor_states
+                .get(&partition_id)
+                .and_then(ProcessorState::partition_processor_status)
+            else {
+                continue;
+            };
+
+            let heartbeat_view = self
+                .heartbeat_views
+                .entry(partition_id)
+                .or_insert_with(|| HeartbeatView::new(now));
+            heartbeat_view.observe(started.heartbeat().sample(), now);
+            let loop_state = heartbeat_view.loop_state(now, &cfg);
+
+            let phase_age = heartbeat_view.phase_age(now);
+            gauge!(
+                PARTITION_APPLY_PHASE_STUCK,
+                PARTITION_LABEL => partition_id.to_string(),
+                PHASE_LABEL => format!("{:?}", heartbeat_view.phase())
+            )
+            .set(
+                if loop_state == LoopState::Busy && phase_age >= cfg.hard_grace() {
+                    1.0
+                } else {
+                    0.0
+                },
+            );
+
+            let fresh_tail = self
+                .tail_observations
+                .get(&partition_id)
+                .filter(|obs| obs.is_fresh(now, cfg.tail_ttl()))
+                .map(TailObservation::lsn);
+
+            let Some(tracker) = self.trackers.get_mut(&partition_id) else {
+                continue;
+            };
+            let input = TickInput {
+                last_applied_lsn: status.last_applied_log_lsn,
+                replay_status: status.replay_status,
+                loop_state,
+                fresh_tail,
+            };
+            let effect = tracker.on_sample(now, input, &cfg);
+            self.act_on_tracker_effect(partition_id, effect);
+        }
+    }
+
+    /// Flares `restate.partition.stop_stuck` for a partition that has been `Stopping` for longer
+    /// than `stop_stuck_timeout`. Observability only: per the builder guardrails, this never
+    /// spawns a second processor over the same store or forces a process exit -- a genuinely
+    /// wedged cooperative shutdown needs external supervision.
+    fn evaluate_stop_stuck(&mut self, now: Instant, cfg: &StallDetectionOptions) {
+        let stopping: HashSet<PartitionId> = self
+            .processor_states
+            .iter()
+            .filter(|(_, state)| matches!(state, ProcessorState::Stopping { .. }))
+            .map(|(id, _)| *id)
+            .collect();
+
+        self.stopping_since.retain(|id, _| stopping.contains(id));
+        for &partition_id in &stopping {
+            let since = *self.stopping_since.entry(partition_id).or_insert(now);
+            let stuck = now.saturating_duration_since(since) >= cfg.stop_stuck_timeout();
+            let labels = [(PARTITION_LABEL, partition_id.to_string())];
+            gauge!(PARTITION_STOP_STUCK, &labels).set(if stuck { 1.0 } else { 0.0 });
+            if stuck {
+                error!(%partition_id, "Partition processor has been Stopping for longer than stop_stuck_timeout; it may require external supervision");
+            }
+        }
+    }
+
+    fn act_on_tracker_effect(&mut self, partition_id: PartitionId, effect: TrackerEffect) {
+        match effect {
+            TrackerEffect::None => {}
+            TrackerEffect::IssueProbe { incarnation, nonce } => {
+                self.spawn_consistent_read_probe(partition_id, incarnation, nonce);
+            }
+            TrackerEffect::Bail => {
+                warn!(%partition_id, "Apply-stall detected: cooperatively restarting the partition processor");
+                if let Some(processor_state) = self.processor_states.get_mut(&partition_id) {
+                    processor_state.stop();
+                }
+            }
+        }
+    }
+
+    /// Spawns the confirmation probe a suspected partition's tracker requested. Bounded by
+    /// `probe_timeout`; a timeout is reported as a probe failure, matching the guardrail that no
+    /// action may ever be taken on unconfirmed evidence.
+    fn spawn_consistent_read_probe(
+        &mut self,
+        partition_id: PartitionId,
+        incarnation: Ulid,
+        nonce: u64,
+    ) {
+        let bifrost = self.bifrost.clone();
+        let probe_timeout = self
+            .updateable_config
+            .live_load()
+            .worker
+            .stall_detection
+            .probe_timeout();
+
+        self.asynchronous_operations.spawn(
+            async move {
+                let log_id = Metadata::with_current(|m| {
+                    m.partition_table_ref()
+                        .get(&partition_id)
+                        .map(Partition::log_id)
+                });
+                let result = match log_id {
+                    Some(log_id) => {
+                        match tokio::time::timeout(
+                            probe_timeout,
+                            bifrost.find_tail(log_id, FindTailOptions::ConsistentRead),
+                        )
+                        .await
+                        {
+                            Ok(Ok(tail)) => Some(ProbeResult::Confirmed {
+                                tail_lsn: tail.offset(),
+                            }),
+                            Ok(Err(_)) | Err(_) => Some(ProbeResult::Failed),
+                        }
+                    }
+                    None => Some(ProbeResult::Failed),
+                };
+
+                AsynchronousEvent {
+                    partition_id,
+                    inner: EventKind::ConsistentReadProbeCompleted {
+                        incarnation,
+                        nonce,
+                        result,
+                    },
+                }
+            }
+            .in_current_tc(),
+        );
+    }
+
+    /// The mandatory `ConsistentRead` sweep (A5): picks the running partition with the oldest
+    /// `last_consistent_attempt_at` (fairness over *attempts*, not successes) and probes it, at
+    /// most one such sweep probe in flight node-wide at a time. This is what reveals lag that a
+    /// frozen `Fast` cache would otherwise hide indefinitely -- see the module doc.
+    fn spawn_consistent_read_sweep(&mut self) {
+        let running: Vec<PartitionId> = self
+            .processor_states
+            .iter()
+            .filter(|(_, state)| matches!(state, ProcessorState::Started { .. }))
+            .map(|(id, _)| *id)
+            .collect();
+        let now = Instant::now();
+        for partition_id in &running {
+            self.tail_observations
+                .entry(*partition_id)
+                .or_insert_with(|| TailObservation::new(Lsn::INVALID, now));
+        }
+
+        let Some(target) = pick_next_consistent_read_sweep_target(
+            running
+                .iter()
+                .filter_map(|id| self.tail_observations.get(id).map(|obs| (*id, obs))),
+        ) else {
+            return;
+        };
+
+        self.consistent_read_sweep_inflight = true;
+        let bifrost = self.bifrost.clone();
+        let probe_timeout = self
+            .updateable_config
+            .live_load()
+            .worker
+            .stall_detection
+            .probe_timeout();
+
+        self.asynchronous_operations.spawn(
+            async move {
+                let log_id = Metadata::with_current(|m| {
+                    m.partition_table_ref().get(&target).map(Partition::log_id)
+                });
+                let result = match log_id {
+                    Some(log_id) => tokio::time::timeout(
+                        probe_timeout,
+                        bifrost.find_tail(log_id, FindTailOptions::ConsistentRead),
+                    )
+                    .await
+                    .ok()
+                    .and_then(Result::ok)
+                    .map(|tail| tail.offset()),
+                    None => None,
+                };
+
+                AsynchronousEvent {
+                    partition_id: target,
+                    inner: EventKind::ConsistentReadSweepCompleted {
+                        probed: Some(target),
+                        result,
+                    },
+                }
+            }
+            .in_current_tc(),
+        );
+    }
+
     fn obtain_new_leader_epoch(
         partition_id: PartitionId,
         leader_epoch_token: LeaderEpochToken,
@@ -814,12 +1164,15 @@ where
             .expect("spawn obtain leader epoch task");
     }
 
-    /// Collect enriched processor status from all running partitions
+    /// Collect enriched processor status from all running partitions. Routed through
+    /// `effective_status` so the apply-stall overlay (downgraded replay status,
+    /// `apply_stalled_since`) is applied uniformly, including for a quarantined processor that is
+    /// currently `Stopping` (which otherwise reports no status at all).
     fn get_state(&self) -> BTreeMap<PartitionId, PartitionProcessorStatus> {
         self.processor_states
-            .iter()
-            .filter_map(|(partition_id, processor_state)| {
-                let mut status = processor_state.partition_processor_status()?;
+            .keys()
+            .filter_map(|partition_id| {
+                let mut status = self.effective_status(*partition_id)?;
                 let labels = [(PARTITION_LABEL, partition_id.to_string())];
 
                 gauge!(PARTITION_TIME_SINCE_LAST_STATUS_UPDATE, &labels)
@@ -833,13 +1186,24 @@ where
                     },
                 );
 
+                gauge!(PARTITION_APPLY_STALLED, &labels).set(
+                    if self.is_apply_stalled(*partition_id) {
+                        1.0
+                    } else {
+                        0.0
+                    },
+                );
+
                 // todo: PartitionProcessorStatus struct is shared across PP and PPM, consider splitting it
                 status.last_archived_log_lsn = self
                     .latest_snapshots
                     .get(partition_id)
                     .map(|s| s.archived_lsn);
 
-                let current_tail_lsn = self.target_tail_lsns.get(partition_id).cloned();
+                let current_tail_lsn = self
+                    .tail_observations
+                    .get(partition_id)
+                    .map(TailObservation::lsn);
                 let target_tail_lsn = if current_tail_lsn > status.target_tail_lsn {
                     current_tail_lsn
                 } else {
@@ -867,6 +1231,62 @@ where
                 Some((*partition_id, status))
             })
             .collect()
+    }
+
+    /// Single source of effective status: `Started`/`Starting` return their live status enriched
+    /// with the apply-stall overlay (downgraded replay status, `apply_stalled_since`);
+    /// `Stopping` -- which normally reports no status -- synthesizes a minimal one whenever the
+    /// partition is quarantined, so the quarantine signal never drops out during a self-bail's
+    /// restart cycle. See the `apply_progress_tracker` module doc.
+    fn effective_status(&self, partition_id: PartitionId) -> Option<PartitionProcessorStatus> {
+        let processor_state = self.processor_states.get(&partition_id)?;
+        let quarantine = self
+            .trackers
+            .get(&partition_id)
+            .and_then(TrackerEntry::quarantine);
+
+        match processor_state {
+            ProcessorState::Stopping { .. } => {
+                let quarantine = quarantine?;
+                let last_applied_log_lsn = self
+                    .trackers
+                    .get(&partition_id)
+                    .and_then(TrackerEntry::last_known_lsn);
+                Some(PartitionProcessorStatus {
+                    replay_status: ReplayStatus::CatchingUp,
+                    last_applied_log_lsn,
+                    apply_stalled_since: Some(quarantine.since()),
+                    updated_at: MillisSinceEpoch::now(),
+                    ..Default::default()
+                })
+            }
+            _ => {
+                let mut status = processor_state.partition_processor_status()?;
+                if let Some(quarantine) = quarantine {
+                    status.apply_stalled_since = Some(quarantine.since());
+                    if status.replay_status == ReplayStatus::Active {
+                        status.replay_status = ReplayStatus::CatchingUp;
+                    }
+                }
+                Some(status)
+            }
+        }
+    }
+
+    fn is_apply_stalled(&self, partition_id: PartitionId) -> bool {
+        self.trackers
+            .get(&partition_id)
+            .is_some_and(TrackerEntry::is_quarantined)
+    }
+
+    /// A partition processor is eligible to publish snapshots when its underlying processor
+    /// reports `Active` *and* it isn't currently quarantined for an apply stall (the overlay would
+    /// otherwise leave a stale, non-advancing snapshot target).
+    fn should_publish_snapshots(&self, partition_id: PartitionId) -> bool {
+        self.processor_states
+            .get(&partition_id)
+            .is_some_and(ProcessorState::should_publish_snapshots)
+            && !self.is_apply_stalled(partition_id)
     }
 
     fn on_command(&mut self, command: ProcessorsManagerCommand) {
@@ -927,16 +1347,13 @@ where
         min_target_lsn: Option<Lsn>,
         sender: oneshot::Sender<SnapshotResult>,
     ) {
-        let processor_state = match self.processor_states.get(&partition_id) {
-            Some(state) => state,
-            None => {
-                let _ = sender.send(Err(SnapshotError {
-                    partition_id,
-                    kind: SnapshotErrorKind::PartitionNotFound,
-                }));
-                return;
-            }
-        };
+        if !self.processor_states.contains_key(&partition_id) {
+            let _ = sender.send(Err(SnapshotError {
+                partition_id,
+                kind: SnapshotErrorKind::PartitionNotFound,
+            }));
+            return;
+        }
 
         let snapshot_repository = self.snapshot_repository.clone();
         let Some(snapshot_repository) = snapshot_repository else {
@@ -947,7 +1364,7 @@ where
             return;
         };
 
-        if !processor_state.should_publish_snapshots() {
+        if !self.should_publish_snapshots(partition_id) {
             let _ = sender.send(Err(SnapshotError {
                 partition_id,
                 kind: SnapshotErrorKind::InvalidState,
@@ -1026,11 +1443,10 @@ where
         // Partitions with a status suitable for taking a snapshot without a running snapshot task
         let candidate_partitions = self
             .processor_states
-            .iter()
-            .filter(|(partition_id, _)| !self.pending_snapshots.contains_key(partition_id))
-            .filter_map(|(partition_id, state)| {
-                state
-                    .partition_processor_status()
+            .keys()
+            .filter(|partition_id| !self.pending_snapshots.contains_key(partition_id))
+            .filter_map(|partition_id| {
+                self.effective_status(*partition_id)
                     .filter(|status| {
                         status.effective_mode == RunMode::Leader
                             && status.replay_status == ReplayStatus::Active
@@ -1550,6 +1966,18 @@ enum EventKind {
     },
     NewTargetTail {
         tail: Option<Lsn>,
+    },
+    /// The mandatory node-wide `ConsistentRead` sweep probe completed (or there was nothing to
+    /// probe this round).
+    ConsistentReadSweepCompleted {
+        probed: Option<PartitionId>,
+        result: Option<Lsn>,
+    },
+    /// A `ConsistentRead` probe issued on behalf of a suspected partition's tracker completed.
+    ConsistentReadProbeCompleted {
+        incarnation: Ulid,
+        nonce: u64,
+        result: Option<ProbeResult>,
     },
     SnapshotStatusUpdated {
         snapshot_status: PartitionSnapshotStatus,

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -106,7 +106,8 @@ use crate::metric_definitions::{
 };
 use crate::metric_definitions::{PARTITION_LABEL, PARTITION_STOP};
 use crate::partition::leadership;
-use crate::partition::{LeadershipInfo, NodeContext, ProcessorError};
+use crate::partition::{LeadershipInfo, LoopPhase, NodeContext, ProcessorError};
+use crate::partition_processor_manager::apply_progress_tracker::QuarantineEpisode;
 use crate::partition_processor_manager::processor_state::{
     LeaderEpochToken, ProcessorState, StartedProcessor,
 };
@@ -1019,7 +1020,7 @@ where
                 fresh_tail,
             };
             let effect = tracker.on_sample(now, input, &cfg);
-            self.act_on_tracker_effect(partition_id, effect);
+            self.act_on_tracker_effect(partition_id, effect, &cfg);
         }
     }
 
@@ -1047,18 +1048,79 @@ where
         }
     }
 
-    fn act_on_tracker_effect(&mut self, partition_id: PartitionId, effect: TrackerEffect) {
+    fn act_on_tracker_effect(
+        &mut self,
+        partition_id: PartitionId,
+        effect: TrackerEffect,
+        cfg: &StallDetectionOptions,
+    ) {
         match effect {
             TrackerEffect::None => {}
             TrackerEffect::IssueProbe { incarnation, nonce } => {
                 self.spawn_consistent_read_probe(partition_id, incarnation, nonce);
             }
-            TrackerEffect::Bail => {
-                warn!(%partition_id, "Apply-stall detected: cooperatively restarting the partition processor");
-                if let Some(processor_state) = self.processor_states.get_mut(&partition_id) {
-                    processor_state.stop();
-                }
-            }
+            TrackerEffect::Bail => self.revalidate_and_commit_bail(partition_id, cfg),
+        }
+    }
+
+    /// Finding 4 (DEFECTB review): the tracker's `Bail` effect is only a *proposal* based on the
+    /// sample from the top of this tick's `evaluate_trackers` pass. Immediately before actually
+    /// calling `stop()`, take a fresh heartbeat sample and re-check the tail -- if the processor
+    /// has resumed in the meantime (or the lag evidence used for an `ApplyStall` bail is no
+    /// longer fresh/confirmed), abandon the bail instead of stopping a processor that's already
+    /// making progress again. Nothing is mutated in that case; the next tick re-evaluates from
+    /// scratch (rule 6 style demotion happens naturally on the next real sample).
+    fn revalidate_and_commit_bail(
+        &mut self,
+        partition_id: PartitionId,
+        cfg: &StallDetectionOptions,
+    ) {
+        let now = Instant::now();
+
+        let Some(ProcessorState::Started {
+            processor: Some(started),
+            ..
+        }) = self.processor_states.get(&partition_id)
+        else {
+            return;
+        };
+        // A fresh phase read, independent of (and later than) the `HeartbeatView` sample the
+        // proposal was based on: confirms the loop is still parked in `select`, not busy having
+        // resumed real work.
+        let (phase, _counter) = started.heartbeat().sample();
+        let still_idle = phase == LoopPhase::InSelect;
+
+        let Some(tracker) = self.trackers.get_mut(&partition_id) else {
+            return;
+        };
+
+        // A LoopDead episode's proof is "the loop still isn't scheduling", not lag -- an
+        // ApplyStall episode (or none yet, e.g. a fresh Stalled->Bail transition) requires
+        // confirmed lag against the freshest tail observation.
+        let is_loop_dead_episode = matches!(
+            tracker.quarantine(),
+            Some(QuarantineEpisode::LoopDead { .. })
+        );
+        let still_lagging = tracker.last_known_lsn().is_some_and(|known| {
+            self.tail_observations
+                .get(&partition_id)
+                .filter(|obs| obs.is_fresh(now, cfg.tail_ttl()))
+                .is_some_and(|obs| obs.lsn().prev() > known)
+        });
+
+        if !still_idle || !(is_loop_dead_episode || still_lagging) {
+            debug!(
+                %partition_id,
+                "Apply-stall bail aborted: the processor resumed before the manager could revalidate"
+            );
+            return;
+        }
+
+        let bail_lsn = tracker.last_known_lsn().unwrap_or(Lsn::INVALID);
+        tracker.commit_bail(now, bail_lsn, cfg);
+        warn!(%partition_id, "Apply-stall detected: cooperatively restarting the partition processor");
+        if let Some(processor_state) = self.processor_states.get_mut(&partition_id) {
+            processor_state.stop();
         }
     }
 
@@ -2314,6 +2376,218 @@ mod tests {
             status.apply_stalled_since.is_some(),
             "apply_stalled_since must survive Started -> Stopped -> Starting"
         );
+
+        TaskCenter::shutdown_node("test completed", 0).await;
+        RocksDbManager::get().shutdown().await;
+        Ok(())
+    }
+
+    /// Finding 1 negative control (DEFECTB review, merge-blocking integration coverage): a
+    /// legitimately long apply (well past `grace`, with more records still sitting unapplied in
+    /// the log the whole time) must never itself be reported as a stall. Uses the test-only
+    /// slow-apply hook (`RESTATE_TEST_SLOW_APPLY_MILLIS`) so every record's application takes far
+    /// longer than `grace`, while the apply loop stays in `ApplyingBatch` throughout -- this
+    /// proves that phase, not raw elapsed time since progress, gates suspicion (the exact
+    /// distinction finding 1's fix restored; `tracker_state_machine_unit` pins the same invariant
+    /// at the pure state-machine level with explicit RED->GREEN evidence for the fix).
+    #[test(restate_core::test)]
+    async fn long_apply_negative_control() -> googletest::Result<()> {
+        use std::sync::Arc;
+
+        use restate_bifrost::ErrorRecoveryStrategy;
+        use restate_storage_api::deduplication_table::{DedupInformation, EpochSequenceNumber};
+        use restate_types::cluster::cluster_state::ReplayStatus;
+        use restate_types::config::StallDetectionOptions;
+        use restate_types::identifiers::LeaderEpoch;
+        use restate_types::partitions::Partition;
+        use restate_types::sharding::KeyRange;
+        use restate_types::time::MillisSinceEpoch;
+        use restate_util_time::FriendlyDuration;
+        use restate_wal_protocol::control::UpdatePartitionDurabilityCommand;
+        use restate_wal_protocol::{Command, Destination, Envelope, Header, Source};
+
+        use crate::partition::RESTATE_TEST_SLOW_APPLY_MILLIS;
+
+        const SLOW_APPLY_MILLIS: u64 = 300;
+        const NUM_RECORDS: u64 = 4;
+
+        let mut nodes_config = NodesConfiguration::new_for_testing();
+        let node_id = GenerationalNodeId::new(45, 45);
+        let node_config = NodeConfig::builder()
+            .name("45".to_owned())
+            .current_generation(node_id)
+            .address(AdvertisedAddress::default())
+            .roles(Role::Worker | Role::Admin)
+            .binary_version(RestateVersion::current())
+            .build();
+        nodes_config.upsert_node(node_config);
+
+        let mut env_builder = TestCoreEnvBuilder::with_incoming_only_connector()
+            .set_my_node_id(node_id)
+            .set_nodes_config(nodes_config);
+        let health_status = HealthStatus::default();
+
+        RocksDbManager::init();
+
+        let bifrost_svc = BifrostService::new(env_builder.metadata_writer.clone())
+            .with_factory(memory_loglet::Factory::default());
+        let bifrost = bifrost_svc.handle();
+
+        let replica_set_states = PartitionReplicaSetStates::default();
+        let partition_store_manager = PartitionStoreManager::create(true).await?;
+
+        let ingestion_client = IngestionClient::new(
+            env_builder.networking.clone(),
+            env_builder.metadata.updateable_partition_table(),
+            PartitionRouting::new(replica_set_states.clone(), TaskCenter::current()),
+            NonZeroUsize::new(10 * 1024 * 1024).unwrap(),
+            SessionOptions::default(),
+        );
+
+        // Fast-but-real stall-detection thresholds: `grace` is well under a single record's
+        // artificial apply delay, so if phase were ignored (finding 1's bug), a single
+        // idle+lagging sample would trip suspicion almost immediately.
+        let mut configuration = Configuration::default();
+        configuration.worker.stall_detection = StallDetectionOptions {
+            grace: FriendlyDuration::from_millis(100),
+            heartbeat_fresh: FriendlyDuration::from_millis(50),
+            hard_grace: FriendlyDuration::from_secs(30),
+            ..StallDetectionOptions::default()
+        };
+
+        let metadata_writer = env_builder.metadata_writer.clone();
+        let partition_processor_manager = PartitionProcessorManager::new(
+            health_status,
+            Live::from_value(configuration),
+            metadata_writer.clone(),
+            partition_store_manager,
+            replica_set_states.clone(),
+            &mut env_builder.router_builder,
+            bifrost.clone(),
+            None,
+            ingestion_client,
+        );
+
+        let _env = env_builder.build().await;
+
+        // `bootstrap_logs_metadata` seeds each log's chain with `ProviderKind::InMemory` but
+        // leaves `Logs::configuration().default_provider` at its type default (`Replicated`).
+        // `BifrostAdmin::ensure_log_exists` -- called on every processor (re)spawn -- resolves
+        // that default provider unconditionally, even for an already-provisioned log, so with
+        // only the in-memory factory registered every incarnation would fail before ever
+        // reaching the apply loop. Not related to findings 1-6; corrected here so this test can
+        // exercise a real, running processor.
+        {
+            use restate_core::Metadata;
+            use restate_types::logs::metadata::{LogsConfiguration, ProviderConfiguration};
+
+            let logs = Metadata::with_current(|m| m.logs_snapshot());
+            let mut builder = (*logs).clone().try_into_builder().expect("valid logs");
+            builder.set_configuration(LogsConfiguration {
+                default_provider: ProviderConfiguration::InMemory,
+            });
+            metadata_writer.submit(Arc::new(builder.build()));
+        }
+
+        let processors_manager_handle = partition_processor_manager.handle();
+
+        bifrost_svc.start().await.into_test_result()?;
+        TaskCenter::spawn(
+            TaskKind::SystemService,
+            "partition-processor-manager",
+            partition_processor_manager.run(),
+        )?;
+
+        let current_replica_set = ReplicaSetState {
+            version: Version::MIN,
+            members: vec![MemberState {
+                node_id: node_id.as_plain(),
+                durable_lsn: Lsn::INVALID,
+            }],
+        };
+        replica_set_states.note_observed_membership(
+            PartitionId::MIN,
+            Default::default(),
+            &current_replica_set,
+            &None,
+        );
+
+        // Wait until the (fresh, empty-log) processor has started and caught up.
+        loop {
+            let state = processors_manager_handle.get_state().await?;
+            if state
+                .get(&PartitionId::MIN)
+                .is_some_and(|s| s.replay_status == ReplayStatus::Active)
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        // Arm the slow-apply hook, then append several records so the log's tail stays ahead of
+        // the applied LSN for the whole time the (slow) batch is being applied.
+        unsafe {
+            std::env::set_var(
+                RESTATE_TEST_SLOW_APPLY_MILLIS,
+                SLOW_APPLY_MILLIS.to_string(),
+            );
+        }
+
+        let log_id = Partition::new(PartitionId::MIN, KeyRange::FULL).log_id();
+        let mut appender =
+            bifrost.create_appender::<Envelope>(log_id, ErrorRecoveryStrategy::Wait)?;
+        let mut esn = EpochSequenceNumber::new(LeaderEpoch::INVALID);
+        for _ in 0..NUM_RECORDS {
+            let header = Header {
+                dest: Destination::Processor {
+                    partition_key: KeyRange::FULL.start(),
+                    dedup: Some(DedupInformation::self_proposal(esn)),
+                },
+                source: Source::Processor {
+                    partition_key: Some(KeyRange::FULL.start()),
+                    leader_epoch: LeaderEpoch::INVALID,
+                },
+            };
+            let envelope = Envelope::new(
+                header,
+                Command::UpdatePartitionDurability(UpdatePartitionDurabilityCommand {
+                    partition_id: PartitionId::MIN,
+                    durable_point: Lsn::OLDEST,
+                    modification_time: MillisSinceEpoch::now(),
+                }),
+            );
+            appender.append(Arc::new(envelope)).await?;
+            esn = esn.next();
+        }
+
+        // Poll continuously until the whole (slow) batch has applied, asserting at every sample
+        // that the long apply was never reported as a stall.
+        loop {
+            let state = processors_manager_handle.get_state().await?;
+            let status = state
+                .get(&PartitionId::MIN)
+                .expect("partition must still be present throughout the slow apply");
+            assert!(
+                status.apply_stalled_since.is_none(),
+                "a long but legitimate apply must never be reported as a stall (finding 1)"
+            );
+            if status.last_applied_log_lsn == Some(Lsn::new(NUM_RECORDS)) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        let status = processors_manager_handle
+            .get_state()
+            .await?
+            .remove(&PartitionId::MIN)
+            .expect("partition must still be present");
+        assert_eq!(status.replay_status, ReplayStatus::Active);
+        assert!(status.apply_stalled_since.is_none());
+
+        unsafe {
+            std::env::remove_var(RESTATE_TEST_SLOW_APPLY_MILLIS);
+        }
 
         TaskCenter::shutdown_node("test completed", 0).await;
         RocksDbManager::get().shutdown().await;

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -105,6 +105,7 @@ use crate::metric_definitions::{
     PARTITION_APPLY_PHASE_STUCK, PARTITION_APPLY_STALLED, PHASE_LABEL,
 };
 use crate::metric_definitions::{PARTITION_LABEL, PARTITION_STOP};
+use crate::partition::leadership;
 use crate::partition::{LeadershipInfo, NodeContext, ProcessorError};
 use crate::partition_processor_manager::processor_state::{
     LeaderEpochToken, ProcessorState, StartedProcessor,
@@ -705,6 +706,42 @@ where
                                         gauge!(PARTITION_BLOCKED_FLARE, PARTITION_LABEL => partition_id.to_string(), REASON_LABEL => FLARE_REASON_SNAPSHOT_UNAVAILABLE).set(1);
                                         // configuration problem; until we have peer-to-peer state exchange we can only wait
                                         RestartDelay::MaxBackoff
+                                    }
+                                }
+                                Err(ProcessorError::ActionEffect(
+                                    leadership::Error::AnnounceNotApplied {
+                                        leader_epoch,
+                                        committed_for,
+                                        bail_lsn,
+                                    },
+                                )) => {
+                                    // A2/A4 (Option D): our own committed AnnounceLeader marker
+                                    // never applied -- authoritative lag evidence in its own
+                                    // right. Quarantine the same way an A-bail would, using the
+                                    // exact FSM LSN captured at the watchdog's deadline.
+                                    counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => ERROR_STOP).increment(1);
+                                    warn!(
+                                        %partition_id, %leader_epoch, committed_for = ?committed_for, %bail_lsn,
+                                        "Partition processor's committed AnnounceLeader marker was never applied; quarantining and restarting"
+                                    );
+
+                                    let now = Instant::now();
+                                    let cfg =
+                                        self.updateable_config.live_load().worker.stall_detection;
+                                    let is_first_bail = !self.is_apply_stalled(partition_id);
+                                    let tracker =
+                                        self.trackers.entry(partition_id).or_insert_with(|| {
+                                            TrackerEntry::new(Ulid::new(), now, &cfg)
+                                        });
+                                    tracker.on_announce_not_applied(now, *bail_lsn, &cfg);
+
+                                    if is_first_bail {
+                                        RestartDelay::Fixed
+                                    } else {
+                                        RestartDelay::Exponential {
+                                            start_time,
+                                            last_delay: delay,
+                                        }
                                     }
                                 }
                                 Err(err) => {
@@ -2120,6 +2157,163 @@ mod tests {
 
             version = version.next();
         }
+
+        TaskCenter::shutdown_node("test completed", 0).await;
+        RocksDbManager::get().shutdown().await;
+        Ok(())
+    }
+
+    /// Stage 3 / A2 / A4: a Candidate-watchdog (Option D) bail must establish the same
+    /// `ApplyStall` quarantine episode an A-bail would, using the exact FSM LSN captured at the
+    /// watchdog's deadline, and that episode must remain visible through `effective_status` once
+    /// the manager schedules the restart (`Started` -> `Stopped(AnnounceNotApplied)` ->
+    /// `Starting`). Drives `on_asynchronous_event` directly rather than through a full leadership
+    /// election -- the watchdog's own state machine is covered by
+    /// `partition::leadership::tests`; this test is only about the PPM-side quarantine handoff.
+    #[test(restate_core::test)]
+    async fn d_bail_establishes_quarantine() -> googletest::Result<()> {
+        use std::sync::Arc;
+
+        use tokio::sync::watch;
+        use tokio_util::sync::CancellationToken;
+
+        use crate::partition::leadership;
+        use crate::partition::{LoopHeartbeat, ProcessorError, TargetLeaderState};
+        use crate::partition_processor_manager::apply_progress_tracker::QuarantineEpisode;
+        use crate::partition_processor_manager::processor_state::{
+            LeaderState, ProcessorState, StartedProcessor,
+        };
+        use crate::partition_processor_manager::{AsynchronousEvent, EventKind};
+        use restate_core::network::ShardSender;
+        use restate_types::cluster::cluster_state::PartitionProcessorStatus;
+        use restate_types::identifiers::LeaderEpoch;
+        use restate_types::sharding::KeyRange;
+
+        let mut nodes_config = NodesConfiguration::new_for_testing();
+        let node_id = GenerationalNodeId::new(44, 44);
+        let node_config = NodeConfig::builder()
+            .name("44".to_owned())
+            .current_generation(node_id)
+            .address(AdvertisedAddress::default())
+            .roles(Role::Worker | Role::Admin)
+            .binary_version(RestateVersion::current())
+            .build();
+        nodes_config.upsert_node(node_config);
+
+        let mut env_builder = TestCoreEnvBuilder::with_incoming_only_connector()
+            .set_my_node_id(node_id)
+            .set_nodes_config(nodes_config);
+        let health_status = HealthStatus::default();
+
+        RocksDbManager::init();
+
+        let bifrost_svc = BifrostService::new(env_builder.metadata_writer.clone())
+            .with_factory(memory_loglet::Factory::default());
+        let bifrost = bifrost_svc.handle();
+
+        let replica_set_states = PartitionReplicaSetStates::default();
+        let partition_store_manager = PartitionStoreManager::create(true).await?;
+
+        let ingestion_client = IngestionClient::new(
+            env_builder.networking.clone(),
+            env_builder.metadata.updateable_partition_table(),
+            PartitionRouting::new(replica_set_states.clone(), TaskCenter::current()),
+            NonZeroUsize::new(10 * 1024 * 1024).unwrap(),
+            SessionOptions::default(),
+        );
+
+        let mut partition_processor_manager = PartitionProcessorManager::new(
+            health_status,
+            Live::from_value(Configuration::default()),
+            env_builder.metadata_writer.clone(),
+            partition_store_manager,
+            replica_set_states.clone(),
+            &mut env_builder.router_builder,
+            bifrost,
+            None,
+            ingestion_client,
+        );
+
+        let _env = env_builder.build().await;
+        bifrost_svc.start().await.into_test_result()?;
+
+        // Normally done by `run()`'s startup; needed here since this test drives the manager
+        // directly rather than through its own event loop.
+        let (_pp_rpc_control, pp_rpc_shards) =
+            partition_processor_manager.pp_rpc_svc.take().start();
+        partition_processor_manager.pp_rpc_shards = Some(pp_rpc_shards);
+
+        // This node must still be a replica of the partition, or the Stopped handler would GC
+        // the tracker this test is about to create instead of carrying it into the restart.
+        let current_replica_set = ReplicaSetState {
+            version: Version::MIN,
+            members: vec![MemberState {
+                node_id: node_id.as_plain(),
+                durable_lsn: Lsn::INVALID,
+            }],
+        };
+        replica_set_states.note_observed_membership(
+            PartitionId::MIN,
+            Default::default(),
+            &current_replica_set,
+            &None,
+        );
+
+        // Craft a `Started` processor state directly: this test only needs to exercise the
+        // D-bail handler and the quarantine overlay, not a real running partition processor.
+        let (control_tx, _control_rx) = watch::channel(TargetLeaderState::Follower);
+        let (rpc_tx, _rpc_rx) = ShardSender::new();
+        let (_watch_tx, watch_rx) = watch::channel(PartitionProcessorStatus::default());
+        let started = StartedProcessor::new(
+            CancellationToken::new(),
+            KeyRange::FULL,
+            control_tx,
+            rpc_tx,
+            watch_rx,
+            Arc::new(LoopHeartbeat::new()),
+        );
+        partition_processor_manager.processor_states.insert(
+            PartitionId::MIN,
+            ProcessorState::Started {
+                processor: Some(started),
+                leader_state: LeaderState::Follower,
+                start_time: std::time::Instant::now(),
+                delay: None,
+            },
+        );
+
+        let bail_lsn = Lsn::new(42);
+        partition_processor_manager.on_asynchronous_event(AsynchronousEvent {
+            partition_id: PartitionId::MIN,
+            inner: EventKind::Stopped(Err(ProcessorError::ActionEffect(
+                leadership::Error::AnnounceNotApplied {
+                    leader_epoch: LeaderEpoch::from(1),
+                    committed_for: Duration::from_secs(1),
+                    bail_lsn,
+                },
+            ))),
+        });
+
+        let quarantine = partition_processor_manager
+            .trackers
+            .get(&PartitionId::MIN)
+            .and_then(|tracker| tracker.quarantine())
+            .expect("D-bail must establish a quarantine episode");
+        assert!(matches!(
+            quarantine,
+            QuarantineEpisode::ApplyStall {
+                bail_lsn: lsn,
+                ..
+            } if lsn == bail_lsn
+        ));
+
+        let status = partition_processor_manager
+            .effective_status(PartitionId::MIN)
+            .expect("status must remain visible across the restart");
+        assert!(
+            status.apply_stalled_since.is_some(),
+            "apply_stalled_since must survive Started -> Stopped -> Starting"
+        );
 
         TaskCenter::shutdown_node("test completed", 0).await;
         RocksDbManager::get().shutdown().await;

--- a/crates/worker/src/partition_processor_manager/apply_progress_tracker.rs
+++ b/crates/worker/src/partition_processor_manager/apply_progress_tracker.rs
@@ -64,11 +64,18 @@ pub enum LoopState {
 /// Tracks one partition processor's [`LoopHeartbeat`](crate::partition::processor::LoopHeartbeat)
 /// on the manager side: turns a raw `(phase, counter)` sample into a [`LoopState`] by locally
 /// timestamping counter changes (never encoding an `Instant` into the shared atomic).
+///
+/// `(InSelect, 0)` is both the real `LoopHeartbeat`'s initial value *and* this view's
+/// construction-time placeholder, so a freshly-constructed view (e.g. right after an incarnation
+/// reset) must not be read as "just observed a fresh beat" -- that would be synthetic freshness
+/// from having never actually sampled the new incarnation yet, not evidence of anything. Finding
+/// 2 (DEFECTB review): `has_observed_change` gates that distinction.
 #[derive(Debug, Clone, Copy)]
 pub struct HeartbeatView {
     last_phase: LoopPhase,
     last_counter: u64,
     changed_at: Instant,
+    has_observed_change: bool,
 }
 
 impl HeartbeatView {
@@ -77,6 +84,7 @@ impl HeartbeatView {
             last_phase: LoopPhase::InSelect,
             last_counter: 0,
             changed_at: now,
+            has_observed_change: false,
         }
     }
 
@@ -84,6 +92,7 @@ impl HeartbeatView {
     pub fn observe(&mut self, sample: (LoopPhase, u64), now: Instant) {
         if sample.1 != self.last_counter {
             self.changed_at = now;
+            self.has_observed_change = true;
         }
         self.last_phase = sample.0;
         self.last_counter = sample.1;
@@ -93,7 +102,13 @@ impl HeartbeatView {
         let age = now.saturating_duration_since(self.changed_at);
         match self.last_phase {
             LoopPhase::ApplyingBatch | LoopPhase::ControlOp => LoopState::Busy,
-            LoopPhase::InSelect if age <= cfg.heartbeat_fresh() => LoopState::ReaderIdle,
+            // Never report ReaderIdle from the construction-time placeholder alone -- only once a
+            // genuine counter change has been observed from this incarnation. Staying at the
+            // placeholder for `hard_grace` is still sound evidence of loop-death (the loop never
+            // scheduled even once), so LoopDead does not need this gate.
+            LoopPhase::InSelect if self.has_observed_change && age <= cfg.heartbeat_fresh() => {
+                LoopState::ReaderIdle
+            }
             LoopPhase::InSelect if age >= cfg.hard_grace() => LoopState::LoopDead,
             LoopPhase::InSelect => LoopState::Stale,
         }
@@ -291,6 +306,12 @@ pub struct TrackerEntry {
     incarnation: Ulid,
     last_known_lsn: Option<Lsn>,
     last_progress_at: Instant,
+    /// Finding 1 (DEFECTB review): when the *current, unbroken* streak of reader-idle + lagging
+    /// samples began, while `detect == Healthy`. Reset to `None` by any Busy/Stale sample or by
+    /// the tail no longer looking ahead -- `last_progress_at` alone is not enough, since it only
+    /// advances on real progress and can be arbitrarily old after a long legitimate `ApplyingBatch`,
+    /// which would let a single idle+lagging sample satisfy `>= grace` immediately.
+    reader_idle_since: Option<Instant>,
     detect: Detect,
     quarantine: Option<QuarantineEpisode>,
     restart_history: RestartHistory,
@@ -303,6 +324,7 @@ impl TrackerEntry {
             incarnation,
             last_known_lsn: None,
             last_progress_at: now,
+            reader_idle_since: None,
             detect: Detect::Healthy,
             quarantine: None,
             restart_history: RestartHistory::fresh(now, cfg),
@@ -329,6 +351,7 @@ impl TrackerEntry {
         self.incarnation = incarnation;
         self.last_known_lsn = None;
         self.last_progress_at = now;
+        self.reader_idle_since = None;
         self.detect = Detect::Healthy;
     }
 
@@ -359,6 +382,7 @@ impl TrackerEntry {
         {
             self.last_known_lsn = Some(lsn);
             self.last_progress_at = now;
+            self.reader_idle_since = None;
             self.detect = Detect::Healthy;
             if let Some(QuarantineEpisode::ApplyStall { bail_lsn, .. }) = self.quarantine
                 && lsn > bail_lsn
@@ -376,21 +400,17 @@ impl TrackerEntry {
         // A3: a loop-dead observation is independent evidence, evaluated before (and without
         // disturbing the kind of) any active ApplyStall episode.
         if input.loop_state == LoopState::LoopDead {
-            return self.handle_loop_dead_sample(now, cfg);
+            return self.handle_loop_dead_sample(now);
         }
 
         self.advance_lag_detection(now, input, cfg)
     }
 
-    fn handle_loop_dead_sample(
-        &mut self,
-        now: Instant,
-        cfg: &StallDetectionOptions,
-    ) -> TrackerEffect {
+    fn handle_loop_dead_sample(&mut self, now: Instant) -> TrackerEffect {
         if matches!(self.quarantine, Some(QuarantineEpisode::ApplyStall { .. })) {
             // A3: never let a loop-dead sample overwrite an active ApplyStall episode's kind.
             // It's still independent grounds to (re-)attempt a bail, subject to the same spacing.
-            return self.try_bail(now, cfg);
+            return self.propose_bail(now);
         }
 
         let (since, bails) = match self.quarantine {
@@ -398,7 +418,7 @@ impl TrackerEntry {
             _ => (MillisSinceEpoch::now(), 0),
         };
         self.quarantine = Some(QuarantineEpisode::LoopDead { since, bails });
-        self.try_bail(now, cfg)
+        self.propose_bail(now)
     }
 
     fn advance_lag_detection(
@@ -421,12 +441,21 @@ impl TrackerEntry {
                     input.replay_status,
                     ReplayStatus::Active | ReplayStatus::CatchingUp
                 );
-                if idle
+                let idle_and_lagging = idle
                     && eligible_replay
                     && self.last_known_lsn.is_some()
-                    && lagging(self.last_known_lsn)
-                    && now.saturating_duration_since(self.last_progress_at) >= cfg.grace()
-                {
+                    && lagging(self.last_known_lsn);
+
+                if !idle_and_lagging {
+                    // Finding 1: any Busy/Stale sample, or the tail no longer looking ahead,
+                    // resets the streak -- a single idle+lagging sample right after a long
+                    // legitimate `ApplyingBatch` must not satisfy the grace window instantly.
+                    self.reader_idle_since = None;
+                    return TrackerEffect::None;
+                }
+
+                let since = *self.reader_idle_since.get_or_insert(now);
+                if now.saturating_duration_since(since) >= cfg.grace() {
                     self.detect = Detect::Suspect {
                         since: now,
                         next_probe_at: now,
@@ -442,7 +471,10 @@ impl TrackerEntry {
             } => {
                 if !idle || !lagging(self.last_known_lsn) {
                     // Rule 2: any Busy/stale sample, or the tail no longer looking ahead (stale
-                    // observation expiry included), restarts the window from Healthy.
+                    // observation expiry included), restarts the window from Healthy. Clear the
+                    // idle streak too, so a stale timestamp from *before* Suspect was entered
+                    // can't let a subsequent idle+lagging sample skip the grace window (finding 1).
+                    self.reader_idle_since = None;
                     self.detect = Detect::Healthy;
                     return TrackerEffect::None;
                 }
@@ -500,7 +532,7 @@ impl TrackerEntry {
                     (since + cfg.bail_grace()).max(self.restart_history.next_permitted_bail_at);
                 if now >= bail_deadline {
                     if lagging(self.last_known_lsn) {
-                        self.try_bail(now, cfg)
+                        self.propose_bail(now)
                     } else {
                         // Revalidation failed at the moment we'd act: demote instead of bailing
                         // on stale evidence (guardrail: never act without confirmed lag).
@@ -589,12 +621,24 @@ impl TrackerEntry {
         }
     }
 
-    fn try_bail(&mut self, now: Instant, cfg: &StallDetectionOptions) -> TrackerEffect {
+    /// Rule 7 / the loop-dead bail path: proposes a bail if the spacing
+    /// (`next_permitted_bail_at`) allows one. Read-only -- does **not** mutate any state,
+    /// including `next_permitted_bail_at` itself. The manager must revalidate reader-idle (and,
+    /// for an `ApplyStall` episode, confirmed lag) immediately before calling `stop()` (finding 4,
+    /// DEFECTB review): [`Self::commit_bail`] if revalidation still holds, or nothing otherwise --
+    /// the tracker's state is untouched either way, so the next tick re-evaluates from scratch.
+    fn propose_bail(&self, now: Instant) -> TrackerEffect {
         if now < self.restart_history.next_permitted_bail_at {
-            return TrackerEffect::None;
+            TrackerEffect::None
+        } else {
+            TrackerEffect::Bail
         }
+    }
 
-        let bail_lsn = self.last_known_lsn.unwrap_or(Lsn::INVALID);
+    /// Commits a bail the manager has freshly revalidated immediately before calling `stop()`
+    /// (finding 4). Bumps the active quarantine episode's `bails` count (creating an `ApplyStall`
+    /// episode if none was active yet) and the restart-history backoff.
+    pub fn commit_bail(&mut self, now: Instant, bail_lsn: Lsn, cfg: &StallDetectionOptions) {
         self.quarantine = Some(match self.quarantine {
             Some(QuarantineEpisode::ApplyStall { since, bails, .. }) => {
                 QuarantineEpisode::ApplyStall {
@@ -619,8 +663,6 @@ impl TrackerEntry {
         self.restart_history.next_permitted_bail_at = now + self.restart_history.next_backoff;
         self.restart_history.next_backoff =
             (self.restart_history.next_backoff * 2).min(cfg.bail_backoff_cap());
-
-        TrackerEffect::Bail
     }
 
     /// A2/A4 (Option D): records a Candidate-watchdog bail. A committed-but-unapplied
@@ -735,8 +777,21 @@ mod tests {
         assert_eq!(effect, TrackerEffect::None);
         assert!(!tracker.is_quarantined());
 
-        // Now sit reader-idle + lagging for a full grace period from this point.
-        let grace_elapsed = mid_grace + cfg.grace() + Duration::from_secs(1);
+        // Finding 1 (DEFECTB review): a *single* idle+lagging sample taken long after the last
+        // progress must not immediately arm suspicion -- the grace window requires a continuous
+        // idle+lagging streak, timed from when that streak actually started, not from
+        // `last_progress_at` (which the preceding long Busy period left arbitrarily stale).
+        let idle_streak_starts = mid_grace + Duration::from_secs(1);
+        let effect = tracker.on_sample(idle_streak_starts, idle_lagging(Lsn::new(10)), &cfg);
+        assert_eq!(effect, TrackerEffect::None);
+        assert!(
+            matches!(tracker.detect, Detect::Healthy),
+            "one idle+lagging sample right after a long Busy period must not skip the grace window"
+        );
+
+        // Now sit reader-idle + lagging continuously for a full grace period from when the streak
+        // actually started.
+        let grace_elapsed = idle_streak_starts + cfg.grace() + Duration::from_secs(1);
         let effect = tracker.on_sample(grace_elapsed, idle_lagging(Lsn::new(10)), &cfg);
         assert_eq!(effect, TrackerEffect::None);
         assert!(matches!(tracker.detect, Detect::Suspect { .. }));
@@ -815,10 +870,13 @@ mod tests {
         assert_eq!(bail_lsn, Lsn::new(10));
         assert_eq!(bails, 0);
 
-        // Bail fires once bail_grace has elapsed from the Stalled entry.
+        // Bail fires once bail_grace has elapsed from the Stalled entry. `on_sample` only
+        // *proposes* the bail (finding 4, DEFECTB review); the manager must revalidate and then
+        // call `commit_bail` immediately before actually stopping the processor.
         let bail_time = stalled_time + cfg.bail_grace() + Duration::from_secs(1);
         let effect = tracker.on_sample(bail_time, idle_lagging(Lsn::new(10)), &cfg);
         assert_eq!(effect, TrackerEffect::Bail);
+        tracker.commit_bail(bail_time, Lsn::new(10), &cfg);
         let Some(QuarantineEpisode::ApplyStall {
             bail_lsn, bails, ..
         }) = tracker.quarantine()
@@ -1043,5 +1101,161 @@ mod tests {
         // A busy phase is Busy regardless of age.
         view.observe((LoopPhase::ApplyingBatch, 2), t0);
         assert_eq!(view.loop_state(dead, &cfg), LoopState::Busy);
+    }
+
+    /// Finding 2 (DEFECTB review): a freshly-constructed `HeartbeatView` -- e.g. right after an
+    /// incarnation reset -- starts at the same `(InSelect, 0)` value the real `LoopHeartbeat`
+    /// itself starts at. That must never be read as "just observed a fresh beat": no beat has
+    /// actually been observed yet, so it must classify as `Stale` (can't confirm idle or dead),
+    /// not `ReaderIdle`, until a genuine counter change is seen. Eventually staying at the
+    /// placeholder for `hard_grace` is still sound loop-death evidence.
+    #[test]
+    fn heartbeat_view_default_sample_is_not_reader_idle() {
+        let cfg = cfg();
+        let t0 = Instant::now();
+        let view = HeartbeatView::new(t0);
+
+        // Immediately at construction: not ReaderIdle (no beat observed yet).
+        assert_eq!(view.loop_state(t0, &cfg), LoopState::Stale);
+
+        // Still not ReaderIdle even once "fresh" by age alone -- there's still no observed beat.
+        let still_fresh_by_age = t0 + cfg.heartbeat_fresh() / 2;
+        assert_eq!(view.loop_state(still_fresh_by_age, &cfg), LoopState::Stale);
+
+        // But staying at the placeholder for hard_grace is still genuine loop-death evidence:
+        // the loop never scheduled even once.
+        let dead = t0 + cfg.hard_grace() + Duration::from_secs(1);
+        assert_eq!(view.loop_state(dead, &cfg), LoopState::LoopDead);
+    }
+
+    /// Finding 2: the default sample must not clear a `LoopDead` quarantine. Only a *genuinely
+    /// observed* fresh beat from the new incarnation may clear it.
+    #[test]
+    fn loop_dead_default_heartbeat_sample_does_not_clear_quarantine() {
+        let cfg = cfg();
+        let t0 = Instant::now();
+        let incarnation = Ulid::new();
+        let mut tracker = TrackerEntry::new(incarnation, t0, &cfg);
+
+        // Establish a known LSN so the loop-dead sample below isn't itself mistaken for progress
+        // (a fresh tracker's `last_known_lsn` is `None`, and rule 1 treats any `Some(lsn)` as
+        // progress against `None`).
+        tracker.on_sample(
+            t0,
+            TickInput {
+                last_applied_lsn: Some(Lsn::new(5)),
+                replay_status: ReplayStatus::Active,
+                loop_state: LoopState::ReaderIdle,
+                fresh_tail: Some(Lsn::new(6)),
+            },
+            &cfg,
+        );
+
+        // Force a LoopDead episode.
+        let dead_time = t0 + cfg.hard_grace() + Duration::from_secs(1);
+        tracker.on_sample(dead_time, loop_dead_sample(Some(Lsn::new(5))), &cfg);
+        assert!(matches!(
+            tracker.quarantine(),
+            Some(QuarantineEpisode::LoopDead { .. })
+        ));
+
+        // Simulate the restart: a fresh `HeartbeatView` for the new incarnation, sampled
+        // immediately -- this is the exact `(InSelect, 0)` construction-time placeholder, not a
+        // real observed beat.
+        let restart_time = dead_time + Duration::from_millis(1);
+        tracker.on_incarnation_started(restart_time, Ulid::new());
+        let mut fresh_view = HeartbeatView::new(restart_time);
+        let placeholder_loop_state = fresh_view.loop_state(restart_time, &cfg);
+        assert_eq!(
+            placeholder_loop_state,
+            LoopState::Stale,
+            "sanity: the construction-time placeholder must not classify as ReaderIdle"
+        );
+
+        let effect = tracker.on_sample(
+            restart_time,
+            TickInput {
+                last_applied_lsn: Some(Lsn::new(5)),
+                replay_status: ReplayStatus::Active,
+                loop_state: placeholder_loop_state,
+                fresh_tail: Some(Lsn::new(6)),
+            },
+            &cfg,
+        );
+        assert_eq!(effect, TrackerEffect::None);
+        assert!(
+            tracker.is_quarantined(),
+            "the default (InSelect, 0) sample must not clear a LoopDead quarantine"
+        );
+
+        // Once a genuine beat is observed (counter actually changes) and it's fresh, the
+        // quarantine clears as before.
+        fresh_view.observe((LoopPhase::InSelect, 1), restart_time);
+        let real_loop_state = fresh_view.loop_state(restart_time, &cfg);
+        assert_eq!(real_loop_state, LoopState::ReaderIdle);
+        let effect = tracker.on_sample(
+            restart_time,
+            TickInput {
+                last_applied_lsn: Some(Lsn::new(5)),
+                replay_status: ReplayStatus::Active,
+                loop_state: real_loop_state,
+                fresh_tail: Some(Lsn::new(6)),
+            },
+            &cfg,
+        );
+        assert_eq!(effect, TrackerEffect::None);
+        assert!(
+            !tracker.is_quarantined(),
+            "a genuinely observed fresh beat must still clear the LoopDead quarantine"
+        );
+    }
+
+    /// Finding 4 (DEFECTB review): `on_sample` returning `TrackerEffect::Bail` is only a
+    /// *proposal* -- nothing about the bail (the quarantine's `bails` count, the restart-history
+    /// backoff) is committed until the caller explicitly calls `commit_bail`, which the manager
+    /// only does after freshly revalidating reader-idle/lag immediately before `stop()`. If the
+    /// manager declines to commit, the tracker's state is untouched and the next sample can
+    /// propose again.
+    #[test]
+    fn bail_is_a_proposal_until_committed() {
+        let cfg = cfg();
+        let t0 = Instant::now();
+        let incarnation = Ulid::new();
+        let mut tracker = TrackerEntry::new(incarnation, t0, &cfg);
+        tracker.on_sample(
+            t0,
+            TickInput {
+                last_applied_lsn: Some(Lsn::new(5)),
+                replay_status: ReplayStatus::Active,
+                loop_state: LoopState::ReaderIdle,
+                fresh_tail: Some(Lsn::new(6)),
+            },
+            &cfg,
+        );
+
+        let dead_time = t0 + cfg.hard_grace() + Duration::from_secs(1);
+        let effect = tracker.on_sample(dead_time, loop_dead_sample(Some(Lsn::new(5))), &cfg);
+        assert_eq!(effect, TrackerEffect::Bail);
+        // The episode itself is established eagerly (it's evidence, not an action), but the bail
+        // itself has not been committed yet.
+        let Some(QuarantineEpisode::LoopDead { bails, .. }) = tracker.quarantine() else {
+            panic!("expected a LoopDead episode");
+        };
+        assert_eq!(
+            bails, 0,
+            "commit_bail was never called -- bails must not be bumped yet"
+        );
+
+        // The manager declines to commit (revalidation failed): calling on_sample again with the
+        // same evidence proposes again, since next_permitted_bail_at was never advanced.
+        let effect = tracker.on_sample(dead_time, loop_dead_sample(Some(Lsn::new(5))), &cfg);
+        assert_eq!(effect, TrackerEffect::Bail);
+
+        // Now the manager revalidates successfully and commits.
+        tracker.commit_bail(dead_time, Lsn::new(5), &cfg);
+        let Some(QuarantineEpisode::LoopDead { bails, .. }) = tracker.quarantine() else {
+            panic!("expected a LoopDead episode");
+        };
+        assert_eq!(bails, 1);
     }
 }

--- a/crates/worker/src/partition_processor_manager/apply_progress_tracker.rs
+++ b/crates/worker/src/partition_processor_manager/apply_progress_tracker.rs
@@ -121,6 +121,13 @@ impl HeartbeatView {
     pub fn phase_age(&self, now: Instant) -> Duration {
         now.saturating_duration_since(self.changed_at)
     }
+
+    /// The raw `(phase, counter)` this view last observed. Lets a caller detect "has anything
+    /// happened since this specific sample" by comparing against a fresh raw read, independent of
+    /// `loop_state`'s freshness/gating logic (finding 4, DEFECTB re-review).
+    pub fn last_sample(&self) -> (LoopPhase, u64) {
+        (self.last_phase, self.last_counter)
+    }
 }
 
 /// A single tail observation, fed by both the 1s `Fast` poller and the mandatory `ConsistentRead`

--- a/crates/worker/src/partition_processor_manager/apply_progress_tracker.rs
+++ b/crates/worker/src/partition_processor_manager/apply_progress_tracker.rs
@@ -622,6 +622,44 @@ impl TrackerEntry {
 
         TrackerEffect::Bail
     }
+
+    /// A2/A4 (Option D): records a Candidate-watchdog bail. A committed-but-unapplied
+    /// `AnnounceLeader` marker is itself authoritative lag evidence -- a second legitimate birth
+    /// site for `ApplyStall`, so this always creates or promotes to `ApplyStall` (unlike a
+    /// loop-dead bail, which preserves whatever episode kind was already active). Uses the exact
+    /// FSM-captured `bail_lsn` the caller hands in, never a possibly-stale tracker sample (A4).
+    ///
+    /// Unlike [`Self::try_bail`], there is no `next_permitted_bail_at` gate here: the partition
+    /// processor has already exited by the time this runs (the watchdog's deadline firing *is*
+    /// the bail), so this only records the episode and restart-history bookkeeping for the
+    /// manager's restart-delay decision and any future bail.
+    pub fn on_announce_not_applied(
+        &mut self,
+        now: Instant,
+        bail_lsn: Lsn,
+        cfg: &StallDetectionOptions,
+    ) {
+        let bails = match self.quarantine {
+            Some(QuarantineEpisode::ApplyStall { bails, .. }) => bails,
+            Some(QuarantineEpisode::LoopDead { bails, .. }) => bails,
+            None => 0,
+        };
+        let since = match self.quarantine {
+            Some(QuarantineEpisode::ApplyStall { since, .. }) => since,
+            _ => MillisSinceEpoch::now(),
+        };
+        self.quarantine = Some(QuarantineEpisode::ApplyStall {
+            since,
+            bail_lsn,
+            bails: bails + 1,
+        });
+
+        self.restart_history.count += 1;
+        self.restart_history.bail_lsn = Some(bail_lsn);
+        self.restart_history.next_permitted_bail_at = now + self.restart_history.next_backoff;
+        self.restart_history.next_backoff =
+            (self.restart_history.next_backoff * 2).min(cfg.bail_backoff_cap());
+    }
 }
 
 #[cfg(test)]

--- a/crates/worker/src/partition_processor_manager/apply_progress_tracker.rs
+++ b/crates/worker/src/partition_processor_manager/apply_progress_tracker.rs
@@ -1,0 +1,1009 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Detects a partition processor whose apply loop is lagging with no progress and no legitimate
+//! busy work in progress ("apply-stall"), or whose loop has stopped scheduling entirely
+//! ("loop-dead"), and drives the sticky quarantine signal that both downgrades the reported
+//! status and eventually restarts the processor.
+//!
+//! This module is deliberately synchronous and clock-driven by the caller (the
+//! `PartitionProcessorManager`): every type here is plain data plus pure transition functions, so
+//! the whole state machine is unit-testable without spawning a processor or touching Bifrost. The
+//! manager is responsible for turning [`TrackerEffect::IssueProbe`] into an actual
+//! `ConsistentRead` tail probe and [`TrackerEffect::Bail`] into a `processor_state.stop()` call.
+//!
+//! Two independent "episode kinds" can quarantine a processor, each with its own clear proof
+//! (never conflated -- see the module's design doc, DEFECTB):
+//! - [`QuarantineEpisode::ApplyStall`]: born only from authoritative confirmed lag (a
+//!   `ConsistentRead` probe, or -- from Stage 3 -- a committed `AnnounceLeader` marker that never
+//!   applied). Clears only once the applied LSN passes `bail_lsn`.
+//! - [`QuarantineEpisode::LoopDead`]: born from a stale-`InSelect` heartbeat (the loop has
+//!   stopped scheduling). Clears as soon as the heartbeat is fresh again, regardless of LSN --
+//!   a caught-up idle processor that restarts cleanly may never see a new LSN to clear against.
+//!
+//! `ApplyStall` always dominates `LoopDead`: a loop-dead sample never overwrites an active
+//! `ApplyStall` episode, but confirmed lag may promote an existing `LoopDead` episode to
+//! `ApplyStall`.
+
+use std::time::Duration;
+
+use tokio::time::Instant;
+use ulid::Ulid;
+
+use restate_types::cluster::cluster_state::ReplayStatus;
+use restate_types::config::StallDetectionOptions;
+use restate_types::logs::{Lsn, SequenceNumber};
+use restate_types::time::MillisSinceEpoch;
+
+use crate::partition::LoopPhase;
+
+/// The manager's classification of a partition processor's apply loop for one tick, derived from
+/// a [`HeartbeatView`] sample.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoopState {
+    /// Parked in `select`, and the heartbeat is fresh: genuinely waiting for work.
+    ReaderIdle,
+    /// Applying a batch or running a control operation, of any age. Busy is never itself
+    /// evidence of a stall -- long-running legitimate work (e.g. leader init) looks the same.
+    Busy,
+    /// Parked in `select`, heartbeat neither fresh nor stale enough to call dead. Treated like a
+    /// non-idle sample for detection purposes (never arms suspicion, never proves loop-death).
+    Stale,
+    /// Parked in `select` with a heartbeat stale enough that the loop provably cannot be
+    /// running (see `hard_grace`).
+    LoopDead,
+}
+
+/// Tracks one partition processor's [`LoopHeartbeat`](crate::partition::processor::LoopHeartbeat)
+/// on the manager side: turns a raw `(phase, counter)` sample into a [`LoopState`] by locally
+/// timestamping counter changes (never encoding an `Instant` into the shared atomic).
+#[derive(Debug, Clone, Copy)]
+pub struct HeartbeatView {
+    last_phase: LoopPhase,
+    last_counter: u64,
+    changed_at: Instant,
+}
+
+impl HeartbeatView {
+    pub fn new(now: Instant) -> Self {
+        Self {
+            last_phase: LoopPhase::InSelect,
+            last_counter: 0,
+            changed_at: now,
+        }
+    }
+
+    /// Feed a fresh `(phase, counter)` sample taken from the processor's `LoopHeartbeat`.
+    pub fn observe(&mut self, sample: (LoopPhase, u64), now: Instant) {
+        if sample.1 != self.last_counter {
+            self.changed_at = now;
+        }
+        self.last_phase = sample.0;
+        self.last_counter = sample.1;
+    }
+
+    pub fn loop_state(&self, now: Instant, cfg: &StallDetectionOptions) -> LoopState {
+        let age = now.saturating_duration_since(self.changed_at);
+        match self.last_phase {
+            LoopPhase::ApplyingBatch | LoopPhase::ControlOp => LoopState::Busy,
+            LoopPhase::InSelect if age <= cfg.heartbeat_fresh() => LoopState::ReaderIdle,
+            LoopPhase::InSelect if age >= cfg.hard_grace() => LoopState::LoopDead,
+            LoopPhase::InSelect => LoopState::Stale,
+        }
+    }
+
+    pub fn phase(&self) -> LoopPhase {
+        self.last_phase
+    }
+
+    pub fn phase_age(&self, now: Instant) -> Duration {
+        now.saturating_duration_since(self.changed_at)
+    }
+}
+
+/// A single tail observation, fed by both the 1s `Fast` poller and the mandatory `ConsistentRead`
+/// sweep. `last_consistent_attempt_at` is the A5 fairness input: it advances on every attempt
+/// (success, error, *and* timeout), so a permanently-failing partition cannot monopolize the
+/// single node-wide probe slot by "never succeeding" -- see
+/// [`pick_next_consistent_read_sweep_target`].
+#[derive(Debug, Clone, Copy)]
+pub struct TailObservation {
+    lsn: Lsn,
+    observed_at: Instant,
+    last_consistent_attempt_at: Instant,
+}
+
+impl TailObservation {
+    pub fn new(lsn: Lsn, now: Instant) -> Self {
+        Self {
+            lsn,
+            observed_at: now,
+            last_consistent_attempt_at: now,
+        }
+    }
+
+    pub fn lsn(&self) -> Lsn {
+        self.lsn
+    }
+
+    /// A `Fast` (possibly stale-cached) tail observation. May only arm suspicion, never confirm
+    /// it -- see the module doc and the tracker's evidence rule.
+    pub fn observe_fast(&mut self, lsn: Lsn, now: Instant) {
+        if lsn > self.lsn {
+            self.lsn = lsn;
+        }
+        self.observed_at = now;
+    }
+
+    /// A successful `ConsistentRead` observation: authoritative evidence. This is what reveals
+    /// lag that a frozen `Fast` cache would otherwise hide forever (see the module doc) --
+    /// `self.lsn` is monotonic across both observation kinds, so a sweep result that's higher
+    /// than anything `Fast` has reported immediately becomes the new known tail.
+    pub fn observe_consistent(&mut self, lsn: Lsn, now: Instant) {
+        if lsn > self.lsn {
+            self.lsn = lsn;
+        }
+        self.observed_at = now;
+        self.last_consistent_attempt_at = now;
+    }
+
+    /// A `ConsistentRead` attempt that errored or timed out: advances the fairness clock (A5)
+    /// without changing the known tail or its freshness.
+    pub fn mark_consistent_attempt(&mut self, now: Instant) {
+        self.last_consistent_attempt_at = now;
+    }
+
+    pub fn is_fresh(&self, now: Instant, tail_ttl: Duration) -> bool {
+        now.saturating_duration_since(self.observed_at) <= tail_ttl
+    }
+}
+
+/// A5: selects the running partition with the oldest `last_consistent_attempt_at` -- round-robin
+/// over *attempts*, not successes, so a partition whose probes always error or time out still
+/// yields its slot to others within a bounded number of sweep rounds.
+pub fn pick_next_consistent_read_sweep_target<'a, Id: Copy + 'a>(
+    observations: impl IntoIterator<Item = (Id, &'a TailObservation)>,
+) -> Option<Id> {
+    observations
+        .into_iter()
+        .min_by_key(|(_, obs)| obs.last_consistent_attempt_at)
+        .map(|(id, _)| id)
+}
+
+/// A snapshot of everything the tracker needs to evaluate one partition for one tick.
+#[derive(Debug, Clone, Copy)]
+pub struct TickInput {
+    pub last_applied_lsn: Option<Lsn>,
+    pub replay_status: ReplayStatus,
+    pub loop_state: LoopState,
+    /// The freshest tail observation, if one exists within `tail_ttl`; `None` if stale or absent.
+    /// May come from either `Fast` or `ConsistentRead` -- either is enough to *arm* suspicion
+    /// (Healthy -> Suspect). Only an explicit, active `ConsistentRead` probe result
+    /// (`on_probe_result`) can ever *confirm* it, which is what actually creates an
+    /// `ApplyStall` episode -- so this field's provenance doesn't need tracking here.
+    pub fresh_tail: Option<Lsn>,
+}
+
+pub enum ProbeResult {
+    /// The probe completed and observed this tail. Whether it's still ahead of the last applied
+    /// LSN (still lagging) or not (the reader had already caught up) is decided by
+    /// `on_probe_result` re-reading `last_known_lsn` at completion time, not carried here.
+    Confirmed {
+        tail_lsn: Lsn,
+    },
+    Failed,
+}
+
+/// What the manager must do in response to a tracker transition. The tracker never performs I/O
+/// itself -- the manager owns spawning probes and calling `processor_state.stop()`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrackerEffect {
+    None,
+    /// Issue one `ConsistentRead` probe tagged with this incarnation and nonce.
+    IssueProbe {
+        incarnation: Ulid,
+        nonce: u64,
+    },
+    /// Call `processor_state.stop()` now. The tracker has already updated its own quarantine and
+    /// restart-history bookkeeping.
+    Bail,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Detect {
+    Healthy,
+    Suspect {
+        since: Instant,
+        next_probe_at: Instant,
+        probe_backoff: Duration,
+    },
+    Confirming {
+        since: Instant,
+        incarnation: Ulid,
+        nonce: u64,
+        /// Carried forward from the `Suspect` state that spawned this probe so a failed probe
+        /// can double it (capped) without needing separate bookkeeping on `TrackerEntry`.
+        probe_backoff: Duration,
+    },
+    Observing {
+        since: Instant,
+        until: Instant,
+    },
+    Stalled {
+        since: Instant,
+    },
+}
+
+/// The sticky, generation-surviving quarantine signal. Not reset by an incarnation change --
+/// only cleared by its own kind's clear proof (see the module doc).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuarantineEpisode {
+    ApplyStall {
+        since: MillisSinceEpoch,
+        bail_lsn: Lsn,
+        bails: u32,
+    },
+    LoopDead {
+        since: MillisSinceEpoch,
+        bails: u32,
+    },
+}
+
+impl QuarantineEpisode {
+    pub fn since(&self) -> MillisSinceEpoch {
+        match self {
+            QuarantineEpisode::ApplyStall { since, .. } => *since,
+            QuarantineEpisode::LoopDead { since, .. } => *since,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RestartHistory {
+    count: u32,
+    bail_lsn: Option<Lsn>,
+    next_permitted_bail_at: Instant,
+    next_backoff: Duration,
+}
+
+impl RestartHistory {
+    fn fresh(now: Instant, cfg: &StallDetectionOptions) -> Self {
+        Self {
+            count: 0,
+            bail_lsn: None,
+            next_permitted_bail_at: now,
+            next_backoff: cfg.bail_backoff_base(),
+        }
+    }
+}
+
+/// Per-partition apply-progress state, owned by the `PartitionProcessorManager`. See the module
+/// doc for the overall design.
+#[derive(Debug, Clone, Copy)]
+pub struct TrackerEntry {
+    incarnation: Ulid,
+    last_known_lsn: Option<Lsn>,
+    last_progress_at: Instant,
+    detect: Detect,
+    quarantine: Option<QuarantineEpisode>,
+    restart_history: RestartHistory,
+    next_nonce: u64,
+}
+
+impl TrackerEntry {
+    pub fn new(incarnation: Ulid, now: Instant, cfg: &StallDetectionOptions) -> Self {
+        Self {
+            incarnation,
+            last_known_lsn: None,
+            last_progress_at: now,
+            detect: Detect::Healthy,
+            quarantine: None,
+            restart_history: RestartHistory::fresh(now, cfg),
+            next_nonce: 0,
+        }
+    }
+
+    pub fn quarantine(&self) -> Option<QuarantineEpisode> {
+        self.quarantine
+    }
+
+    pub fn is_quarantined(&self) -> bool {
+        self.quarantine.is_some()
+    }
+
+    pub fn last_known_lsn(&self) -> Option<Lsn> {
+        self.last_known_lsn
+    }
+
+    /// Rule 8: a new processor incarnation started. Progress and live detection reset (fresh
+    /// grace period); the sticky quarantine and restart history are retained; any outstanding
+    /// probe is implicitly orphaned because its tag will no longer match.
+    pub fn on_incarnation_started(&mut self, now: Instant, incarnation: Ulid) {
+        self.incarnation = incarnation;
+        self.last_known_lsn = None;
+        self.last_progress_at = now;
+        self.detect = Detect::Healthy;
+    }
+
+    /// Evaluate one sample (status watch, tail observation, and heartbeat, all resolved to a
+    /// point-in-time view by the caller). Called from the manager's `tracker_tick` and whenever a
+    /// fresh observation arrives.
+    pub fn on_sample(
+        &mut self,
+        now: Instant,
+        input: TickInput,
+        cfg: &StallDetectionOptions,
+    ) -> TrackerEffect {
+        // C2/rule 10: a LoopDead episode clears on any fresh heartbeat, regardless of LSN -- a
+        // caught-up idle processor may never see new work to prove progress against. Checked
+        // unconditionally, ahead of the progress branch below: after an incarnation reset,
+        // `last_known_lsn` is `None`, so the very first sample always looks like "progress" (rule
+        // 1) even when the LSN is unchanged from before the restart -- that must not suppress
+        // this clear.
+        if matches!(self.quarantine, Some(QuarantineEpisode::LoopDead { .. }))
+            && input.loop_state == LoopState::ReaderIdle
+        {
+            self.quarantine = None;
+        }
+
+        // Rule 1: progress dominates every other transition.
+        if let Some(lsn) = input.last_applied_lsn
+            && self.last_known_lsn.is_none_or(|known| lsn > known)
+        {
+            self.last_known_lsn = Some(lsn);
+            self.last_progress_at = now;
+            self.detect = Detect::Healthy;
+            if let Some(QuarantineEpisode::ApplyStall { bail_lsn, .. }) = self.quarantine
+                && lsn > bail_lsn
+            {
+                self.quarantine = None;
+            }
+            if let Some(bail_lsn) = self.restart_history.bail_lsn
+                && lsn > bail_lsn
+            {
+                self.restart_history = RestartHistory::fresh(now, cfg);
+            }
+            return TrackerEffect::None;
+        }
+
+        // A3: a loop-dead observation is independent evidence, evaluated before (and without
+        // disturbing the kind of) any active ApplyStall episode.
+        if input.loop_state == LoopState::LoopDead {
+            return self.handle_loop_dead_sample(now, cfg);
+        }
+
+        self.advance_lag_detection(now, input, cfg)
+    }
+
+    fn handle_loop_dead_sample(
+        &mut self,
+        now: Instant,
+        cfg: &StallDetectionOptions,
+    ) -> TrackerEffect {
+        if matches!(self.quarantine, Some(QuarantineEpisode::ApplyStall { .. })) {
+            // A3: never let a loop-dead sample overwrite an active ApplyStall episode's kind.
+            // It's still independent grounds to (re-)attempt a bail, subject to the same spacing.
+            return self.try_bail(now, cfg);
+        }
+
+        let (since, bails) = match self.quarantine {
+            Some(QuarantineEpisode::LoopDead { since, bails }) => (since, bails),
+            _ => (MillisSinceEpoch::now(), 0),
+        };
+        self.quarantine = Some(QuarantineEpisode::LoopDead { since, bails });
+        self.try_bail(now, cfg)
+    }
+
+    fn advance_lag_detection(
+        &mut self,
+        now: Instant,
+        input: TickInput,
+        cfg: &StallDetectionOptions,
+    ) -> TrackerEffect {
+        let idle = input.loop_state == LoopState::ReaderIdle;
+        let lagging = |known: Option<Lsn>| {
+            input
+                .fresh_tail
+                .zip(known)
+                .is_some_and(|(tail, known)| tail.prev() > known)
+        };
+
+        match self.detect {
+            Detect::Healthy => {
+                let eligible_replay = matches!(
+                    input.replay_status,
+                    ReplayStatus::Active | ReplayStatus::CatchingUp
+                );
+                if idle
+                    && eligible_replay
+                    && self.last_known_lsn.is_some()
+                    && lagging(self.last_known_lsn)
+                    && now.saturating_duration_since(self.last_progress_at) >= cfg.grace()
+                {
+                    self.detect = Detect::Suspect {
+                        since: now,
+                        next_probe_at: now,
+                        probe_backoff: cfg.probe_backoff_base(),
+                    };
+                }
+                TrackerEffect::None
+            }
+            Detect::Suspect {
+                since,
+                next_probe_at,
+                probe_backoff,
+            } => {
+                if !idle || !lagging(self.last_known_lsn) {
+                    // Rule 2: any Busy/stale sample, or the tail no longer looking ahead (stale
+                    // observation expiry included), restarts the window from Healthy.
+                    self.detect = Detect::Healthy;
+                    return TrackerEffect::None;
+                }
+                if now >= next_probe_at {
+                    let nonce = self.next_nonce;
+                    self.next_nonce += 1;
+                    self.detect = Detect::Confirming {
+                        since,
+                        incarnation: self.incarnation,
+                        nonce,
+                        probe_backoff,
+                    };
+                    TrackerEffect::IssueProbe {
+                        incarnation: self.incarnation,
+                        nonce,
+                    }
+                } else {
+                    // Keep the same backoff/next_probe_at; nothing to do yet.
+                    TrackerEffect::None
+                }
+            }
+            Detect::Confirming { .. } => {
+                // Only probe completion (`on_probe_result`) drives this state forward.
+                TrackerEffect::None
+            }
+            Detect::Observing { since, until } => {
+                if !idle {
+                    // Rule 5: Busy during the recovery window means the reader resumed on its
+                    // own; give it a fresh probe opportunity rather than declaring it stalled.
+                    self.detect = Detect::Suspect {
+                        since: now,
+                        next_probe_at: now,
+                        probe_backoff: cfg.probe_backoff_base(),
+                    };
+                    return TrackerEffect::None;
+                }
+                if now >= until {
+                    self.detect = Detect::Stalled { since };
+                    self.enter_stalled();
+                }
+                TrackerEffect::None
+            }
+            Detect::Stalled { since } => {
+                if !idle {
+                    // Rule 6: Stalled suspension -- demote, quarantine stays (only rule 1 clears
+                    // ApplyStall).
+                    self.detect = Detect::Suspect {
+                        since: now,
+                        next_probe_at: now,
+                        probe_backoff: cfg.probe_backoff_base(),
+                    };
+                    return TrackerEffect::None;
+                }
+                let bail_deadline =
+                    (since + cfg.bail_grace()).max(self.restart_history.next_permitted_bail_at);
+                if now >= bail_deadline {
+                    if lagging(self.last_known_lsn) {
+                        self.try_bail(now, cfg)
+                    } else {
+                        // Revalidation failed at the moment we'd act: demote instead of bailing
+                        // on stale evidence (guardrail: never act without confirmed lag).
+                        self.detect = Detect::Suspect {
+                            since: now,
+                            next_probe_at: now,
+                            probe_backoff: cfg.probe_backoff_base(),
+                        };
+                        TrackerEffect::None
+                    }
+                } else {
+                    TrackerEffect::None
+                }
+            }
+        }
+    }
+
+    /// Rule 5: Observing -> Stalled. Creates/extends the ApplyStall episode; this and Stage 3's
+    /// `AnnounceNotApplied` path (A2) are the only two legitimate ApplyStall birth sites.
+    fn enter_stalled(&mut self) {
+        let bail_lsn = self.last_known_lsn.unwrap_or(Lsn::INVALID);
+        self.quarantine = Some(match self.quarantine {
+            // A3: promote an existing LoopDead episode rather than losing its history.
+            Some(QuarantineEpisode::LoopDead { bails, .. })
+            | Some(QuarantineEpisode::ApplyStall { bails, .. }) => QuarantineEpisode::ApplyStall {
+                since: MillisSinceEpoch::now(),
+                bail_lsn,
+                bails,
+            },
+            None => QuarantineEpisode::ApplyStall {
+                since: MillisSinceEpoch::now(),
+                bail_lsn,
+                bails: 0,
+            },
+        });
+    }
+
+    /// Rule 3/4: feed a completed `ConsistentRead` probe result. Discards results whose tag no
+    /// longer matches the current incarnation/nonce (superseded or orphaned by an incarnation
+    /// change).
+    pub fn on_probe_result(
+        &mut self,
+        now: Instant,
+        incarnation: Ulid,
+        nonce: u64,
+        result: ProbeResult,
+        cfg: &StallDetectionOptions,
+    ) {
+        let Detect::Confirming {
+            since,
+            incarnation: expected_incarnation,
+            nonce: expected_nonce,
+            probe_backoff,
+        } = self.detect
+        else {
+            return;
+        };
+        if incarnation != expected_incarnation || nonce != expected_nonce {
+            return;
+        }
+
+        match result {
+            ProbeResult::Failed => {
+                // Rule 3: stay Suspect, backing off (capped) before the next probe attempt.
+                self.detect = Detect::Suspect {
+                    since,
+                    next_probe_at: now + probe_backoff,
+                    probe_backoff: (probe_backoff * 2).min(cfg.probe_backoff_cap()),
+                };
+            }
+            ProbeResult::Confirmed { tail_lsn } => {
+                if self
+                    .last_known_lsn
+                    .is_none_or(|known| tail_lsn.prev() > known)
+                {
+                    // Rule 4: the probe may itself have healed the reader; give it a bounded
+                    // recovery window before declaring Stalled.
+                    self.detect = Detect::Observing {
+                        since,
+                        until: now + cfg.recovery_window(),
+                    };
+                } else {
+                    self.detect = Detect::Healthy;
+                }
+            }
+        }
+    }
+
+    fn try_bail(&mut self, now: Instant, cfg: &StallDetectionOptions) -> TrackerEffect {
+        if now < self.restart_history.next_permitted_bail_at {
+            return TrackerEffect::None;
+        }
+
+        let bail_lsn = self.last_known_lsn.unwrap_or(Lsn::INVALID);
+        self.quarantine = Some(match self.quarantine {
+            Some(QuarantineEpisode::ApplyStall { since, bails, .. }) => {
+                QuarantineEpisode::ApplyStall {
+                    since,
+                    bail_lsn,
+                    bails: bails + 1,
+                }
+            }
+            Some(QuarantineEpisode::LoopDead { since, bails }) => QuarantineEpisode::LoopDead {
+                since,
+                bails: bails + 1,
+            },
+            None => QuarantineEpisode::ApplyStall {
+                since: MillisSinceEpoch::now(),
+                bail_lsn,
+                bails: 1,
+            },
+        });
+
+        self.restart_history.count += 1;
+        self.restart_history.bail_lsn = Some(bail_lsn);
+        self.restart_history.next_permitted_bail_at = now + self.restart_history.next_backoff;
+        self.restart_history.next_backoff =
+            (self.restart_history.next_backoff * 2).min(cfg.bail_backoff_cap());
+
+        TrackerEffect::Bail
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use ulid::Ulid;
+
+    use super::*;
+
+    fn cfg() -> StallDetectionOptions {
+        // The production defaults happen to already be small/distinguishable enough to drive
+        // deterministically in tests; used directly rather than duplicating them here.
+        StallDetectionOptions::default()
+    }
+
+    fn idle_lagging(lsn_ahead_of: Lsn) -> TickInput {
+        TickInput {
+            last_applied_lsn: Some(lsn_ahead_of),
+            replay_status: ReplayStatus::Active,
+            loop_state: LoopState::ReaderIdle,
+            fresh_tail: Some(lsn_ahead_of.next().next()),
+        }
+    }
+
+    fn busy_sample(last_applied: Lsn) -> TickInput {
+        TickInput {
+            last_applied_lsn: Some(last_applied),
+            replay_status: ReplayStatus::Active,
+            loop_state: LoopState::Busy,
+            fresh_tail: None,
+        }
+    }
+
+    fn loop_dead_sample(last_applied: Option<Lsn>) -> TickInput {
+        TickInput {
+            last_applied_lsn: last_applied,
+            replay_status: ReplayStatus::Active,
+            loop_state: LoopState::LoopDead,
+            fresh_tail: None,
+        }
+    }
+
+    /// Full-table state machine test: Healthy -> Suspect (grace) -> Confirming (probe) ->
+    /// Observing (recovery window) -> Stalled -> bail, plus the ApplyStall clear proof (progress
+    /// past bail_lsn), the "any Busy/stale sample restarts the window" rule, and probe
+    /// single-flight/backoff (stale nonce discarded, failure backs off).
+    #[test]
+    fn tracker_state_machine_unit() {
+        let cfg = cfg();
+        let t0 = Instant::now();
+        let incarnation = Ulid::new();
+        let mut tracker = TrackerEntry::new(incarnation, t0, &cfg);
+
+        // Starting point: some initial progress at LSN 10.
+        let effect = tracker.on_sample(
+            t0,
+            TickInput {
+                last_applied_lsn: Some(Lsn::new(10)),
+                replay_status: ReplayStatus::Active,
+                loop_state: LoopState::ReaderIdle,
+                fresh_tail: Some(Lsn::new(11)),
+            },
+            &cfg,
+        );
+        assert_eq!(effect, TrackerEffect::None);
+        assert_eq!(tracker.last_known_lsn(), Some(Lsn::new(10)));
+
+        // A Busy sample midway through what would otherwise be a grace window must not arm
+        // suspicion (rule 2: "any Busy/stale sample restarts it").
+        let mid_grace = t0 + Duration::from_secs(15);
+        let effect = tracker.on_sample(mid_grace, busy_sample(Lsn::new(10)), &cfg);
+        assert_eq!(effect, TrackerEffect::None);
+        assert!(!tracker.is_quarantined());
+
+        // Now sit reader-idle + lagging for a full grace period from this point.
+        let grace_elapsed = mid_grace + cfg.grace() + Duration::from_secs(1);
+        let effect = tracker.on_sample(grace_elapsed, idle_lagging(Lsn::new(10)), &cfg);
+        assert_eq!(effect, TrackerEffect::None);
+        assert!(matches!(tracker.detect, Detect::Suspect { .. }));
+
+        // Suspect -> Confirming: issues exactly one probe.
+        let probe_time = grace_elapsed + Duration::from_millis(1);
+        let effect = tracker.on_sample(probe_time, idle_lagging(Lsn::new(10)), &cfg);
+        let TrackerEffect::IssueProbe {
+            incarnation: probe_incarnation,
+            nonce,
+        } = effect
+        else {
+            panic!("expected IssueProbe, got {effect:?}");
+        };
+        assert_eq!(probe_incarnation, incarnation);
+
+        // A stale-tagged probe result (wrong nonce) must be discarded, not drive a transition.
+        tracker.on_probe_result(
+            probe_time,
+            incarnation,
+            nonce + 1000,
+            ProbeResult::Confirmed {
+                tail_lsn: Lsn::new(12),
+            },
+            &cfg,
+        );
+        assert!(matches!(tracker.detect, Detect::Confirming { .. }));
+
+        // A failed probe backs off and stays Suspect.
+        tracker.on_probe_result(probe_time, incarnation, nonce, ProbeResult::Failed, &cfg);
+        let Detect::Suspect {
+            next_probe_at,
+            probe_backoff,
+            ..
+        } = tracker.detect
+        else {
+            panic!("expected Suspect after a failed probe");
+        };
+        assert_eq!(next_probe_at, probe_time + cfg.probe_backoff_base());
+        assert_eq!(probe_backoff, cfg.probe_backoff_base() * 2);
+
+        // Retry the probe after backoff; this time confirm the lag.
+        let retry_time = next_probe_at;
+        let effect = tracker.on_sample(retry_time, idle_lagging(Lsn::new(10)), &cfg);
+        let TrackerEffect::IssueProbe {
+            nonce: retry_nonce, ..
+        } = effect
+        else {
+            panic!("expected a retried probe, got {effect:?}");
+        };
+        tracker.on_probe_result(
+            retry_time,
+            incarnation,
+            retry_nonce,
+            ProbeResult::Confirmed {
+                tail_lsn: Lsn::new(12),
+            },
+            &cfg,
+        );
+        let Detect::Observing { until, .. } = tracker.detect else {
+            panic!("expected Observing after a confirmed probe");
+        };
+        assert_eq!(until, retry_time + cfg.recovery_window());
+
+        // Still idle, no progress once the recovery window elapses -> Stalled, quarantined.
+        let stalled_time = until;
+        let effect = tracker.on_sample(stalled_time, idle_lagging(Lsn::new(10)), &cfg);
+        assert_eq!(effect, TrackerEffect::None);
+        assert!(matches!(tracker.detect, Detect::Stalled { .. }));
+        let Some(QuarantineEpisode::ApplyStall {
+            bail_lsn, bails, ..
+        }) = tracker.quarantine()
+        else {
+            panic!("expected an ApplyStall quarantine episode");
+        };
+        assert_eq!(bail_lsn, Lsn::new(10));
+        assert_eq!(bails, 0);
+
+        // Bail fires once bail_grace has elapsed from the Stalled entry.
+        let bail_time = stalled_time + cfg.bail_grace() + Duration::from_secs(1);
+        let effect = tracker.on_sample(bail_time, idle_lagging(Lsn::new(10)), &cfg);
+        assert_eq!(effect, TrackerEffect::Bail);
+        let Some(QuarantineEpisode::ApplyStall {
+            bail_lsn, bails, ..
+        }) = tracker.quarantine()
+        else {
+            panic!("expected the ApplyStall episode to persist across the bail");
+        };
+        assert_eq!(bail_lsn, Lsn::new(10));
+        assert_eq!(bails, 1);
+
+        // Simulate the incarnation change after restart: fresh grace, quarantine retained.
+        let restart_time = bail_time + Duration::from_millis(1);
+        let new_incarnation = Ulid::new();
+        tracker.on_incarnation_started(restart_time, new_incarnation);
+        assert!(
+            tracker.is_quarantined(),
+            "quarantine must survive a restart"
+        );
+        assert_eq!(
+            tracker.last_known_lsn(),
+            None,
+            "progress resets on incarnation change"
+        );
+
+        // Real progress (past bail_lsn) is the only thing that clears an ApplyStall episode.
+        let progress_time = restart_time + Duration::from_secs(1);
+        let effect = tracker.on_sample(
+            progress_time,
+            TickInput {
+                last_applied_lsn: Some(Lsn::new(11)),
+                replay_status: ReplayStatus::CatchingUp,
+                loop_state: LoopState::ReaderIdle,
+                fresh_tail: Some(Lsn::new(13)),
+            },
+            &cfg,
+        );
+        assert_eq!(effect, TrackerEffect::None);
+        assert!(
+            !tracker.is_quarantined(),
+            "progress past bail_lsn must clear the ApplyStall episode"
+        );
+    }
+
+    /// C2/rule 10: a caught-up idle processor that goes loop-dead, is bailed, and restarts with a
+    /// fresh heartbeat and no new records must have its quarantine cleared on heartbeat recovery
+    /// alone -- there may be no new LSN to prove progress against.
+    #[test]
+    fn loop_dead_idle_clears_on_restart() {
+        let cfg = cfg();
+        let t0 = Instant::now();
+        let incarnation = Ulid::new();
+        let mut tracker = TrackerEntry::new(incarnation, t0, &cfg);
+
+        // Establish a known LSN so bail_lsn / progress checks have something to compare against.
+        tracker.on_sample(
+            t0,
+            TickInput {
+                last_applied_lsn: Some(Lsn::new(5)),
+                replay_status: ReplayStatus::Active,
+                loop_state: LoopState::ReaderIdle,
+                fresh_tail: Some(Lsn::new(6)),
+            },
+            &cfg,
+        );
+
+        let dead_time = t0 + cfg.hard_grace() + Duration::from_secs(1);
+        let effect = tracker.on_sample(dead_time, loop_dead_sample(Some(Lsn::new(5))), &cfg);
+        assert_eq!(effect, TrackerEffect::Bail);
+        assert!(matches!(
+            tracker.quarantine(),
+            Some(QuarantineEpisode::LoopDead { .. })
+        ));
+
+        // New incarnation after restart; no new records arrive (idle at tail).
+        let restart_time = dead_time + Duration::from_millis(1);
+        let new_incarnation = Ulid::new();
+        tracker.on_incarnation_started(restart_time, new_incarnation);
+        assert!(
+            tracker.is_quarantined(),
+            "quarantine must survive the restart"
+        );
+
+        let idle_after_restart = restart_time + Duration::from_secs(1);
+        let effect = tracker.on_sample(
+            idle_after_restart,
+            TickInput {
+                last_applied_lsn: Some(Lsn::new(5)), // unchanged: nothing new to apply
+                replay_status: ReplayStatus::Active,
+                loop_state: LoopState::ReaderIdle,
+                fresh_tail: Some(Lsn::new(6)),
+            },
+            &cfg,
+        );
+        assert_eq!(effect, TrackerEffect::None);
+        assert!(
+            !tracker.is_quarantined(),
+            "a fresh heartbeat alone must clear a LoopDead episode, with no LSN progress required"
+        );
+    }
+
+    /// A3: confirmed lag must promote an existing LoopDead episode rather than being blocked by
+    /// it, and a subsequent loop-dead sample must never overwrite an active ApplyStall episode's
+    /// kind (only its bail bookkeeping).
+    #[test]
+    fn apply_stall_dominates_loop_dead() {
+        let cfg = cfg();
+        let t0 = Instant::now();
+        let incarnation = Ulid::new();
+        let mut tracker = TrackerEntry::new(incarnation, t0, &cfg);
+        tracker.on_sample(
+            t0,
+            TickInput {
+                last_applied_lsn: Some(Lsn::new(10)),
+                replay_status: ReplayStatus::Active,
+                loop_state: LoopState::ReaderIdle,
+                fresh_tail: Some(Lsn::new(11)),
+            },
+            &cfg,
+        );
+
+        // Force a LoopDead episode first.
+        let dead_time = t0 + cfg.hard_grace() + Duration::from_secs(1);
+        tracker.on_sample(dead_time, loop_dead_sample(Some(Lsn::new(10))), &cfg);
+        assert!(matches!(
+            tracker.quarantine(),
+            Some(QuarantineEpisode::LoopDead { .. })
+        ));
+
+        // Manually drive the tracker into Stalled (bypassing the full grace/probe timeline is not
+        // possible via the public API, so directly assert the promotion behavior of
+        // `enter_stalled`, which is what rule 5 / the Observing->Stalled transition calls).
+        tracker.detect = Detect::Observing {
+            since: dead_time,
+            until: dead_time,
+        };
+        let recovery_time = dead_time + Duration::from_secs(1);
+        tracker.on_sample(recovery_time, idle_lagging(Lsn::new(10)), &cfg);
+        assert!(
+            matches!(
+                tracker.quarantine(),
+                Some(QuarantineEpisode::ApplyStall { .. })
+            ),
+            "confirmed lag must promote LoopDead to ApplyStall"
+        );
+
+        // A subsequent loop-dead sample must not revert the episode kind back to LoopDead.
+        let later_dead_time = recovery_time + cfg.hard_grace() + Duration::from_secs(1);
+        tracker.on_sample(later_dead_time, loop_dead_sample(Some(Lsn::new(10))), &cfg);
+        assert!(
+            matches!(
+                tracker.quarantine(),
+                Some(QuarantineEpisode::ApplyStall { .. })
+            ),
+            "a loop-dead sample must never overwrite an active ApplyStall episode's kind"
+        );
+    }
+
+    /// A5: the sweep must round-robin by *attempt* time, not success time, so a partition whose
+    /// `ConsistentRead` probes always error or time out cannot starve the others of the single
+    /// node-wide probe slot.
+    #[test]
+    fn sweep_fairness_under_persistent_failure() {
+        let t0 = Instant::now();
+        let mut observations: BTreeMap<u16, TailObservation> = (0..4)
+            .map(|id| (id, TailObservation::new(Lsn::new(1), t0)))
+            .collect();
+
+        let mut picks_per_partition: BTreeMap<u16, u32> = BTreeMap::new();
+        let mut now = t0;
+        for round in 0u64..40 {
+            let picked = pick_next_consistent_read_sweep_target(
+                observations.iter().map(|(&id, obs)| (id, obs)),
+            )
+            .expect("at least one partition must be picked");
+            *picks_per_partition.entry(picked).or_default() += 1;
+            now += Duration::from_secs(5);
+
+            let obs = observations.get_mut(&picked).unwrap();
+            if picked == 0 {
+                // Partition 0 always errors/times out: only its attempt clock advances.
+                obs.mark_consistent_attempt(now);
+            } else {
+                obs.observe_consistent(Lsn::new(2 + round), now);
+            }
+        }
+
+        // Every partition, including the permanently-failing one, must have been picked a
+        // roughly even number of times -- none may be starved by the always-failing partition
+        // monopolizing the slot, and the always-failing partition must not itself be starved by
+        // the others.
+        assert_eq!(
+            picks_per_partition.len(),
+            4,
+            "every partition must get a turn"
+        );
+        for (&id, &picks) in &picks_per_partition {
+            assert!(
+                picks >= 8,
+                "partition {id} was picked only {picks} times out of 40 rounds across 4 partitions"
+            );
+        }
+    }
+
+    #[test]
+    fn heartbeat_view_loop_state_classification() {
+        let cfg = cfg();
+        let t0 = Instant::now();
+        let mut view = HeartbeatView::new(t0);
+
+        // A fresh InSelect beat is reader-idle.
+        view.observe((LoopPhase::InSelect, 1), t0);
+        assert_eq!(view.loop_state(t0, &cfg), LoopState::ReaderIdle);
+
+        // The same beat, well past heartbeat_fresh but short of hard_grace, is neither idle nor
+        // dead -- the ambiguous "Stale" zone that must not arm suspicion nor prove loop-death.
+        let mid = t0 + cfg.heartbeat_fresh() + Duration::from_secs(1);
+        assert_eq!(view.loop_state(mid, &cfg), LoopState::Stale);
+
+        // Once the same beat is old enough, it proves loop-death.
+        let dead = t0 + cfg.hard_grace() + Duration::from_secs(1);
+        assert_eq!(view.loop_state(dead, &cfg), LoopState::LoopDead);
+
+        // A busy phase is Busy regardless of age.
+        view.observe((LoopPhase::ApplyingBatch, 2), t0);
+        assert_eq!(view.loop_state(dead, &cfg), LoopState::Busy);
+    }
+}

--- a/crates/worker/src/partition_processor_manager/processor_state.rs
+++ b/crates/worker/src/partition_processor_manager/processor_state.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use tokio::sync::watch;
@@ -21,7 +22,7 @@ use restate_types::identifiers::LeaderEpoch;
 use restate_types::net::partition_processor::PartitionLeaderService;
 use restate_types::sharding::KeyRange;
 
-use crate::partition::{LeadershipInfo, TargetLeaderState};
+use crate::partition::{LeadershipInfo, LoopHeartbeat, TargetLeaderState};
 
 pub type LeaderEpochToken = Ulid;
 
@@ -328,6 +329,7 @@ pub struct StartedProcessor {
     control_tx: watch::Sender<TargetLeaderState>,
     rpc_shard_tx: ShardSender<PartitionLeaderService>,
     watch_rx: watch::Receiver<PartitionProcessorStatus>,
+    heartbeat: Arc<LoopHeartbeat>,
 }
 
 impl StartedProcessor {
@@ -337,6 +339,7 @@ impl StartedProcessor {
         control_tx: watch::Sender<TargetLeaderState>,
         rpc_shard_tx: ShardSender<PartitionLeaderService>,
         watch_rx: watch::Receiver<PartitionProcessorStatus>,
+        heartbeat: Arc<LoopHeartbeat>,
     ) -> Self {
         Self {
             cancellation_token,
@@ -344,7 +347,12 @@ impl StartedProcessor {
             control_tx,
             rpc_shard_tx,
             watch_rx,
+            heartbeat,
         }
+    }
+
+    pub fn heartbeat(&self) -> &Arc<LoopHeartbeat> {
+        &self.heartbeat
     }
 
     fn cancel(&self) {

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -28,7 +28,7 @@ use restate_wal_protocol::Envelope;
 
 use crate::PartitionProcessorBuilder;
 use crate::partition::NodeContext;
-use crate::partition::{ProcessorError, TargetLeaderState};
+use crate::partition::{LoopHeartbeat, ProcessorError, TargetLeaderState};
 use crate::partition_processor_manager::processor_state::StartedProcessor;
 
 pub struct SpawnPartitionProcessorTask<T> {
@@ -89,8 +89,15 @@ where
         let (control_tx, control_rx) = watch::channel(TargetLeaderState::Follower);
         let (net_tx, net_rx) = ShardSender::new();
         let (watch_tx, watch_rx) = watch::channel(PartitionProcessorStatus::default());
+        let heartbeat = Arc::new(LoopHeartbeat::new());
 
-        let pp_builder = PartitionProcessorBuilder::new(control_rx, net_rx, watch_tx, node_ctx);
+        let pp_builder = PartitionProcessorBuilder::new(
+            control_rx,
+            net_rx,
+            watch_tx,
+            node_ctx,
+            Arc::clone(&heartbeat),
+        );
 
         let key_range = partition.key_range;
 
@@ -239,6 +246,7 @@ where
             control_tx,
             net_tx,
             watch_rx,
+            heartbeat,
         );
 
         Ok((state, root_task_handle))

--- a/release-notes/unreleased/apply-stall-detection-and-self-bail.md
+++ b/release-notes/unreleased/apply-stall-detection-and-self-bail.md
@@ -1,0 +1,59 @@
+# Release Notes: Automatic detection and recovery of stalled partition processors
+
+## Behavioral Change / New Feature
+
+### What Changed
+A partition processor whose apply loop is stalled -- the log has records past the last applied
+LSN, but the processor is neither applying them nor doing other legitimate work -- previously kept
+reporting `replay_status = active` indefinitely. Recovering it required an operator to notice and
+manually restart the node or run `restatectl partition leader pin` to move leadership elsewhere.
+
+Each worker's partition processor manager now runs an apply-progress tracker per partition. It
+combines a lightweight heartbeat from the partition processor's own event loop with periodic tail
+observations (including a new low-rate, authoritative `ConsistentRead` check that can't be fooled
+by a stale cached tail) to distinguish a genuinely stalled processor from one that is idle, busy
+applying a large batch, or doing legitimate long-running work such as leader initialization.
+
+When a stall is confirmed:
+- The reported replay status is downgraded from `Active` to `CatchingUp`, and a new
+  `apply_stalled_since` timestamp is attached to the partition's status, visible via
+  `restatectl partition list` and the `partition_state` introspection table.
+- If the stall persists past a grace period, the processor cooperatively stops itself and is
+  restarted by the manager's existing supervision -- no new partition processor is ever started
+  alongside a still-running one, and the node never force-exits the process.
+- The quarantine signal is sticky: it survives the Starting/Stopping states around the restart and
+  is only cleared once the worker observes real progress past the LSN recorded at quarantine time
+  (or, for a loop that had stopped scheduling entirely rather than lagging, once its heartbeat is
+  fresh again).
+- The cluster controller's leader-selection scheduler treats a quarantined node as ineligible for
+  leadership. If every alive replica of a partition is quarantined, the controller stops trying to
+  reassign that partition's leader (`target_leader` is cleared) rather than repeatedly re-electing
+  a node that cannot make progress; a `restatectl partition leader pin`/freeze remains available for
+  manual override.
+
+A healthy but idle partition processor -- caught up with the log and simply waiting for new work --
+is never touched by this detection.
+
+### Why This Matters
+Previously, a wedged partition processor could silently report itself as healthy while making no
+progress, hiding the problem from monitoring and requiring manual intervention to recover. This
+closes that gap: detection and recovery now happen automatically, and the unhealthy state is
+visible in the reported status the whole time it persists.
+
+### Impact on Users
+- New `worker.stall-detection` configuration section (enabled by default) controls the grace
+  periods, probe timeouts, and backoff used by the detector; see the configuration reference for
+  the full list of keys.
+- New metrics: `restate.partition.apply_stalled`, `restate.partition.apply_phase_stuck`, and
+  `restate.partition.stop_stuck`.
+- New `apply_stalled_since` field on partition processor status, surfaced through
+  `restatectl partition list` and the `partition_state` datafusion table.
+- Partition processors may now restart automatically in scenarios that previously required manual
+  intervention; this is expected behavior and is logged and reflected in the metrics above.
+
+### Migration Guidance
+No action required. Operators who want to disable the new detection can set
+`worker.stall-detection.enabled = false`.
+
+### Related Issues
+- Defect B: partition processor apply-stall detection and safe self-bail.

--- a/release-notes/unreleased/apply-stall-detection-and-self-bail.md
+++ b/release-notes/unreleased/apply-stall-detection-and-self-bail.md
@@ -34,6 +34,14 @@ When a stall is confirmed:
 A healthy but idle partition processor -- caught up with the log and simply waiting for new work --
 is never touched by this detection.
 
+A second, faster-acting watchdog covers a leader-elect specifically: if a candidate's own
+`AnnounceLeader` marker commits to the log but is never applied within
+`candidate-activation-timeout` (default 30s from commit, extended for as long as the candidate
+keeps making apply progress on other backlog), it self-bails immediately rather than waiting on the
+slower general detector. This is quarantined the same way -- the committed-but-unapplied marker is
+itself authoritative evidence of a stall, so the partition is marked `apply_stalled_since` and
+excluded from leader candidacy until real progress is observed.
+
 ### Why This Matters
 Previously, a wedged partition processor could silently report itself as healthy while making no
 progress, hiding the problem from monitoring and requiring manual intervention to recover. This

--- a/tools/restatectl/src/commands/partition/list.rs
+++ b/tools/restatectl/src/commands/partition/list.rs
@@ -185,6 +185,7 @@ pub async fn list_partitions(
                     processor.status.effective_mode(),
                     processor.status.replay_status(),
                     processor.status.target_tail_lsn.map(Into::into),
+                    processor.status.apply_stalled_since,
                 ),
                 Cell::new(
                     processor
@@ -309,7 +310,24 @@ fn render_mode(
     }
 }
 
-fn render_replay_status(effective: RunMode, status: ReplayStatus, target_lsn: Option<Lsn>) -> Cell {
+fn render_replay_status(
+    effective: RunMode,
+    status: ReplayStatus,
+    target_lsn: Option<Lsn>,
+    apply_stalled_since: Option<prost_types::Timestamp>,
+) -> Cell {
+    if apply_stalled_since.is_some() {
+        // The apply-stall detector already downgrades the underlying replay status to
+        // CatchingUp, but call it out explicitly so it isn't mistaken for ordinary catch-up.
+        return Cell::new(format!(
+            "Stalled ({})",
+            target_lsn
+                .map(|x| x.to_string())
+                .unwrap_or_else(|| "-".to_owned())
+        ))
+        .fg(Color::Red);
+    }
+
     match (status, effective) {
         (ReplayStatus::Unknown, _) => Cell::new("UNKNOWN").fg(Color::Red),
         (ReplayStatus::Starting, _) => Cell::new("Starting").fg(Color::Yellow),


### PR DESCRIPTION
## Problem

A partition processor whose apply loop silently stalls while records are available — for example when its log read stream is wedged — keeps reporting `replay_status = Active`. Because leader selection treats `Active` as healthy, such a node remains a first-class leadership candidate. If it is elected, it can never actually activate: becoming effective leader requires applying its own `AnnounceLeader` marker off the same stalled reader. The partition is then left without an effective leader and with no automatic recovery; today the only remedy is a manual `restatectl partition leader pin`.

## What this does

Two guarantees, carefully gated so a healthy-idle or legitimately long-applying processor is never affected:

1. A stalled processor stops looking healthy (truthful status).
2. A wedged processor safely self-bails (restart) so it recovers automatically.

Three parts, landed as three stages:

- **Apply-progress tracker (worker).** A per-partition `ApplyProgressTracker` fed by a lightweight per-loop `LoopHeartbeat` and tail observations. It detects "lagging + not advancing + reader-idle", confirms with an authoritative `ConsistentRead` probe (plus a mandatory low-rate round-robin sweep so a stale cached tail cannot hide a wedge), allows a recovery window (the confirmation probe can itself unblock the reader), then overlays the reported status (`Active → CatchingUp` and a new `apply_stalled_since`) and — if the stall persists — self-bails via a cooperative stop and supervised restart. It distinguishes a silently-stalled loop (stale `InSelect` heartbeat) from a legitimate long apply (`ApplyingBatch`), and revalidates immediately before stopping so a processor that resumed in the meantime is never bailed.

- **Leadership quarantine (scheduler).** A generation-keyed quarantine derived from the worker's durable `apply_stalled_since`. A quarantined node is excluded from leader candidacy, and `target_leader` is cleared when every replica is quarantined — ending the otherwise-endless re-instruct loop. Fails closed when a node's generation is momentarily unavailable but a quarantine memo exists.

- **Candidate activation watchdog.** A leader-elect that commits its `AnnounceLeader` marker but cannot apply it within a bounded timeout bails (restart), bounding the "elected but cannot activate" window instead of waiting on the slower stall detector.

## Compatibility

Additive wire field only (`apply_stalled_since`, a new optional `PartitionProcessorStatus` field — no `ReplayStatus` enum change). Mixed-version safe: an older controller falls back to the existing `CatchingUp` leader-score penalty; an older worker simply never sets the field.

## Config, metrics, visibility

- New `worker.stall-detection` options (all durations, with conservative defaults; the feature can be disabled).
- New metrics: `restate.partition.apply_stalled`, `restate.partition.apply_phase_stuck`, `restate.partition.stop_stuck`.
- `apply_stalled_since` is surfaced in `restatectl partition list` and the `partition_state` introspection table.
- Release note included.

## Testing

- Unit tests: tracker state machine (grace/observe/stall/bail transitions, episode precedence, sweep fairness), heartbeat coherence, scheduler quarantine + `target_leader` clearing, and the Candidate watchdog.
- Integration tests (PPM harness): an end-to-end frozen-reader scenario (detect → quarantine via the status overlay → self-bail → restart → recover to `Active`), a long-apply negative control, and pre-stop-revalidation reject/commit paths.
- `cargo clippy --all-features --tests -- -D warnings` clean; `cargo fmt` clean.

## Follow-up (non-blocking)

Strengthen the frozen-reader integration test's non-vacuity — a fully no-op bail would currently escape it (it is backstopped by the pre-stop-revalidation unit tests, which assert the stop path directly).

Related to the log read-stream freeze fixes (#5049, #5054); this hardens the partition-processor / leadership layer against the same class of wedge.
