### PR TITLE
[Restate UI] Update to v1.0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9074,8 +9074,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "1.0.15"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v1.0.15#6b0f65b2c302072a984abb5b5a5e27e2c340c614"
+version = "1.0.17"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v1.0.17#ce52cb5c15d68588bc81d315d220b7bbbc88df72"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -39,7 +39,7 @@ restate-util-time = { workspace = true }
 restate-types = { workspace = true }
 restate-util-string = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "1.0.15", tag = "v1.0.15" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "1.0.17", tag = "v1.0.17" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v1.0.17
published at https://github.com/restatedev/restate-web-ui/releases/download/v1.0.17/ui-v1.0.17.zip