### PR TITLE
remove an ineffective bilrost annotation

### DIFF
--- a/crates/storage-api/src/vqueue_table/metadata.rs
+++ b/crates/storage-api/src/vqueue_table/metadata.rs
@@ -533,7 +533,6 @@ pub enum Action {
     #[bilrost(tag(5))]
     /// An item or have been removed from the (stage)
     RemoveEntry {
-        #[bilrost(encoding(fixed))]
         stage: Stage,
     },
 }

--- a/crates/storage-api/src/vqueue_table/metadata.rs
+++ b/crates/storage-api/src/vqueue_table/metadata.rs
@@ -532,9 +532,7 @@ pub enum Action {
     ResumeVQueue {},
     #[bilrost(tag(5))]
     /// An item or have been removed from the (stage)
-    RemoveEntry {
-        stage: Stage,
-    },
+    RemoveEntry { stage: Stage },
 }
 
 #[derive(Debug, Clone, bilrost::Message)]


### PR DESCRIPTION
This annotation is currently (bilrost 0.1015 and earlier) has no effect on the representation of the data.

It's not currently a problem; varint representation of enumerations like `Stage` is already considerably cheaper, and they don't support "fixed" encoding anyway, so this could never have taken effect. It does mean that it's possible this variant was meant to be a `message`-variant and isn't, which makes these (ignored! oops!) attributes error-prone. In bilrost 0.1016, attributes in this position will cause an error at derive time (which is how this was discovered).