### PR TITLE
Add HTTP ingress drain control

### DIFF
--- a/crates/core/protobuf/node_ctl_svc.proto
+++ b/crates/core/protobuf/node_ctl_svc.proto
@@ -34,11 +34,13 @@ service NodeCtlSvc {
   rpc TriggerCompaction(TriggerCompactionRequest)
       returns (TriggerCompactionResponse);
 
-  // Stops accepting new HTTP ingress traffic and reports drain progress. The
-  // first call returns after listeners are closed and graceful shutdown has
+  // Stops accepting new HTTP ingress traffic and reports HTTP drain progress.
+  // The first call returns after listeners are closed and graceful shutdown has
   // been initiated on every accepted connection. Repeat calls poll for the
-  // DRAINED state. The transition is scoped to the current node generation and
-  // is irreversible until the process restarts.
+  // DRAINED state. DRAINED reports only HTTP listener and connection
+  // quiescence; it is not a process-shutdown or worker-drain barrier. The
+  // transition is scoped to the current node generation and is irreversible
+  // until the process restarts.
   rpc DrainHttpIngress(DrainHttpIngressRequest)
       returns (DrainHttpIngressResponse);
 }
@@ -154,6 +156,8 @@ enum HttpIngressDrainStatus {
   HTTP_INGRESS_DRAIN_STATUS_NOT_PRESENT = 1;
   HTTP_INGRESS_DRAIN_STATUS_ACTIVE = 2;
   HTTP_INGRESS_DRAIN_STATUS_DRAINING = 3;
+  // No accepted HTTP ingress connections remain; worker and process activity
+  // are not covered.
   HTTP_INGRESS_DRAIN_STATUS_DRAINED = 4;
 }
 

--- a/crates/core/protobuf/node_ctl_svc.proto
+++ b/crates/core/protobuf/node_ctl_svc.proto
@@ -33,6 +33,14 @@ service NodeCtlSvc {
   // Trigger manual compaction of RocksDB databases on this node.
   rpc TriggerCompaction(TriggerCompactionRequest)
       returns (TriggerCompactionResponse);
+
+  // Stops accepting new HTTP ingress traffic and reports drain progress. The
+  // first call returns after listeners are closed and graceful shutdown has
+  // been initiated on every accepted connection. Repeat calls poll for the
+  // DRAINED state. The transition is scoped to the current node generation and
+  // is irreversible until the process restarts.
+  rpc DrainHttpIngress(DrainHttpIngressRequest)
+      returns (DrainHttpIngressResponse);
 }
 
 enum ClusterFeature {
@@ -133,6 +141,27 @@ message TriggerCompactionRequest {
 
 message TriggerCompactionResponse {
   repeated DatabaseCompactionResult results = 1;
+}
+
+message DrainHttpIngressRequest {
+  // The node process that the caller intends to drain. The request is rejected
+  // if this does not match the currently running generation.
+  restate.common.GenerationalNodeId expected_node_id = 1;
+}
+
+enum HttpIngressDrainStatus {
+  HTTP_INGRESS_DRAIN_STATUS_UNSPECIFIED = 0;
+  HTTP_INGRESS_DRAIN_STATUS_NOT_PRESENT = 1;
+  HTTP_INGRESS_DRAIN_STATUS_ACTIVE = 2;
+  HTTP_INGRESS_DRAIN_STATUS_DRAINING = 3;
+  HTTP_INGRESS_DRAIN_STATUS_DRAINED = 4;
+}
+
+message DrainHttpIngressResponse {
+  restate.common.GenerationalNodeId node_id = 1;
+  HttpIngressDrainStatus status = 2;
+  uint64 in_flight_requests = 3;
+  uint64 in_flight_connections = 4;
 }
 
 message DatabaseCompactionResult {

--- a/crates/ingress-http/src/drain.rs
+++ b/crates/ingress-http/src/drain.rs
@@ -1,0 +1,245 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IngressDrainStatus {
+    Active,
+    Draining,
+    Drained,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IngressDrainProgress {
+    pub status: IngressDrainStatus,
+    pub in_flight_requests: u64,
+    pub in_flight_connections: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct IngressDrainHandle {
+    inner: Arc<Inner>,
+}
+
+#[derive(Debug)]
+struct Inner {
+    drain: CancellationToken,
+    state: watch::Sender<State>,
+    in_flight_requests: AtomicU64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct State {
+    status: IngressDrainStatus,
+    admission_closed: bool,
+    in_flight_connections: u64,
+    connections_awaiting_goaway: u64,
+}
+
+impl Default for IngressDrainHandle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IngressDrainHandle {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                drain: CancellationToken::new(),
+                state: watch::Sender::new(State {
+                    status: IngressDrainStatus::Active,
+                    admission_closed: false,
+                    in_flight_connections: 0,
+                    connections_awaiting_goaway: 0,
+                }),
+                in_flight_requests: AtomicU64::new(0),
+            }),
+        }
+    }
+
+    /// Starts the irreversible drain and waits until the admission barrier has been crossed.
+    ///
+    /// Once this returns, listeners have been closed and every accepted connection has initiated
+    /// graceful shutdown. Existing requests may still be running.
+    pub async fn drain(&self) -> IngressDrainProgress {
+        self.start_draining();
+
+        let mut state = self.inner.state.subscribe();
+        state
+            .wait_for(|state| state.admission_closed && state.connections_awaiting_goaway == 0)
+            .await
+            .expect("the ingress drain state sender is retained by the handle");
+        self.to_progress(*state.borrow())
+    }
+
+    pub fn progress(&self) -> IngressDrainProgress {
+        self.to_progress(*self.inner.state.borrow())
+    }
+
+    pub(crate) fn cancellation_token(&self) -> CancellationToken {
+        self.inner.drain.clone()
+    }
+
+    pub(crate) fn start_draining(&self) {
+        self.inner.state.send_if_modified(|state| {
+            if state.status != IngressDrainStatus::Active {
+                return false;
+            }
+            state.status = IngressDrainStatus::Draining;
+            state.connections_awaiting_goaway = state.in_flight_connections;
+            true
+        });
+        self.inner.drain.cancel();
+    }
+
+    pub(crate) fn admission_closed(&self) {
+        self.inner.state.send_if_modified(|state| {
+            if state.admission_closed {
+                return false;
+            }
+            state.admission_closed = true;
+            true
+        });
+    }
+
+    pub(crate) fn drained(&self) {
+        self.inner.state.send_if_modified(|state| {
+            if state.status == IngressDrainStatus::Drained {
+                return false;
+            }
+            debug_assert!(state.admission_closed);
+            debug_assert_eq!(state.in_flight_connections, 0);
+            state.status = IngressDrainStatus::Drained;
+            true
+        });
+    }
+
+    pub(crate) fn connection_started(&self) -> ConnectionGuard {
+        self.inner.state.send_modify(|state| {
+            state.in_flight_connections += 1;
+            if state.status != IngressDrainStatus::Active {
+                state.connections_awaiting_goaway += 1;
+            }
+        });
+        ConnectionGuard {
+            drain: self.clone(),
+            goaway_initiated: false,
+        }
+    }
+
+    pub(crate) fn request_started(&self) -> RequestGuard {
+        self.inner
+            .in_flight_requests
+            .fetch_add(1, Ordering::Relaxed);
+        RequestGuard(self.clone())
+    }
+
+    fn to_progress(&self, state: State) -> IngressDrainProgress {
+        IngressDrainProgress {
+            status: state.status,
+            in_flight_requests: self.inner.in_flight_requests.load(Ordering::Relaxed),
+            in_flight_connections: state.in_flight_connections,
+        }
+    }
+}
+
+pub(crate) struct ConnectionGuard {
+    drain: IngressDrainHandle,
+    goaway_initiated: bool,
+}
+
+impl ConnectionGuard {
+    pub(crate) fn goaway_initiated(&mut self) {
+        if self.goaway_initiated {
+            return;
+        }
+        self.goaway_initiated = true;
+        self.drain.inner.state.send_modify(|state| {
+            debug_assert!(state.connections_awaiting_goaway > 0);
+            state.connections_awaiting_goaway -= 1;
+        });
+    }
+}
+
+impl Drop for ConnectionGuard {
+    fn drop(&mut self) {
+        self.drain.inner.state.send_modify(|state| {
+            debug_assert!(state.in_flight_connections > 0);
+            state.in_flight_connections -= 1;
+            if state.status != IngressDrainStatus::Active && !self.goaway_initiated {
+                debug_assert!(state.connections_awaiting_goaway > 0);
+                state.connections_awaiting_goaway -= 1;
+            }
+        });
+    }
+}
+
+pub(crate) struct RequestGuard(IngressDrainHandle);
+
+impl Drop for RequestGuard {
+    fn drop(&mut self) {
+        let previous = self
+            .0
+            .inner
+            .in_flight_requests
+            .fetch_sub(1, Ordering::Relaxed);
+        debug_assert!(previous > 0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn drain_waits_for_admission_barrier_and_is_idempotent() {
+        let drain = IngressDrainHandle::new();
+        let mut connection = drain.connection_started();
+        let request = drain.request_started();
+
+        let pending_drain = tokio::spawn({
+            let drain = drain.clone();
+            async move { drain.drain().await }
+        });
+        tokio::task::yield_now().await;
+
+        drain.admission_closed();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), pending_drain)
+                .await
+                .is_err(),
+            "drain must wait until existing connections have initiated GOAWAY"
+        );
+
+        connection.goaway_initiated();
+        let progress = tokio::time::timeout(Duration::from_secs(1), drain.drain())
+            .await
+            .unwrap();
+        assert_eq!(progress.status, IngressDrainStatus::Draining);
+        assert_eq!(progress.in_flight_connections, 1);
+        assert_eq!(progress.in_flight_requests, 1);
+
+        drop(request);
+        drop(connection);
+        drain.drained();
+        let progress = drain.drain().await;
+        assert_eq!(progress.status, IngressDrainStatus::Drained);
+        assert_eq!(progress.in_flight_connections, 0);
+        assert_eq!(progress.in_flight_requests, 0);
+    }
+}

--- a/crates/ingress-http/src/layers/in_flight_requests.rs
+++ b/crates/ingress-http/src/layers/in_flight_requests.rs
@@ -1,0 +1,83 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use pin_project_lite::pin_project;
+use tower::{Layer, Service};
+
+use crate::drain::{IngressDrainHandle, RequestGuard};
+
+#[derive(Clone)]
+pub(crate) struct InFlightRequestsLayer(IngressDrainHandle);
+
+impl InFlightRequestsLayer {
+    pub(crate) fn new(drain: IngressDrainHandle) -> Self {
+        Self(drain)
+    }
+}
+
+impl<S> Layer<S> for InFlightRequestsLayer {
+    type Service = InFlightRequests<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        InFlightRequests {
+            inner,
+            drain: self.0.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct InFlightRequests<S> {
+    inner: S,
+    drain: IngressDrainHandle,
+}
+
+impl<S, Request> Service<Request> for InFlightRequests<S>
+where
+    S: Service<Request>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = InFlightRequestFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        InFlightRequestFuture {
+            inner: self.inner.call(request),
+            _guard: self.drain.request_started(),
+        }
+    }
+}
+
+pin_project! {
+    pub(crate) struct InFlightRequestFuture<F> {
+        #[pin]
+        inner: F,
+        _guard: RequestGuard,
+    }
+}
+
+impl<F> Future for InFlightRequestFuture<F>
+where
+    F: Future,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().inner.poll(cx)
+    }
+}

