### PR TITLE
[restatectl] Forced-seal support

### DIFF
--- a/crates/admin/src/cluster_controller/grpc_svc_handler.rs
+++ b/crates/admin/src/cluster_controller/grpc_svc_handler.rs
@@ -241,6 +241,7 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
                 request.segment_index.map(SegmentIndex::from),
                 false, /* permanent_seal */
                 request.context,
+                request.tail_lsn.map(Into::into),
             )
             .await
             .map_err(|_| Status::aborted("Node is shutting down"))?

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -23,7 +23,7 @@ use rand::seq::IteratorRandom;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time;
 use tokio::time::{Instant, Interval, MissedTickBehavior};
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use restate_bifrost::{Bifrost, MaybeSealedSegment};
 use restate_core::network::tonic_service_filter::{TonicServiceFilter, WaitForReady};
@@ -213,6 +213,7 @@ enum ClusterControllerCommand {
         log_id: LogId,
         segment_index: Option<SegmentIndex>,
         permanent_seal: bool,
+        tail_lsn: Option<Lsn>,
         context: std::collections::HashMap<String, String>,
         response_tx: oneshot::Sender<anyhow::Result<Lsn>>,
     },
@@ -320,6 +321,7 @@ impl ClusterControllerHandle {
         segment_index: Option<SegmentIndex>,
         permanent_seal: bool,
         context: std::collections::HashMap<String, String>,
+        tail_lsn: Option<Lsn>,
     ) -> Result<anyhow::Result<Lsn>, ShutdownError> {
         let (response_tx, response_rx) = oneshot::channel();
 
@@ -330,6 +332,7 @@ impl ClusterControllerHandle {
                 segment_index,
                 permanent_seal,
                 context,
+                tail_lsn,
                 response_tx,
             })
             .await;
