### PR TITLE
[Restate UI] Update to v1.0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9074,8 +9074,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "1.0.15"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v1.0.15#6b0f65b2c302072a984abb5b5a5e27e2c340c614"
+version = "1.0.16"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v1.0.16#4beafac31aa1dd2c70c28aabe7ad1f9e95e33b96"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -39,7 +39,7 @@ restate-util-time = { workspace = true }
 restate-types = { workspace = true }
 restate-util-string = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "1.0.15", tag = "v1.0.15" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "1.0.16", tag = "v1.0.16" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v1.0.16
published at https://github.com/restatedev/restate-web-ui/releases/download/v1.0.16/ui-v1.0.16.zip