### PR TITLE
Park partition processors with a sealed store instead of retrying

### DIFF
--- a/crates/storage-query-datafusion/src/partition_state/row.rs
+++ b/crates/storage-query-datafusion/src/partition_state/row.rs
@@ -46,7 +46,14 @@ pub(crate) fn append_partition_row(
         row.last_record_applied_at(ts.as_u64() as i64);
     }
 
-    row.fmt_replay_status(state.replay_status);
+    if state.is_broken() {
+        // A parked processor is not replaying anything. Leave the column NULL rather than
+        // reporting the default `starting`, which would read as progress.
+        row.fmt_broken_reason(state.broken_reason);
+    } else {
+        row.fmt_replay_status(state.replay_status);
+    }
+
     if let Some(lsn) = state.durable_lsn {
         row.durable_log_lsn(lsn.into());
     }

--- a/crates/storage-query-datafusion/src/partition_state/schema.rs
+++ b/crates/storage-query-datafusion/src/partition_state/schema.rs
@@ -45,7 +45,7 @@ define_table!(
         /// Last record applied at
         last_record_applied_at: TimestampMillisecond,
 
-        /// Replay status
+        /// Replay status. NULL if the processor is broken, since it is not replaying
         replay_status: DataType::Utf8,
 
         /// Durable log LSN
@@ -70,5 +70,9 @@ define_table!(
         /// Partition-store on-disk storage version (StorageVersion discriminant).
         /// Set once on partition open.
         storage_version: DataType::UInt32,
+
+        /// Why the node gave up on running this partition processor, if it did.
+        /// NULL while the processor is healthy.
+        broken_reason: DataType::Utf8,
     )
 );

--- a/crates/types/build.rs
+++ b/crates/types/build.rs
@@ -116,6 +116,11 @@ fn build_restate_proto(out_dir: &Path) -> std::io::Result<()> {
             "DetailedRunMode",
             "#[derive(::strum::Display, ::restate_encoding::NetSerde, ::bilrost::Enumeration)]",
         )