@@ -568,6 +571,7 @@ impl<T: TransportConnect> Service<T> {
                 segment_index,
                 permanent_seal,
                 mut context,
+                tail_lsn,
                 response_tx,
             } => {
                 let bifrost = self.bifrost.clone();
@@ -580,6 +584,7 @@ impl<T: TransportConnect> Service<T> {
                         log_id,
                         segment_index,
                         permanent_seal,
+                        forced_tail_lsn: tail_lsn,
                         context,
                         bifrost,
                     }
@@ -786,6 +791,9 @@ struct SealChainTask {
     segment_index: Option<SegmentIndex>,
     permanent_seal: bool,
     context: std::collections::HashMap<String, String>,
+    /// If set, we will use this tail LSN value instead of the actual calculated tail from the
+    /// underlying loglet.
+    forced_tail_lsn: Option<Lsn>,
     bifrost: Bifrost,
 }
 
@@ -798,13 +806,26 @@ impl SealChainTask {
             .tail()
             .index();
 
+        if let Some(forced_tail_lsn) = &self.forced_tail_lsn {
+            warn!(
+                context = ?self.context,
+                "Force-sealing log {} with tail LSN {forced_tail_lsn} due to an admin request",
+                self.log_id
+            );
+        }
+
         let segment_index = self.segment_index.unwrap_or(actual_tail_segment);
         let seal_metadata = SealMetadata::with_context(self.permanent_seal, self.context);
 
         let tail_lsn = self
             .bifrost
             .admin()
-            .seal(self.log_id, segment_index, seal_metadata)
+            .seal(
+                self.log_id,
+                segment_index,
+                seal_metadata,
+                self.forced_tail_lsn,
+            )
             .await?;
 
         Ok(tail_lsn)

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -398,6 +398,7 @@ impl BifrostInner {
                                 log_id,
                                 loglet.segment_index(),
                                 SealMetadata::new("find-tail", my_node_id()),
+                                None,
                             )
                             .await
                         {
@@ -1253,7 +1254,7 @@ mod tests {
         // seal and don't extend the chain.
         let _ = bifrost
             .admin()
-            .seal(LOG_ID, SegmentIndex::from(0), SealMetadata::default())
+            .seal(LOG_ID, SegmentIndex::from(0), SealMetadata::default(), None)
             .await?;
 
         // appends should stall!

--- a/crates/bifrost/src/bifrost_admin.rs
+++ b/crates/bifrost/src/bifrost_admin.rs
@@ -105,7 +105,7 @@ impl<'a> BifrostAdmin<'a> {
             .ok_or(Error::UnknownLogId(log_id))?;
 
         let sealed_segment = loop {
-            let sealed_segment = self.seal_inner(log_id, segment_index, None).await?;
+            let sealed_segment = self.seal_inner(log_id, segment_index, None, None).await?;
             if sealed_segment.tail.is_sealed() {
                 break sealed_segment;
             }
@@ -156,7 +156,7 @@ impl<'a> BifrostAdmin<'a> {
             .ok_or(Error::UnknownLogId(log_id))?;
 
         let sealed_segment = loop {
-            let sealed_segment = self.seal_inner(log_id, segment_index, None).await?;
+            let sealed_segment = self.seal_inner(log_id, segment_index, None, None).await?;
             if sealed_segment.tail.is_sealed() {
                 break sealed_segment;
             }
@@ -184,6 +184,7 @@ impl<'a> BifrostAdmin<'a> {
         log_id: LogId,
         segment_index: SegmentIndex,
         seal_metadata: Option<SealMetadata>,
+        forced_tail_lsn: Option<Lsn>,
     ) -> Result<MaybeSealedSegment> {
         self.inner.fail_if_shutting_down()?;
         // first find the tail segment for this log.
@@ -223,7 +224,11 @@ impl<'a> BifrostAdmin<'a> {
             }
         }
 
-        let tail = loglet.find_tail(FindTailOptions::ConsistentRead).await?;
+        let tail = if let Some(forced_tail_lsn) = forced_tail_lsn {
+            TailState::Sealed(forced_tail_lsn)
+        } else {
+            loglet.find_tail(FindTailOptions::ConsistentRead).await?
+        };
 
         if let Some(seal_metadata) = seal_metadata
             && tail.is_sealed()
@@ -255,9 +260,10 @@ impl<'a> BifrostAdmin<'a> {
         log_id: LogId,
         segment_index: SegmentIndex,
         metadata: SealMetadata,
+        forced_tail_lsn: Option<Lsn>,
     ) -> Result<Lsn> {
         let maybe_sealed = self
-            .seal_inner(log_id, segment_index, Some(metadata))
+            .seal_inner(log_id, segment_index, Some(metadata), forced_tail_lsn)
             .await?;
         if let TailState::Sealed(lsn) = maybe_sealed.tail {
             Ok(lsn)

--- a/crates/bifrost/src/read_stream.rs
+++ b/crates/bifrost/src/read_stream.rs
@@ -653,13 +653,13 @@ impl Stream for LogReadStream {
     }
 }
 
-// NOTE: This function assumes that chain sealing is supported/enabled.
 async fn seal_chain(bifrost: &BifrostInner, log_id: LogId, segment_index: SegmentIndex) {
     match BifrostAdmin::new(bifrost)
         .seal(
             log_id,
             segment_index,
             SealMetadata::new("read-stream", my_node_id()),
+            None,
         )
         .await
     {

--- a/crates/core/protobuf/cluster_ctrl_svc.proto
+++ b/crates/core/protobuf/cluster_ctrl_svc.proto
@@ -164,6 +164,9 @@ message SealChainRequest {
   // if not set.
   optional uint32 segment_index = 2;
   map<string, string> context = 3;
+  // forces the tail LSN to this value. This is extremely dangerous and should be
+  // used with extreme caution. If not set, the tail LSN is safely determined automatically.
+  optional uint64 tail_lsn = 4;
   // todo: option for permanently sealing the chain when this is fully supported
 }
 

--- a/tools/restatectl/src/commands/log/forced_seal.rs
+++ b/tools/restatectl/src/commands/log/forced_seal.rs
@@ -10,16 +10,16 @@
 
 use std::collections::HashMap;
 
+use anyhow::bail;
 use cling::prelude::*;
-use tracing::error;
 
+use restate_cli_util::ui::console::confirm_or_exit;
 use restate_cli_util::{CliContext, c_println};
 use restate_core::protobuf::cluster_ctrl_svc::{SealChainRequest, new_cluster_ctrl_client};
-use restate_types::logs::LogId;
+use restate_types::logs::{LogId, Lsn, SequenceNumber};
 use restate_types::nodes_config::Role;
 
 use crate::connection::ConnectionInfo;
-use crate::util::RangeParam;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[cling(run = "seal")]
@@ -29,28 +29,26 @@ pub struct SealOpts {
     segment_index: Option<u32>,
     /// The log id or range to seal and extend, e.g. "0", "1-4".
     #[clap(required = true)]
-    log_id: Vec<RangeParam>,
+    log_id: u32,
+    #[clap(required = true)]
+    tail_lsn: u64,
     /// Reason for sealing the log chain. This will appear as metadata on the chain.
     #[clap(long)]
     reason: Option<String>,
 }
 
 async fn seal(connection: &ConnectionInfo, opts: &SealOpts) -> anyhow::Result<()> {
-    for log_id in opts.log_id.iter().flatten().map(LogId::from) {
-        if let Err(err) = inner_seal(connection, opts, log_id).await {
-            error!("Failed to seal log chain for log={log_id}: {err}");
-        }
-        c_println!("");
+    let log_id = LogId::from(opts.log_id);
+    let tail_lsn = Lsn::from(opts.tail_lsn);
+
+    if tail_lsn == Lsn::INVALID {
+        bail!("tail LSN must be a valid non-zero value");
     }
 
-    Ok(())
-}
+    confirm_or_exit(&format!(
+        "Force-seal log {log_id} with tail LSN {tail_lsn}? This can cause permanent data loss"
+    ))?;
 
-async fn inner_seal(
-    connection: &ConnectionInfo,
-    opts: &SealOpts,
-    log_id: LogId,
-) -> anyhow::Result<()> {
     let mut context = HashMap::default();
     context.insert("source".to_owned(), "restatectl".to_owned());
     if let Some(reason) = &opts.reason {
@@ -59,7 +57,7 @@ async fn inner_seal(
     let request = SealChainRequest {
         log_id: log_id.into(),
         segment_index: opts.segment_index,
-        tail_lsn: None,
+        tail_lsn: Some(tail_lsn.as_u64()),
         context,
     };
 

--- a/tools/restatectl/src/commands/log/mod.rs
+++ b/tools/restatectl/src/commands/log/mod.rs
@@ -13,6 +13,7 @@ mod describe_log;
 // #[cfg(feature = "dump-local-log")]
 // mod dump_log;
 mod find_tail;
+mod forced_seal;
 mod gen_metadata;
 pub mod list_logs;
 mod reconfigure;
@@ -45,6 +46,9 @@ pub enum Logs {
     Reconfigure(reconfigure::ReconfigureOpts),
     /// Force sealing the current log chain
     Seal(seal::SealOpts),
+    /// [DANGEROUS] Force sealing the current log chain.
+    #[clap(hide = true)]
+    ForcedSeal(forced_seal::SealOpts),
     /// Find and show tail state of a log
     FindTail(find_tail::FindTailOpts),
 }


### PR DESCRIPTION

Adds a new hidden command to restatectl to force sealing a log-chain with custom tail LSN.

Note that if the forced-seal sets the tail LSN to a higher value than the global tail of the tail loglet (replicated loglet), the read stream
will get stuck on that last known global tail of the loglet (not the chain sealed tail). This issue https://github.com/restatedev/restate/issues/5107
should let us emit a proper data loss gap when this happens.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/5106).
* #5121
* #5120
* #5119
* #5114
* #5113
* #5116
* #5112
* #5109
* __->__ #5106