--- a/crates/ingress-http/src/layers/mod.rs
+++ b/crates/ingress-http/src/layers/mod.rs
@@ -8,5 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+pub(crate) mod in_flight_requests;
 pub mod load_shed;
 pub mod tracing_context_extractor;

--- a/crates/ingress-http/src/lib.rs
+++ b/crates/ingress-http/src/lib.rs
@@ -8,12 +8,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod drain;
 mod handler;
 mod layers;
 mod metric_definitions;
 mod rpc_request_dispatcher;
 mod server;
 
+pub use drain::{IngressDrainHandle, IngressDrainProgress, IngressDrainStatus};
 pub use rpc_request_dispatcher::InvocationClientRequestDispatcher;
 pub use server::{HyperServerIngress, IngressServerError};
 

--- a/crates/ingress-http/src/server.rs
+++ b/crates/ingress-http/src/server.rs
@@ -45,7 +45,9 @@ use restate_types::schema::service::ServiceMetadataResolver;
 use restate_util_time::DurationExt;
 
 use super::*;
+use crate::drain::{IngressDrainHandle, IngressDrainStatus};
 use crate::handler::Handler;
+use crate::layers::in_flight_requests::InFlightRequestsLayer;
 use crate::metric_definitions::{HTTP_CONNECTION_CREATED, HTTP_CONNECTION_DROPPED};
 
 #[derive(Debug, thiserror::Error, CodedError)]
@@ -54,6 +56,8 @@ pub enum IngressServerError {
     #[code(unknown)]
     Running(#[from] hyper::Error),
 }
+
+const FINAL_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub struct HyperServerIngress<Schemas, Dispatcher> {
     listeners: Listeners<HttpIngressPort>,
@@ -66,6 +70,8 @@ pub struct HyperServerIngress<Schemas, Dispatcher> {
     dispatcher: Dispatcher,
 
     health: HealthStatus<IngressStatus>,
+    drain: IngressDrainHandle,
+    final_drain_timeout: Duration,
 }
 
 impl<Schemas, Dispatcher> HyperServerIngress<Schemas, Dispatcher>
@@ -117,7 +123,19 @@ where
             schemas,
             dispatcher,
             health,
+            drain: IngressDrainHandle::new(),
+            final_drain_timeout: FINAL_DRAIN_TIMEOUT,
         }
+    }
+
+    pub fn drain_handle(&self) -> IngressDrainHandle {
+        self.drain.clone()
+    }
+
+    #[cfg(test)]
+    fn with_final_drain_timeout(mut self, timeout: Duration) -> Self {
+        self.final_drain_timeout = timeout;
+        self
     }
 
     #[instrument(
@@ -135,6 +153,8 @@ where
             schemas,
             dispatcher,
             health,
+            drain,
+            final_drain_timeout,
         } = self;
 
         // Prepare the handler
@@ -190,6 +210,7 @@ where
             .layer(RequestBodyLimitLayer::new(request_size_limit))
             .layer(CorsLayer::very_permissive())
             .layer(layers::load_shed::LoadShedLayer::new(concurrency_limit))
