### PR TITLE
[worker] restore missing command application latency and count

### DIFF
--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -97,7 +97,8 @@ use self::processor::commands::{
 use self::processor::*;
 use self::state_machine::StateMachine;
 use crate::metric_definitions::{
-    LEADER_LABEL, LEADER_LABEL_LEADER, PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS,
+    LEADER_LABEL, LEADER_LABEL_FOLLOWER, LEADER_LABEL_LEADER, PARTITION_APPLY_COMMAND,
+    PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS,
 };
 use crate::partition::leadership::LeadershipState;
 use crate::partition::processor::leadership::LeadershipContext;
@@ -973,7 +974,11 @@ where
         txn: &'a mut PartitionStoreTransaction<'b>,
         action_collector: &'a mut ActionCollector,
     ) -> Result<NextStep, ProcessorError> {
-        match record.as_ref().kind() {
+        let start = Instant::now();
+        let record_kind = record.as_ref().kind();
+        let command: &'static str = record_kind.into();
+        let is_leader = self.leadership_state.is_leader();
+        let res = match record_kind {
             v2::CommandKind::AnnounceLeader => {
                 AnnounceLeaderContext {
                     txn,
@@ -1043,6 +1048,13 @@ where
                     state_machine::Error::UnknownCommandKind,
                 ))
             }
-        }
+        };
+        histogram!(
+            PARTITION_APPLY_COMMAND,
+            "command" => command,
+            LEADER_LABEL => if is_leader { LEADER_LABEL_LEADER } else { LEADER_LABEL_FOLLOWER },
+        )
+        .record(start.elapsed());
+        res
     }
 }


### PR DESCRIPTION

It seems that the recent PP loop refactoring we lost the command application latency and counts for `PartitionScoped` commands. They're still there for the `KeyScoped` ones.
