### PR TITLE
[worker] get rid of ghost per partition metrics by reporting per-node aggregates

### DIFF
--- a/crates/worker/src/metric_definitions.rs
+++ b/crates/worker/src/metric_definitions.rs
@@ -51,10 +51,12 @@ pub const USAGE_LEADER_JOURNAL_ENTRY_COUNT: &str = "restate.usage.leader_journal
 
 pub const NUM_PARTITIONS: &str = "restate.num_partitions";
 pub const NUM_ACTIVE_PARTITIONS: &str = "restate.num_active_partitions";
+pub const NUM_ACTIVE_PARTITION_LEADERS: &str = "restate.num_active_partition_leaders";
 pub const PARTITION_TIME_SINCE_LAST_STATUS_UPDATE: &str =
-    "restate.partition.time_since_last_status_update";
+    "restate.partition.time_since_last_status_update.seconds";
 pub const PARTITION_APPLIED_LSN_LAG: &str = "restate.partition.applied_lsn_lag";
-pub const PARTITION_IS_EFFECTIVE_LEADER: &str = "restate.partition.is_effective_leader";
+pub const PARTITION_NUM_UNKNOWN_APPLIED_LSN_LAG: &str =
+    "restate.partition.num_unknown_applied_lsn_lag";
 
 pub const PARTITION_RECORD_COMMITTED_TO_READ_LATENCY_SECONDS: &str =
     "restate.partition.record_committed_to_read_latency.seconds";
@@ -122,27 +124,33 @@ pub(crate) fn describe_metrics() {
     );
 
     describe_gauge!(
-        PARTITION_IS_EFFECTIVE_LEADER,
+        NUM_ACTIVE_PARTITION_LEADERS,
         Unit::Count,
-        "Set to 1 if the partition is an effective leader"
+        "Number of active partition leaders started by partition processor manager on this node"
     );
 
     describe_gauge!(
         PARTITION_TIME_SINCE_LAST_STATUS_UPDATE,
         Unit::Seconds,
-        "Number of seconds since the last partition status update"
+        "Current quantiles of the number of seconds since the last status update, across the partitions on this node"
     );
 
     describe_gauge!(
         PARTITION_APPLIED_LSN_LAG,
         Unit::Count,
-        "Number of records between last applied lsn and the log tail"
+        "Current quantiles of the number of records between last applied lsn and the log tail, across the partitions on this node"
+    );
+
+    describe_gauge!(
+        PARTITION_NUM_UNKNOWN_APPLIED_LSN_LAG,
+        Unit::Count,
+        "Number of partitions with unknown applied lsn lag"
     );
 
     describe_gauge!(
         SNAPSHOT_AGE,
         Unit::Seconds,
-        "The age of the latest partition snapshot in seconds"
+        "Current quantiles of the age in seconds of the latest snapshot, across the partitions on this node"
     );
 
     describe_counter!(

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -86,13 +86,12 @@ use restate_worker_api::{ProcessorsManagerCommand, ProcessorsManagerHandle};
 
 use crate::metric_definitions::{
     ERROR_STOP, FLARE_REASON_MIGRATION_BARRIER, FLARE_REASON_SNAPSHOT_UNAVAILABLE,
-    FLARE_REASON_VERSION_BARRIER, GAP_STOP, PARTITION_BLOCKED_FLARE, PARTITION_IS_EFFECTIVE_LEADER,
-    PARTITION_START, REASON_LABEL, STARTUP_ERROR_STOP, TYPE_LABEL,
+    FLARE_REASON_VERSION_BARRIER, GAP_STOP, NORMAL_STOP, NUM_ACTIVE_PARTITION_LEADERS,
+    NUM_ACTIVE_PARTITIONS, NUM_PARTITIONS, PARTITION_APPLIED_LSN_LAG, PARTITION_BLOCKED_FLARE,
+    PARTITION_LABEL, PARTITION_NUM_UNKNOWN_APPLIED_LSN_LAG, PARTITION_START, PARTITION_STOP,
+    PARTITION_TIME_SINCE_LAST_STATUS_UPDATE, REASON_LABEL, SNAPSHOT_AGE, STARTUP_ERROR_STOP,
+    TYPE_LABEL,
 };
-use crate::metric_definitions::{NORMAL_STOP, PARTITION_TIME_SINCE_LAST_STATUS_UPDATE};
-use crate::metric_definitions::{NUM_ACTIVE_PARTITIONS, PARTITION_APPLIED_LSN_LAG};
-use crate::metric_definitions::{NUM_PARTITIONS, SNAPSHOT_AGE};
-use crate::metric_definitions::{PARTITION_LABEL, PARTITION_STOP};
 use crate::partition::{LeadershipInfo, NodeContext, ProcessorError};
 use crate::partition_processor_manager::processor_state::{
     LeaderEpochToken, ProcessorState, StartedProcessor,
@@ -577,7 +576,6 @@ where
                         );
                     }
                 }