+            .layer(InFlightRequestsLayer::new(drain.clone()))
             .layer(layers::tracing_context_extractor::HttpTraceContextExtractorLayer)
             .service(Handler::new(schemas, dispatcher));
 
@@ -200,6 +221,7 @@ where
         // move `CorsLayer` above `RequestBodyLimitLayer`.
 
         let shutdown = cancellation_token();
+        let drain_requested = drain.cancellation_token();
 
         if let Some(uds_path) = listeners.uds_address() {
             Span::current().record("uds.path", uds_path.display().to_string());
@@ -209,14 +231,34 @@ where
             Span::current().record("server.port", socket_addr.port());
         }
         info!("Ingress HTTP listening");
-        health.update(IngressStatus::Ready);
+        if drain.progress().status == IngressDrainStatus::Active {
+            health.update(IngressStatus::Ready);
+        } else {
+            health.update(IngressStatus::Draining);
+        }
 
         let mut inflight = TaskTracker::default();
         let force_shutdown = CancellationToken::new();
+        let connection_shutdown = ConnectionShutdown {
+            drain: drain_requested.clone(),
+            force: force_shutdown.clone(),
+            progress: drain.clone(),
+        };
 
-        // UDS
+        let mut final_shutdown = false;
         loop {
             tokio::select! {
+                biased;
+                _ = shutdown.cancelled() => {
+                    info!("HTTP ingress shutdown requested");
+                    final_shutdown = true;
+                    drain.start_draining();
+                    break;
+                }
+                _ = drain_requested.cancelled() => {
+                    info!("HTTP ingress drain requested");
+                    break;
+                }
                 res = listeners.accept() => {
                     let (stream, peer_addr) = res?;
                     match stream {
@@ -226,8 +268,7 @@ where
                                 peer_addr,
                                 service.clone(),
                                 http2_max_concurrent_streams,
-                                shutdown.child_token(),
-                                force_shutdown.child_token(),
+                                connection_shutdown.clone(),
                                 &mut inflight,
                             )?;
                         }
@@ -237,26 +278,42 @@ where
                                 peer_addr,
                                 service.clone(),
                                 http2_max_concurrent_streams,
-                                shutdown.child_token(),
-                                force_shutdown.child_token(),
+                                connection_shutdown.clone(),
                                 &mut inflight,
                             )?;
                         }
 
                     }
                 }
-                  _ = shutdown.cancelled() => {
-                      info!("HTTP ingress shutdown requested");
-                      drop(listeners);
-                      inflight.close();
-                      break;
+            }
+        }
+
+        drop(listeners);
+        inflight.close();
+        health.update(IngressStatus::Draining);
+        drain.admission_closed();
+
+        if !final_shutdown {
+            tokio::select! {
+                () = inflight.wait() => {
+                    drain.drained();
+                    health.update(IngressStatus::Drained);
+                    info!("All in-flight HTTP ingress connections drained");
+                    // Retain task-center ownership of the role until normal shutdown.
+                    shutdown.cancelled().await;
+                    return Ok(());
+                }
+                () = shutdown.cancelled() => {
+                    final_shutdown = true;
                 }
             }
         }
 
-        // drain in-flight requests (give them some time to finish)
-        match tokio::time::timeout(Duration::from_secs(5), inflight.wait()).await {
+        debug_assert!(final_shutdown);
+        match tokio::time::timeout(final_drain_timeout, inflight.wait()).await {
             Ok(()) => {
+                drain.drained();
+                health.update(IngressStatus::Drained);
                 info!("All in-flight HTTP ingress connections drained");
             }
             Err(_) => {
@@ -278,8 +335,7 @@ where
         remote_peer: SocketAddress,
         handler: T,
         http2_max_concurrent_streams: Option<NonZeroU32>,
-        drain: CancellationToken,
-        force_shutdown: CancellationToken,
+        shutdown: ConnectionShutdown,
         inflight: &mut TaskTracker,
     ) -> anyhow::Result<()>
     where
@@ -299,6 +355,7 @@ where
     {
         let connect_info = ConnectInfo::new(remote_peer);
         counter!(HTTP_CONNECTION_CREATED).increment(1);
+        let mut connection_guard = shutdown.progress.connection_started();
 
         let io = TokioIo::new(stream);
         let handler = hyper_util::service::TowerToHyperService::new(handler.map_request(
@@ -311,7 +368,7 @@ where
         let tc_executor = TaskCenterExecutor::new(
             TaskCenter::current(),
             inflight.clone(),
-            force_shutdown.clone(),
+            shutdown.force.clone(),
         );
 
         // Spawn a tokio task to serve the connection
@@ -349,18 +406,26 @@ where
                             }
                         }
                     }
-                    _ = drain.cancelled(), if !draining => {
+                    _ = shutdown.drain.cancelled(), if !draining => {
                         // Ask clients to not send any more requests on this connection
                         serve_connection_fut.as_mut().graceful_shutdown();
+                        connection_guard.goaway_initiated();
                         draining = true;
                     }
-                    _ = force_shutdown.cancelled() => { break; }
+                    _ = shutdown.force.cancelled() => { break; }
                 }
             }
         }.in_current_tc());
 
         Ok(())
     }
+}
+
+#[derive(Clone)]
+struct ConnectionShutdown {
+    drain: CancellationToken,
+    force: CancellationToken,
+    progress: IngressDrainHandle,
 }
 
 #[derive(Clone)]