+        .enum_attribute(
+            "BrokenReason",
+            "#[derive(::strum::Display, ::restate_encoding::NetSerde, ::bilrost::Enumeration)]",
+        )
+        .enum_attribute("BrokenReason", "#[strum(serialize_all = \"snake_case\")]")
         .btree_map([
             ".restate.cluster.ClusterState",
             ".restate.cluster.AliveNode",

--- a/crates/types/protobuf/restate/cluster.proto
+++ b/crates/types/protobuf/restate/cluster.proto
@@ -70,6 +70,18 @@ enum ReplayStatus {
   CATCHING_UP = 3;
 }
 
+// Why a partition processor has been parked on a node. A parked processor is
+// not retried automatically; it needs operator intervention to recover.
+// Since v1.7.3
+enum BrokenReason {
+  // The partition processor is not broken.
+  BrokenReason_NOT_BROKEN = 0;
+  // The local partition store's applied LSN is ahead of the log tail, which
+  // indicates data loss in the log. The store has been sealed and must be
+  // replaced before this node can run the partition again.
+  BrokenReason_AHEAD_OF_LOG = 1;
+}
+
 message PartitionProcessorStatus {
   reserved 8;
   google.protobuf.Timestamp updated_at = 1;
@@ -93,6 +105,9 @@ message PartitionProcessorStatus {
   // Partition-store on-disk storage version (StorageVersion discriminant).
   optional uint32 storage_version = 16;
   DetailedRunMode detailed_effective_mode = 17;
+  // Set when this node has parked the partition processor instead of retrying
+  // it. All other fields carry their defaults in that case.
+  BrokenReason broken_reason = 18;
 }
 
 message ReplicationProperty { string replication_property = 1; }

--- a/crates/types/src/cluster/cluster_state.rs
+++ b/crates/types/src/cluster/cluster_state.rs
@@ -19,7 +19,7 @@ use crate::identifiers::{LeaderEpoch, PartitionId};
 use crate::logs::Lsn;
 use crate::partitions::StorageVersion;
 use crate::partitions::features::PersistedFeatures;
-pub use crate::protobuf::cluster::DetailedRunMode;
+pub use crate::protobuf::cluster::{BrokenReason, DetailedRunMode};
 use crate::time::MillisSinceEpoch;
 use crate::{GenerationalNodeId, PlainNodeId, Version};
 
@@ -211,9 +211,22 @@ pub struct PartitionProcessorStatus {
     /// Since v1.7.3 (if Unknown, use effective_mode)
     #[bilrost(17)]
     pub detailed_effective_mode: DetailedRunMode,
+
+    /// Set when the node has parked this partition processor instead of retrying it.
+    /// All other fields carry their defaults in that case.
+    ///
+    /// Since v1.7.3
+    #[bilrost(18)]
+    pub broken_reason: BrokenReason,
 }
 
 impl PartitionProcessorStatus {
+    /// The node running this processor gave up on it and will not retry until an
+    /// operator intervenes.
+    pub fn is_broken(&self) -> bool {
+        self.broken_reason != BrokenReason::NotBroken
+    }
+
     pub fn effective_mode(&self) -> DetailedRunMode {
         match self.detailed_effective_mode {
             DetailedRunMode::Unknown => self.effective_mode.into(),
@@ -269,6 +282,7 @@ impl Default for PartitionProcessorStatus {
             last_applied_schema_version: None,
             enabled_features: PersistedFeatures::default(),
             storage_version: None,
+            broken_reason: BrokenReason::NotBroken,
         }
     }
 }

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -57,7 +57,7 @@ use restate_partition_store::snapshots::{
 use restate_partition_store::{SnapshotError, SnapshotErrorKind};
 use restate_types::GenerationalNodeId;
 use restate_types::cluster::cluster_state::ReplayStatus;
-use restate_types::cluster::cluster_state::{PartitionProcessorStatus, RunMode};
+use restate_types::cluster::cluster_state::{BrokenReason, PartitionProcessorStatus, RunMode};
 use restate_types::config::Configuration;
 use restate_types::epoch::EpochMetadata;
 use restate_types::health::HealthStatus;
@@ -144,6 +144,14 @@ type SnapshotResultInternal = Result<(PartitionId, PartitionSnapshotStatus), Sna
 struct PendingSnapshotTask {
     snapshot_id: SnapshotId,
     sender: Option<oneshot::Sender<SnapshotResult>>,
+}
+
+/// What to do with a partition once its processor's runtime task has terminated.
+enum PostStopAction {
+    Restart(RestartDelay),
+    /// Give up on the partition: retrying cannot fix the failure, so we park the processor
+    /// in [`ProcessorState::Broken`] until an operator intervenes.
+    Park(BrokenReason),
 }
 
 enum RestartDelay {
@@ -391,6 +399,10 @@ where
             task.cancel();
         }
 
+        // broken processors have no runtime task left to await, so drop them upfront to keep
+        // `await_processors_termination` from waiting on an event that can never arrive
+        self.processor_states.retain(|_, state| !state.is_broken());
+
         // stop all running processors
         for processor_state in self.processor_states.values_mut() {
             processor_state.stop();
@@ -557,6 +569,16 @@ where
                                     runtime_handle.cancel();
                                     self.await_runtime_task_result(partition_id, runtime_handle);
                                 }
+                                ProcessorState::Broken { .. } => {
+                                    // Unreachable in practice: we only park a processor as
+                                    // broken after its runtime task reported termination.
+                                    // Stop the new one and stay broken.
+                                    debug!(
+                                        "Started partition processor for a partition we gave up on. Stopping it."
+                                    );
+                                    runtime_handle.cancel();
+                                    self.await_runtime_task_result(partition_id, runtime_handle);
+                                }
                             }
                         } else {
                             debug!("Started partition processor is no longer needed. Stopping it.");
@@ -579,18 +601,18 @@ where
             }
             EventKind::Stopped(result) => {
                 self.unregister_pp_rpc_shard(partition_id);
-                let delay = match self.processor_states.remove(&partition_id) {
+                let action = match self.processor_states.remove(&partition_id) {
                     None => {
                         debug!("Stopped partition processor which is no longer running.");
                         // immediately try to restart if we are still part of the partition's membership
                         counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => NORMAL_STOP).increment(1);
-                        RestartDelay::Immediate
+                        PostStopAction::Restart(RestartDelay::Immediate)
                     }
                     Some(processor_state) => match processor_state {
                         ProcessorState::Starting { .. } => {
                             counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => STARTUP_ERROR_STOP).increment(1);
                             warn!(%partition_id, "Partition processor failed to start: {result:?}");
-                            RestartDelay::Fixed
+                            PostStopAction::Restart(RestartDelay::Fixed)
                         }
                         ProcessorState::Started {
                             processor,
@@ -610,19 +632,24 @@ where
                                     counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => ERROR_STOP).increment(1);
                                     gauge!(PARTITION_BLOCKED_FLARE, PARTITION_LABEL => partition_id.to_string(), REASON_LABEL => FLARE_REASON_VERSION_BARRIER).set(1);
                                     error!(%partition_id, "Partition processor start error: {e}");
-                                    RestartDelay::MaxBackoff
+                                    PostStopAction::Restart(RestartDelay::MaxBackoff)
                                 }
                                 Err(e @ ProcessorError::MigrationBarrier { .. }) => {
                                     counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => ERROR_STOP).increment(1);
                                     gauge!(PARTITION_BLOCKED_FLARE, PARTITION_LABEL => partition_id.to_string(), REASON_LABEL => FLARE_REASON_MIGRATION_BARRIER).set(1);
                                     error!(%partition_id, "Partition processor start error: {e}");
-                                    RestartDelay::MaxBackoff
+                                    PostStopAction::Restart(RestartDelay::MaxBackoff)
                                 }
                                 Err(e @ ProcessorError::PartitionAheadOfLog { .. }) => {
                                     counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => ERROR_STOP).increment(1);
                                     gauge!(PARTITION_BLOCKED_FLARE, PARTITION_LABEL => partition_id.to_string(), REASON_LABEL => FLARE_REASON_AHEAD_OF_LOG).set(1);
-                                    error!(%partition_id, "Partition processor start error: {e}");
-                                    RestartDelay::MaxBackoff
+                                    error!(
+                                        %partition_id,
+                                        "Partition processor start error: {e}. The local partition store \
+                                        is sealed; this node will not run this partition again until the \
+                                        store has been dropped and replaced by a safe snapshot",
+                                    );
+                                    PostStopAction::Park(BrokenReason::AheadOfLog)
                                 }
                                 Err(ProcessorError::TrimGapEncountered {
                                     read_pointer: sequence_number,
@@ -641,7 +668,7 @@ where
                                         );
                                         self.fast_forward_on_startup.insert(partition_id, *to_lsn);
 
-                                        RestartDelay::Immediate
+                                        PostStopAction::Restart(RestartDelay::Immediate)
                                     } else {
                                         error!(
                                             %partition_id,
@@ -650,7 +677,7 @@ where
                                         );
                                         gauge!(PARTITION_BLOCKED_FLARE, PARTITION_LABEL => partition_id.to_string(), REASON_LABEL => FLARE_REASON_SNAPSHOT_UNAVAILABLE).set(1);
                                         // configuration problem; until we have peer-to-peer state exchange we can only wait
-                                        RestartDelay::MaxBackoff
+                                        PostStopAction::Restart(RestartDelay::MaxBackoff)
                                     }
                                 }
                                 Err(err) => {
@@ -660,12 +687,12 @@ where
                                     };
                                     counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => ERROR_STOP).increment(1);
                                     error!(%partition_id, %err, "Partition processor exited unexpectedly, {}", next_delay);