-                gauge!(NUM_ACTIVE_PARTITIONS).set(self.processor_states.len() as f64);
             }
             EventKind::Stopped(result) => {
                 self.unregister_pp_rpc_shard(partition_id);
@@ -679,8 +677,6 @@ where
                 if !self.restart_partition_processor_if_replica(partition_id, delay) {
                     debug!("Partition processor stopped: {result:?}");
                 }
-
-                gauge!(NUM_ACTIVE_PARTITIONS).set(self.processor_states.len() as f64);
             }
             EventKind::NewLeaderEpoch {
                 leader_epoch_token,
@@ -816,28 +812,29 @@ where
 
     /// Collect enriched processor status from all running partitions
     fn get_state(&self) -> BTreeMap<PartitionId, PartitionProcessorStatus> {
-        self.processor_states
+        let mut num_active_leaders: u32 = 0;
+        let mut num_unknown_applied_lsn_lag: u32 = 0;
+        let mut last_updated_samples = Vec::with_capacity(self.processor_states.len());
+        let mut applied_lsn_lag_samples = Vec::with_capacity(self.processor_states.len());
+        let mut snapshot_age_samples = Vec::with_capacity(self.processor_states.len());
+
+        let statuses = self
+            .processor_states
             .iter()
             .filter_map(|(partition_id, processor_state)| {
                 let mut status = processor_state.partition_processor_status()?;
-                let labels = [(PARTITION_LABEL, partition_id.to_string())];
 
-                gauge!(PARTITION_TIME_SINCE_LAST_STATUS_UPDATE, &labels)
-                    .set(status.updated_at.elapsed());
-
-                gauge!(PARTITION_IS_EFFECTIVE_LEADER, &labels).set(
-                    if status.is_effective_leader() {
-                        1.0
-                    } else {
-                        0.0
-                    },
-                );
+                last_updated_samples.push(status.updated_at.elapsed().as_secs());
+                num_active_leaders += u32::from(status.is_effective_leader());
 
                 // todo: PartitionProcessorStatus struct is shared across PP and PPM, consider splitting it
-                status.last_archived_log_lsn = self
-                    .latest_snapshots
-                    .get(partition_id)
-                    .map(|s| s.archived_lsn);
+                let latest_snapshot = self.latest_snapshots.get(partition_id);
+                if let Some(snapshot) = latest_snapshot {
+                    snapshot_age_samples
+                        .push(snapshot.latest_snapshot_created_at.elapsed().as_secs());
+                }
+
+                status.last_archived_log_lsn = latest_snapshot.map(|s| s.archived_lsn);
 
                 let current_tail_lsn = self.target_tail_lsns.get(partition_id).cloned();
                 let target_tail_lsn = if current_tail_lsn > status.target_tail_lsn {
@@ -848,25 +845,34 @@ where
 
                 match target_tail_lsn {
                     None => {
-                        // unknown might indicate an issue, so we set the metric to infinity
-                        gauge!(PARTITION_APPLIED_LSN_LAG, &labels).set(f64::INFINITY);
+                        num_unknown_applied_lsn_lag += 1;
                     }
                     Some(target_tail_lsn) => {
                         status.target_tail_lsn = Some(target_tail_lsn);
 
                         // tail lsn always points to the next "free" lsn slot. Therefor the lag is calculate as `lsn-1`
                         // hence we do target_tail_lsn.prev() below
-                        gauge!(PARTITION_APPLIED_LSN_LAG, &labels).set(
+                        applied_lsn_lag_samples.push(
                             target_tail_lsn.prev().as_u64().saturating_sub(
                                 status.last_applied_log_lsn.unwrap_or(Lsn::OLDEST).as_u64(),
-                            ) as f64,
+                            ),
                         );
                     }
                 }
 
                 Some((*partition_id, status))
             })
-            .collect()
+            .collect();
+        report_quantile_gauges(
+            PARTITION_TIME_SINCE_LAST_STATUS_UPDATE,
+            &mut last_updated_samples,
+        );
+        report_quantile_gauges(PARTITION_APPLIED_LSN_LAG, &mut applied_lsn_lag_samples);
+        report_quantile_gauges(SNAPSHOT_AGE, &mut snapshot_age_samples);
+        gauge!(PARTITION_NUM_UNKNOWN_APPLIED_LSN_LAG).set(num_unknown_applied_lsn_lag as f64);
+        gauge!(NUM_ACTIVE_PARTITIONS).set(self.processor_states.len() as f64);
+        gauge!(NUM_ACTIVE_PARTITION_LEADERS).set(num_active_leaders as f64);
+        statuses
     }
 
     fn on_command(&mut self, command: ProcessorsManagerCommand) {
@@ -989,8 +995,6 @@ where
         partition_id: PartitionId,
         snapshot_status: PartitionSnapshotStatus,
     ) {
-        gauge!(SNAPSHOT_AGE, PARTITION_LABEL => partition_id.to_string())
-            .set(snapshot_status.latest_snapshot_created_at.elapsed());
         match self.latest_snapshots.entry(partition_id) {
             Entry::Occupied(mut e) => {
                 if snapshot_status.archived_lsn >= e.get().archived_lsn {
@@ -1343,8 +1347,6 @@ where
                 self.latest_snapshots.remove(&partition_id);
             }
         }
-
-        gauge!(NUM_ACTIVE_PARTITIONS).set(self.processor_states.len() as f64);
     }
 
     /// Starts a partition processor if this node is part of the replica set of the given partition.
@@ -1555,6 +1557,23 @@ enum EventKind {
         snapshot_status: PartitionSnapshotStatus,
     },
     SnapshotStatusUpdateSkipped,
+}
+
+fn report_quantile_gauges(metric_name: &'static str, samples: &mut [u64]) {
+    const PARTITION_METRIC_QUANTILES: [(&str, f64); 4] =
+        [("0.5", 0.5), ("0.9", 0.9), ("0.99", 0.99), ("1.0", 1.0)];
+
+    samples.sort_unstable();
+
+    for (quantile_label, quantile) in PARTITION_METRIC_QUANTILES {
+        let value = if samples.is_empty() {
+            f64::NAN
+        } else {
+            let rank = (quantile * samples.len() as f64).ceil() as usize;
+            samples[rank.saturating_sub(1)] as f64
+        };
+        gauge!(metric_name, "quantile" => quantile_label).set(value);
+    }
 }
 
 #[cfg(test)]

--- a/monitoring/grafana/restate-internals.json
+++ b/monitoring/grafana/restate-internals.json
@@ -3539,7 +3539,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Gap between applied LSN and log tail per partition",
+      "description": "Distribution of the gap between applied LSN and log tail across active partitions, by node. Partitions with unknown lag are shown on the right axis.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3590,7 +3590,41 @@
           },
           "unit": "short"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "E"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "Unknown partitions"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 7,
@@ -3622,12 +3656,48 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "restate_partition_applied_lsn_lag{cluster_name=\"$cluster\", node_name=~\"$node\", partition=~\"$partition\"}",
-          "legendFormat": "{{node_name}}/p{{partition}}",
+          "expr": "restate_partition_applied_lsn_lag{cluster_name=\"$cluster\", node_name=~\"$node\", quantile=\"0.5\"}",
+          "legendFormat": "{{node_name}} p50",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "restate_partition_applied_lsn_lag{cluster_name=\"$cluster\", node_name=~\"$node\", quantile=\"0.9\"}",
+          "legendFormat": "{{node_name}} p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "restate_partition_applied_lsn_lag{cluster_name=\"$cluster\", node_name=~\"$node\", quantile=\"0.99\"}",
+          "legendFormat": "{{node_name}} p99",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "restate_partition_applied_lsn_lag{cluster_name=\"$cluster\", node_name=~\"$node\", quantile=\"1.0\"}",
+          "legendFormat": "{{node_name}} max",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "restate_partition_num_unknown_applied_lsn_lag{cluster_name=\"$cluster\", node_name=~\"$node\"}",
+          "legendFormat": "{{node_name}} unknown",
+          "refId": "E"
         }
       ],