@@ -469,7 +534,7 @@ mod tests {
 
         let socket_dir = tempfile::tempdir().unwrap();
         let socket_path = socket_dir.path().join("ingress.sock");
-        bootstrap_test(
+        let _drain = bootstrap_test(
             Listeners::new_unix_listener(socket_path.clone()).unwrap(),
             mock_dispatcher,
         )
@@ -504,10 +569,160 @@ mod tests {
         restate_test_util::assert_eq!(response_value.greeting, "Igal");
     }
 
+    #[restate_core::test]
+    async fn explicit_drain_closes_admission_and_preserves_in_flight_request() {
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let release = Arc::new(Semaphore::new(0));
+        let mut mock_dispatcher = MockRequestDispatcher::default();
+        mock_dispatcher.expect_call().once().return_once({
+            let release = release.clone();
+            move |invocation_request| {
+                Box::pin(async move {
+                    let _ = started_tx.send(());
+                    let _permit = release.acquire().await.unwrap();
+                    Ok(InvocationOutput {
+                        request_id: Default::default(),
+                        invocation_id: Some(invocation_request.invocation_id()),
+                        completion_expiry_time: None,
+                        response: InvocationOutputResponse::Success(
+                            InvocationTarget::service("greeter.Greeter", "greet"),
+                            serde_json::to_vec(&GreetingResponse {
+                                greeting: "Igal".to_string(),
+                            })
+                            .unwrap()
+                            .into(),
+                        ),
+                    })
+                })
+            }
+        });
+
+        let socket_dir = tempfile::tempdir().unwrap();
+        let socket_path = socket_dir.path().join("ingress.sock");
+        let drain = bootstrap_test(
+            Listeners::new_unix_listener(socket_path.clone()).unwrap(),
+            mock_dispatcher,
+        )
+        .await;
+        let client = Client::builder(TokioExecutor::new())
+            .http2_only(true)
+            .build::<_, Full<Bytes>>(UnixSocketConnector::new(socket_path));
+
+        let response = tokio::spawn({
+            let client = client.clone();
+            async move {
+                client
+                    .request(
+                        http::Request::post("http://localhost/greeter.Greeter/greet")
+                            .header(http::header::CONTENT_TYPE, "application/json")
+                            .body(Full::new(Bytes::new()))
+                            .unwrap(),
+                    )
+                    .await
+            }
+        });
+        started_rx.await.unwrap();
+
+        let progress = tokio::time::timeout(Duration::from_secs(1), drain.drain())
+            .await
+            .unwrap();
+        assert_eq!(progress.status, IngressDrainStatus::Draining);
+        assert_eq!(progress.in_flight_requests, 1);
+        assert_eq!(progress.in_flight_connections, 1);
+
+        let new_request = client.request(
+            http::Request::post("http://localhost/greeter.Greeter/greet")
+                .header(http::header::CONTENT_TYPE, "application/json")
+                .body(Full::new(Bytes::new()))
+                .unwrap(),
+        );
+        assert!(
+            tokio::time::timeout(Duration::from_secs(1), new_request)
+                .await
+                .expect("new request should fail promptly")
+                .is_err(),
+            "a draining ingress must not admit another request"
+        );
+
+        release.add_permits(1);
+        assert_eq!(
+            response.await.unwrap().unwrap().status(),
+            http::StatusCode::OK
+        );
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while drain.progress().status != IngressDrainStatus::Drained {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("ingress should become drained after the response is flushed");
+        assert_eq!(drain.progress().in_flight_requests, 0);
+        assert_eq!(drain.progress().in_flight_connections, 0);
+    }
+
+    #[restate_core::test]
+    async fn task_cancellation_applies_final_drain_timeout() {
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let mut mock_dispatcher = MockRequestDispatcher::default();
+        mock_dispatcher.expect_call().once().return_once(move |_| {
+            Box::pin(async move {
+                let _ = started_tx.send(());
+                std::future::pending().await
+            })
+        });
+
+        let socket_dir = tempfile::tempdir().unwrap();
+        let socket_path = socket_dir.path().join("ingress.sock");
+        let drain = bootstrap_test_with_final_drain_timeout(
+            Listeners::new_unix_listener(socket_path.clone()).unwrap(),
+            mock_dispatcher,
+            Duration::from_millis(10),
+        )
+        .await;
+        let client = Client::builder(TokioExecutor::new())
+            .http2_only(true)
+            .build::<_, Full<Bytes>>(UnixSocketConnector::new(socket_path));
+        let response = tokio::spawn(async move {
+            client
+                .request(
+                    http::Request::post("http://localhost/greeter.Greeter/greet")
+                        .header(http::header::CONTENT_TYPE, "application/json")
+                        .body(Full::new(Bytes::new()))
+                        .unwrap(),
+                )
+                .await
+        });
+        started_rx.await.unwrap();
+        drain.drain().await;
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            TaskCenter::cancel_tasks(Some(TaskKind::HttpIngressRole), None),
+        )
+        .await
+        .expect("task cancellation must force an outstanding request after the final timeout");
+        assert!(response.await.unwrap().is_err());
+        assert_eq!(drain.progress().in_flight_requests, 0);
+        assert_eq!(drain.progress().in_flight_connections, 0);
+    }
+
     async fn bootstrap_test(
         listeners: Listeners<HttpIngressPort>,
         mock_request_dispatcher: MockRequestDispatcher,
-    ) {
+    ) -> IngressDrainHandle {
+        bootstrap_test_with_final_drain_timeout(
+            listeners,
+            mock_request_dispatcher,
+            FINAL_DRAIN_TIMEOUT,
+        )
+        .await
+    }
+
+    async fn bootstrap_test_with_final_drain_timeout(
+        listeners: Listeners<HttpIngressPort>,
+        mock_request_dispatcher: MockRequestDispatcher,
+        final_drain_timeout: Duration,
+    ) -> IngressDrainHandle {
         let _env = TestCoreEnv::create_with_single_node(1, 1).await;
         let health = Health::default();
 
@@ -520,7 +735,10 @@ mod tests {
             Live::from_value(mock_schemas()),
             Arc::new(mock_request_dispatcher),
             health.ingress_status(),
-        );
-        TaskCenter::spawn(TaskKind::SystemService, "ingress", ingress.run()).unwrap();
+        )
+        .with_final_drain_timeout(final_drain_timeout);
+        let drain = ingress.drain_handle();
+        TaskCenter::spawn(TaskKind::HttpIngressRole, "ingress", ingress.run()).unwrap();
+        drain
     }
 }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -468,6 +468,7 @@ impl Node {
 
         let metadata_writer = self.metadata_manager.writer();
         let metadata = Metadata::current();
+        let ingress_drain = self.ingress_role.as_ref().map(IngressRole::drain_handle);
 
         // Start metadata manager
         spawn_metadata_manager(self.metadata_manager)?;
@@ -482,6 +483,7 @@ impl Node {
                     self.server_builder,
                     metadata_writer,
                     self.prometheus,
+                    ingress_drain,
                 )
                 .await?;
                 Ok(())

--- a/crates/node/src/network_server/grpc_svc_handler.rs
+++ b/crates/node/src/network_server/grpc_svc_handler.rs
@@ -561,5 +561,8 @@ mod tests {
         let not_initialized =
             ensure_node_generation(expected, Some(NodeId::Plain(PlainNodeId::new(1)))).unwrap_err();
         assert_eq!(not_initialized.code(), Code::Unavailable);
+
+        let not_initialized = ensure_node_generation(expected, None).unwrap_err();
+        assert_eq!(not_initialized.code(), Code::Unavailable);
     }
 }

--- a/crates/node/src/network_server/grpc_svc_handler.rs
+++ b/crates/node/src/network_server/grpc_svc_handler.rs
@@ -28,16 +28,17 @@ use restate_types::net::connect_opts::GrpcConnectionOptions;
 use restate_core::network::net_util::{DNSResolution, create_tonic_channel};
 use restate_core::protobuf::node_ctl_svc::node_ctl_svc_server::{NodeCtlSvc, NodeCtlSvcServer};
 use restate_core::protobuf::node_ctl_svc::{
-    ClusterHealthResponse, DatabaseCompactionResult, EmbeddedMetadataClusterHealth,
-    GetMetadataRequest, GetMetadataResponse, IdentResponse, ProvisionClusterRequest,
+    ClusterHealthResponse, DatabaseCompactionResult, DrainHttpIngressRequest,
+    DrainHttpIngressResponse, EmbeddedMetadataClusterHealth, GetMetadataRequest,
+    GetMetadataResponse, HttpIngressDrainStatus, IdentResponse, ProvisionClusterRequest,
     ProvisionClusterResponse, TriggerCompactionRequest, TriggerCompactionResponse,
     cluster_features_from_proto,
 };
 use restate_core::{Identification, MetadataWriter};
 use restate_core::{Metadata, MetadataKind};
+use restate_ingress_http::{IngressDrainHandle, IngressDrainStatus};
 use restate_metadata_store::{MetadataStoreClient, ReadError, WriteError};
 use restate_rocksdb::RocksDbManager;
-use restate_types::Version;
 use restate_types::config::{Configuration, NetworkingOptions};
 use restate_types::errors::{ConversionError, MaybeRetryableError};
 use restate_types::logs::metadata::{NodeSetSize, ProviderConfiguration};