-                                    next_delay
+                                    PostStopAction::Restart(next_delay)
                                 }
                                 Ok(_) => {
                                     counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => NORMAL_STOP).increment(1);
                                     info!(%partition_id, "Partition processor stopped");
-                                    RestartDelay::Immediate
+                                    PostStopAction::Restart(RestartDelay::Immediate)
                                 }
                             }
                         }
@@ -675,13 +702,28 @@ where
                                     .unregister_all(processor.key_range());
                             }
                             counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => NORMAL_STOP).increment(1);
-                            RestartDelay::Immediate
+                            PostStopAction::Restart(RestartDelay::Immediate)
                         }
+                        // Unreachable in practice: a broken processor has no runtime task that
+                        // could report back. Stay broken rather than silently restarting.
+                        ProcessorState::Broken { reason, .. } => PostStopAction::Park(reason),
                     },
                 };
 
-                if !self.restart_partition_processor_if_replica(partition_id, delay) {
-                    debug!("Partition processor stopped: {result:?}");
+                match action {
+                    PostStopAction::Restart(delay) => {
+                        if !self.restart_partition_processor_if_replica(partition_id, delay) {
+                            debug!("Partition processor stopped: {result:?}");
+                        }
+                    }
+                    PostStopAction::Park(reason) => {
+                        if self.should_run_processor(partition_id) {
+                            self.processor_states
+                                .insert(partition_id, ProcessorState::broken(reason));
+                        } else {
+                            debug!("Partition processor stopped: {result:?}");
+                        }
+                    }
                 }
             }
             EventKind::NewLeaderEpoch {
@@ -1341,7 +1383,16 @@ where
         // All the remaining running processors are no longer part of the observed partition
         // configuration. Let's terminate them.
         for partition_id in running_processors.into_iter() {
-            if let Some(processor) = self.processor_states.get_mut(&partition_id) {
+            let Some(processor) = self.processor_states.get_mut(&partition_id) else {
+                continue;
+            };
+
+            if processor.is_broken() {
+                // A broken processor has no runtime task that would report its termination,
+                // so drop it right away instead of waiting for a `Stopped` event.
+                debug!(%partition_id, "Forget broken partition processor because it is no longer a member of the partition configuration");
+                self.processor_states.remove(&partition_id);
+            } else {
                 debug!(%partition_id, "Stop partition processor because it is no longer a member of the partition configuration");
                 processor.stop();
 
@@ -1350,9 +1401,19 @@ where
                         "Partition processor stop requested with snapshot task result outstanding"
                     );
                 }
-                self.latest_snapshots.remove(&partition_id);
             }
+            self.latest_snapshots.remove(&partition_id);
         }