-      "title": "Applied LSN Lag",
+      "title": "Applied LSN Lag Quantiles",
       "type": "timeseries"
     },
     {
@@ -4022,7 +4092,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Maximum snapshot age per partition (across all nodes). High values indicate snapshots may be stale.",
+      "description": "Distribution of the age of the latest snapshot across the partitions known to each node. High values indicate snapshots may be stale. Note that partitions that have never been snapshotted contribute no sample, so they do not show up here at all.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -4104,9 +4174,18 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "max by (partition) (restate_partition_snapshot_age_seconds{cluster_name=\"$cluster\", node_name=~\"$node\", partition=~\"$partition\"})",
-          "legendFormat": "p{{partition}}",
+          "expr": "restate_partition_snapshot_age_seconds{cluster_name=\"$cluster\", node_name=~\"$node\", quantile=\"0.5\"}",
+          "legendFormat": "{{node_name}} p50",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "restate_partition_snapshot_age_seconds{cluster_name=\"$cluster\", node_name=~\"$node\", quantile=\"1.0\"}",
+          "legendFormat": "{{node_name}} max",
+          "refId": "B"
         }
       ],
       "title": "Snapshot Age",
@@ -5911,7 +5990,7 @@
         "multi": true,
         "name": "partition",
         "options": [],
-        "query": "label_values(restate_partition_is_effective_leader{cluster_name=\"$cluster\"}, partition)",
+        "query": "label_values(restate_partition_start_total{cluster_name=\"$cluster\"}, partition)",
         "refresh": 1,
         "regex": "",
         "sort": 3,

--- a/monitoring/grafana/restate-overview.json
+++ b/monitoring/grafana/restate-overview.json
@@ -261,7 +261,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(restate_partition_is_effective_leader{cluster_name=\"$cluster\", node_name=~\"$node\"}) / max(restate_num_partitions{cluster_name=\"$cluster\", node_name=~\"$node\"})",
+          "expr": "sum(restate_num_active_partition_leaders{cluster_name=\"$cluster\", node_name=~\"$node\"}) / max(restate_num_partitions{cluster_name=\"$cluster\", node_name=~\"$node\"})",
           "legendFormat": "Leaders",
           "refId": "A"
         }
@@ -713,7 +713,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (node_name) (restate_partition_is_effective_leader{cluster_name=\"$cluster\", node_name=~\"$node\"})",
+          "expr": "sum by (node_name) (restate_num_active_partition_leaders{cluster_name=\"$cluster\", node_name=~\"$node\"})",
           "legendFormat": "{{node_name}}",
           "refId": "A"
         }
@@ -778,7 +778,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (node_name) (restate_num_active_partitions{cluster_name=\"$cluster\", node_name=~\"$node\"}) - sum by (node_name) (restate_partition_is_effective_leader{cluster_name=\"$cluster\", node_name=~\"$node\"})",
+          "expr": "sum by (node_name) (restate_num_active_partitions{cluster_name=\"$cluster\", node_name=~\"$node\"}) - sum by (node_name) (restate_num_active_partition_leaders{cluster_name=\"$cluster\", node_name=~\"$node\"})",
           "legendFormat": "{{node_name}}",
           "refId": "A"
         }
@@ -924,7 +924,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(restate_partition_is_effective_leader{cluster_name=\"$cluster\", node_name=~\"$node\"})",
+          "expr": "sum(restate_num_active_partition_leaders{cluster_name=\"$cluster\", node_name=~\"$node\"})",
           "legendFormat": "leaders",
           "refId": "A"
         },
@@ -933,7 +933,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(restate_num_active_partitions{cluster_name=\"$cluster\", node_name=~\"$node\"}) - sum(restate_partition_is_effective_leader{cluster_name=\"$cluster\", node_name=~\"$node\"})",
+          "expr": "sum(restate_num_active_partitions{cluster_name=\"$cluster\", node_name=~\"$node\"}) - sum(restate_num_active_partition_leaders{cluster_name=\"$cluster\", node_name=~\"$node\"})",
           "legendFormat": "followers",
           "refId": "B"
         },

--- a/release-notes/unreleased/aggregate-partition-metrics-by-node.md
+++ b/release-notes/unreleased/aggregate-partition-metrics-by-node.md
@@ -1,0 +1,35 @@
+# Release Notes: Report partition metrics as per-node aggregates
+
+## Breaking Change
+
+### What Changed
+
+High-cardinality per-partition gauges for applied LSN lag, snapshot age, and time since the
+last status update are now reported as per-node quantile gauges. The effective-leader gauge is
+replaced by a per-node active-leader count, and a new gauge counts partitions whose applied
+LSN lag is unknown.
+
+### Why This Matters
+
+Metrics no longer leave stale per-partition series behind when partitions move between nodes.
+
+### Impact on Users
+
+Dashboards and alerts that query the affected per-partition gauges or their `partition` label
+must be updated to use the new per-node gauges and quantiles. The bundled Grafana
+dashboards have been updated.
+
+### Migration Guidance
+
+Update custom Prometheus queries as follows:
+
+- Replace `restate_partition_is_effective_leader` with
+  `restate_num_active_partition_leaders`.
+- Query `restate_partition_applied_lsn_lag` and `restate_partition_snapshot_age_seconds` as
+  quantile gauges without the `partition` label.
+- Replace `restate_partition_time_since_last_status_update` with the quantile gauge
+  `restate_partition_time_since_last_status_update_seconds`.
+- Use `restate_partition_num_unknown_applied_lsn_lag` to monitor partitions with unknown lag.
+
+If you're using our official grafana dashboards, just re-import the latest version and it takes
+care of this migration for you.


### PR DESCRIPTION

Fixes #4802

When a partition completely moves away from a node, the guages that it used to report are not cleaned (and don't expire) which results into misleading aggregations into the dashboard. The obvious solution is to stop reporting those partition metrics when the partition moves away but the crate we're using doesn't support doing so (see [this comment](https://github.com/restatedev/restate/issues/4802#issuecomment-4613508412) for details).

So instead, this PR, drops the per partition metrics and moves them into per node aggregates instead. Further drilldowns can then be done by `restatectl` or the logs for historical data around partition leadership. This should drop the metrics cardinality quite a bit (even with the new histograms). Those metrics are published from a function that gets called every 1.5s, so it's not really on the hot path. So there should be no perf concerns.