@@ -47,16 +48,21 @@ use restate_types::protobuf::cluster::ClusterConfiguration as ProtoClusterConfig
 use restate_types::protobuf::common::DatabaseKind;
 use restate_types::replication::ReplicationProperty;
 use restate_types::storage::StorageCodec;
+use restate_types::{GenerationalNodeId, NodeId, Version};
 
 use crate::{ClusterConfiguration, provision_cluster_metadata};
 
 pub struct NodeCtlSvcHandler {
     metadata_writer: MetadataWriter,
+    ingress_drain: Option<IngressDrainHandle>,
 }
 
 impl NodeCtlSvcHandler {
-    pub fn new(metadata_writer: MetadataWriter) -> Self {
-        Self { metadata_writer }
+    pub fn new(metadata_writer: MetadataWriter, ingress_drain: Option<IngressDrainHandle>) -> Self {
+        Self {
+            metadata_writer,
+            ingress_drain,
+        }
     }
 
     pub fn into_server(self, config: &NetworkingOptions) -> NodeCtlSvcServer<Self> {
@@ -325,6 +331,65 @@ impl NodeCtlSvc for NodeCtlSvcHandler {
 
         Ok(Response::new(TriggerCompactionResponse { results }))
     }
+
+    async fn drain_http_ingress(
+        &self,
+        request: Request<DrainHttpIngressRequest>,
+    ) -> Result<Response<DrainHttpIngressResponse>, Status> {
+        let expected_node_id: GenerationalNodeId = request
+            .into_inner()
+            .expected_node_id
+            .ok_or_else(|| Status::invalid_argument("expected_node_id is required"))?
+            .into();
+
+        let actual_node_id =
+            ensure_node_generation(expected_node_id, Identification::get().node_id)?;
+
+        let (status, in_flight_requests, in_flight_connections) =
+            if let Some(ingress_drain) = &self.ingress_drain {
+                let progress = ingress_drain.drain().await;
+                (
+                    match progress.status {
+                        IngressDrainStatus::Active => HttpIngressDrainStatus::Active,
+                        IngressDrainStatus::Draining => HttpIngressDrainStatus::Draining,
+                        IngressDrainStatus::Drained => HttpIngressDrainStatus::Drained,
+                    },
+                    progress.in_flight_requests,
+                    progress.in_flight_connections,
+                )
+            } else {
+                (HttpIngressDrainStatus::NotPresent, 0, 0)
+            };
+
+        Ok(Response::new(DrainHttpIngressResponse {
+            node_id: Some(actual_node_id.into()),
+            status: status.into(),
+            in_flight_requests,
+            in_flight_connections,
+        }))
+    }
+}
+
+fn ensure_node_generation(
+    expected_node_id: GenerationalNodeId,
+    actual_node_id: Option<NodeId>,
+) -> Result<GenerationalNodeId, Status> {
+    let actual_node_id = match actual_node_id {
+        Some(NodeId::Generational(node_id)) => node_id,
+        Some(NodeId::Plain(_)) | None => {
+            return Err(Status::unavailable(
+                "this node does not have a generational node id yet",
+            ));
+        }
+    };
+
+    if expected_node_id != actual_node_id {
+        return Err(Status::failed_precondition(format!(
+            "expected node generation {expected_node_id}, but connected to {actual_node_id}"
+        )));
+    }
+
+    Ok(actual_node_id)
 }
 
 pub struct MetadataProxySvcHandler {
@@ -460,7 +525,12 @@ fn write_err_to_status(err: WriteError) -> Status {
 
 #[cfg(test)]
 mod tests {
+    use tonic::Code;
+
     use restate_types::protobuf::common::DatabaseKind;
+    use restate_types::{GenerationalNodeId, NodeId, PlainNodeId};
+
+    use super::ensure_node_generation;
 
     #[test]
     fn database_kind_db_names() {
@@ -471,5 +541,25 @@ mod tests {
         );
         assert_eq!(DatabaseKind::LocalLoglet.db_name(), "local-loglet");
         assert_eq!(DatabaseKind::PartitionStore.db_name(), "db");
+    }
+
+    #[test]
+    fn ingress_drain_is_fenced_by_node_generation() {
+        let expected = GenerationalNodeId::new(1, 9);
+        assert_eq!(
+            ensure_node_generation(expected, Some(NodeId::Generational(expected))).unwrap(),
+            expected
+        );
+
+        let mismatch = ensure_node_generation(
+            expected,
+            Some(NodeId::Generational(GenerationalNodeId::new(1, 10))),
+        )
+        .unwrap_err();
+        assert_eq!(mismatch.code(), Code::FailedPrecondition);
+
+        let not_initialized =
+            ensure_node_generation(expected, Some(NodeId::Plain(PlainNodeId::new(1)))).unwrap_err();
+        assert_eq!(not_initialized.code(), Code::Unavailable);
     }
 }

--- a/crates/node/src/network_server/service.rs
+++ b/crates/node/src/network_server/service.rs
@@ -15,6 +15,7 @@ use restate_core::TaskCenter;
 use restate_core::network::grpc::CoreNodeSvcHandler;
 use restate_core::network::{ConnectionManager, NetworkServerBuilder};
 use restate_core::{Identification, MetadataWriter};
+use restate_ingress_http::IngressDrainHandle;
 use restate_tracing_instrumentation::prometheus_metrics::Prometheus;
 use restate_types::config::Configuration;
 
@@ -31,6 +32,7 @@ impl NetworkServer {
         mut server_builder: NetworkServerBuilder,
         metadata_writer: MetadataWriter,
         prometheus: Prometheus,
+        ingress_drain: Option<IngressDrainHandle>,
     ) -> Result<(), anyhow::Error> {
         // Configure Metric Exporter
         let mut state_builder = NodeCtrlHandlerStateBuilder::default();
@@ -81,7 +83,7 @@ impl NetworkServer {
         );
 
         server_builder.register_grpc_service(
-            NodeCtlSvcHandler::new(metadata_writer)
+            NodeCtlSvcHandler::new(metadata_writer, ingress_drain)
                 .into_server(&Configuration::pinned().networking),
             restate_core::protobuf::node_ctl_svc::FILE_DESCRIPTOR_SET,
         );

--- a/crates/node/src/roles/ingress.rs
+++ b/crates/node/src/roles/ingress.rs
@@ -11,7 +11,9 @@
 use restate_core::network::{Networking, TransportConnect};
 use restate_core::partitions::PartitionRouting;
 use restate_core::{TaskCenter, TaskKind};
-use restate_ingress_http::{HyperServerIngress, InvocationClientRequestDispatcher};
+use restate_ingress_http::{
+    HyperServerIngress, IngressDrainHandle, InvocationClientRequestDispatcher,
+};
 use restate_types::config::IngressOptions;
 use restate_types::health::HealthStatus;
 use restate_types::live::{BoxLiveLoad, Live};
@@ -62,5 +64,9 @@ impl<T: TransportConnect> IngressRole<T> {
         )?;
 
         Ok(())
+    }
+
+    pub fn drain_handle(&self) -> IngressDrainHandle {
+        self.ingress_http.drain_handle()
     }
 }

--- a/crates/types/protobuf/restate/common.proto
+++ b/crates/types/protobuf/restate/common.proto
@@ -120,6 +120,8 @@ enum IngressStatus {
   IngressStatus_UNKNOWN = 0;
   IngressStatus_READY = 1;
   IngressStatus_STARTING_UP = 2;
+  IngressStatus_DRAINING = 3;
+  IngressStatus_DRAINED = 4;
 }
 
 enum MetadataKind {

--- a/release-notes/unreleased/http-ingress-prestop-drain.md
+++ b/release-notes/unreleased/http-ingress-prestop-drain.md
@@ -9,13 +9,14 @@ now place the local running node's HTTP ingress role into an irreversible drain 
 of that process. `--current` resolves the local node's exact generation before draining, while
 `--node <generational-node-id>` remains available for an explicitly targeted node. Draining closes
 listeners, sends graceful shutdown notifications to existing connections, and reports the
-outstanding request and connection counts. Existing requests remain active until normal node
-shutdown applies its bounded final deadline.
+outstanding request and connection counts. Existing accepted HTTP requests and connections remain
+active until normal node shutdown applies its bounded final deadline.
 
 ### Why This Matters
 
-Operators can stop new ingress traffic early in a planned node termination and wait for the HTTP
-role to become quiescent before proceeding with the rest of the shutdown sequence.
+Operators can stop new ingress traffic early in a planned node termination and observe when the
+HTTP role has become quiescent. This status is an HTTP admission and connection signal only: it is
+not sufficient by itself to decide that a process or its worker roles are safe to terminate.
 
 ### Impact on Users
 

--- a/release-notes/unreleased/http-ingress-prestop-drain.md
+++ b/release-notes/unreleased/http-ingress-prestop-drain.md
@@ -4,10 +4,12 @@
 
 ### What Changed
 
-`restatectl nodes drain-http-ingress --node <generational-node-id>` can now place one running
-node's HTTP ingress role into an irreversible drain for the lifetime of that process. Draining
-closes its listeners, sends graceful shutdown notifications to existing connections, and reports
-the outstanding request and connection counts. Existing requests remain active until normal node
+`restatectl --single-address http://127.0.0.1:5122 nodes drain-http-ingress --current --json` can
+now place the local running node's HTTP ingress role into an irreversible drain for the lifetime
+of that process. `--current` resolves the local node's exact generation before draining, while
+`--node <generational-node-id>` remains available for an explicitly targeted node. Draining closes
+listeners, sends graceful shutdown notifications to existing connections, and reports the
+outstanding request and connection counts. Existing requests remain active until normal node
 shutdown applies its bounded final deadline.
 
 ### Why This Matters

--- a/release-notes/unreleased/http-ingress-prestop-drain.md
+++ b/release-notes/unreleased/http-ingress-prestop-drain.md
@@ -1,0 +1,21 @@
+# Graceful HTTP ingress drain control
+
+## New Feature
+
+### What Changed
+
+`restatectl nodes drain-http-ingress --node <generational-node-id>` can now place one running
+node's HTTP ingress role into an irreversible drain for the lifetime of that process. Draining
+closes its listeners, sends graceful shutdown notifications to existing connections, and reports
+the outstanding request and connection counts. Existing requests remain active until normal node
+shutdown applies its bounded final deadline.
+
+### Why This Matters
+
+Operators can stop new ingress traffic early in a planned node termination and wait for the HTTP
+role to become quiescent before proceeding with the rest of the shutdown sequence.
+
+### Impact on Users
+
+There is no change to normal ingress behavior. A drained ingress role becomes active again only
+after the node process restarts with a new generation.

--- a/tools/restatectl/src/commands/node/drain_http_ingress.rs
+++ b/tools/restatectl/src/commands/node/drain_http_ingress.rs
@@ -1,0 +1,106 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::Context;
+use cling::prelude::*;
+
+use restate_cli_util::{CliContext, c_println};
+use restate_core::protobuf::node_ctl_svc::{
+    DrainHttpIngressRequest, HttpIngressDrainStatus, new_node_ctl_client,
+};
+use restate_types::GenerationalNodeId;
+use restate_types::net::address::{AdvertisedAddress, FabricPort};
+
+use crate::connection::ConnectionInfo;
+use crate::util::grpc_channel;
+
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[cling(run = "drain_http_ingress")]
+/// Starts or polls the lifetime-scoped HTTP ingress drain on one node.
+///
+/// Use `--single-address http://127.0.0.1:5122` to address the local node directly without
+/// reading the nodes configuration. This is the recommended mode for a preStop hook.
+pub struct DrainHttpIngressOpts {
+    /// The exact node generation to drain (for example N1:9)
+    #[arg(long)]
+    node: GenerationalNodeId,
+
+    /// Print the response as JSON
+    #[arg(long)]
+    json: bool,
+}
+
+async fn drain_http_ingress(
+    connection: &ConnectionInfo,
+    opts: &DrainHttpIngressOpts,
+) -> anyhow::Result<()> {
+    let address = target_address(connection, opts.node).await?;
+    let channel = grpc_channel(address);
+    let mut client = new_node_ctl_client(channel, &CliContext::get().network);
+    let request = DrainHttpIngressRequest {
+        expected_node_id: Some(opts.node.into()),
+    };
+
+    let timeout = CliContext::get().request_timeout();
+    let response = tokio::time::timeout(timeout, client.drain_http_ingress(request))
+        .await
+        .map_err(|_| anyhow::anyhow!("HTTP ingress drain request timed out after {timeout:?}"))??
+        .into_inner();
+    let status = HttpIngressDrainStatus::try_from(response.status)
+        .unwrap_or(HttpIngressDrainStatus::Unspecified);
+    let status = status_name(status);
+
+    if opts.json {
+        c_println!(
+            "{}",
+            serde_json::json!({
+                "node_id": response.node_id.map(|node_id| node_id.to_string()),
+                "status": status,
+                "in_flight_requests": response.in_flight_requests,
+                "in_flight_connections": response.in_flight_connections,
+            })
+        );
+    } else {
+        c_println!(
+            "{} HTTP ingress: {}; in-flight requests: {}; in-flight connections: {}",
+            opts.node,
+            status,
+            response.in_flight_requests,
+            response.in_flight_connections,
+        );
+    }
+
+    Ok(())
+}
+
+async fn target_address(
+    connection: &ConnectionInfo,
+    node_id: GenerationalNodeId,
+) -> anyhow::Result<AdvertisedAddress<FabricPort>> {
+    if let Some(address) = &connection.single_address {
+        return Ok(address.clone());
+    }
+
+    let nodes_config = connection
+        .get_nodes_configuration()
+        .await
+        .context("failed to discover the target node; use --single-address to connect directly")?;
+    Ok(nodes_config.find_node_by_id(node_id)?.address.clone())
+}
+
+fn status_name(status: HttpIngressDrainStatus) -> &'static str {
+    match status {
+        HttpIngressDrainStatus::NotPresent => "not-present",
+        HttpIngressDrainStatus::Active => "active",
+        HttpIngressDrainStatus::Draining => "draining",
+        HttpIngressDrainStatus::Drained => "drained",
+        HttpIngressDrainStatus::Unspecified => "unspecified",
+    }
+}

--- a/tools/restatectl/src/commands/node/drain_http_ingress.rs
+++ b/tools/restatectl/src/commands/node/drain_http_ingress.rs
@@ -27,7 +27,9 @@ use crate::util::grpc_channel;
 /// Starts or polls the lifetime-scoped HTTP ingress drain on one node.
 ///
 /// Use `--single-address http://127.0.0.1:5122` to address the local node directly without
-/// reading the nodes configuration. This is the recommended mode for a preStop hook.
+/// reading the nodes configuration.
+/// A `drained` result reports HTTP admission and connection quiescence only; it must not by
+/// itself be used as the condition to terminate a process or its worker roles.
 pub struct DrainHttpIngressOpts {
     /// The exact node generation to drain (for example N1:9)
     #[arg(long, required_unless_present = "current", conflicts_with = "current")]

--- a/tools/restatectl/src/commands/node/drain_http_ingress.rs
+++ b/tools/restatectl/src/commands/node/drain_http_ingress.rs
@@ -12,11 +12,12 @@ use anyhow::Context;
 use cling::prelude::*;
 
 use restate_cli_util::{CliContext, c_println};
+use restate_core::protobuf::node_ctl_svc::node_ctl_svc_client::NodeCtlSvcClient;
 use restate_core::protobuf::node_ctl_svc::{
-    DrainHttpIngressRequest, HttpIngressDrainStatus, new_node_ctl_client,
+    DrainHttpIngressRequest, HttpIngressDrainStatus, IdentResponse, new_node_ctl_client,
 };
-use restate_types::GenerationalNodeId;
 use restate_types::net::address::{AdvertisedAddress, FabricPort};
+use restate_types::{GenerationalNodeId, NodeId};
 
 use crate::connection::ConnectionInfo;
 use crate::util::grpc_channel;
@@ -29,8 +30,12 @@ use crate::util::grpc_channel;
 /// reading the nodes configuration. This is the recommended mode for a preStop hook.
 pub struct DrainHttpIngressOpts {
     /// The exact node generation to drain (for example N1:9)
-    #[arg(long)]
-    node: GenerationalNodeId,
+    #[arg(long, required_unless_present = "current", conflicts_with = "current")]
+    node: Option<GenerationalNodeId>,
+
+    /// Drain the node at --single-address using its current generation
+    #[arg(long, conflicts_with = "node")]
+    current: bool,
 
     /// Print the response as JSON
     #[arg(long)]
@@ -41,12 +46,14 @@ async fn drain_http_ingress(
     connection: &ConnectionInfo,
     opts: &DrainHttpIngressOpts,
 ) -> anyhow::Result<()> {
-    let address = target_address(connection, opts.node).await?;
+    let address = target_address(connection, opts).await?;
     let channel = grpc_channel(address);
     let mut client = new_node_ctl_client(channel, &CliContext::get().network);
-    let request = DrainHttpIngressRequest {
-        expected_node_id: Some(opts.node.into()),
+    let node_id = match opts.node {
+        Some(node_id) => node_id,
+        None => current_node_id(&mut client).await?,
     };
+    let request = drain_request(node_id);
 
     let timeout = CliContext::get().request_timeout();
     let response = tokio::time::timeout(timeout, client.drain_http_ingress(request))
@@ -70,7 +77,7 @@ async fn drain_http_ingress(
     } else {
         c_println!(
             "{} HTTP ingress: {}; in-flight requests: {}; in-flight connections: {}",
-            opts.node,
+            node_id,
             status,
             response.in_flight_requests,
             response.in_flight_connections,
@@ -82,17 +89,57 @@ async fn drain_http_ingress(
 
 async fn target_address(
     connection: &ConnectionInfo,
-    node_id: GenerationalNodeId,
+    opts: &DrainHttpIngressOpts,
 ) -> anyhow::Result<AdvertisedAddress<FabricPort>> {
+    if opts.current {
+        return current_address(connection.single_address.as_ref());
+    }
+
     if let Some(address) = &connection.single_address {
         return Ok(address.clone());
     }
+
+    let node_id = opts.node.expect("--node is required without --current");
 
     let nodes_config = connection
         .get_nodes_configuration()
         .await
         .context("failed to discover the target node; use --single-address to connect directly")?;
     Ok(nodes_config.find_node_by_id(node_id)?.address.clone())
+}
+
+fn current_address(
+    single_address: Option<&AdvertisedAddress<FabricPort>>,
+) -> anyhow::Result<AdvertisedAddress<FabricPort>> {
+    single_address
+        .cloned()
+        .context("--current requires --single-address")
+}
+
+async fn current_node_id(
+    client: &mut NodeCtlSvcClient<tonic::transport::Channel>,
+) -> anyhow::Result<GenerationalNodeId> {
+    let timeout = CliContext::get().request_timeout();
+    let response = tokio::time::timeout(timeout, client.get_ident(()))
+        .await
+        .map_err(|_| anyhow::anyhow!("GetIdent request timed out after {timeout:?}"))??
+        .into_inner();
+
+    current_node_id_from_ident(response)
+}
+
+fn current_node_id_from_ident(response: IdentResponse) -> anyhow::Result<GenerationalNodeId> {
+    response
+        .node_id
+        .map(NodeId::from)
+        .and_then(NodeId::as_generational)
+        .context("the node at --single-address has not initialized a generational node ID")
+}
+
+fn drain_request(node_id: GenerationalNodeId) -> DrainHttpIngressRequest {
+    DrainHttpIngressRequest {
+        expected_node_id: Some(node_id.into()),
+    }
 }
 
 fn status_name(status: HttpIngressDrainStatus) -> &'static str {
@@ -102,5 +149,196 @@ fn status_name(status: HttpIngressDrainStatus) -> &'static str {
         HttpIngressDrainStatus::Draining => "draining",
         HttpIngressDrainStatus::Drained => "drained",
         HttpIngressDrainStatus::Unspecified => "unspecified",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use futures::stream;
+    use tokio::sync::{Mutex, oneshot};
+    use tonic::{Request, Response, Status, transport::Server};
+
+    use restate_core::protobuf::node_ctl_svc::node_ctl_svc_server::{NodeCtlSvc, NodeCtlSvcServer};
+    use restate_core::protobuf::node_ctl_svc::{
+        ClusterHealthResponse, DrainHttpIngressResponse, GetMetadataRequest, GetMetadataResponse,
+        ProvisionClusterRequest, ProvisionClusterResponse, TriggerCompactionRequest,
+        TriggerCompactionResponse,
+    };
+
+    use super::*;
+
+    #[derive(Debug, PartialEq)]
+    enum Call {
+        GetIdent,
+        Drain(Option<restate_types::protobuf::common::GenerationalNodeId>),
+    }
+
+    struct TestNodeCtlSvc {
+        node_id: GenerationalNodeId,
+        calls: Arc<Mutex<Vec<Call>>>,
+    }
+
+    #[tonic::async_trait]
+    impl NodeCtlSvc for TestNodeCtlSvc {
+        async fn get_ident(
+            &self,
+            _request: Request<()>,
+        ) -> Result<Response<IdentResponse>, Status> {
+            self.calls.lock().await.push(Call::GetIdent);
+            Ok(Response::new(IdentResponse {
+                node_id: Some(self.node_id.into()),
+                ..Default::default()
+            }))
+        }
+
+        async fn get_metadata(
+            &self,
+            _request: Request<GetMetadataRequest>,
+        ) -> Result<Response<GetMetadataResponse>, Status> {
+            Err(Status::unimplemented("not needed by this test"))
+        }
+
+        async fn provision_cluster(
+            &self,
+            _request: Request<ProvisionClusterRequest>,
+        ) -> Result<Response<ProvisionClusterResponse>, Status> {
+            Err(Status::unimplemented("not needed by this test"))
+        }
+
+        async fn cluster_health(
+            &self,
+            _request: Request<()>,
+        ) -> Result<Response<ClusterHealthResponse>, Status> {
+            Err(Status::unimplemented("not needed by this test"))
+        }
+
+        async fn trigger_compaction(
+            &self,
+            _request: Request<TriggerCompactionRequest>,
+        ) -> Result<Response<TriggerCompactionResponse>, Status> {
+            Err(Status::unimplemented("not needed by this test"))
+        }
+
+        async fn drain_http_ingress(
+            &self,
+            request: Request<DrainHttpIngressRequest>,
+        ) -> Result<Response<DrainHttpIngressResponse>, Status> {
+            self.calls
+                .lock()
+                .await
+                .push(Call::Drain(request.into_inner().expected_node_id));
+            Ok(Response::new(DrainHttpIngressResponse {
+                node_id: Some(self.node_id.into()),
+                status: HttpIngressDrainStatus::Drained.into(),
+                in_flight_requests: 0,
+                in_flight_connections: 0,
+            }))
+        }
+    }
+
+    #[test]
+    fn current_and_node_are_exclusive() {
+        assert!(
+            DrainHttpIngressOpts::try_parse_from([
+                "drain-http-ingress",
+                "--current",
+                "--node",
+                "N1:9",
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn either_current_or_node_is_required() {
+        assert!(DrainHttpIngressOpts::try_parse_from(["drain-http-ingress"]).is_err());
+        assert_eq!(
+            DrainHttpIngressOpts::try_parse_from(["drain-http-ingress", "--current"])
+                .expect("--current should parse")
+                .node,
+            None
+        );
+    }
+
+    #[test]
+    fn current_requires_single_address() {
+        assert!(current_address(None).is_err());
+    }
+
+    #[test]
+    fn current_uses_the_exact_ident_generation_for_the_drain_request() {
+        let expected_node_id = GenerationalNodeId::new(1, 9);
+        let response = IdentResponse {
+            node_id: Some(expected_node_id.into()),
+            ..Default::default()
+        };
+
+        let request = drain_request(
+            current_node_id_from_ident(response).expect("ident should contain a generation"),
+        );
+
+        assert_eq!(request.expected_node_id, Some(expected_node_id.into()));
+    }
+
+    #[tokio::test]
+    async fn current_drains_the_generation_resolved_from_the_single_address() {
+        let expected_node_id = GenerationalNodeId::new(1, 9);
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let service = TestNodeCtlSvc {
+            node_id: expected_node_id,
+            calls: Arc::clone(&calls),
+        };
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener should bind");
+        let address = listener
+            .local_addr()
+            .expect("listener should have an address");
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            Server::builder()
+                .add_service(
+                    NodeCtlSvcServer::new(service)
+                        .accept_compressed(tonic::codec::CompressionEncoding::Zstd),
+                )
+                .serve_with_incoming_shutdown(
+                    stream::unfold(listener, |listener| async move {
+                        listener
+                            .accept()
+                            .await
+                            .ok()
+                            .map(|(stream, _)| (Ok::<_, std::io::Error>(stream), listener))
+                    }),
+                    async {
+                        let _ = shutdown_rx.await;
+                    },
+                )
+                .await
+                .expect("server should run");
+        });
+
+        let connection = ConnectionInfo::try_parse_from([
+            "restatectl",
+            "--single-address",
+            &format!("http://{address}"),
+        ])
+        .expect("single address should parse");
+        let opts = DrainHttpIngressOpts::try_parse_from(["drain-http-ingress", "--current"])
+            .expect("current should parse");
+
+        drain_http_ingress(&connection, &opts)
+            .await
+            .expect("drain should succeed");
+
+        shutdown_tx
+            .send(())
+            .expect("server should still be running");
+        server.await.expect("server task should not panic");
+        assert_eq!(
+            *calls.lock().await,
+            vec![Call::GetIdent, Call::Drain(Some(expected_node_id.into()))]
+        );
     }
 }

--- a/tools/restatectl/src/commands/node/mod.rs
+++ b/tools/restatectl/src/commands/node/mod.rs
@@ -9,6 +9,7 @@
 // by the Apache License, Version 2.0.
 
 pub mod disable_node_checker;
+mod drain_http_ingress;
 pub mod list_nodes;
 mod remove_nodes;
 mod storage_state;
@@ -39,6 +40,11 @@ pub enum Nodes {
     SetStorageState(storage_state::SetOpts),
     /// Sets the state of a worker
     SetWorkerState(worker_state::SetOpts),
+    /// Stops accepting new HTTP ingress traffic on a node and reports drain progress.
+    ///
+    /// Use `--single-address http://127.0.0.1:5122` to address the local node directly without
+    /// reading the nodes configuration. This is the recommended mode for a preStop hook.
+    DrainHttpIngress(drain_http_ingress::DrainHttpIngressOpts),
 }
 
 /// Updates the state in the [`NodeConfig`] specified by `state_mut` to the target state


### PR DESCRIPTION
## Why

Restate Server's normal SIGTERM path begins graceful HTTP shutdown only when the process is already terminating. It closes the listeners and initiates graceful HTTP/2 shutdown, but its final HTTP drain deadline is five seconds. An explicit operation is useful for stopping *new* HTTP admission before that final process-shutdown window begins.

## What this PR does

This PR adds a runtime-local HTTP ingress admission drain operation.

1. It closes the local HTTP ingress listeners.
2. It starts graceful shutdown on existing HTTP connections, including HTTP/2 GOAWAY.
3. It reports active HTTP request and connection counts until no accepted HTTP connections remain.
4. It uses an exact generational node ID, so a delayed request cannot drain a restarted process with the same plain node ID.

`restatectl nodes drain-http-ingress --current --single-address <local-nodectl-address>` resolves the current generation through that same local NodeCtl channel before issuing the drain request. `--node <generational-node-id>` remains available for explicit targeting.

## Important limitation

`DRAINED` is an HTTP-admission result only. It means the local ingress listeners are closed and no HTTP connections accepted by that ingress remain. It is **not** a process-quiescence, worker-drain, or safe-to-delete result.

In the rolling-update test, a pod could report zero tracked HTTP requests and connections, then be deleted while a long synchronous invocation still depended on a worker/invoker and service-protocol tunnel path. The invocation audit recorded a single completed invocation, while the synchronous caller timed out waiting for its result. Therefore, Cloud must **not** use `DRAINED` as the success gate for preStop/process termination yet.

## Follow-up needed before safe process drain

The real solution is a coordinated worker drain: stop starting new local service attempts, let eligible in-flight attempts finish or suspend, flush their effects and outputs, then relinquish partitions and terminate. A local ingress conversion from synchronous call to `202 Accepted` does not solve calls admitted through another ingress but routed to the terminating worker.

The acceptance test for that work must roll all three nodes while issuing keyed SDK calls with retries, long `ctx.run` and `ctx.sleep`, and a shared 360-second logical deadline. It must require zero client timeouts, not merely a `DRAINED` status or single invocation audit; it should also count service-closure attempts before the long operation to distinguish completed execution from an interrupted/restarted attempt.

## Validation

- `cargo check`
- `cargo nextest run -p restatectl -p restate-node --lib`
- `cargo fmt --all -- --check`
