### PR TITLE
[shuffle] Only report latest outbox truncation idx from the shuffle

### DIFF
--- a/crates/worker-api/src/processor/outbox.rs
+++ b/crates/worker-api/src/processor/outbox.rs
@@ -31,8 +31,6 @@ pub trait HasOutboxMut: HasOutbox {
 pub trait OutboxAccess {
     /// Sequence number of the next outbox message to be appended.
     fn outbox_tail(&self) -> MessageIndex;
-    /// First outbox message index that needs to be sent out.
-    fn outbox_head(&self) -> Option<MessageIndex>;
 }
 
 /// Mutable view of the outbox: append new messages and truncate delivered ones.
@@ -78,20 +76,12 @@ impl<T: OutboxAccess> OutboxAccess for &T {
     fn outbox_tail(&self) -> MessageIndex {
         (**self).outbox_tail()
     }
-    #[inline]
-    fn outbox_head(&self) -> Option<MessageIndex> {
-        (**self).outbox_head()
-    }
 }
 
 impl<T: OutboxAccess> OutboxAccess for &mut T {
     #[inline]
     fn outbox_tail(&self) -> MessageIndex {
         (**self).outbox_tail()
-    }
-    #[inline]
-    fn outbox_head(&self) -> Option<MessageIndex> {
-        (**self).outbox_head()
     }
 }
 

--- a/crates/worker/src/partition/leadership/leader_state.rs
+++ b/crates/worker/src/partition/leadership/leader_state.rs
@@ -109,7 +109,7 @@ pub struct LeaderState {
     next_fencing_token: FencingToken,
 
     invoker_stream: InvokerStream,
-    shuffle_stream: ReceiverStream<shuffle::OutboxTruncation>,
+    shuffle_stream: WatchStream<Option<shuffle::OutboxTruncation>>,
     schema_stream: WatchStream<Version>,
     rule_book_stream: WatchStream<Arc<RuleBook>>,
     cleaner_handle: CleanerHandle,
@@ -143,7 +143,7 @@ impl LeaderState {
         // token to mint. See `fencing_tokens` / `mint_fencing_token`.
         fencing_tokens: restate_platform::hash::HashMap<InvocationId, FencingToken>,
         next_fencing_token: FencingToken,
-        shuffle_rx: tokio::sync::mpsc::Receiver<shuffle::OutboxTruncation>,
+        shuffle_rx: tokio::sync::watch::Receiver<Option<shuffle::OutboxTruncation>>,
         durability_tracker: DurabilityTracker,
         leader_query_guard: LeaderQueryGuard,
         rule_book_rx: tokio::sync::watch::Receiver<Arc<RuleBook>>,
@@ -172,7 +172,7 @@ impl LeaderState {
             fencing_tokens,
             next_fencing_token,
             invoker_stream: invoker_rx,
-            shuffle_stream: ReceiverStream::new(shuffle_rx),
+            shuffle_stream: WatchStream::new(shuffle_rx),
             durability_tracker,
             network_events_tx,
             network_events_stream: ReceiverStream::new(network_events_rx),
@@ -273,7 +273,8 @@ impl LeaderState {
         });
 
         let invoker_stream = invoker_stream.map(LeaderEvent::Invoker);
-        let shuffle_stream = shuffle_stream.map(LeaderEvent::Shuffle);
+        let shuffle_stream = shuffle_stream
+            .filter_map(|shuffle| std::future::ready(shuffle.map(LeaderEvent::Shuffle)));
         let cleaner_stream = cleaner_handle.effects().map(LeaderEvent::Cleaner);
 
         let dur_tracker_stream = durability_tracker.map(LeaderEvent::PartitionMaintenance);

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -730,7 +730,7 @@ where
                 TimerReader::from(partition_store.clone()),
             );
 
-            let (shuffle_tx, shuffle_rx) = mpsc::channel(config.worker.internal_queue_length());
+            let (shuffle_tx, shuffle_rx) = tokio::sync::watch::channel(None);
 
             let shuffle = Shuffle::new(
                 ShuffleMetadata::new(processor.partition_id(), *leader_epoch),

--- a/crates/worker/src/partition/processor/commands/truncate_outbox.rs
+++ b/crates/worker/src/partition/processor/commands/truncate_outbox.rs
@@ -45,25 +45,29 @@ impl<P: HasOutboxMut> ApplyPartitionCommand<TruncateOutboxCommand>
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use googletest::prelude::*;
+    use std::assert_matches;
+    use std::ops::RangeInclusive;
 
     use restate_bifrost::DataRecord;
     use restate_core::TaskCenter;
     use restate_partition_store::{PartitionStore, PartitionStoreManager};
     use restate_rocksdb::RocksDbManager;
     use restate_storage_api::Transaction;
-    use restate_storage_api::outbox_table::ReadOutboxTable;
+    use restate_storage_api::fsm_table::WriteFsmTable;
+    use restate_storage_api::outbox_table::{OutboxMessage, ReadOutboxTable, WriteOutboxTable};
+    use restate_types::SemanticRestateVersion;
+    use restate_types::invocation::ServiceInvocation;
     use restate_types::logs::{Keys, Lsn, SequenceNumber};
     use restate_types::message::MessageIndex;
-    use restate_types::partitions::{Partition, PersistedFeatures};
+    use restate_types::partitions::Partition;
     use restate_types::sharding::{KeyRange, PartitionId};
     use restate_types::time::NanosSinceEpoch;
     use restate_wal_protocol::v2::{self, Command};
 
     use super::{ApplyPartitionCommand, TruncateOutboxCommand, TruncateOutboxContext};
-    use crate::partition::processor::{HasOutbox, OutboxAccess, ProcessorRawContext};
+    use crate::partition::processor::{
+        HasOutbox, HasOutboxMut, OutboxAccess, OutboxMut, ProcessorRawContext,
+    };
 
     async fn open_store() -> PartitionStore {
         RocksDbManager::init();
@@ -80,11 +84,19 @@ mod tests {
             .unwrap()
     }
 
-    fn empty_processor() -> ProcessorRawContext {
-        ProcessorRawContext::new(
-            Arc::new(Partition::new(PartitionId::MIN, KeyRange::FULL)),
-            PersistedFeatures::default(),
-        )
+    fn mock_outbox_message() -> OutboxMessage {
+        OutboxMessage::ServiceInvocation(Box::new(ServiceInvocation::mock()))
+    }
+
+    async fn populate_outbox(storage: &mut PartitionStore, range: RangeInclusive<MessageIndex>) {
+        let next_sequence_number = range.end() + 1;
+        let message = mock_outbox_message();
+        let mut txn = storage.transaction();
+        for index in range {
+            txn.put_outbox_message(index, &message).unwrap();
+        }
+        txn.put_outbox_seq_number(next_sequence_number).unwrap();
+        txn.commit().await.unwrap();
     }
 
     /// Drives a `TruncateOutbox` record through the partition-command handler and
@@ -117,33 +129,97 @@ mod tests {
     }
 
     #[restate_core::test]
-    async fn truncate_outbox_from_empty() {
+    async fn initializes_outbox_head_from_storage() {
         let mut storage = open_store().await;
-        let mut processor = empty_processor();
 
-        // An outbox message with index 0 has been processed and must now be truncated.
+        let mut processor =
+            ProcessorRawContext::create(SemanticRestateVersion::current(), &mut storage)
+                .await
+                .unwrap();
+        assert_eq!(processor.outbox().outbox_tail(), 0);
+
+        let mut txn = storage.transaction();
+        processor
+            .outbox_mut()
+            .enqueue(&mut txn, &mock_outbox_message())
+            .unwrap();
+        txn.commit().await.unwrap();
+        drop(txn);
         truncate(&mut processor, &mut storage, 0).await;
+        assert_matches!(storage.get_outbox_message(0).await, Ok(None));
 
-        assert_that!(storage.get_outbox_message(0).await.unwrap(), none());
-        // The head catches up to the next available sequence number on truncation. Since we
-        // don't know in advance whether we'll be asked to truncate more than one message, we
-        // track the head as the next position beyond the last truncation point. Leaving it as
-        // None is only safe while the outbox is known to be empty.
-        assert_that!(processor.outbox().outbox_head(), some(eq(1)));
+        populate_outbox(&mut storage, 3..=5).await;
+        let mut processor =
+            ProcessorRawContext::create(SemanticRestateVersion::current(), &mut storage)
+                .await
+                .unwrap();
+        assert_eq!(processor.outbox().outbox_tail(), 6);
+
+        truncate(&mut processor, &mut storage, 4).await;
+        assert_matches!(storage.get_outbox_message(3).await, Ok(None));
+        assert_matches!(storage.get_outbox_message(4).await, Ok(None));
+        assert_matches!(storage.get_outbox_message(5).await, Ok(Some(_)));
     }
 
     #[restate_core::test]
-    async fn truncate_outbox_with_gap() {
+    async fn truncates_and_reuses_outbox() {
         let mut storage = open_store().await;
-        let mut processor = empty_processor();
-        // The outbox holds [3..=5]; the whole range is truncated after message 5 is processed.
-        processor.seed_outbox_in_memory(5, Some(3));
+        populate_outbox(&mut storage, 3..=5).await;
+        let mut processor =
+            ProcessorRawContext::create(SemanticRestateVersion::current(), &mut storage)
+                .await
+                .unwrap();
+
+        // Truncating already-truncated outbox should be a no-op
+        truncate(&mut processor, &mut storage, 2).await;
+
+        truncate(&mut processor, &mut storage, 4).await;
+
+        assert_matches!(storage.get_outbox_message(3).await, Ok(None));
+        assert_matches!(storage.get_outbox_message(4).await, Ok(None));
+        assert_matches!(storage.get_outbox_message(5).await, Ok(Some(_)));
+        assert_eq!(processor.outbox().outbox_tail(), 6);
 
         truncate(&mut processor, &mut storage, 5).await;
 
-        assert_that!(storage.get_outbox_message(3).await.unwrap(), none());
-        assert_that!(storage.get_outbox_message(4).await.unwrap(), none());
-        assert_that!(storage.get_outbox_message(5).await.unwrap(), none());
-        assert_that!(processor.outbox().outbox_head(), some(eq(6)));
+        assert_matches!(storage.get_outbox_message(5).await, Ok(None));
+        assert_eq!(processor.outbox().outbox_tail(), 6);
+
+        let mut txn = storage.transaction();
+        processor
+            .outbox_mut()
+            .enqueue(&mut txn, &mock_outbox_message())
+            .unwrap();
+        txn.commit().await.unwrap();
+        drop(txn);
+
+        assert_matches!(storage.get_outbox_message(6).await, Ok(Some(_)));
+        assert_eq!(processor.outbox().outbox_tail(), 7);
+
+        truncate(&mut processor, &mut storage, 6).await;
+
+        assert_matches!(storage.get_outbox_message(6).await, Ok(None));
+        assert_eq!(processor.outbox().outbox_tail(), 7);
+
+        // Simulating a restart
+        // The Outbox is fully truncated at this point
+        let mut processor =
+            ProcessorRawContext::create(SemanticRestateVersion::current(), &mut storage)
+                .await
+                .unwrap();
+        assert_eq!(processor.outbox().outbox_tail(), 7);
+
+        let mut txn = storage.transaction();
+        processor
+            .outbox_mut()
+            .enqueue(&mut txn, &mock_outbox_message())
+            .unwrap();
+        txn.commit().await.unwrap();
+        drop(txn);
+
+        assert_matches!(storage.get_outbox_message(7).await, Ok(Some(_)));
+        truncate(&mut processor, &mut storage, 7).await;
+        assert_matches!(storage.get_outbox_message(7).await, Ok(None));
+        assert_eq!(processor.outbox().outbox_tail(), 8);
     }
 }

--- a/crates/worker/src/partition/processor/context.rs
+++ b/crates/worker/src/partition/processor/context.rs
@@ -137,17 +137,6 @@ impl ProcessorRawContext {
         }
     }
 
-    /// Seeds the in-memory outbox head/tail without persisting it. Test-only,
-    /// lets partition-command tests start from a partially-truncated outbox.
-    #[cfg(test)]
-    pub fn seed_outbox_in_memory(
-        &mut self,
-        tail: restate_types::message::MessageIndex,
-        head: Option<restate_types::message::MessageIndex>,
-    ) {
-        self.outbox = Outbox::seed(tail, head);
-    }
-
     /// Overwrites the in-memory feature set without persisting it. Test-only,
     /// mirrors the old `StateMachine`-embedded feature cache mutation.
     #[cfg(test)]

--- a/crates/worker/src/partition/processor/outbox.rs
+++ b/crates/worker/src/partition/processor/outbox.rs
@@ -20,7 +20,7 @@ use restate_worker_api::processor::{OutboxAccess, OutboxMut};
 
 pub struct Outbox {
     /// First outbox message index that needs to be sent out.
-    outbox_head_seq: Option<MessageIndex>,
+    outbox_head_seq: MessageIndex,
     /// Sequence number of the next outbox message to be appended.
     outbox_tail_seq: MessageIndex,
 }
@@ -30,17 +30,7 @@ impl Outbox {
     pub fn new_empty() -> Self {
         Self {
             outbox_tail_seq: 0,
-            outbox_head_seq: None,
-        }
-    }
-
-    /// Builds an outbox with pre-set head/tail sequence numbers, without touching
-    /// storage. Lets partition-command tests simulate a partially-truncated outbox.
-    #[cfg(test)]
-    pub fn seed(tail: MessageIndex, head: Option<MessageIndex>) -> Self {
-        Self {
-            outbox_tail_seq: tail,
-            outbox_head_seq: head,
+            outbox_head_seq: 0,
         }
     }
 
@@ -52,7 +42,7 @@ impl Outbox {
         let outbox_head_seq_number = storage.get_outbox_head_seq_number().await?;
         Ok(Self {
             outbox_tail_seq: outbox_seq_number,
-            outbox_head_seq: outbox_head_seq_number,
+            outbox_head_seq: outbox_head_seq_number.unwrap_or(outbox_seq_number),
         })
     }
 }
@@ -60,10 +50,6 @@ impl Outbox {
 impl OutboxAccess for Outbox {
     fn outbox_tail(&self) -> MessageIndex {
         self.outbox_tail_seq
-    }
-
-    fn outbox_head(&self) -> Option<MessageIndex> {
-        self.outbox_head_seq
     }
 }
 
@@ -74,7 +60,11 @@ impl OutboxMut for Outbox {
         to: MessageIndex,
     ) -> Result<(), StorageError> {
         // todo: Add validation or clamping to avoid truncating >= the outbox tail
-        let range = RangeInclusive::new(self.outbox_head_seq.unwrap_or(to), to);
+        if self.outbox_head_seq > to {
+            // We've already truncated those messages before
+            return Ok(());
+        }
+        let range = RangeInclusive::new(self.outbox_head_seq, to);
         trace!(
             restate.outbox.seq_from = range.start(),
             restate.outbox.seq_to = range.end(),
@@ -83,7 +73,7 @@ impl OutboxMut for Outbox {
 
         txn.truncate_outbox(range)?;
 
-        self.outbox_head_seq = Some(to + 1);
+        self.outbox_head_seq = to + 1;
         Ok(())
     }
 

--- a/crates/worker/src/partition/shuffle.rs
+++ b/crates/worker/src/partition/shuffle.rs
@@ -12,7 +12,7 @@ use std::future::Future;
 
 use async_channel::{TryRecvError, TrySendError};
 use metrics::{counter, gauge};
-use tokio::sync::mpsc;
+use tokio::sync::watch;
 use tracing::debug;
 
 use restate_core::cancellation_token;
@@ -44,7 +44,7 @@ impl NewOutboxMessage {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct OutboxTruncation(MessageIndex);
 
 impl OutboxTruncation {
@@ -168,7 +168,7 @@ pub(crate) struct Shuffle<T, OR> {
     outbox_reader: OR,
     ingestion_client: IngestionClient<T, Envelope>,
     // used to tell partition processor about outbox truncations
-    truncation_tx: mpsc::Sender<OutboxTruncation>,
+    truncation_tx: watch::Sender<Option<OutboxTruncation>>,
     hint_rx: async_channel::Receiver<NewOutboxMessage>,
     // used to create the senders into the shuffle
     hint_tx: async_channel::Sender<NewOutboxMessage>,
@@ -182,7 +182,7 @@ where
     pub fn new(
         metadata: ShuffleMetadata,
         outbox_reader: OR,
-        truncation_tx: mpsc::Sender<OutboxTruncation>,
+        truncation_tx: watch::Sender<Option<OutboxTruncation>>,
         channel_size: usize,
         ingestion_client: IngestionClient<T, Envelope>,
     ) -> Self {
@@ -252,10 +252,17 @@ where
                     inflight.push_back(commit_token);
                 }
                 Some(committed) = head => {
-                    let message_index = committed?;
+                    let new_message_index = committed?;
                     _ = inflight.pop_front();
                     ingested_counter.increment(1);
-                    let _ = truncation_tx.try_send(OutboxTruncation::new(message_index));
+                    let _ = truncation_tx.send_if_modified(|current| {
+                        if current.as_ref().is_none_or(|idx| new_message_index > idx.0) {
+                            *current = Some(OutboxTruncation::new(new_message_index));
+                            true
+                        } else {
+                            false
+                        }
+                    });
                 }
             }
         }
@@ -433,7 +440,7 @@ mod ingestion_client_tests {
     use restate_types::partitions::state::{LeadershipState, PartitionReplicaSetStates};
     use restate_types::storage::StorageCodec;
     use test_log::test;
-    use tokio::sync::mpsc;
+    use tokio::sync::watch;
 
     use restate_core::network::{
         BackPressureMode, FailingConnector, ServiceMessage, ServiceStream,
@@ -655,7 +662,7 @@ mod ingestion_client_tests {
             SessionOptions::default(),
         );
 
-        let (truncation_tx, _truncation_rx) = mpsc::channel(1);
+        let (truncation_tx, _truncation_rx) = watch::channel(None);
 
         let shuffle = Shuffle::new(metadata, outbox_reader, truncation_tx, 1, ingestion.clone());
 


### PR DESCRIPTION

Before this PR, the shuffle had a 1000 sized channel between it and the PP. This meant it can accumulate up to 1k outbox truncation messages in that channel. However, outbox truncations are prefix based, so you only care about the latest one. To make things worse, the current state was dropping the "latest" truncation messages when this channel is full (using `try_send`), although it's actually the latest ones that matter.

This PR changes that channel to be a watch channel instead. The PP will just use the latest messages whenever that stream gets polled.

To make this work, it required another fix. On startup, the shuffle scans the outbox for the head of the queue. If the queue is empty, it stores the head as None. The head is then later used for truncation from head until N where N is the idx of the command. If at the moment of truncation, the head was still None, it uses the first command it sees as the head. So when it was writing all messages, the head correctly matched the first record written. Now that we're overriding the commands, there's no guarantee that the shuffle will get the very first truncation command it proposed. So instead, we're initializing the head during enqueue if it's not set.
