### PR TITLE
Fix RecordCache buffer retention

### DIFF
--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -139,5 +139,9 @@ harness = false
 name = "id_encoding"
 harness = false
 
+[[bench]]
+name = "record_cache"
+harness = false
+
 [lints]
 workspace = true

--- a/crates/types/benches/record_cache.rs
+++ b/crates/types/benches/record_cache.rs
@@ -1,0 +1,88 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::{
+    hint::black_box,
+    sync::atomic::{AtomicU32, Ordering},
+};
+
+use bytes::Bytes;
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+use restate_types::{
+    logs::{Keys, LogletId, LogletOffset, Record, RecordCache},
+    storage::PolyBytes,
+    time::NanosSinceEpoch,
+};
+
+const LOGLET_ID: LogletId = LogletId::new_unchecked(1);
+
+fn record(body_size: usize) -> Record {
+    Record::from_parts(
+        NanosSinceEpoch::now(),
+        Keys::None,
+        PolyBytes::Bytes(Bytes::from(vec![42; body_size])),
+    )
+}
+
+fn record_cache_add(c: &mut Criterion) {
+    let mut group = c.benchmark_group("record-cache-add");
+
+    for body_size in [1024, 64 * 1024, 1024 * 1024] {
+        let record = record(body_size);
+        group.throughput(Throughput::Bytes(body_size as u64));
+
+        let PolyBytes::Bytes(body) = record.body() else {
+            unreachable!("benchmark record has a raw body");
+        };
+
+        group.bench_with_input(
+            BenchmarkId::new("raw-body-clone", body_size),
+            &body_size,
+            |b, _| b.iter(|| black_box(Bytes::clone(body))),
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("raw-body-copy", body_size),
+            &body_size,
+            |b, _| b.iter(|| black_box(Bytes::copy_from_slice(body))),
+        );
+
+        group.bench_with_input(BenchmarkId::new("miss", body_size), &body_size, |b, _| {
+            let cache = RecordCache::new(body_size * 128);
+            let offset = AtomicU32::new(1);
+
+            b.iter(|| {
+                cache.add(
+                    LOGLET_ID,
+                    LogletOffset::new(offset.fetch_add(1, Ordering::Relaxed)),
+                    black_box(&record),
+                );
+            });
+        });
+
+        group.bench_with_input(
+            BenchmarkId::new("duplicate", body_size),
+            &body_size,
+            |b, _| {
+                let cache = RecordCache::new(body_size * 128);
+                let offset = LogletOffset::new(1);
+                cache.add(LOGLET_ID, offset, &record);
+
+                b.iter(|| cache.add(LOGLET_ID, offset, black_box(&record)));
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, record_cache_add);
+criterion_main!(benches);

--- a/crates/types/src/logs/record_cache.rs
+++ b/crates/types/src/logs/record_cache.rs
@@ -10,6 +10,7 @@
 
 use std::sync::Arc;
 
+use bytes::Bytes;
 use moka::{
     ops::compute::Op,
     policy::EvictionPolicy,
@@ -23,13 +24,19 @@ use super::{LogletId, LogletOffset, Record, SequenceNumber};
 /// Unique record key across different loglets.
 type RecordKey = (LogletId, LogletOffset);
 
+#[derive(Clone)]
+struct RecordCacheEntry {
+    record: Record,
+    weight: u32,
+}
+
 /// A a simple LRU-based record cache.
 ///
 /// This can be safely shared between all ReplicatedLoglet(s) and the LocalSequencers or the
 /// RemoteSequencers
 #[derive(Clone)]
 pub struct RecordCache {
-    inner: Option<Cache<RecordKey, Record, ahash::RandomState>>,
+    inner: Option<Cache<RecordKey, RecordCacheEntry, ahash::RandomState>>,
 }
 
 impl RecordCache {
@@ -40,12 +47,7 @@ impl RecordCache {
             Some(
                 CacheBuilder::default()
                     .name("ReplicatedLogRecordCache")
-                    .weigher(|_, record: &Record| {
-                        record
-                            .estimated_encode_size()
-                            .try_into()
-                            .unwrap_or(u32::MAX)
-                    })
+                    .weigher(|_, entry: &RecordCacheEntry| entry.weight)
                     .max_capacity(memory_budget_bytes.try_into().unwrap_or(u64::MAX))
                     .eviction_policy(EvictionPolicy::lru())
                     .build_with_hasher(ahash::RandomState::default()),
@@ -66,32 +68,77 @@ impl RecordCache {
             .entry((loglet_id, offset))
             .and_compute_with(|existing| {
                 let Some(existing) = existing else {
-                    return Op::Put(record.clone());
+                    if !Self::fits(inner, record) {
+                        return Op::Nop;
+                    }
+
+                    // ensure the cache entry does not retain a much larger buffer
+                    return Op::Put(Self::cache_owned(record));
                 };
-                match (existing.value().body(), record.body()) {
+
+                match (existing.value().record.body(), record.body()) {
                     (PolyBytes::Bytes(_), PolyBytes::Bytes(_)) => Op::Nop,
-                    (PolyBytes::Bytes(_), PolyBytes::Typed(_)) => Op::Put(record.clone()),
-                    (PolyBytes::Bytes(_), PolyBytes::Both(typed, _)) => {
+                    (PolyBytes::Bytes(_), PolyBytes::Typed(_)) => {
+                        Op::Put(Self::cache_owned(record))
+                    }
+                    (PolyBytes::Bytes(_), PolyBytes::Both(_, _)) => {
                         // we only need to cache the typed value, let's repackage it.
-                        Op::Put(Record::from_parts(
-                            record.created_at(),
-                            record.keys().clone(),
-                            PolyBytes::Typed(Arc::clone(typed)),
-                        ))
+                        Op::Put(Self::cache_owned(record))
                     }
                     // Shouldn't happen (we only cache Typed or Bytes), but let's handle it anyway.
                     (PolyBytes::Both(typed, _), _) =>
-                    // repackge the existing value into Typed only
+                    // repackage the existing value into Typed only
                     {
-                        Op::Put(Record::from_parts(
-                            existing.value().created_at(),
-                            existing.value().keys().clone(),
-                            PolyBytes::Typed(Arc::clone(typed)),
-                        ))
+                        Op::Put(RecordCacheEntry {
+                            record: Record::from_parts(
+                                existing.value().record.created_at(),
+                                existing.value().record.keys().clone(),
+                                PolyBytes::Typed(Arc::clone(typed)),
+                            ),
+                            weight: existing.value().weight,
+                        })
                     }
                     (PolyBytes::Typed(_), _) => Op::Nop,
                 }
             });
+    }
+
+    fn weight(record: &Record) -> u32 {
+        record
+            .estimated_encode_size()
+            .try_into()
+            .unwrap_or(u32::MAX)
+    }
+
+    fn fits(
+        inner: &Cache<RecordKey, RecordCacheEntry, ahash::RandomState>,
+        record: &Record,
+    ) -> bool {
+        inner
+            .policy()
+            .max_capacity()
+            .is_none_or(|max_capacity| u64::from(Self::weight(record)) <= max_capacity)
+    }
+
+    /// Creates the representation retained by the cache.
+    ///
+    /// A [`Bytes`] value can be a small slice of a much larger allocation. Copy raw bodies when
+    /// admitting a record so the cache capacity accounts for the memory it actually retains.
+    /// Typed values are already reference counted, and any `Both` values will be reduced to only
+    /// the typed representation. The weight is retained from the original record because a
+    /// `Typed` value cannot estimate its encoded size.
+    fn cache_owned(record: &Record) -> RecordCacheEntry {
+        let body = match record.body() {
+            PolyBytes::Bytes(bytes) => PolyBytes::Bytes(Bytes::copy_from_slice(bytes)),
+            PolyBytes::Typed(typed) => PolyBytes::Typed(Arc::clone(typed)),
+            // Shouldn't happen (we only cache Typed or Bytes), but handle it anyway:
+            PolyBytes::Both(typed, _) => PolyBytes::Typed(Arc::clone(typed)),
+        };
+
+        RecordCacheEntry {
+            record: Record::from_parts(record.created_at(), record.keys().clone(), body),
+            weight: Self::weight(record),
+        }
     }
 
     /// Writes a record to cache externally
@@ -128,6 +175,226 @@ impl RecordCache {
     pub fn get(&self, loglet_id: LogletId, offset: LogletOffset) -> Option<Record> {
         let inner = self.inner.as_ref()?;
 
-        inner.get(&(loglet_id, offset))
+        inner.get(&(loglet_id, offset)).map(|entry| entry.record)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::assert_matches;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+
+    use bytes::Bytes;
+
+    use super::{LogletId, LogletOffset, PolyBytes, Record, RecordCache};
+    use crate::{logs::Keys, time::NanosSinceEpoch};
+
+    const LOGLET_ID: LogletId = LogletId::new_unchecked(1);
+    const OFFSET: LogletOffset = LogletOffset::new(1);
+
+    struct TrackingBacking {
+        bytes: Vec<u8>,
+        dropped: Arc<AtomicBool>,
+    }
+
+    impl AsRef<[u8]> for TrackingBacking {
+        fn as_ref(&self) -> &[u8] {
+            &self.bytes
+        }
+    }
+
+    impl Drop for TrackingBacking {
+        fn drop(&mut self) {
+            self.dropped.store(true, Ordering::Relaxed);
+        }
+    }
+
+    #[test]
+    fn cache_miss_copies_raw_body_without_retaining_its_backing_allocation() {
+        let dropped = Arc::new(AtomicBool::new(false));
+        let backing = Bytes::from_owner(TrackingBacking {
+            bytes: vec![42; 128 * 1024],
+            dropped: Arc::clone(&dropped),
+        });
+        let body = backing.slice(64 * 1024..65 * 1024);
+        let record = Record::from_parts(
+            NanosSinceEpoch::now(),
+            Keys::None,
+            PolyBytes::Bytes(body.clone()),
+        );
+        let cache = RecordCache::new(2 * 1024);
+
+        cache.add(LOGLET_ID, OFFSET, &record);
+
+        drop(record);
+        drop(body);
+        drop(backing);
+
+        assert!(dropped.load(Ordering::Relaxed));
+
+        let cached = cache.get(LOGLET_ID, OFFSET).unwrap();
+        let PolyBytes::Bytes(cached_body) = cached.body() else {
+            panic!("raw record should remain raw in the cache");
+        };
+
+        assert_eq!(cached_body.as_ref(), &[42; 1024]);
+    }
+
+    #[test]
+    fn cache_miss_retains_typed_values_without_raw_bytes() {
+        let typed = Arc::new("typed body".to_owned());
+        let typed_record = Record::from_parts(
+            NanosSinceEpoch::now(),
+            Keys::None,
+            PolyBytes::Typed(typed.clone()),
+        );
+        let typed_cache = RecordCache::new(4 * 1024);
+
+        typed_cache.add(LOGLET_ID, OFFSET, &typed_record);
+
+        assert!(Arc::ptr_eq(
+            &typed_cache
+                .get(LOGLET_ID, OFFSET)
+                .unwrap()
+                .decode_arc::<String>()
+                .unwrap(),
+            &typed,
+        ));
+
+        let both_cache = RecordCache::new(16 * 1024);
+        both_cache.add(
+            LOGLET_ID,
+            OFFSET,
+            &Record::from_parts(
+                NanosSinceEpoch::now(),
+                Keys::None,
+                PolyBytes::Both(typed.clone(), Bytes::from(vec![42; 8 * 1024])),
+            ),
+        );
+
+        let cached = both_cache.get(LOGLET_ID, OFFSET).unwrap();
+        assert_matches!(cached.body(), PolyBytes::Typed(_));
+        assert!(Arc::ptr_eq(&cached.decode_arc::<String>().unwrap(), &typed,));
+    }
+
+    #[test]
+    fn cache_miss_detaches_both_body_and_preserves_its_weight() {
+        let dropped = Arc::new(AtomicBool::new(false));
+        let backing = Bytes::from_owner(TrackingBacking {
+            bytes: vec![42; 128 * 1024],
+            dropped: Arc::clone(&dropped),
+        });
+        let body = backing.slice(64 * 1024..128 * 1024);
+        let typed = Arc::new("typed body".to_owned());
+        let record = Record::from_parts(
+            NanosSinceEpoch::now(),
+            Keys::None,
+            PolyBytes::Both(typed.clone(), body.clone()),
+        );
+        let expected_weight = u64::from(RecordCache::weight(&record));
+        let cache = RecordCache::new(128 * 1024);
+
+        cache.add(LOGLET_ID, OFFSET, &record);
+
+        drop(record);
+        drop(body);
+        drop(backing);
+
+        assert!(dropped.load(Ordering::Relaxed));
+
+        let cached = cache.get(LOGLET_ID, OFFSET).unwrap();
+        assert!(matches!(cached.body(), PolyBytes::Typed(_)));
+        assert!(Arc::ptr_eq(&cached.decode_arc::<String>().unwrap(), &typed));
+
+        let inner = cache.inner.as_ref().unwrap();
+        inner.run_pending_tasks();
+        assert_eq!(inner.weighted_size(), expected_weight);
+    }
+
+    #[test]
+    fn raw_entry_replaced_with_both_preserves_its_weight() {
+        let cache = RecordCache::new(128 * 1024);
+        cache.add(
+            LOGLET_ID,
+            OFFSET,
+            &Record::from_parts(
+                NanosSinceEpoch::now(),
+                Keys::None,
+                PolyBytes::Bytes(Bytes::from_static(b"raw body")),
+            ),
+        );
+
+        let dropped = Arc::new(AtomicBool::new(false));
+        let backing = Bytes::from_owner(TrackingBacking {
+            bytes: vec![42; 128 * 1024],
+            dropped: Arc::clone(&dropped),
+        });
+        let body = backing.slice(64 * 1024..128 * 1024);
+        let typed = Arc::new("typed body".to_owned());
+        let record = Record::from_parts(
+            NanosSinceEpoch::now(),
+            Keys::None,
+            PolyBytes::Both(typed.clone(), body.clone()),
+        );
+        let expected_weight = u64::from(RecordCache::weight(&record));
+
+        cache.add(LOGLET_ID, OFFSET, &record);
+
+        drop(record);
+        drop(body);
+        drop(backing);
+
+        assert!(dropped.load(Ordering::Relaxed));
+
+        let cached = cache.get(LOGLET_ID, OFFSET).unwrap();
+        assert_matches!(cached.body(), PolyBytes::Typed(_));
+        assert!(Arc::ptr_eq(&cached.decode_arc::<String>().unwrap(), &typed));
+
+        let inner = cache.inner.as_ref().unwrap();
+        inner.run_pending_tasks();
+        assert_eq!(inner.weighted_size(), expected_weight);
+    }
+
+    #[test]
+    fn duplicate_raw_record_does_not_replace_cached_record() {
+        let cache = RecordCache::new(4 * 1024);
+        let first = Record::from_parts(
+            NanosSinceEpoch::now(),
+            Keys::None,
+            PolyBytes::Bytes(Bytes::from_static(b"first")),
+        );
+        let duplicate = Record::from_parts(
+            NanosSinceEpoch::now(),
+            Keys::None,
+            PolyBytes::Bytes(Bytes::from_static(b"duplicate")),
+        );
+
+        cache.add(LOGLET_ID, OFFSET, &first);
+        let first_cached = cache.get(LOGLET_ID, OFFSET).unwrap();
+        cache.add(LOGLET_ID, OFFSET, &duplicate);
+        let cached = cache.get(LOGLET_ID, OFFSET).unwrap();
+
+        assert_matches!(cached.body(), PolyBytes::Bytes(bytes) if bytes.as_ref() == b"first");
+        assert_matches!(
+            (first_cached.body(), cached.body()),
+            (PolyBytes::Bytes(first), PolyBytes::Bytes(cached)) if first.as_ptr() == cached.as_ptr()
+        );
+    }
+
+    #[test]
+    fn oversized_raw_record_is_not_cached() {
+        let cache = RecordCache::new(1024);
+        let record = Record::from_parts(
+            NanosSinceEpoch::now(),
+            Keys::None,
+            PolyBytes::Bytes(Bytes::from(vec![42; 1024])),
+        );
+
+        cache.add(LOGLET_ID, OFFSET, &record);
+
+        assert!(cache.get(LOGLET_ID, OFFSET).is_none());
     }
 }

--- a/release-notes/unreleased/5080-limit-record-cache-retained-memory.md
+++ b/release-notes/unreleased/5080-limit-record-cache-retained-memory.md
@@ -1,0 +1,24 @@
+# Release Notes: Limit RecordCache Retained Memory
+
+## Bug Fix
+
+### What Changed
+
+RecordCache now copies raw record bodies when admitting them to the cache. This prevents a small
+cached body that is a slice of a larger buffer from retaining the full backing allocation.
+
+### Why This Matters
+
+The record cache's memory budget now more accurately bounds the memory retained for raw records,
+reducing the risk of unexpected memory growth and out-of-memory failures under sustained log
+traffic.
+
+### Impact on Users
+
+- Existing deployments gain tighter record-cache memory bounds after upgrading.
+- New deployments receive the same protection automatically.
+- No configuration or application changes are required.
+
+### Migration Guidance
+
+No migration is required.


### PR DESCRIPTION
## Summary

Addresses observed increased node memory use under sustained replicated-log traffic.

- Copy raw `Bytes` into a right-sized allocation only when a RecordCache entry is admitted.
- Keep `Typed` records shared and discard the raw representation of `Both`, which also detaches locally appended records from their reused appender-encoding buffer.
- Preserve the original encoded-size weight when reducing `Both` to `Typed`, so cache capacity remains meaningful for large locally appended records.
- Skip an uncacheable oversized record before inserting it.

## Root cause

Fabric-decoded records retain zero-copy `Bytes` slices. Cloning one into the long-lived RecordCache could pin the much larger backing tonic decode buffer. Locally appended records can similarly retain slices of a reused appender buffer.

## Performance impact

Local Criterion run (`--sample-size 10`). The direct `Bytes::copy_from_slice` cost is paid only on a fresh raw-body cache admission; it is not paid for `Typed`, `Both`, or duplicate raw records.

| Raw body | `Bytes::clone` | `Bytes::copy_from_slice` | Added copy cost |
| --- | ---: | ---: | ---: |
| 1 KiB | 3.53 ns | 28.45 ns | ~24.9 ns |
| 64 KiB | 3.55 ns | 649.85 ns | ~646 ns |
| 1 MiB | 3.57 ns | 12.31 µs | ~12.30 µs |

End-to-end `RecordCache::add` timings for the new implementation:

| Path | 1 KiB | 64 KiB | 1 MiB |
| --- | ---: | ---: | ---: |
| Fresh cache miss | 502 ns | 1.17 µs | 12.89 µs |
| Duplicate entry (no copy) | 192 ns | 189 ns | 185 ns |

## Validation

- Six focused RecordCache tests, including raw and `Both` owner-drop tests plus fresh and replacement-path assertions that detached `Both` entries preserve their original encoded-size weight.
- Criterion benchmark covering shallow clone versus copy and cache miss/duplicate paths at 1 KiB, 64 KiB, and 1 MiB.
- `cargo fmt --all -- --check`, `cargo check -p restate-types`, and targeted `cargo nextest run -p restate-types record_cache`.
- Independent three-node, 2,000-concurrent load validation: after 55 minutes the prior growing `decode_chunk` retention was negligible/absent on all nodes; RecordCache held 18–47 MiB of owned copies and remaining allocator growth was bounded RocksDB cache warming.

## Follow-up

The diagnostic PinGuard probes remain out of tree. A separate small follow-up can expose RecordCache logical `weighted_size` and entry-count metrics at `/metrics` scrape time, with explicit logical-capacity semantics. Object-count heap pprof support requires an upstream/forked `jemalloc_pprof`/`pprof_util` change; the current exporter emits only `inuse_space`.