+    }
+
+    /// Whether this node should be running a processor for the given partition, i.e. we are
+    /// part of its replica set and the manager itself is not shutting down.
+    fn should_run_processor(&self, partition_id: PartitionId) -> bool {
+        !restate_core::is_cancellation_requested()
+            && self
+                .replica_set_states
+                .membership_state(partition_id)
+                .contains(Metadata::with_current(|m| m.my_node_id().as_plain()))
     }
 
     /// Starts a partition processor if this node is part of the replica set of the given partition.
@@ -1362,24 +1423,12 @@ where
         partition_id: PartitionId,
         delay: RestartDelay,
     ) -> bool {
-        // only restart partition processors if the partition processor manager is still supposed to run
-        if restate_core::is_cancellation_requested() {
+        if !self.should_run_processor(partition_id) {
             return false;
         }
 
-        if self
-            .replica_set_states
-            .membership_state(partition_id)
-            .contains(Metadata::with_current(|m| m.my_node_id().as_plain()))
-        {
-            self.start_partition_processor(
-                partition_id,
-                delay.next_delay().map(|d| d.add_jitter(0.3)),
-            );
-            true
-        } else {
-            false
-        }
+        self.start_partition_processor(partition_id, delay.next_delay().map(|d| d.add_jitter(0.3)));
+        true
     }
 
     #[instrument(level = "info", skip_all, fields(partition_id = %partition_id))]

--- a/crates/worker/src/partition_processor_manager/processor_state.rs
+++ b/crates/worker/src/partition_processor_manager/processor_state.rs
@@ -16,10 +16,13 @@ use tracing::debug;
 use ulid::Ulid;
 
 use restate_core::network::ShardSender;
-use restate_types::cluster::cluster_state::{PartitionProcessorStatus, ReplayStatus, RunMode};
+use restate_types::cluster::cluster_state::{
+    BrokenReason, PartitionProcessorStatus, ReplayStatus, RunMode,
+};
 use restate_types::identifiers::LeaderEpoch;
 use restate_types::net::partition_processor::PartitionLeaderService;
 use restate_types::sharding::KeyRange;
+use restate_types::time::MillisSinceEpoch;
 
 use crate::partition::{LeadershipInfo, TargetLeaderState};
 
@@ -48,6 +51,13 @@ pub enum ProcessorState {
     Stopping {
         processor: Option<StartedProcessor>,
     },
+    /// The processor hit a failure that retrying cannot resolve, so this node gave up on
+    /// running it. There is no runtime task backing this state; it is only cleared by an
+    /// operator action (see `restatectl`) or by losing membership of the partition.
+    Broken {
+        reason: BrokenReason,
+        since: MillisSinceEpoch,
+    },
 }
 
 impl ProcessorState {
@@ -57,6 +67,17 @@ impl ProcessorState {
             start_time: Instant::now(),
             delay,
         }
+    }
+
+    pub fn broken(reason: BrokenReason) -> Self {
+        Self::Broken {
+            reason,
+            since: MillisSinceEpoch::now(),
+        }
+    }
+
+    pub fn is_broken(&self) -> bool {
+        matches!(self, ProcessorState::Broken { .. })
     }
 
     pub fn stopping(processor: StartedProcessor) -> Self {
@@ -94,6 +115,11 @@ impl ProcessorState {
             ProcessorState::Stopping { .. } => {
                 // already stopping
             }
+            ProcessorState::Broken { .. } => {
+                // Nothing to stop; there is no runtime task that would report back a
+                // `Stopped` event. Callers that want to get rid of a broken processor must
+                // drop the state instead of waiting for it to terminate.
+            }
         };
     }
 
@@ -124,6 +150,9 @@ impl ProcessorState {
             }
             ProcessorState::Stopping { .. } => {
                 // we first need to stop before we check whether we should run again
+            }
+            ProcessorState::Broken { .. } => {
+                // a broken processor cannot run in any mode
             }
         }
     }
