### PR TITLE
[Bifrost] Make find-tail resilient to repair races

### DIFF
--- a/crates/bifrost/src/providers/replicated_loglet/tasks/find_tail.rs
+++ b/crates/bifrost/src/providers/replicated_loglet/tasks/find_tail.rs
@@ -339,12 +339,17 @@ impl<T: TransportConnect> FindTailTask<T> {
                             .expect("at least one node is known and sealed");
                         let current_known_global = self.known_global_tail.latest_offset();
                         if max_local_tail < current_known_global {
-                            // what? Something went seriously wrong. This indicates that we somehow
+                            // what? Something went wrong. This indicates that we somehow
                             // have previously determined that global tail is higher than the max
-                            // observed local tail on f-majority of nodes.
-                            panic!(
-                                "max_local_tail={max_local_tail} is less than known_global_tail={current_known_global}"
+                            // observed local tail on f-majority of nodes. This can happen if by the
+                            // time we have collected the local tails, we updated our world view of
+                            // the global tail and those local tails are not old. The hope here is
+                            // that if we started a new round of GetLogletInfo, we would see the new
+                            // local tails and we can converge.
+                            debug!(
+                                "max_local_tail={max_local_tail} is less than known_global_tail={current_known_global}, restarting find-tail procedure!"
                             );
+                            continue 'find_tail;
                         } else if max_local_tail == current_known_global ||
                         // max_local_tail > known_global_tail
                         // Does a write-quorum check pass for this tail? In other words, do we have


### PR DESCRIPTION

When concurrent repair runs the global tail might move forward beyond our view of local tails which we collected, instead of panicking we should restart the find-tail procedure.
