### PR TITLE
[CI] Label Docker/OCI images with last tag as prefix

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -211,6 +211,18 @@ jobs:
             org.opencontainers.image.base.name=${{ steps.base-image.outputs.name }}
             org.opencontainers.image.base.digest=${{ steps.base-image.outputs.digest }}
 
+      - name: Set OCI image version
+        id: image-version
+        run: |
+          # Cargo.toml is the single source of truth for the version, so the label
+          # agrees with what the binary reports: RestateVersion::current() uses
+          # CARGO_PKG_VERSION.
+          IMAGE_VERSION=$(cargo metadata --no-deps --format-version 1 | \
+            jq -er '.packages[] | select(.name == "restate-server") | .version')
+
+          echo "version=${IMAGE_VERSION}" >> $GITHUB_OUTPUT
+          echo "OCI image version: ${IMAGE_VERSION}"
+
       - name: Build${{(inputs.uploadImageAsTarball == '' || github.ref == 'refs/heads/main') && ' and push ' || ' '}}Docker image
         id: build
         uses: docker/build-push-action@v6
@@ -223,7 +235,14 @@ jobs:
           outputs: |
             ${{ (inputs.uploadImageAsTarball == '' || github.ref == 'refs/heads/main') && 'type=registry' || '' }}
             ${{ inputs.uploadImageAsTarball != '' && 'type=oci,dest=restate.tar' || '' }}
-          labels: ${{ steps.meta.outputs.labels }}
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            org.opencontainers.image.version=${{ steps.image-version.outputs.version }}
+          # also annotate the multi-platform index so the version is readable
+          # without pulling a per-platform manifest
+          annotations: |
+            index:org.opencontainers.image.version=${{ steps.image-version.outputs.version }}
+            manifest:org.opencontainers.image.version=${{ steps.image-version.outputs.version }}
           # on main, always push both platforms, otherwise use platform input
           platforms: ${{ github.ref == 'refs/heads/main' && 'linux/arm64,linux/amd64' || (inputs.platforms || 'linux/arm64,linux/amd64') }}
           network: host


### PR DESCRIPTION
Before this change images would be have a label of tag, branch, or PR number. This changes tagging to rules to be to be tag, OR <lasttag>+<BRANCH/PR Number>.

For example, PR5026, would be 1.7.2+pr5026, following schemantic versioning, while main would be 1.7.2+main.

The rationale for this change is help signal compatability for the Restate N-1 downgrades. Rather than guess based on tags or looking up hashes, this allows for SEMVAR comparision.