@@ -177,6 +206,10 @@ impl ProcessorState {
             }
             ProcessorState::Stopping { .. } => {
                 // we first need to stop before we check whether we should run again
+                None
+            }
+            ProcessorState::Broken { .. } => {
+                debug!("Ignoring leadership request for a broken partition processor.");
                 None
             }
         }
@@ -234,6 +267,9 @@ impl ProcessorState {
             ProcessorState::Stopping { .. } => {
                 debug!("Received leader epoch while stopping partition processor. Ignoring.");
             }
+            ProcessorState::Broken { .. } => {
+                debug!("Received leader epoch for a broken partition processor. Ignoring.");
+            }
         }
     }
 
@@ -243,7 +279,7 @@ impl ProcessorState {
             ProcessorState::Started { leader_state, .. } => {
                 matches!(leader_state, LeaderState::AwaitingLeaderEpoch(token) if *token == leader_epoch_token)
             }
-            ProcessorState::Stopping { .. } => false,
+            ProcessorState::Stopping { .. } | ProcessorState::Broken { .. } => false,
         }
     }
 
@@ -301,6 +337,13 @@ impl ProcessorState {
                 // todo report stopping status back to the cluster controller
                 None
             }
+            ProcessorState::Broken { reason, since } => Some(PartitionProcessorStatus {
+                broken_reason: *reason,
+                // report when we gave up rather than "now", so that operators can see how
+                // long the partition has been sitting broken.
+                updated_at: *since,
+                ..Default::default()
+            }),
         }
     }
 

--- a/release-notes/unreleased/park-broken-partition-processors.md
+++ b/release-notes/unreleased/park-broken-partition-processors.md
@@ -1,0 +1,36 @@
+# Release Notes: Partition processors are parked instead of retried when the local store is sealed
+
+## Behavioral Change
+
+### What Changed
+
+When a partition processor fails because its local partition store is sealed (the store's applied
+LSN is ahead of the log tail, which indicates data loss in the log), the node no longer retries the
+processor on a backoff. It parks the processor and reports it as **broken**:
+
+- `restatectl partition list` shows `Broken (ahead-of-log)` in the `STATUS` column.
+- `restatectl status` counts broken processors separately, e.g. `2 (1 broken)` under `FOLLOWERS`.
+- The `partition_state` SQL table has a new `broken_reason` column (`NULL` while healthy). Its
+  `replay_status` is `NULL` for a broken processor, since there is no replay in progress.
+- The `restate.partition.blocked_flare{reason="ahead_of_log"}` gauge is still raised.
+
+Other blocked states (version barrier, migration barrier, missing snapshot) are unchanged and keep
+retrying, because a cluster upgrade or a newly published snapshot can resolve them on its own.
+
+### Why This Matters
+
+A sealed store cannot be repaired by retrying: the local data must be discarded and replaced from a
+snapshot. Retrying every 30 seconds only produced log noise and made it impossible to tell a
+transiently failing processor from one that will never recover.
+
+### Impact on Users
+
+- A parked processor stays down until an operator intervenes, the node restarts, or the node leaves
+  the partition's replica set. Previously it would keep retrying (and keep failing).
+- Nothing to do for healthy deployments; the new state is only reachable via a sealed partition
+  store.
+
+### Migration Guidance
+
+None. Older `restatectl` builds ignore the new field and render a broken processor as a follower
+that never becomes active.

