### PR TITLE
[worker] Change background appender channel to be memory-bound instead of record count bound

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,6 +1104,7 @@ dependencies = [
  "restate-bifrost",
  "restate-core",
  "restate-errors",
+ "restate-memory",
  "restate-metadata-server",
  "restate-rocksdb",
  "restate-test-util",

--- a/crates/bifrost/src/background_appender.rs
+++ b/crates/bifrost/src/background_appender.rs
@@ -13,6 +13,7 @@ use std::num::NonZeroUsize;
 use bytes::BytesMut;
 use futures::FutureExt;
 use pin_project::pin_project;
+use restate_memory::{MemoryLease, MemoryPool, NonZeroByteCount};
 use tokio::sync::mpsc::error::TryRecvError;
 use tokio::sync::{mpsc, oneshot};
 use tracing::{trace, warn};
@@ -31,8 +32,9 @@ use crate::{Appender, InputRecord, Result};
 #[pin_project]
 pub struct BackgroundAppender<T> {
     appender: Appender<T>,
-    /// The number of records that can be buffered in the append queue
-    queue_capacity: usize,
+    /// Memory pool that buffered records are charged against (see [`LogSender::enqueue`]).
+    /// The appender enforces the memory pool budget at enqueue time.
+    memory_pool: MemoryPool,
     /// The number of records that can get batched together before appending to the log
     max_batch_size: usize,
     /// Reusable vector for buffering recv() operations
@@ -42,10 +44,19 @@ pub struct BackgroundAppender<T> {
 }
 
 impl<T: StorageEncode> BackgroundAppender<T> {
-    pub fn new(appender: Appender<T>, queue_capacity: usize, max_batch_size: usize) -> Self {
+    /// If `memory_limit` is provided, each buffered record reserves its estimated encoded size
+    /// from an internally owned pool (going into overdraft if needed) and releases it after the
+    /// record is durably appended.
+    pub fn new(
+        appender: Appender<T>,
+        memory_limit: Option<NonZeroByteCount>,
+        max_batch_size: usize,
+    ) -> Self {
         Self {
             appender,
-            queue_capacity,
+            memory_pool: memory_limit
+                .map(MemoryPool::with_capacity)
+                .unwrap_or(MemoryPool::unlimited()),
             max_batch_size,
             current_batch: Batch::with_capacity(max_batch_size),
             notif_buffer: Vec::with_capacity(max_batch_size),
@@ -56,7 +67,8 @@ impl<T: StorageEncode> BackgroundAppender<T> {
     /// automatically react to TaskCenter's shutdown signal, it gives control over the shutdown
     /// behaviour to the owner of [`AppenderHandle`] to drain or drop when appropriate.
     pub fn start(self, name: &'static str) -> Result<AppenderHandle<T>, ShutdownError> {
-        let (tx, rx) = tokio::sync::mpsc::channel(self.queue_capacity);
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let mem_pool = self.memory_pool.clone();
         let record_size_limit = self.appender.record_size_limit();
         let preference = self.appender.preference.clone();
 
@@ -70,6 +82,7 @@ impl<T: StorageEncode> BackgroundAppender<T> {
             inner_handle: Some(handle),
             sender: Some(LogSender {
                 arena: BytesMut::default(),
+                mem_pool,
                 tx,
                 record_size_limit,
                 preference,
@@ -78,7 +91,7 @@ impl<T: StorageEncode> BackgroundAppender<T> {
         })
     }
 
-    async fn run(self, mut rx: mpsc::Receiver<AppendOperation>) -> Result<()> {
+    async fn run(self, mut rx: mpsc::UnboundedReceiver<AppendOperation>) -> Result<()> {
         let Self {
             mut appender,
             max_batch_size,
@@ -163,13 +176,17 @@ impl<T: StorageEncode> BackgroundAppender<T> {
         notif_buffer: &mut Vec<oneshot::Sender<()>>,
     ) -> Result<()> {
         let mut batch = Vec::with_capacity(buffered_records.inner.len());
+        // Holds the batch's memory leases until the append completes.
+        let mut leases = Vec::with_capacity(buffered_records.inner.len());
         for record in buffered_records.inner.drain(..) {
             match record {
-                AppendOperation::Enqueue(record) => {
+                AppendOperation::Enqueue(record, lease) => {
                     batch.push(record);
+                    leases.push(lease);
                 }
-                AppendOperation::EnqueueWithNotification(record, tx) => {
+                AppendOperation::EnqueueWithNotification(record, tx, lease) => {
                     batch.push(record);
+                    leases.push(lease);
                     notif_buffer.push(tx);
                 }
                 AppendOperation::Canary(tx) => {
@@ -182,6 +199,9 @@ impl<T: StorageEncode> BackgroundAppender<T> {
         if !batch.is_empty() {
             appender.append_batch_erased(batch.into()).await?;
         }
+
+        // Records are durably appended, we can now drop the leases.
+        drop(leases);
 
         // Notify those who asked for a commit notification
         notif_buffer.drain(..).for_each(|tx| {
@@ -248,9 +268,14 @@ impl<T> AppenderHandle<T> {
         Ok(())
     }
 
-    /// If you need an owned LogSender, clone this.
+    /// Returns the sender owned by this handle.
     pub fn sender(&mut self) -> &mut LogSender<T> {
         self.sender.as_mut().unwrap()
+    }
+
+    /// Returns a shared reference to the sender owned by this handle.
+    pub fn sender_ref(&self) -> &LogSender<T> {
+        self.sender.as_ref().unwrap()
     }
 
     /// Waits for the underlying appender task to finish.
@@ -267,9 +292,15 @@ impl<T> AppenderHandle<T> {
     }
 }
 
+pub struct EnqueueWithNotificationResult {
+    pub commit_token: CommitToken,
+    pub bytes_written: usize,
+}
+
 pub struct LogSender<T> {
     arena: BytesMut,
-    tx: tokio::sync::mpsc::Sender<AppendOperation>,
+    mem_pool: MemoryPool,
+    tx: tokio::sync::mpsc::UnboundedSender<AppendOperation>,
     record_size_limit: NonZeroUsize,
     /// Controls the recovery preference of the underlying appender.
     ///
@@ -278,20 +309,29 @@ pub struct LogSender<T> {
     _phantom: std::marker::PhantomData<T>,
 }
 
-impl<T> Clone for LogSender<T> {
-    fn clone(&self) -> Self {
-        Self {
-            arena: BytesMut::default(),
-            tx: self.tx.clone(),
-            record_size_limit: self.record_size_limit,
-            preference: self.preference.clone(),
-            _phantom: std::marker::PhantomData,
+impl<T: StorageEncode> LogSender<T> {
+    /// Returns whether the next record or batch can be admitted.
+    pub fn has_capacity(&self) -> bool {
+        self.mem_pool.available() > 0
+    }
+
+    /// Waits until the next record or batch can be admitted.
+    pub fn wait_for_capacity(&self) -> impl std::future::Future<Output = ()> + 'static {
+        let mem_pool = self.mem_pool.clone();
+        async move { mem_pool.wait_until_available().await }
+    }
+
+    fn admit<E>(&self, payload: E) -> Result<E, EnqueueError<E>> {
+        if self.tx.is_closed() {
+            Err(EnqueueError::Closed(payload))
+        } else if self.mem_pool.available() == 0 {
+            Err(EnqueueError::Full(payload))
+        } else {
+            Ok(payload)
         }
     }
-}
 
-impl<T: StorageEncode> LogSender<T> {
-    fn check_record_size<E>(&self, record: &Record) -> Result<(), EnqueueError<E>> {
+    fn check_record_size<E>(&self, record: &Record) -> Result<usize, EnqueueError<E>> {
         let record_size = record.estimated_encode_size();
         if record_size > self.record_size_limit.get() {
             return Err(EnqueueError::RecordTooLarge {
@@ -299,163 +339,173 @@ impl<T: StorageEncode> LogSender<T> {
                 limit: self.record_size_limit,
             });
         }
-        Ok(())
+        Ok(record_size)
     }
 
-    /// Attempt to enqueue a record to the appender. Returns immediately if the
-    /// appender is pushing back or if the appender is draining or drained.
-    pub fn try_enqueue<A>(&mut self, record: A) -> Result<(), EnqueueError<A>>
-    where
-        A: Into<InputRecord<T>>,
-    {
-        let permit = match self.tx.try_reserve() {
-            Ok(permit) => permit,
-            Err(mpsc::error::TrySendError::Full(_)) => return Err(EnqueueError::Full(record)),
-            Err(mpsc::error::TrySendError::Closed(_)) => return Err(EnqueueError::Closed(record)),
-        };
-
-        let record = record.into().into_record().ensure_encoded(&mut self.arena);
-        self.check_record_size(&record)?;
-        permit.send(AppendOperation::Enqueue(record));
-        Ok(())
-    }
-
-    /// Enqueues an append and returns a commit token
-    pub fn try_enqueue_with_notification<A>(
-        &mut self,
-        record: A,
-    ) -> Result<CommitToken, EnqueueError<A>>
-    where
-        A: Into<InputRecord<T>>,
-    {
-        let permit = match self.tx.try_reserve() {
-            Ok(permit) => permit,
-            Err(mpsc::error::TrySendError::Full(_)) => return Err(EnqueueError::Full(record)),
-            Err(mpsc::error::TrySendError::Closed(_)) => return Err(EnqueueError::Closed(record)),
-        };
-
-        let (tx, rx) = oneshot::channel();
-        let record = record.into().into_record().ensure_encoded(&mut self.arena);
-        self.check_record_size(&record)?;
-        permit.send(AppendOperation::EnqueueWithNotification(record, tx));
-        Ok(CommitToken { rx })
-    }
-
-    /// Waits for capacity on the channel and returns an error if the appender is
+    /// Enqueues a record while charging its estimated size to the appender's memory
+    /// pool. Returns [`EnqueueError::Full`] without encoding the record if the pool is exhausted.
+    /// Otherwise, the record is admitted and may put the pool into deficit once its encoded size
+    /// is known. Also returns an error if the record exceeds the size limit or if the appender is
     /// draining or drained.
-    pub async fn enqueue<A>(&mut self, record: A) -> Result<(), EnqueueError<A>>
+    pub fn enqueue<A>(&mut self, record: A) -> Result<usize, EnqueueError<Record>>
     where
         A: Into<InputRecord<T>>,
     {
-        let Ok(permit) = self.tx.reserve().await else {
-            return Err(EnqueueError::Closed(record));
-        };
-        let record = record.into().into_record().ensure_encoded(&mut self.arena);
-        self.check_record_size(&record)?;
-        permit.send(AppendOperation::Enqueue(record));
+        let record = self.admit(record.into().into_record())?;
+        let record = record.ensure_encoded(&mut self.arena);
+        let record_size = self.check_record_size(&record)?;
+        let lease = self.mem_pool.force_reserve(record_size);
+        self.tx
+            .send(AppendOperation::Enqueue(record, lease))
+            .map_err(|r| {
+                EnqueueError::Closed(record_from_append_operation(r.0).expect("has record"))
+            })?;
 
-        Ok(())
+        Ok(record_size)
     }
 
-    /// Waits for capacity on the channel and returns an error if the appender is
-    /// draining or drained.
+    /// Enqueues a record bypassing all memory accounting (i.e. will never fail with `Full`).
+    pub fn enqueue_unaccounted<A>(&mut self, record: A) -> Result<usize, EnqueueError<Record>>
+    where
+        A: Into<InputRecord<T>>,
+    {
+        let record = record.into().into_record().ensure_encoded(&mut self.arena);
+        let record_size = self.check_record_size(&record)?;
+        self.tx
+            .send(AppendOperation::Enqueue(record, MemoryLease::unlinked()))
+            .map_err(|r| {
+                EnqueueError::Closed(record_from_append_operation(r.0).expect("has record"))
+            })?;
+
+        Ok(record_size)
+    }
+
+    /// Enqueues a record while charging its estimated size to the appender's memory
+    /// pool. Returns [`EnqueueError::Full`] without encoding the record if the pool is exhausted.
+    /// Otherwise, the record is admitted and may put the pool into deficit once its encoded size
+    /// is known. Returns an error if the appender is draining or drained.
     ///
     /// Unlike [`enqueue`](Self::enqueue), this does not check the record size and
     /// accepts a record of any size.
     ///
     /// Callers have to ensure that record is not larger than the network message size limit.
-    pub async fn enqueue_unchecked<A>(&mut self, record: A) -> Result<(), EnqueueError<A>>
+    pub fn enqueue_unchecked<A>(&mut self, record: A) -> Result<usize, EnqueueError<Record>>
     where
         A: Into<InputRecord<T>>,
     {
-        let Ok(permit) = self.tx.reserve().await else {
-            return Err(EnqueueError::Closed(record));
-        };
-        let record = record.into().into_record().ensure_encoded(&mut self.arena);
-        permit.send(AppendOperation::Enqueue(record));
+        let record = self.admit(record.into().into_record())?;
+        let record = record.ensure_encoded(&mut self.arena);
+        let record_size = record.estimated_encode_size();
+        let lease = self.mem_pool.force_reserve(record_size);
+        self.tx
+            .send(AppendOperation::Enqueue(record, lease))
+            .map_err(|r| {
+                EnqueueError::Closed(record_from_append_operation(r.0).expect("has record"))
+            })?;
 
-        Ok(())
+        Ok(record_size)
     }
 
-    /// Attempt to enqueue a record to the appender. Returns immediately if the
-    /// appender is pushing back or if the appender is draining or drained.
+    /// Enqueues all records in the iterator without blocking, charging their estimated sizes to
+    /// the appender's memory pool.
     ///
-    /// Attempts to enqueue all records in the iterator. This will immediately return if there is
-    /// no capacity in the channel to enqueue _all_ records.
-    pub fn try_enqueue_many<I, A>(&mut self, records: I) -> Result<(), EnqueueError<I>>
+    /// Fails with [`EnqueueError::Full`] if the memory pool is exhausted. Otherwise, the records
+    /// are admitted as one overdraft unit that may put the pool in deficit by as much as the sum of
+    /// of the record sizes.
+    ///
+    /// Note that records are enqueued one at a time: if a record fails the size check or the
+    /// appender is draining, records enqueued before the failure remain in the queue. The function
+    /// returns the estimated encoded size of all records enqueued.
+    pub fn enqueue_many<I, A>(&mut self, records: I) -> Result<usize, EnqueueError<()>>
     where
         I: Iterator<Item = A> + ExactSizeIterator,
         A: Into<InputRecord<T>>,
     {
-        let permits = match self.tx.try_reserve_many(records.len()) {
-            Ok(permit) => permit,
-            Err(mpsc::error::TrySendError::Full(_)) => return Err(EnqueueError::Full(records)),
-            Err(mpsc::error::TrySendError::Closed(_)) => return Err(EnqueueError::Closed(records)),
-        };
-
-        for (permit, record) in std::iter::zip(permits, records) {
-            let record = record.into().into_record().ensure_encoded(&mut self.arena);
-            self.check_record_size(&record)?;
-            permit.send(AppendOperation::Enqueue(record));
+        if records.len() == 0 {
+            return Ok(0);
         }
-        Ok(())
+        self.admit(())?;
+
+        let mut written_bytes = 0;
+        for record in records {
+            let record = record.into().into_record().ensure_encoded(&mut self.arena);
+            let record_size = self.check_record_size(&record)?;
+            let lease = self.mem_pool.force_reserve(record_size);
+            self.tx
+                .send(AppendOperation::Enqueue(record, lease))
+                .map_err(|_| EnqueueError::Closed(()))?;
+            written_bytes += record_size;
+        }
+
+        Ok(written_bytes)
     }
 
-    /// Attempts to enqueue all records in the iterator. This function waits until there is enough
-    /// capacity in the channel to enqueue _all_ records to avoid partial enqueues.
+    /// Enqueues all records in the iterator without blocking or checking their encoded sizes.
+    /// The entire iterator is admitted as one overdraft unit.
     ///
-    /// The method is cancel safe in the sense that if enqueue_many is used in a `tokio::select!`,
-    /// no records are enqueued if another branch completed.
-    pub async fn enqueue_many<I, A>(&mut self, records: I) -> Result<(), EnqueueError<I>>
+    /// Fails with [`EnqueueError::Full`] if the memory pool is exhausted. Otherwise, the records
+    /// are admitted as one overdraft unit that may put the pool in deficit by as much as the sum of
+    /// of the record sizes.
+    ///
+    /// Callers have to ensure that every record is not larger than the network message size limit.
+    pub fn enqueue_many_unchecked<I, A>(&mut self, records: I) -> Result<usize, EnqueueError<()>>
     where
         I: Iterator<Item = A> + ExactSizeIterator,
         A: Into<InputRecord<T>>,
     {
-        let Ok(permits) = self.tx.reserve_many(records.len()).await else {
-            return Err(EnqueueError::Closed(records));
-        };
+        if records.len() == 0 {
+            return Ok(0);
+        }
+        self.admit(())?;
 
-        for (permit, record) in std::iter::zip(permits, records) {
+        let mut written_bytes = 0;
+        for record in records {
             let record = record.into().into_record().ensure_encoded(&mut self.arena);
-            self.check_record_size(&record)?;
-            permit.send(AppendOperation::Enqueue(record));
+            let record_size = record.estimated_encode_size();
+            let lease = self.mem_pool.force_reserve(record_size);
+            self.tx
+                .send(AppendOperation::Enqueue(record, lease))
+                .map_err(|_| EnqueueError::Closed(()))?;
+            written_bytes += record_size;
         }
 
-        Ok(())
+        Ok(written_bytes)
     }
 
-    /// Enqueues a record and returns a [`CommitToken`] future that's resolved when the record is
-    /// committed.
-    pub async fn enqueue_with_notification<A>(
+    /// Enqueues a record and returns its estimated encoded size together with a [`CommitToken`]
+    /// future that's resolved when the record is committed.
+    /// Returns [`EnqueueError::Full`] without encoding the record if the pool is exhausted.
+    /// Otherwise, the record is admitted and may put the pool into deficit once its encoded size
+    /// is known.
+    pub fn enqueue_with_notification<A>(
         &mut self,
         record: A,
-    ) -> Result<CommitToken, EnqueueError<A>>
+    ) -> Result<EnqueueWithNotificationResult, EnqueueError<Record>>
     where
         A: Into<InputRecord<T>>,
     {
-        let Ok(permit) = self.tx.reserve().await else {
-            return Err(EnqueueError::Closed(record));
-        };
-
+        let record = self.admit(record.into().into_record())?;
         let (tx, rx) = oneshot::channel();
-        let record = record.into().into_record().ensure_encoded(&mut self.arena);
-        self.check_record_size(&record)?;
-        permit.send(AppendOperation::EnqueueWithNotification(record, tx));
+        let record = record.ensure_encoded(&mut self.arena);
+        let record_size = self.check_record_size(&record)?;
+        let lease = self.mem_pool.force_reserve(record_size);
+        self.tx
+            .send(AppendOperation::EnqueueWithNotification(record, tx, lease))
+            .map_err(|a| {
+                EnqueueError::Closed(record_from_append_operation(a.0).expect("has record"))
+            })?;
 
-        Ok(CommitToken { rx })
+        Ok(EnqueueWithNotificationResult {
+            commit_token: CommitToken { rx },
+            bytes_written: record_size,
+        })
     }
 
     /// Returns a [`CommitToken`] that is resolved once all previously enqueued records are committed.
-    pub async fn notify_committed(&self) -> Result<CommitToken, EnqueueError<()>> {
-        let Ok(permit) = self.tx.reserve().await else {
-            // channel is closed, this should happen the appender is draining or has been darained
-            // already
-            return Err(EnqueueError::Closed(()));
-        };
-
+    pub fn notify_committed(&self) -> Result<CommitToken, EnqueueError<()>> {
         let (tx, rx) = oneshot::channel();
         let canary = AppendOperation::Canary(tx);
-        permit.send(canary);
+        self.tx.send(canary).map_err(|_| EnqueueError::Closed(()))?;
 
         Ok(CommitToken { rx })
     }
@@ -488,8 +538,8 @@ impl std::future::Future for CommitToken {
 }
 
 enum AppendOperation {
-    Enqueue(Record),
-    EnqueueWithNotification(Record, oneshot::Sender<()>),
+    Enqueue(Record, MemoryLease),
+    EnqueueWithNotification(Record, oneshot::Sender<()>, MemoryLease),
     // A message denoting a request to be notified when it's processed by the appender.
     // It's used to check if previously enqueued appends have been committed or not
     Canary(oneshot::Sender<()>),
@@ -498,8 +548,10 @@ enum AppendOperation {
 impl AppendOperation {
     fn cost_in_bytes(&self) -> usize {
         match self {
-            AppendOperation::Enqueue(record) => record.estimated_encode_size(),
-            AppendOperation::EnqueueWithNotification(record, _) => record.estimated_encode_size(),
+            AppendOperation::Enqueue(record, _) => record.estimated_encode_size(),
+            AppendOperation::EnqueueWithNotification(record, _, _) => {
+                record.estimated_encode_size()
+            }
             AppendOperation::Canary(_) => 0,
         }
     }
@@ -535,12 +587,25 @@ impl Batch {
     }
 }
 
+fn record_from_append_operation(op: AppendOperation) -> Option<Record> {
+    match op {
+        AppendOperation::Enqueue(record, _) => Some(record),
+        AppendOperation::EnqueueWithNotification(record, _, _) => Some(record),
+        AppendOperation::Canary(_) => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use static_assertions::assert_not_impl_any;
+
     use restate_types::logs::{Keys, Record};
     use restate_types::storage::PolyBytes;
     use restate_types::time::NanosSinceEpoch;
+
+    use super::*;
+
+    assert_not_impl_any!(LogSender<String>: Clone);
 
     fn make_record_with_size(size: usize) -> Record {
         // Create a record with approximately the given size
@@ -558,14 +623,14 @@ mod tests {
         // Test that Enqueue operations report their record size
         let record = make_record_with_size(100);
         let expected_size = record.estimated_encode_size();
-        let op = AppendOperation::Enqueue(record);
+        let op = AppendOperation::Enqueue(record, MemoryLease::unlinked());
         assert_eq!(op.cost_in_bytes(), expected_size);
 
         // Test that EnqueueWithNotification also reports record size
         let record = make_record_with_size(200);
         let expected_size = record.estimated_encode_size();
         let (tx, _rx) = oneshot::channel();
-        let op = AppendOperation::EnqueueWithNotification(record, tx);
+        let op = AppendOperation::EnqueueWithNotification(record, tx, MemoryLease::unlinked());
         assert_eq!(op.cost_in_bytes(), expected_size);
 
         // Test that control operations have zero cost
@@ -587,7 +652,7 @@ mod tests {
         // Add a 400-byte record
         let record = make_record_with_size(400);
         let record_size = record.estimated_encode_size();
-        batch.push(AppendOperation::Enqueue(record));
+        batch.push(AppendOperation::Enqueue(record, MemoryLease::unlinked()));
         assert_eq!(batch.bytes_accumulated, record_size);
 
         // Can fit another record if total stays under limit
@@ -609,7 +674,7 @@ mod tests {
                 "Should fit record {i}"
             );
             let record = make_record_with_size(100);
-            batch.push(AppendOperation::Enqueue(record));
+            batch.push(AppendOperation::Enqueue(record, MemoryLease::unlinked()));
         }
 
         // Now at max count, cannot fit more regardless of size
@@ -628,7 +693,7 @@ mod tests {
             let record = make_record_with_size(100);
             let size = record.estimated_encode_size();
             expected_total += size;
-            batch.push(AppendOperation::Enqueue(record));
+            batch.push(AppendOperation::Enqueue(record, MemoryLease::unlinked()));
             assert_eq!(batch.bytes_accumulated, expected_total);
         }
 

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -25,6 +25,7 @@ use restate_types::live::LiveLoadExt;
 use restate_core::MetadataWriter;
 use restate_core::my_node_id;
 use restate_core::{Metadata, ShutdownError};
+use restate_memory::NonZeroByteCount;
 use restate_types::config::Configuration;
 use restate_types::logs::metadata::SealMetadata;
 use restate_types::logs::metadata::{LogletParams, Logs, SegmentIndex};
@@ -206,16 +207,17 @@ impl Bifrost {
         ))
     }
 
+    /// See [`BackgroundAppender::new`] for the semantics of `memory_limit`.
     pub fn create_background_appender<T: StorageEncode>(
         &self,
         log_id: LogId,
         error_recovery_strategy: ErrorRecoveryStrategy,
-        queue_capacity: usize,
+        memory_limit: Option<NonZeroByteCount>,
         max_batch_size: usize,
     ) -> Result<BackgroundAppender<T>> {
         Ok(BackgroundAppender::new(
             self.create_appender(log_id, error_recovery_strategy)?,
-            queue_capacity,
+            memory_limit,
             max_batch_size,
         ))
     }
@@ -1359,7 +1361,7 @@ mod tests {
         let bifrost = Bifrost::init_in_memory(env.metadata_writer).await;
 
         let background_appender: crate::BackgroundAppender<String> = bifrost
-            .create_background_appender(LogId::new(0), ErrorRecoveryStrategy::Wait, 10, 10)?;
+            .create_background_appender(LogId::new(0), ErrorRecoveryStrategy::Wait, None, 10)?;
 
         let mut handle = background_appender.start("test-appender")?;
         let sender = handle.sender();
@@ -1367,8 +1369,8 @@ mod tests {
         // A string with 100 bytes
         let payload = String::from_utf8(vec![b't'; 100]).unwrap();
 
-        // try_enqueue should fail with RecordTooLarge
-        let result = sender.try_enqueue(payload.clone());
+        // enqueue should fail with RecordTooLarge
+        let result = sender.enqueue(payload.clone());
         assert_that!(
             result,
             pat!(Err(pat!(EnqueueError::RecordTooLarge {
@@ -1378,7 +1380,7 @@ mod tests {
         );
 
         // enqueue (async) should also fail with RecordTooLarge
-        let result = sender.enqueue(payload.clone()).await;
+        let result = sender.enqueue(payload.clone());
         assert_that!(
             result,
             pat!(Err(pat!(EnqueueError::RecordTooLarge {
@@ -1387,8 +1389,8 @@ mod tests {
             })))
         );
 
-        // try_enqueue_with_notification should also fail
-        let result = sender.try_enqueue_with_notification(payload.clone());
+        // enqueue_with_notification should also fail
+        let result = sender.enqueue_with_notification(payload.clone());
         assert!(matches!(
             result,
             Err(EnqueueError::RecordTooLarge {
@@ -1415,14 +1417,14 @@ mod tests {
         let bifrost = Bifrost::init_in_memory(env.metadata_writer).await;
 
         let background_appender: crate::BackgroundAppender<String> = bifrost
-            .create_background_appender(LogId::new(0), ErrorRecoveryStrategy::Wait, 10, 10)?;
+            .create_background_appender(LogId::new(0), ErrorRecoveryStrategy::Wait, None, 10)?;
 
         let mut handle = background_appender.start("test-appender")?;
         let sender = handle.sender();
 
         // With a 10KB limit, the ~2KB estimated record should succeed
         let payload = "test".to_string();
-        sender.enqueue(payload).await?;
+        sender.enqueue(payload)?;
 
         // Drain and wait for commit
         handle.drain().await?;
@@ -1442,21 +1444,16 @@ mod tests {
         let bifrost = Bifrost::init_in_memory(env.metadata_writer).await;
 
         let background_appender: crate::BackgroundAppender<String> = bifrost
-            .create_background_appender(LogId::new(0), ErrorRecoveryStrategy::Wait, 1000, 100)?;
+            .create_background_appender(LogId::new(0), ErrorRecoveryStrategy::Wait, None, 100)?;
 
         let mut handle = background_appender.start("test-appender")?;
         let sender = handle.sender();
 
-        // Rapidly enqueue many records using try_enqueue (non-blocking)
+        // Rapidly enqueue many records using enqueue
         let mut enqueued = 0;
         for i in 0..100 {
-            match sender.try_enqueue(format!("rapid-record-{i}")) {
-                Ok(()) => enqueued += 1,
-                Err(EnqueueError::Full(_)) => {
-                    // Queue is full, use async enqueue
-                    sender.enqueue(format!("rapid-record-{i}")).await?;
-                    enqueued += 1;
-                }
+            match sender.enqueue(format!("rapid-record-{i}")) {
+                Ok(_) => enqueued += 1,
                 Err(e) => return Err(e.into()),
             }
         }
@@ -1464,7 +1461,7 @@ mod tests {
         assert_that!(enqueued, eq(100));
 
         // Wait for all to be committed
-        let token = sender.notify_committed().await?;
+        let token = sender.notify_committed()?;
         token.await?;
 
         handle.drain().await?;

--- a/crates/bifrost/src/lib.rs
+++ b/crates/bifrost/src/lib.rs
@@ -27,7 +27,9 @@ mod types;
 mod watchdog;
 
 pub use appender::Appender;
-pub use background_appender::{AppenderHandle, BackgroundAppender, CommitToken, LogSender};
+pub use background_appender::{
+    AppenderHandle, BackgroundAppender, CommitToken, EnqueueWithNotificationResult, LogSender,
+};
 pub use bifrost::{Bifrost, ErrorRecoveryStrategy};
 pub use bifrost_admin::{BifrostAdmin, MaybeSealedSegment};
 pub use data_record::{DataRecord, DataRecordError};

--- a/crates/memory/Cargo.toml
+++ b/crates/memory/Cargo.toml
@@ -25,7 +25,7 @@ tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt", "macros", "time"] }
+tokio = { workspace = true, features = ["rt", "macros", "time", "test-util"] }
 
 [lints]
 workspace = true

--- a/crates/memory/src/pool.rs
+++ b/crates/memory/src/pool.rs
@@ -108,6 +108,20 @@ impl MemoryPool {
         }
     }
 
+    /// Returns the number of bytes in overdraft (used - capacity). Returns zero if
+    /// usage is still within capacity.
+    #[inline]
+    pub fn overdraft(&self) -> usize {
+        match &self.inner {
+            Some(inner) => {
+                let capacity = inner.capacity.load(Ordering::Relaxed);
+                let used = inner.used.load(Ordering::Relaxed);
+                used.saturating_sub(capacity)
+            }
+            None => 0,
+        }
+    }
+
     /// Tries to reserve `size` bytes without waiting.
     ///
     /// Returns `None` if insufficient capacity.
@@ -163,6 +177,59 @@ impl MemoryPool {
                         return lease;
                     }
                     notified.await;
+                }
+            }
+            None => MemoryLease {
+                budget: self.clone(),
+                size,
+            },
+        }
+    }
+
+    /// Waits until there's any available budget. There's no guarantees
+    /// though that by the time the caller is woken up, that the budget
+    /// will still be available.
+    pub async fn wait_until_available(&self) {
+        let Some(inner) = &self.inner else {
+            return;
+        };
+        loop {
+            let notified = inner.notify.notified();
+            if self.available() > 0 {
+                break;
+            }
+            notified.await;
+        }
+    }
+
+    /// Reserves `size` bytes unconditionally, without checking capacity.
+    ///
+    /// The pool may go into overdraft: `used` exceeds `capacity`, `available()`
+    /// reports 0, and ordinary `try_reserve`/`reserve` callers wait until enough
+    /// leases are returned to repay the debt. Never waits.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the total amount of reserved memory would exceed `usize::MAX`.
+    #[inline]
+    pub fn force_reserve(&self, size: usize) -> MemoryLease {
+        if size == 0 {
+            return MemoryLease {
+                budget: self.clone(),
+                size,
+            };
+        }
+        match &self.inner {
+            Some(inner) => {
+                inner
+                    .used
+                    .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |used| {
+                        used.checked_add(size)
+                    })
+                    .expect("MemoryPool used counter overflowed");
+                MemoryLease {
+                    budget: self.clone(),
+                    size,
                 }
             }
             None => MemoryLease {
@@ -480,7 +547,9 @@ const _: () = {
 
 #[cfg(test)]
 mod tests {
+    use std::assert_matches;
     use std::num::NonZeroUsize;
+    use std::time::Duration;
 
     use super::*;
 
@@ -729,5 +798,84 @@ mod tests {
 
         assert_eq!(count.load(Ordering::Relaxed), 100);
         assert_eq!(budget.used(), bytes(0));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn force_reserve() {
+        let budget = budget(100);
+        let r1 = budget.try_reserve(90).expect("should succeed");
+        assert_eq!(r1.size(), bytes(90));
+        assert_eq!(budget.used(), bytes(90));
+        assert_eq!(budget.available(), 10);
+        assert_eq!(budget.overdraft(), 0);
+
+        assert_matches!(budget.try_reserve(20), None);
+        let r2 = budget.force_reserve(20);
+        assert_eq!(r2.size(), bytes(20));
+        assert_eq!(budget.used(), bytes(110));
+        // available() should still report 0 even though we're in overdraft
+        assert_eq!(budget.available(), 0);
+        assert_eq!(budget.overdraft(), 10);
+
+        // Try to reserve anything while in overdraft will fail
+        assert_matches!(budget.try_reserve(1), None);
+
+        let r3 = budget.force_reserve(50);
+        assert_eq!(r3.size(), bytes(50));
+        assert_eq!(budget.used(), bytes(160));
+        assert_eq!(budget.available(), 0);
+        assert_eq!(budget.overdraft(), 60);
+
+        let mut waiter1 = std::pin::pin!(budget.reserve(10));
+        let mut waiter2 = std::pin::pin!(budget.wait_until_available());
+
+        // Waiters will be blocked
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), waiter1.as_mut())
+                .await
+                .is_err()
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), waiter2.as_mut())
+                .await
+                .is_err()
+        );
+
+        drop(r3);
+        assert_eq!(budget.used(), bytes(110));
+        assert_eq!(budget.available(), 0);
+        assert_eq!(budget.overdraft(), 10);
+
+        // Returning capacity while in overdraft won't fullfill waiters
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), waiter1.as_mut())
+                .await
+                .is_err()
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), waiter2.as_mut())
+                .await
+                .is_err()
+        );
+
+        drop(r2);
+        assert_eq!(budget.used(), bytes(90));
+        assert_eq!(budget.available(), 10);
+        assert_eq!(budget.overdraft(), 0);
+
+        // Only then will waiters be unblocked
+        // waiter2 is waiting for available() to be > 0, so it should be
+        // immediately unblocked.
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), waiter2.as_mut())
+                .await
+                .is_ok()
+        );
+        // waiter1 is trying to reserve 10 bytes, which it'll be able to acquire
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), waiter1.as_mut())
+                .await
+                .is_ok()
+        );
     }
 }

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -154,6 +154,19 @@ pub struct WorkerOptions {
     #[cfg_attr(feature = "schemars", schemars(skip))]
     #[serde(skip_serializing_if = "std::ops::Not::not", default)]
     pub use_multi_db_layout: bool,
+
+    /// # Self-proposal queue memory limit
+    ///
+    /// The amount of memory a partition leader may use to buffer commands it proposes to its
+    /// own log (timers, invoker effects, RPCs, etc.) before pushing back on their producers.
+    /// Larger values improve append batching and throughput at the cost of memory usage and
+    /// commit tail latency. The limit applies to each partition individually.
+    ///
+    /// Default: 64 MiB
+    ///
+    /// Since v1.7.3
+    #[cfg_attr(feature = "schemars", schemars(skip))]
+    pub self_proposal_queue_memory_limit: NonZeroByteCount,
 }
 
 impl WorkerOptions {
@@ -217,6 +230,9 @@ impl Default for WorkerOptions {
             ),
             rule_book_poll_interval: NonZeroFriendlyDuration::from_secs_unchecked(30),
             use_multi_db_layout: false,
+            self_proposal_queue_memory_limit: NonZeroByteCount::new(
+                NonZeroUsize::new(64 * 1024 * 1024).expect("non zero"),
+            ),
         }
     }
 }

--- a/crates/worker/src/partition/leadership/leader_state.rs
+++ b/crates/worker/src/partition/leadership/leader_state.rs
@@ -117,6 +117,7 @@ pub struct LeaderState {
     // Unregisters the leader-query registry entry on drop. Must live as long as
     // the partition processor's select! is willing to serve scheduler queries.
     _leader_query_guard: LeaderQueryGuard,
+    encoding_arena: BytesMut,
 }
 
 impl LeaderState {
@@ -173,6 +174,7 @@ impl LeaderState {
             network_events_tx,
             network_events_stream: ReceiverStream::new(network_events_rx),
             _leader_query_guard: leader_query_guard,
+            encoding_arena: BytesMut::with_capacity(128 * 1024),
         }
     }
 
@@ -206,33 +208,48 @@ impl LeaderState {
     ///
     /// Important: The future needs to be cancellation safe since it is polled as a tokio::select
     /// arm!
-    pub async fn run(
-        &mut self,
-        ctx: impl Processor + HasVQueues,
-    ) -> Result<Vec<LeaderEvent>, Error> {
-        let timer_stream = std::pin::pin!(stream::unfold(
-            &mut self.timer_service,
-            |timer_service| async {
-                let timer_value = timer_service.as_mut().next_timer().await;
-                Some((LeaderEvent::Timer(timer_value), timer_service))
-            }
-        ));
+    pub async fn run(&mut self, ctx: impl Processor + HasVQueues) -> Result<(), Error> {
+        let LeaderState {
+            partition_key_range,
+            shuffle_task_handle,
+            timer_service,
+            scheduler,
+            invoker_task_handle,
+            self_proposer,
+            awaiting_rpc_actions,
+            awaiting_rpc_self_propose,
+            fencing_tokens,
+            invoker_stream,
+            shuffle_stream,
+            schema_stream,
+            rule_book_stream,
+            cleaner_handle,
+            durability_tracker,
+            network_events_stream,
+            encoding_arena,
+            ..
+        } = self;
+        let partition_key_range = *partition_key_range;
+
+        let timer_stream = std::pin::pin!(stream::unfold(timer_service, |timer_service| async {
+            let timer_value = timer_service.as_mut().next_timer().await;
+            Some((LeaderEvent::Timer(timer_value), timer_service))
+        }));
         let vqueue_metas = ctx.vqueues();
 
         // todo(asoli): consider adding the scheduler pick_next() directly to the tokio::select!
         // if we have problems with latency
-        let scheduler_stream =
-            std::pin::pin!(stream::unfold(&mut self.scheduler, |scheduler| async {
-                match scheduler.schedule_next(vqueue_metas).await {
-                    Ok(decisions) => Some((LeaderEvent::Scheduler(decisions), scheduler)),
-                    Err(e) => {
-                        error!("Fatal error when polling scheduler: {e}");
-                        None
-                    }
+        let scheduler_stream = std::pin::pin!(stream::unfold(scheduler, |scheduler| async {
+            match scheduler.schedule_next(vqueue_metas).await {
+                Ok(decisions) => Some((LeaderEvent::Scheduler(decisions), scheduler)),
+                Err(e) => {
+                    error!("Fatal error when polling scheduler: {e}");
+                    None
                 }
-            }));
+            }
+        }));
 
-        let schema_stream = (&mut self.schema_stream).filter_map(|_| {
+        let schema_stream = schema_stream.filter_map(|_| {
             // only upsert schema iff version is newer than current version
             let current_version = ctx.fsm().schema_version();
 
@@ -243,7 +260,7 @@ impl LeaderState {
             )
         });
 
-        let rule_book_stream = (&mut self.rule_book_stream).filter_map(|book| {
+        let rule_book_stream = rule_book_stream.filter_map(|book| {
             // Only propose iff the cache holds a rule book that's
             // newer than the partition's current in-memory book.
             let current_version = ctx.fsm().rule_book().version();
@@ -252,62 +269,84 @@ impl LeaderState {
             )
         });
 
-        let invoker_stream = (&mut self.invoker_stream).map(LeaderEvent::Invoker);
-        let shuffle_stream = (&mut self.shuffle_stream).map(LeaderEvent::Shuffle);
-        let cleaner_stream = self.cleaner_handle.effects().map(LeaderEvent::Cleaner);
+        let invoker_stream = invoker_stream.map(LeaderEvent::Invoker);
+        let shuffle_stream = shuffle_stream.map(LeaderEvent::Shuffle);
+        let cleaner_stream = cleaner_handle.effects().map(LeaderEvent::Cleaner);
 
-        let dur_tracker_stream =
-            (&mut self.durability_tracker).map(LeaderEvent::PartitionMaintenance);
+        let dur_tracker_stream = durability_tracker.map(LeaderEvent::PartitionMaintenance);
+        let network_events_stream = network_events_stream.map(LeaderEvent::NetworkService);
 
-        let awaiting_rpc_self_propose_stream =
-            (&mut self.awaiting_rpc_self_propose).map(|_| LeaderEvent::AwaitingRpcSelfProposeDone);
-
-        let network_event_stream =
-            (&mut self.network_events_stream).map(LeaderEvent::NetworkService);
-
-        let all_streams = futures::stream_select!(
+        let mut all_streams = futures::stream_select!(
             scheduler_stream,
             invoker_stream,
             shuffle_stream,
             timer_stream,
             cleaner_stream,
-            awaiting_rpc_self_propose_stream,
             dur_tracker_stream,
             schema_stream,
             rule_book_stream,
-            network_event_stream
+            network_events_stream
         );
-        let mut all_streams = all_streams.ready_chunks(BATCH_READY_UP_TO);
 
-        let shuffle_task_handle = self.shuffle_task_handle.as_mut().expect("is set");
-        let invoker_task_handle = self.invoker_task_handle.as_mut().expect("is set");
-        tokio::select! {
-            // watch the shuffle task in case it crashed
-            result = shuffle_task_handle => {
-                // it's not possible to await the shuffler handle
-                // if it returns an error. Hence we take it here.
-                // run() should then never be called again.
-                self.shuffle_task_handle.take();
-                match result {
-                    Ok(Ok(_)) => Err(Error::task_terminated_unexpectedly("shuffle")),
-                    Ok(Err(err)) => Err(Error::task_failed("shuffle", err)),
-                    Err(shutdown_error) => Err(Error::Shutdown(shutdown_error))
+        let event = loop {
+            let event = tokio::select! {
+                // watch the shuffle task in case it crashed
+                result = &mut *shuffle_task_handle.as_mut().expect("is set") => {
+                    // it's not possible to await the shuffler handle
+                    // if it returns an error. Hence we take it here.
+                    // run() should then never be called again.
+                    shuffle_task_handle.take();
+                    return match result {
+                        Ok(Ok(_)) => Err(Error::task_terminated_unexpectedly("shuffle")),
+                        Ok(Err(err)) => Err(Error::task_failed("shuffle", err)),
+                        Err(shutdown_error) => Err(Error::Shutdown(shutdown_error))
+                    }
                 }
-            }
-            result = invoker_task_handle => {
-                self.invoker_task_handle.take();
-                match result {
-                    Ok(()) => Err(Error::task_terminated_unexpectedly("invoker")),
-                    Err(shutdown_error) => Err(Error::Shutdown(shutdown_error)),
+                result = &mut *invoker_task_handle.as_mut().expect("is set") => {
+                    invoker_task_handle.take();
+                    return match result {
+                        Ok(()) => Err(Error::task_terminated_unexpectedly("invoker")),
+                        Err(shutdown_error) => Err(Error::Shutdown(shutdown_error)),
+                    }
                 }
+                Some(event) = all_streams.next(), if self_proposer.has_capacity() => {
+                    event
+                },
+                _ = self_proposer.wait_for_capacity(), if !self_proposer.has_capacity() => {
+                    continue;
+                },
+                // Joining the inflight commit notification futures
+                Some(_) = awaiting_rpc_self_propose.next() => {
+                    continue;
+                },
+                result = self_proposer.join_on_err() => {
+                    return Err(result.expect_err("never should never be returned"))
+                }
+            };
+            break event;
+        };
+
+        let mut handled_so_far = 0;
+        let mut loop_event = Some(event);
+        // Let's greedly handle ready events as long as we have capacity to self-propose.
+        while let Some(event) = loop_event {
+            let mut handler = LeaderEventHandler {
+                partition_key_range,
+                self_proposer,
+                awaiting_rpc_actions,
+                awaiting_rpc_self_propose,
+                fencing_tokens,
+                arena: encoding_arena,
+            };
+
+            handler.handle_event(event)?;
+            handled_so_far += 1;
+            if handled_so_far >= BATCH_READY_UP_TO || !self_proposer.has_capacity() {
+                break;
             }
-            Some(action_effects) = all_streams.next() => {
-                Ok(action_effects)
-            },
-            result = self.self_proposer.join_on_err() => {
-                Err(result.expect_err("never should never be returned"))
-            }
+            loop_event = all_streams.next().now_or_never().flatten();
         }
+        Ok(())
     }
 
     /// Stops all leader relevant tasks.
@@ -389,176 +428,162 @@ impl LeaderState {
             }
         }
     }
+}
 
-    pub async fn handle_events(
-        &mut self,
-        events: impl IntoIterator<Item = LeaderEvent>,
-    ) -> Result<(), Error> {
-        let mut arena = BytesMut::with_capacity(128 * 1024);
-        for event in events {
-            match event {
-                LeaderEvent::Scheduler(decisions) => {
-                    let Decisions {
-                        qids,
-                        num_run,
-                        num_yield,
-                    } = decisions;
-                    trace!(
-                        "Scheduler decided to run {num_run} entries and yield {num_yield} entries across {} vqueues",
-                        qids.len()
+struct LeaderEventHandler<'a> {
+    partition_key_range: KeyRange,
+    self_proposer: &'a mut SelfProposer,
+    awaiting_rpc_actions: &'a mut HashMap<PartitionProcessorRpcRequestId, RpcReciprocal>,
+    awaiting_rpc_self_propose: &'a mut FuturesUnordered<SelfAppendFuture>,
+    fencing_tokens: &'a mut restate_platform::hash::HashMap<InvocationId, FencingToken>,
+    arena: &'a mut BytesMut,
+}
+
+impl LeaderEventHandler<'_> {
+    fn handle_event(&mut self, event: LeaderEvent) -> Result<(), Error> {
+        match event {
+            LeaderEvent::Scheduler(decisions) => {
+                let Decisions {
+                    qids,
+                    num_run,
+                    num_yield,
+                } = decisions;
+                trace!(
+                    "Scheduler decided to run {num_run} entries and yield {num_yield} entries across {} vqueues",
+                    qids.len()
+                );
+
+                let arena = &mut self.arena;
+                let commands: Vec<_> = qids
+                    .into_iter()
+                    .chunk_by(|(id, _)| id.partition_key())
+                    .into_iter()
+                    // one command per partition key
+                    .map(|(partition_key, group)| {
+                        let decisions = SchedulerDecisionsCommand {
+                            qids: group.collect(),
+                        };
+
+                        arena.reserve(decisions.encoded_len());
+                        // safe to unwrap because we reserved enough space
+                        decisions.bilrost_encode(&mut *arena).unwrap();
+
+                        (
+                            partition_key,
+                            Command::VQSchedulerDecisions(arena.split().freeze()),
+                        )
+                        // an action goes into command, and resources are popped
+                    })
+                    // Unfortunately chunk_by cannot generate an ExactSizeIterator.
+                    // I'm hoping that this is a temporary measure until SelfProposer is redesigned.
+                    .collect();
+                self.self_proposer.self_propose_many(commands.into_iter())?;
+            }
+            LeaderEvent::PartitionMaintenance(partition_durability) => {
+                // based on configuration, whether to consider partition-local durability in
+                // the replica-set as a sufficient source of durability, or only snapshots.
+                self.self_proposer.self_propose(
+                    self.partition_key_range.start(),
+                    Command::UpdatePartitionDurability(partition_durability),
+                )?;
+            }
+            LeaderEvent::Invoker(fenced) => {
+                let invocation_id = fenced.effect.invocation_id;
+                // Fence stale effects at write time: only self-propose if the effect carries
+                // the token of the invocation's *current* attempt. A mismatch (or a missing
+                // entry) means the effect is a straggler from a previous attempt that has
+                // since been re-invoked / paused / aborted, so it must not be written -- this
+                // is what stops it from being applied to a newer attempt.
+                if self.fencing_tokens.get(&invocation_id) == Some(&fenced.fencing_token) {
+                    // A terminal effect ends this attempt: stop accepting its token (GC). A
+                    // later re-invoke mints a fresh one.
+                    if fenced.effect.kind.is_terminal() {
+                        self.fencing_tokens.remove(&invocation_id);
+                    }
+                    self.self_proposer.self_propose(
+                        invocation_id.partition_key(),
+                        Command::InvokerEffect(fenced.effect),
+                    )?;
+                } else {
+                    debug!(
+                        restate.invocation.id = %invocation_id,
+                        "Dropping stale invoker effect at write time (fencing token mismatch)"
                     );
-
-                    let commands: Vec<_> = qids
-                        .into_iter()
-                        .chunk_by(|(id, _)| id.partition_key())
-                        .into_iter()
-                        // one command per partition key
-                        .map(|(partition_key, group)| {
-                            let decisions = SchedulerDecisionsCommand {
-                                qids: group.collect(),
-                            };
-
-                            arena.reserve(decisions.encoded_len());
-                            // safe to unwrap because we reserved enough space
-                            decisions.bilrost_encode(&mut arena).unwrap();
-
-                            (
-                                partition_key,
-                                Command::VQSchedulerDecisions(arena.split().freeze()),
-                            )
-                            // an action goes into command, and resources are popped
-                        })
-                        // Unfortunately chunk_by cannot generate an ExactSizeIterator.
-                        // I'm hoping that this is a temporary measure until SelfProposer is redesigned.
-                        .collect();
-                    self.self_proposer
-                        .self_propose_many(commands.into_iter())
-                        .await?;
-                }
-                LeaderEvent::PartitionMaintenance(partition_durability) => {
-                    // based on configuration, whether to consider partition-local durability in
-                    // the replica-set as a sufficient source of durability, or only snapshots.
-                    self.self_proposer
-                        .self_propose(
-                            self.partition_key_range.start(),
-                            Command::UpdatePartitionDurability(partition_durability),
-                        )
-                        .await?;
-                }
-                LeaderEvent::Invoker(fenced) => {
-                    let invocation_id = fenced.effect.invocation_id;
-                    // Fence stale effects at write time: only self-propose if the effect carries
-                    // the token of the invocation's *current* attempt. A mismatch (or a missing
-                    // entry) means the effect is a straggler from a previous attempt that has
-                    // since been re-invoked / paused / aborted, so it must not be written -- this
-                    // is what stops it from being applied to a newer attempt.
-                    if self.fencing_tokens.get(&invocation_id) == Some(&fenced.fencing_token) {
-                        // A terminal effect ends this attempt: stop accepting its token (GC). A
-                        // later re-invoke mints a fresh one.
-                        if fenced.effect.kind.is_terminal() {
-                            self.fencing_tokens.remove(&invocation_id);
-                        }
-                        self.self_proposer
-                            .self_propose(
-                                invocation_id.partition_key(),
-                                Command::InvokerEffect(fenced.effect),
-                            )
-                            .await?;
-                    } else {
-                        debug!(
-                            restate.invocation.id = %invocation_id,
-                            "Dropping stale invoker effect at write time (fencing token mismatch)"
-                        );
-                    }
-                }
-                LeaderEvent::Shuffle(outbox_truncation) => {
-                    // todo: Until we support partition splits we need to get rid of outboxes or introduce partition
-                    //  specific destination messages that are identified by a partition_id
-                    self.self_proposer
-                        .self_propose(
-                            self.partition_key_range.start(),
-                            Command::TruncateOutbox(outbox_truncation.index()),
-                        )
-                        .await?;
-                }
-                LeaderEvent::Timer(timer) => {
-                    self.self_proposer
-                        .self_propose(timer.invocation_id().partition_key(), Command::Timer(timer))
-                        .await?;
-                }
-                LeaderEvent::Cleaner(effect) => {
-                    let (invocation_id, cmd) = match effect {
-                        CleanerEffect::PurgeJournal(invocation_id) => (
-                            invocation_id,
-                            Command::PurgeJournal(PurgeInvocationRequest {
-                                invocation_id,
-                                response_sink: None,
-                            }),
-                        ),
-                        CleanerEffect::PurgeInvocation(invocation_id) => (
-                            invocation_id,
-                            Command::PurgeInvocation(PurgeInvocationRequest {
-                                invocation_id,
-                                response_sink: None,
-                            }),
-                        ),
-                    };
-
-                    self.self_proposer
-                        .self_propose(invocation_id.partition_key(), cmd)
-                        .await?;
-                }
-                LeaderEvent::UpsertSchema(schema) => {
-                    if SemanticRestateVersion::current()
-                        .is_equal_or_newer_than(&RESTATE_VERSION_1_7_0)
-                    {
-                        self.self_proposer
-                            .self_propose(
-                                self.partition_key_range.start(),
-                                Command::UpsertSchema(UpsertSchemaCommand {
-                                    partition_key_range: Keys::RangeInclusive(
-                                        self.partition_key_range.into(),
-                                    ),
-                                    schema,
-                                }),
-                            )
-                            .await?;
-                    }
-                }
-                LeaderEvent::UpsertRuleBook(rule_book) => {
-                    let cmd = restate_wal_protocol::control::UpsertRuleBookCommand { rule_book };
-                    arena.reserve(cmd.encoded_len());
-                    // safe to unwrap because we reserved enough space
-                    cmd.bilrost_encode(&mut arena).unwrap();
-
-                    self.self_proposer
-                        .self_propose(
-                            self.partition_key_range.start(),
-                            Command::UpsertRuleBook(UpsertRuleBookCommandWrapper {
-                                partition_key_range: self.partition_key_range,
-                                command: arena.split().freeze(),
-                            }),
-                        )
-                        .await?;
-                }
-                LeaderEvent::AwaitingRpcSelfProposeDone => {
-                    // Nothing to do here
-                }
-                LeaderEvent::NetworkService(event) => {
-                    self.handle_network_service_event(event).await
                 }
             }
+            LeaderEvent::Shuffle(outbox_truncation) => {
+                // todo: Until we support partition splits we need to get rid of outboxes or introduce partition
+                //  specific destination messages that are identified by a partition_id
+                self.self_proposer.self_propose(
+                    self.partition_key_range.start(),
+                    Command::TruncateOutbox(outbox_truncation.index()),
+                )?;
+            }
+            LeaderEvent::Timer(timer) => {
+                self.self_proposer
+                    .self_propose(timer.invocation_id().partition_key(), Command::Timer(timer))?;
+            }
+            LeaderEvent::Cleaner(effect) => {
+                let (invocation_id, cmd) = match effect {
+                    CleanerEffect::PurgeJournal(invocation_id) => (
+                        invocation_id,
+                        Command::PurgeJournal(PurgeInvocationRequest {
+                            invocation_id,
+                            response_sink: None,
+                        }),
+                    ),
+                    CleanerEffect::PurgeInvocation(invocation_id) => (
+                        invocation_id,
+                        Command::PurgeInvocation(PurgeInvocationRequest {
+                            invocation_id,
+                            response_sink: None,
+                        }),
+                    ),
+                };
+
+                self.self_proposer
+                    .self_propose(invocation_id.partition_key(), cmd)?;
+            }
+            LeaderEvent::UpsertSchema(schema) => {
+                if SemanticRestateVersion::current().is_equal_or_newer_than(&RESTATE_VERSION_1_7_0)
+                {
+                    self.self_proposer.self_propose(
+                        self.partition_key_range.start(),
+                        Command::UpsertSchema(UpsertSchemaCommand {
+                            partition_key_range: Keys::RangeInclusive(
+                                self.partition_key_range.into(),
+                            ),
+                            schema,
+                        }),
+                    )?;
+                }
+            }
+            LeaderEvent::UpsertRuleBook(rule_book) => {
+                let cmd = restate_wal_protocol::control::UpsertRuleBookCommand { rule_book };
+                self.arena.reserve(cmd.encoded_len());
+                // safe to unwrap because we reserved enough space
+                cmd.bilrost_encode(&mut self.arena).unwrap();
+
+                self.self_proposer.self_propose(
+                    self.partition_key_range.start(),
+                    Command::UpsertRuleBook(UpsertRuleBookCommandWrapper {
+                        partition_key_range: self.partition_key_range,
+                        command: self.arena.split().freeze(),
+                    }),
+                )?;
+            }
+            LeaderEvent::NetworkService(event) => self.handle_network_service_event(event),
         }
 
         Ok(())
     }
 
-    async fn handle_network_service_event(&mut self, event: NetworkServiceEvent) {
+    fn handle_network_service_event(&mut self, event: NetworkServiceEvent) {
         match event {
             NetworkServiceEvent::RpcProposal {
                 proposal,
                 reciprocal,
-            } => self.handle_rpc_proposal(proposal, reciprocal).await,
+            } => self.handle_rpc_proposal(proposal, reciprocal),
             NetworkServiceEvent::IngestRecords {
                 records,
                 reciprocal,
@@ -578,13 +603,12 @@ impl LeaderState {
                         };
                         reciprocal.send(status.into());
                     },
-                )
-                .await;
+                );
             }
         }
     }
 
-    async fn handle_rpc_proposal(&mut self, proposal: RpcProposal, reciprocal: RpcReciprocal) {
+    fn handle_rpc_proposal(&mut self, proposal: RpcProposal, reciprocal: RpcReciprocal) {
         let RpcProposal {
             partition_key,
             cmd,
@@ -594,23 +618,18 @@ impl LeaderState {
         match reply_on {
             ReplyOn::Apply { request_id } => {
                 self.handle_rpc_proposal_command(request_id, reciprocal, partition_key, cmd)
-                    .await;
             }
             ReplyOn::Commit { response } => {
                 self.append_and_respond_asynchronously(partition_key, cmd, reciprocal, response)
-                    .await;
             }
             ReplyOn::ApplyAndFence {
                 request_id,
                 invocation_id,
-            } => {
-                self.propose_pause_and_fence(request_id, reciprocal, invocation_id, cmd)
-                    .await;
-            }
+            } => self.propose_pause_and_fence(request_id, reciprocal, invocation_id, cmd),
         }
     }
 
-    async fn handle_rpc_proposal_command(
+    fn handle_rpc_proposal_command(
         &mut self,
         request_id: PartitionProcessorRpcRequestId,
         reciprocal: Reciprocal<
@@ -631,7 +650,7 @@ impl LeaderState {
             }
             Entry::Vacant(v) => {
                 // In this case, no one proposed this command yet, let's try to propose it
-                if let Err(e) = self.self_proposer.self_propose(partition_key, cmd).await {
+                if let Err(e) = self.self_proposer.self_propose(partition_key, cmd) {
                     reciprocal.send(Err(PartitionProcessorRpcError::Internal(e.to_string())));
                 } else {
                     v.insert(reciprocal);
@@ -651,7 +670,7 @@ impl LeaderState {
     /// dropped at write time with no pause in the committed log. After a successful append the
     /// pause's LSN is fixed, and because the leader self-proposes from a single task, every later
     /// invoker-effect self-propose observes the cleared map and is fenced.
-    async fn propose_pause_and_fence(
+    fn propose_pause_and_fence(
         &mut self,
         request_id: PartitionProcessorRpcRequestId,
         reciprocal: Reciprocal<
@@ -675,7 +694,6 @@ impl LeaderState {
                 if let Err(e) = self
                     .self_proposer
                     .self_propose(invocation_id.partition_key(), cmd)
-                    .await
                 {
                     reciprocal.send(Err(PartitionProcessorRpcError::Internal(e.to_string())));
                 } else {
@@ -692,7 +710,7 @@ impl LeaderState {
     /// Records appended this way are never filtered by the dedup mechanism during leadership
     /// transitions, making this safe for fire-and-forget ingress commands (signals, invocation
     /// responses).
-    async fn append_and_respond_asynchronously(
+    fn append_and_respond_asynchronously(
         &mut self,
         partition_key: PartitionKey,
         cmd: Command,
@@ -702,11 +720,10 @@ impl LeaderState {
         match self
             .self_proposer
             .append_with_notification(partition_key, cmd)
-            .await
         {
-            Ok(commit_token) => {
+            Ok(result) => {
                 self.awaiting_rpc_self_propose.push(SelfAppendFuture::new(
-                    commit_token,
+                    result.commit_token,
                     |result: Result<(), PartitionProcessorRpcError>| {
                         reciprocal.send(result.map(|_| success_response));
                     },
@@ -716,26 +733,24 @@ impl LeaderState {
         }
     }
 
-    async fn forward_many_and_respond_on_commit<F>(
+    fn forward_many_and_respond_on_commit<F>(
         &mut self,
         records: impl ExactSizeIterator<Item = IngestRecord>,
         callback: F,
     ) where
         F: FnOnce(Result<(), PartitionProcessorRpcError>) + Send + Sync + 'static,
     {
-        match self
-            .self_proposer
-            .forward_many_with_notification(records)
-            .await
-        {
-            Ok(commit_token) => {
+        match self.self_proposer.forward_many_with_notification(records) {
+            Ok(result) => {
                 self.awaiting_rpc_self_propose
-                    .push(SelfAppendFuture::new(commit_token, callback));
+                    .push(SelfAppendFuture::new(result.commit_token, callback));
             }
             Err(e) => callback(Err(PartitionProcessorRpcError::Internal(e.to_string()))),
         }
     }
+}
 
+impl LeaderState {
     pub fn handle_actions(
         &mut self,
         processor: impl Processor + HasVQueues,

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -158,7 +158,6 @@ pub(crate) enum LeaderEvent {
     PartitionMaintenance(UpdatePartitionDurabilityCommand),
     UpsertSchema(Schema),
     UpsertRuleBook(Arc<restate_limiter::RuleBook>),
-    AwaitingRpcSelfProposeDone,
     NetworkService(NetworkServiceEvent),
 }
 
@@ -313,9 +312,7 @@ where
             &node_ctx.bifrost,
         )?;
 
-        self_proposer
-            .self_propose(ctx.key_range().start(), announce_leader)
-            .await?;
+        self_proposer.self_propose_unaccounted(ctx.key_range().start(), announce_leader)?;
 
         self.state = State::Candidate {
             at: Instant::now(),
@@ -572,17 +569,15 @@ where
                         .collect::<Vec<_>>()
                         .join(", ")
                 );
-                self_proposer
-                    .self_propose(
-                        processor.key_range().start(),
-                        Command::VersionBarrier(VersionBarrierCommand {
-                            version: barrier_version,
-                            partition_key_range: Keys::RangeInclusive(processor.key_range().into()),
-                            human_reason: Some("Apply state-machine feature changes".to_owned()),
-                            feature_changes: feature_changes.into_iter().map(|c| c.id()).collect(),
-                        }),
-                    )
-                    .await?;
+                self_proposer.self_propose_unaccounted(
+                    processor.key_range().start(),
+                    Command::VersionBarrier(VersionBarrierCommand {
+                        version: barrier_version,
+                        partition_key_range: Keys::RangeInclusive(processor.key_range().into()),
+                        human_reason: Some("Apply state-machine feature changes".to_owned()),
+                        feature_changes: feature_changes.into_iter().map(|c| c.id()).collect(),
+                    }),
+                )?;
 
                 // Switch to BecomingLeader state until we finish any pending tasks to enable the
                 // new features. We will transition us to an effective leader when the state
@@ -849,12 +844,9 @@ where
     /// * Follower: Nothing to do
     /// * Candidate: Monitor appender task
     /// * Leader: Await events and monitor appender task
-    pub async fn run(
-        &mut self,
-        ctx: impl Processor + HasVQueues,
-    ) -> Result<Vec<LeaderEvent>, Error> {
+    pub async fn run(&mut self, ctx: impl Processor + HasVQueues) -> Result<(), Error> {
         match &mut self.state {
-            State::Follower => Ok(futures::future::pending::<Vec<_>>().await),
+            State::Follower => futures::future::pending().await,
             State::Candidate { self_proposer, .. }
             | State::BecomingLeader { self_proposer, .. } => Err(self_proposer
                 .as_mut()
@@ -864,20 +856,6 @@ where
                 .expect_err("never should never be returned")),
             State::Leader(leader_state) => leader_state.run(ctx).await,
         }
-    }
-
-    pub async fn handle_events(
-        &mut self,
-        events: impl IntoIterator<Item = LeaderEvent>,
-    ) -> Result<(), Error> {
-        match &mut self.state {
-            State::Follower | State::Candidate { .. } | State::BecomingLeader { .. } => {
-                // nothing to do :-)
-            }
-            State::Leader(leader_state) => leader_state.handle_events(events).await?,
-        }
-
-        Ok(())
     }
 
     // This is returned only if we're leaders (otherwise there's no messages to be sent to the invoker)

--- a/crates/worker/src/partition/leadership/self_proposer.rs
+++ b/crates/worker/src/partition/leadership/self_proposer.rs
@@ -12,22 +12,21 @@ use std::sync::Arc;
 
 use futures::never::Never;
 
-use restate_bifrost::{Bifrost, CommitToken, EnqueueError, ErrorRecoveryStrategy, InputRecord};
+use restate_bifrost::{
+    Bifrost, EnqueueError, EnqueueWithNotificationResult, ErrorRecoveryStrategy, InputRecord,
+};
 use restate_storage_api::deduplication_table::{DedupInformation, EpochSequenceNumber};
 use restate_types::{
-    identifiers::PartitionKey, logs::LogId, net::ingest::IngestRecord, time::NanosSinceEpoch,
+    config::Configuration, identifiers::PartitionKey, logs::LogId, net::ingest::IngestRecord,
+    time::NanosSinceEpoch,
 };
 use restate_wal_protocol::{Command, Destination, Envelope, Header, Source};
 
 use crate::partition::leadership::Error;
 
-// Constants since it's very unlikely that we can derive a meaningful configuration
-// that the user can reason about.
-//
-// The queue size is small to reduce the tail latency. This comes at the cost of throughput but
-// this runs within a single processor and the expected throughput is bound by the overall
-// throughput of the processor itself.
-const BIFROST_QUEUE_SIZE: usize = 50;
+// A constant since it's very unlikely that we can derive a meaningful configuration
+// that the user can reason about. The queue's memory budget, on the other hand, is
+// configurable via `worker.self-proposal-queue-memory-limit`.
 const MAX_BIFROST_APPEND_BATCH: usize = 5000;
 
 static BIFROST_APPENDER_TASK: &str = "bifrost-appender";
@@ -43,11 +42,14 @@ impl SelfProposer {
         epoch_sequence_number: EpochSequenceNumber,
         bifrost: &Bifrost,
     ) -> Result<Self, Error> {
+        let memory_limit = Configuration::pinned()
+            .worker
+            .self_proposal_queue_memory_limit;
         let bifrost_appender = bifrost
             .create_background_appender(
                 log_id,
                 ErrorRecoveryStrategy::ExtendChainPreferred,
-                BIFROST_QUEUE_SIZE,
+                Some(memory_limit),
                 MAX_BIFROST_APPEND_BATCH,
             )?
             .start("self-appender")?;
@@ -69,13 +71,11 @@ impl SelfProposer {
     }
 
     /// Self-propose many commands to Bifrost, attaching ESN-based dedup information.
-    ///
-    /// Note that self_propose_many will return an error if the number of commands is greater than
-    /// the internal channel's max capacity.
-    pub async fn self_propose_many(
+    /// Returns the number of bytes proposed (the serialized size of all the commands).
+    pub fn self_propose_many(
         &mut self,
         cmds: impl ExactSizeIterator<Item = (PartitionKey, Command)>,
-    ) -> Result<(), Error> {
+    ) -> Result<usize, Error> {
         // allocate a sequence number range for the batch
         let leader_epoch = self.epoch_sequence_number.leader_epoch;
 
@@ -100,11 +100,10 @@ impl SelfProposer {
             Arc::new(Envelope::new(header, cmd))
         });
 
-        // Only blocks if background append is pushing back (queue full)
-        self.bifrost_appender
+        let bytes_written = self
+            .bifrost_appender
             .sender()
             .enqueue_many(envelopes)
-            .await
             .map_err(|e| Error::SelfProposer(e.to_string()))?;
 
         // update the sequence number range for the next batch
@@ -113,37 +112,53 @@ impl SelfProposer {
             sequence_number: end_seq,
         };
 
-        Ok(())
+        Ok(bytes_written)
     }
 
     /// Self-propose a single command to Bifrost, attaching ESN-based dedup information.
-    pub async fn self_propose(
+    /// Returns the number of bytes proposed (the serialized size of the command).
+    pub fn self_propose(
         &mut self,
         partition_key: PartitionKey,
         cmd: Command,
-    ) -> Result<(), Error> {
+    ) -> Result<usize, Error> {
         let envelope = Envelope::new(self.create_self_propose_header(partition_key), cmd);
 
-        // Only blocks if background append is pushing back (queue full)
         self.bifrost_appender
             .sender()
             .enqueue(Arc::new(envelope))
-            .await
-            .map_err(|e| Error::SelfProposer(e.to_string()))?;
-
-        Ok(())
+            .map_err(|e| Error::SelfProposer(e.to_string()))
     }
 
-    /// Append a command to Bifrost **without** dedup information, returning a [`CommitToken`].
+    /// Self-propose a single command to Bifrost, attaching ESN-based dedup information.
+    /// Compared to [`SelfProposer::self_propose`], this method bypasses all memory accounting
+    /// on the appender.
+    /// This should only be used for commands that can't afford a backpressue.
+    /// Returns the number of bytes proposed (the serialized size of the command).
+    pub fn self_propose_unaccounted(
+        &mut self,
+        partition_key: PartitionKey,
+        cmd: Command,
+    ) -> Result<usize, Error> {
+        let envelope = Envelope::new(self.create_self_propose_header(partition_key), cmd);
+
+        self.bifrost_appender
+            .sender()
+            .enqueue_unaccounted(Arc::new(envelope))
+            .map_err(|e| Error::SelfProposer(e.to_string()))
+    }
+
+    /// Append a command to Bifrost **without** dedup information, returning the number of bytes
+    /// written and a [`CommitToken`](restate_bifrost::CommitToken).
     ///
     /// Unlike [`Self::self_propose`], this does not attach an epoch sequence number. Records
     /// appended this way are never filtered by the dedup mechanism during leadership transitions,
     /// which makes them safe for fire-and-forget ingress commands (signals, invocation responses).
-    pub async fn append_with_notification(
+    pub fn append_with_notification(
         &mut self,
         partition_key: PartitionKey,
         cmd: Command,
-    ) -> Result<CommitToken, Error> {
+    ) -> Result<EnqueueWithNotificationResult, Error> {
         let header = Header {
             dest: Destination::Processor {
                 partition_key,
@@ -156,58 +171,42 @@ impl SelfProposer {
         };
         let envelope = Envelope::new(header, cmd);
 
-        let commit_token = self
-            .bifrost_appender
+        self.bifrost_appender
             .sender()
             .enqueue_with_notification(Arc::new(envelope))
-            .await
-            .map_err(|e| Error::SelfProposer(e.to_string()))?;
-
-        Ok(commit_token)
+            .map_err(|e| Error::SelfProposer(e.to_string()))
     }
 
-    /// Forward externally-created records to Bifrost, returning a [`CommitToken`].
+    /// Forward externally-created records to Bifrost, returning the number of bytes written and a
+    /// [`CommitToken`](restate_bifrost::CommitToken).
     ///
     /// The records already carry their own dedup information in their headers; no ESN is attached.
-    /// Internally this uses `enqueue_unchecked` which does not check the record size. Hence
+    /// Internally this uses `enqueue_many_unchecked` which does not check record sizes. Hence
     /// the only limit here is the networking max message size.
-    pub async fn forward_many_with_notification(
+    pub fn forward_many_with_notification(
         &mut self,
         records: impl ExactSizeIterator<Item = IngestRecord>,
-    ) -> Result<CommitToken, EnqueueError<()>> where {
+    ) -> Result<EnqueueWithNotificationResult, EnqueueError<()>> {
         let sender = self.bifrost_appender.sender();
 
-        // This should ideally be implemented
-        // by using `sender.enqueue_many`
-        // but since we have no guarantee over the
-        // underlying channel size a `reserve_many()` might
-        // return a misleading Closed error
-        //
-        // sender
-        //     .enqueue_many(records)
-        //     .await
-        //     .map_err(|e| Error::SelfProposer(e.to_string()))?;
-        //
-        // so instead we do this.
-
-        for record in records {
+        let inputs = records.map(|record| {
             // Skip decoding the envelope; build the InputRecord directly from the raw bytes.
             // The ingestion client should only handle payloads of type Envelope.
-            let input = unsafe {
+            unsafe {
                 InputRecord::from_bytes_unchecked(
                     NanosSinceEpoch::now(),
                     record.keys,
                     record.record,
                 )
-            };
+            }
+        });
 
-            sender
-                .enqueue_unchecked(input)
-                .await
-                .map_err(|e| e.drop_payload())?;
-        }
+        let bytes_written = sender.enqueue_many_unchecked(inputs)?;
 
-        sender.notify_committed().await
+        Ok(EnqueueWithNotificationResult {
+            commit_token: sender.notify_committed()?,
+            bytes_written,
+        })
     }
 
     fn create_self_propose_header(&mut self, partition_key: PartitionKey) -> Header {
@@ -236,5 +235,13 @@ impl SelfProposer {
             Ok(()) => Error::task_terminated_unexpectedly(BIFROST_APPENDER_TASK),
             Err(err) => Error::task_failed(BIFROST_APPENDER_TASK, err),
         })
+    }
+
+    pub fn has_capacity(&self) -> bool {
+        self.bifrost_appender.sender_ref().has_capacity()
+    }
+
+    pub fn wait_for_capacity(&self) -> impl std::future::Future<Output = ()> + 'static {
+        self.bifrost_appender.sender_ref().wait_for_capacity()
     }
 }

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -638,11 +638,7 @@ where
                     self.ctx.vqueues_mut().try_compact();
                 },
                 result = self.leadership_state.run(&mut self.ctx) => {
-                    let events = result?;
-                    // We process the events not directly in the run future because it
-                    // requires the run future to be cancellation safe. In the future this could be
-                    // implemented.
-                    self.leadership_state.handle_events(events).await?;
+                    result?;
                 }
                 Some(leader_query_cmd) = self.leader_query_rx.recv() => {
                     self.on_leader_query(leader_query_cmd);

--- a/tools/bifrost-benchpress/Cargo.toml
+++ b/tools/bifrost-benchpress/Cargo.toml
@@ -21,6 +21,7 @@ restate-workspace-hack = { workspace = true }
 restate-bifrost = { workspace = true, features = ["memory-loglet", "local-loglet"] }
 restate-core = { workspace = true, features = ["test-util"] }
 restate-errors = { workspace = true }
+restate-memory = { workspace = true }
 restate-metadata-server = { workspace = true }
 restate-rocksdb = { workspace = true }
 restate-test-util = { workspace = true }

--- a/tools/bifrost-benchpress/src/write_to_read.rs
+++ b/tools/bifrost-benchpress/src/write_to_read.rs
@@ -18,6 +18,7 @@ use tracing::info;
 
 use restate_bifrost::{Bifrost, ErrorRecoveryStrategy};
 use restate_core::{Metadata, TaskCenter, TaskHandle, TaskKind};
+use restate_memory::NonZeroByteCount;
 use restate_types::logs::{KeyFilter, LogId, Lsn, SequenceNumber, WithKeys};
 
 use crate::Arguments;
@@ -31,10 +32,10 @@ pub struct WriteToReadOpts {
     #[clap(long, default_value = "2000")]
     max_batch_size: usize,
 
-    /// Number of records that can be buffered in background appender before back-pressure kicks
-    /// in.
-    #[clap(long, default_value = "5000")]
-    write_buffer_size: usize,
+    /// Number of bytes that can be buffered in the background appender before back-pressure
+    /// kicks in.
+    #[clap(long, default_value = "2500000")]
+    write_buffer_size: NonZeroByteCount,
 
     /// The number of records to write during this test
     #[clap(long, default_value = "400000")]
@@ -97,7 +98,7 @@ pub async fn run(_common_args: &Arguments, args: &WriteToReadOpts, bifrost: Bifr
                     .create_background_appender(
                         LOG_ID,
                         ErrorRecoveryStrategy::ExtendChainPreferred,
-                        args.write_buffer_size,
+                        Some(args.write_buffer_size),
                         args.max_batch_size,
                     )?
                     .start("writer")?;
@@ -109,7 +110,9 @@ pub async fn run(_common_args: &Arguments, args: &WriteToReadOpts, bifrost: Bifr
                         precise_ts: clock.raw(),
                         blob: blob.clone(),
                     };
-                    sender.enqueue(record.with_no_keys()).await.unwrap();
+                    // enqueue() never blocks; apply back-pressure when the buffer is exhausted
+                    sender.wait_for_capacity().await;
+                    sender.enqueue(record.with_no_keys()).unwrap();
                     append_latency.record(start.elapsed().as_nanos() as u64)?;
                     if counter % 10000 == 0 {
                         info!("Appended {} records", counter);

--- a/util/bytecount/src/lib.rs
+++ b/util/bytecount/src/lib.rs
@@ -160,6 +160,16 @@ impl PartialOrd<ByteCount<true>> for ByteCount<false> {
         Some(self.0.cmp(&other.0))
     }
 }
+impl FromStr for ByteCount<false> {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s: ByteSize = s.parse()?;
+
+        Ok(Self::new(
+            NonZeroUsize::new(s.0 as usize).ok_or_else(|| "ByteCount cannot be zero".to_owned())?,
+        ))
+    }
+}
 
 impl FromStr for ByteCount<true> {
     type Err = String;


### PR DESCRIPTION

Context:

Before this PR, the background appender's channel was a bounded channel of size 50. This has two caveats:
1. Large commands (e.g. large schema upserts) can inflate the size of this channel in the worst case to 1.5GB (per partition). A coordinated event (e.g. schema change) can end accumulating 10s of GBs of unaccounted memory across all partitions causing the node to OOM.
2. On the other hands, if the append latency is high, and the records are tiny (as shown later in the benchmarks), this 50 records arbitrary limits hinders the batching efficiency quite a bit.

Solution:

The main problem is that the number of records is just hard to configure correctly across different workloads. We want reasonable batching efficiency with bounded memory growth. As such, this PR switches the background appender channel to be memory-bound instead of record-count bound. The memory bound is configurable and will default to 64MB (i.e. allowing the background appender to do up to two full batches per run, though we might want to tune how large we want a single batch to be).

Implementation wise:
1. We're switching the underlying channel to be unbounded channel with a `MemoryPool` on top.
2. Because we don't know how much to reserve from the memory pool beforehand, we're going to allow overcomitting the memory pool by at most once `enqueueXX` call.
  a. To simplify reasoning about the overcomitting, I'm dropping the `Clone` support for the `LogSender`. Otherwise, we might overcomitt by more than one enqueue calls across concurrent senders. We don't currently need it to be `Clone`, so this was a no-op.
3. Once the memory pool is fully exhusted, the background appender is going to start rejecting future appends. As such, the `LeaderState` stops polling the effects stream once the pool is exhusted, and waits for it to become available again. Because leader state has an exclusive reference over the self proposer (and its underlying sender), it can be sure that if it sees that the pool has capacity, it'll be able to send without getting any reservation.
4. As a nice side effect for all the self proposer APIs becoming `sync`, we no longer need to worry about cancellation safety, so the events are handled inline inside `LeaderState::run`.

Benchmarks (Steady State):

Started a local one node cluster comparing base against this commit. The workfload is a 30s of Counter::get on a virtual object coming from 1000 concurrent connections.

```
# Base

❯❯❯ wrk -t1 -c1000 --latency -d30s -s ./scripts/wrk/counter.lua http://localhost:8080                                                                                                                                                                                                                                 ✘ 130 main
thread 1784573163 started
Running 30s test @ http://localhost:8080
  1 threads and 1000 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    56.97ms   89.58ms   1.36s    98.26%
    Req/Sec    21.23k     2.93k   29.85k    76.59%
  Latency Distribution
     50%   45.84ms
     75%   53.83ms
     90%   62.58ms
     99%  581.58ms
  631995 requests in 30.04s, 168.16MB read
Requests/sec:  21036.54
Transfer/sec:      5.60MB
thread 1784573163 made 632995 requests and got 631995 responses

```

```
# This commit

❯❯❯ wrk -t1 -c1000 --latency -d30s -s ./scripts/wrk/counter.lua http://localhost:8080                                                      main
thread 1784573695 started
Running 30s test @ http://localhost:8080
  1 threads and 1000 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    55.14ms   88.14ms   1.17s    98.28%
    Req/Sec    22.02k     2.79k   31.03k    76.92%
  Latency Distribution
     50%   44.09ms
     75%   51.81ms
     90%   60.31ms
     99%  574.92ms
  655652 requests in 30.07s, 174.45MB read
Requests/sec:  21805.57
Transfer/sec:      5.80MB
thread 1784573695 made 656652 requests and got 655652 responses
```

So there's no degradation perf wise for this whole branch.

Benchmarks (higher append latency):

Where this becomes interesting is when append latency is higher because the 50recs bounded channel gets filled faster, and starts pushing back specially with tiny records, and due to the lack of pipelining, the throughput of the system collapses. So doing the same benchmarks but with a 200ms sleep in the background appender:

```
# Base

❯❯❯ wrk -t1 -c1000 --latency -d30s -s ./scripts/wrk/counter.lua http://localhost:8080                                                      main
thread 1784574220 started
Running 30s test @ http://localhost:8080
  1 threads and 1000 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.04s   308.07ms   2.00s    68.70%
    Req/Sec     0.87k   592.52     2.87k    65.53%
  Latency Distribution
     50%  916.07ms
     75%    1.14s
     90%    1.52s
     99%    1.97s
  25328 requests in 30.08s, 6.74MB read
  Socket errors: connect 0, read 0, write 0, timeout 1437
Requests/sec:    842.15
Transfer/sec:    229.45KB
thread 1784574220 made 26329 requests and got 25328 responses

```

vs:

```
# This commit

❯❯❯ wrk -t1 -c1000 --latency -d30s -s ./scripts/wrk/counter.lua http://localhost:8080                                                      main
thread 1784573956 started
Running 30s test @ http://localhost:8080
  1 threads and 1000 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   590.43ms  136.85ms   1.85s    81.02%
    Req/Sec     1.72k   679.51     3.67k    71.75%
  Latency Distribution
     50%  605.69ms
     75%  611.69ms
     90%  617.10ms
     99%    1.44s
  50304 requests in 30.00s, 13.38MB read
Requests/sec:   1676.56
Transfer/sec:    456.80KB
thread 1784573956 made 51305 requests and got 50304 responses
```

This commit was able to have twice the throughput of the base branch under high latency.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/5076).
* __->__ #5076
* #5057