--- a/tools/restatectl/src/commands/partition/list.rs
+++ b/tools/restatectl/src/commands/partition/list.rs
@@ -21,7 +21,8 @@ use restate_core::protobuf::cluster_ctrl_svc::{ClusterStateRequest, new_cluster_
 use restate_types::logs::Lsn;
 use restate_types::nodes_config::Role;
 use restate_types::protobuf::cluster::{
-    DeadNode, DetailedRunMode, PartitionProcessorStatus, ReplayStatus, RunMode, node_state,
+    BrokenReason, DeadNode, DetailedRunMode, PartitionProcessorStatus, ReplayStatus, RunMode,
+    node_state,
 };
 use restate_types::{GenerationalNodeId, PlainNodeId, Version};
 
@@ -184,6 +185,7 @@ pub async fn list_partitions(
                 render_replay_status(
                     processor.status.effective_mode(),
                     processor.status.replay_status(),
+                    processor.status.broken_reason(),
                     processor.status.target_tail_lsn.map(Into::into),
                 ),
                 Cell::new(
@@ -309,7 +311,22 @@ fn render_mode(
     }
 }
 
-fn render_replay_status(effective: RunMode, status: ReplayStatus, target_lsn: Option<Lsn>) -> Cell {
+fn render_replay_status(
+    effective: RunMode,
+    status: ReplayStatus,
+    broken_reason: BrokenReason,
+    target_lsn: Option<Lsn>,
+) -> Cell {
+    // A broken processor isn't running at all, so its replay status carries no information.
+    match broken_reason {
+        BrokenReason::NotBroken => {}
+        BrokenReason::AheadOfLog => {
+            return Cell::new("Broken (ahead-of-log)")
+                .fg(Color::Red)
+                .add_attribute(Attribute::Bold);
+        }
+    }
+
     match (status, effective) {
         (ReplayStatus::Unknown, _) => Cell::new("UNKNOWN").fg(Color::Red),
         (ReplayStatus::Starting, _) => Cell::new("Starting").fg(Color::Yellow),

--- a/tools/restatectl/src/commands/status.rs
+++ b/tools/restatectl/src/commands/status.rs
@@ -26,7 +26,7 @@ use restate_types::health::MetadataServerStatus;
 use restate_types::logs::metadata::Logs;
 use restate_types::nodes_config::{NodeConfig, NodesConfiguration, Role};
 use restate_types::protobuf::cluster::node_state::State;
-use restate_types::protobuf::cluster::{AliveNode, RunMode};
+use restate_types::protobuf::cluster::{AliveNode, BrokenReason, RunMode};
 use restate_types::{GenerationalNodeId, NodeId};
 use restate_util_time::DurationExt;
 
@@ -158,6 +158,12 @@ async fn alive_node_status(
     let counter = alive_node.partitions.values().fold(
         PartitionCounter::default(),
         |mut counter, partition_status| {
+            // a broken processor is neither leading nor following, it isn't running at all
+            if partition_status.broken_reason() != BrokenReason::NotBroken {
+                counter.broken += 1;
+                return counter;
+            }
+
             let effective =
                 RunMode::try_from(partition_status.effective_mode).expect("valid effective mode");
             let planned =
@@ -251,6 +257,7 @@ struct PartitionCounter {
     followers: u16,
     upgrading: u16,
     downgrading: u16,
+    broken: u16,
 }
 
 impl PartitionCounter {
@@ -273,6 +280,9 @@ impl PartitionCounter {
         write!(buf, "{}", self.followers).expect("must succeed");
         if self.downgrading > 0 {
             write!(buf, "+{}", self.downgrading).expect("must succeed");
+        }
+        if self.broken > 0 {
+            write!(buf, " ({} broken)", self.broken).expect("must succeed");
         }
 
         buf


### PR DESCRIPTION

## What

- New `ProcessorState::Broken`. The PPM parks a processor on
  `ProcessorError::PartitionAheadOfLog` rather than restarting it with
  `RestartDelay::MaxBackoff`. Other blocked states (version/migration barrier,
  missing snapshot) keep retrying — those can resolve on their own.
- Broken entries have no runtime task backing them, so they are dropped directly
  when the node leaves the partition's replica set and before
  `await_processors_termination` on shutdown.
- Reported through the new `PartitionProcessorStatus::broken_reason`
  (`BrokenReason`, bilrost tag 18 / proto field 18).

## Why

A sealed store cannot be repaired by retrying: the local data has to be dropped
and replaced from a snapshot. Retrying every 30s only produced log noise and made
a permanently broken partition indistinguishable from a flapping one.

## Observability

- `restatectl partition list` → `Broken (ahead-of-log)` in `STATUS`
- `restatectl status` → `2 (1 broken)` under `FOLLOWERS`
- `sys_partition_state.broken_reason` (NULL while healthy)

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/5112).
* #5121
* #5120
* #5119
* #5114
* #5113
* #5116
* __->__ #5112
* #5109
* #5106