### PR TITLE
Add drop_partition_store, and wait for in-flight database closes

### DIFF
--- a/crates/partition-store/src/partition_store_manager.rs
+++ b/crates/partition-store/src/partition_store_manager.rs
@@ -108,18 +108,6 @@ impl SharedState {
             cell.note_durable_lsn(durable_lsn);
         };
     }
-
-    #[cfg(test)]
-    pub async fn drop_partition(
-        &self,
-        partition_id: PartitionId,
-    ) -> Result<(), restate_rocksdb::RocksError> {
-        let Some(cell) = self.partitions.read().get(&partition_id).cloned() else {
-            return Ok(());
-        };
-        let mut state_guard = cell.inner.write().await;
-        cell.drop_cf(&mut state_guard).await
-    }
 }
 
 pub struct PartitionStoreManager {
@@ -390,12 +378,37 @@ impl PartitionStoreManager {
             .await
     }
 
-    #[cfg(test)]
-    pub async fn drop_partition(
-        &self,
-        partition_id: PartitionId,
-    ) -> Result<(), restate_rocksdb::RocksError> {
-        self.state.drop_partition(partition_id).await
+    /// Deletes this node's local copy of the partition, discarding all of its data.
+    ///
+    /// Returns `true` if a local column family existed and was dropped, `false` if there was
+    /// nothing to delete.
+    ///
+    /// The caller is responsible for making sure that no partition processor is using the store:
+    /// the partition cell's lock keeps concurrent opens out, but it cannot stop a processor that
+    /// is already holding a [`PartitionDb`] clone.
+    #[instrument(level = "error", skip_all, fields(partition_id = %partition.partition_id, cf_name = %partition.cf_name()))]
+    pub async fn drop_partition_store(&self, partition: &Partition) -> Result<bool, RocksError> {
+        let rocksdb = self.open_rocksdb(partition).await?;
+        // resolves `State::Unknown` so that a column family we have never opened in this process
+        // is still found (and dropped) below
+        let cell = self.state.get_or_open(partition, &rocksdb).await;
+
+        let mut state_guard = cell.inner.write().await;
+        let existed = state_guard.db().is_some();
+        cell.drop_cf(&mut state_guard).await?;
+        drop(state_guard);
+
+        // Note: we deliberately don't close the database here. In the multi-db layout this was its
+        // only column family, so dropping `rocksdb` below closes it in the background, and
+        // `RocksDbManager` makes a subsequent open wait for that shutdown to finish.
+        drop(rocksdb);
+
+        if existed {
+            info!("Dropped local partition store");
+        } else {
+            debug!("No local partition store to drop");
+        }
+        Ok(existed)
     }
 
     /// Opens a partition store by importing an already-downloaded snapshot, discarding any

--- a/crates/partition-store/src/tests/mod.rs
+++ b/crates/partition-store/src/tests/mod.rs
@@ -86,6 +86,67 @@ async fn read_write() {
     RocksDbManager::get().shutdown().await;
 }
 
+/// Dropping a partition releases the last reference to its database, whose shutdown then runs
+/// in the background. In the multi-db layout that partition owns the whole database, so
+/// re-opening it must wait for the shutdown to complete: until then rocksdb still holds the
+/// directory's file lock and rotates its LOG files.
+///
+/// This exercises `RocksDbManager`'s open/close interlock; it lives here because this is where
+/// the rocksdb test harness is. A single round often wins the race by chance, hence the loop.
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reopen_partition_after_background_close() {
+    let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+    let partition = Partition::new(PartitionId::MIN, KeyRange::new(0, PartitionKey::MAX - 1));
+
+    let (manager, store) = storage_test_environment_with_manager().await;
+    drop(store);
+
+    for round in 0..10 {
+        manager.drop_partition_store(&partition).await.unwrap();
+        manager
+            .open(&partition, None)
+            .await
+            .unwrap_or_else(|err| panic!("re-open after drop failed on round {round}: {err}"));
+    }
+
+    RocksDbManager::get().shutdown().await;
+}
+
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
+async fn drop_partition_store_deletes_local_data() {
+    use restate_storage_api::Transaction;
+    use restate_storage_api::fsm_table::{ReadFsmTable, WriteFsmTable};
+    use restate_types::logs::Lsn;
+
+    let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+    let partition = Partition::new(PartitionId::MIN, KeyRange::new(0, PartitionKey::MAX - 1));
+
+    let (manager, mut store) = storage_test_environment_with_manager().await;
+
+    {
+        let mut txn = store.transaction();
+        txn.put_applied_lsn(Lsn::new(100)).unwrap();
+        txn.commit().await.expect("commit succeeds");
+    }
+    assert_eq!(Some(Lsn::new(100)), store.get_applied_lsn().await.unwrap());
+    drop(store);
+
+    assert!(
+        manager.drop_partition_store(&partition).await.unwrap(),
+        "the partition's column family existed and was dropped"
+    );
+    assert!(
+        !manager.drop_partition_store(&partition).await.unwrap(),
+        "dropping a partition we no longer hold is a no-op"
+    );
+
+    // re-opening provisions a fresh store; the data we wrote before the drop is gone
+    let mut store = manager.open(&partition, None).await.unwrap();
+    assert_eq!(None, store.get_applied_lsn().await.unwrap());
+
+    RocksDbManager::get().shutdown().await;
+}
+
 pub(crate) fn mock_service_invocation(service_id: ServiceId) -> Box<ServiceInvocation> {
     let invocation_target = InvocationTarget::mock_from_service_id(service_id);
     Box::new(ServiceInvocation::initialize(

--- a/crates/partition-store/src/tests/snapshots_test/mod.rs
+++ b/crates/partition-store/src/tests/snapshots_test/mod.rs
@@ -62,7 +62,10 @@ pub(crate) async fn run_tests(
     // drop; we restore from them below. `snapshots_dir` (a TempDir) still owns the parent dir.
     let _exported_dir = snapshot.base_dir.into_path();
 
-    manager.drop_partition(partition_id).await.unwrap();
+    manager
+        .drop_partition_store(&Partition::new(partition_id, key_range))
+        .await
+        .unwrap();
 
     let snapshot_meta: PartitionSnapshotMetadata = serde_json::from_str(&metadata_json).unwrap();
 

--- a/crates/rocksdb/src/db_manager.rs
+++ b/crates/rocksdb/src/db_manager.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 
 use parking_lot::RwLock;
 use rocksdb::{Cache, RateLimiter, RateLimiterMode, WriteBufferManager};
+use tokio::sync::Semaphore;
 use tokio_util::task::TaskTracker;
 use tracing::{debug, error, info, warn};
 
@@ -41,6 +42,12 @@ pub struct RocksDbManager {
     // auto updates to changes in common.rocksdb_memory_limit and common.rocksdb_memtable_total_size_limit
     pub(crate) write_buffer_manager: WriteBufferManager,
     dbs: RwLock<HashMap<DbName, Weak<RocksDb>>>,
+    /// Databases whose shutdown is still running, keyed by name.
+    ///
+    /// RocksDB only releases a database directory's file lock once its shutdown completes, so
+    /// re-opening the same database has to wait for the in-flight close first. The semaphore
+    /// holds no permits and is closed by the shutdown task to release waiters.
+    closing_dbs: RwLock<HashMap<DbName, Arc<Semaphore>>>,
     shutting_down: AtomicBool,
     close_db_tasks: TaskTracker,
     high_pri_pool: threadpool::ThreadPool,
@@ -116,6 +123,7 @@ impl RocksDbManager {
             cache,
             write_buffer_manager,
             dbs,
+            closing_dbs: RwLock::default(),
             shutting_down: AtomicBool::new(false),
             close_db_tasks: TaskTracker::default(),
             high_pri_pool,
@@ -164,6 +172,11 @@ impl RocksDbManager {
         // get latest options
         let name = db_spec.name.clone();
         let path = db_spec.path.clone();
+
+        // A previous instance of this database may still be shutting down, in which case rocksdb
+        // has not released the directory's file lock yet and opening would fail.
+        self.wait_for_pending_close(&name).await;
+
         let wrapper = RocksDb::open(self, db_spec).await?;
         self.dbs
             .write()
@@ -183,6 +196,7 @@ impl RocksDbManager {
             .store(true, std::sync::atomic::Ordering::Release);
         self.shutdown().await;
         self.dbs.write().clear();
+        self.closing_dbs.write().clear();
         self.shutting_down
             .store(false, std::sync::atomic::Ordering::Release);
         Ok(())
@@ -236,15 +250,55 @@ impl RocksDbManager {
         self.dbs.read().values().filter_map(Weak::upgrade).collect()
     }
 
+    /// Waits for an in-flight close of the named database to complete, if there is one.
+    async fn wait_for_pending_close(&self, name: &DbName) {
+        let Some(semaphore) = self.closing_dbs.read().get(name).cloned() else {
+            return;
+        };
+
+        debug!(db = %name, "Waiting for the previous instance of this database to finish closing");
+        // never granted; resolves with an error once the shutdown task closes the semaphore
+        let _ = semaphore.acquire().await;
+    }
+
+    /// Marks the named database as closing. Callers must pass the returned semaphore to
+    /// [`Self::finish_pending_close`] once the shutdown has completed.
+    fn register_pending_close(&self, name: DbName) -> Arc<Semaphore> {
+        let semaphore = Arc::new(Semaphore::new(0));
+        self.closing_dbs.write().insert(name, semaphore.clone());
+        semaphore
+    }
+
+    fn finish_pending_close(&self, name: &DbName, semaphore: &Arc<Semaphore>) {
+        {
+            let mut guard = self.closing_dbs.write();
+            // only clear our own registration; the database may have been opened and closed again
+            if guard
+                .get(name)
+                .is_some_and(|current| Arc::ptr_eq(current, semaphore))
+            {
+                guard.remove(name);
+            }
+        }
+        // releases anyone that started waiting before we removed the entry above
+        semaphore.close();
+    }
+
     /// Closes the database and waits for completion.
-    pub(crate) async fn close_db(&self, db: Arc<RocksDb>) -> Result<(), Arc<RocksDb>> {
+    pub(crate) async fn close_db(&'static self, db: Arc<RocksDb>) -> Result<(), Arc<RocksDb>> {
         let db = Arc::try_unwrap(db)?;
+        let name = db.name().clone();
         // unconditionally remove the db from the map
-        self.dbs.write().remove(db.name());
+        self.dbs.write().remove(&name);
+        let semaphore = self.register_pending_close(name.clone());
         let handle = self.close_db_tasks.spawn_blocking(move || {
             db.db.shutdown();
+            // `db` is dropped as this closure returns, which is what destroys the underlying
+            // rocksdb database and releases its directory lock.
         });
         let _ = handle.await;
+        // Only now is the lock gone, so it is safe to let a waiting open proceed.
+        self.finish_pending_close(&name, &semaphore);
         Ok(())
     }
 
@@ -256,13 +310,22 @@ impl RocksDbManager {
     /// [`RocksDbManager`]'s shutdown routine.
     ///
     /// if you need to wait for the shutdown, then use [`RocksDb::close`] instead.
-    pub(crate) fn background_close_db(&self, db: RocksAccess) {
-        let Some(_db) = self.dbs.write().remove(db.name()) else {
+    pub(crate) fn background_close_db(&'static self, db: RocksAccess) {
+        let name = db.name().clone();
+        let Some(_db) = self.dbs.write().remove(&name) else {
             // database has already been closed via other means
             return;
         };
+        // Opening this database again has to wait for this shutdown: rocksdb holds the
+        // directory's file lock until it completes.
+        let semaphore = self.register_pending_close(name.clone());
         self.close_db_tasks.spawn_blocking(move || {
             db.shutdown();
+            // Destroying the database is what releases its directory lock; `shutdown` above only
+            // flushes. Waiters must not be released before this, or their open fails with
+            // "lock hold by current process".
+            drop(db);
+            self.finish_pending_close(&name, &semaphore);
         });
     }
 


### PR DESCRIPTION

## Drop the local partition store

`PartitionStoreManager::drop_partition_store` deletes this node's copy of a
partition and reports whether a column family was actually there. It replaces the
two `#[cfg(test)]` `drop_partition` helpers, so tests now exercise the path
production will use. Unlike those helpers it resolves `State::Unknown`, so it also
finds a column family that exists on disk but was never opened in this process.

## Wait for in-flight closes

RocksDB releases a database directory's file lock only once its shutdown
completes, but `RocksDb`'s `Drop` closes the database in the *background*
(`background_close_db`) and `RocksDb::open` does not retry. Dropping a partition
and re-opening it therefore failed with errors like:

- `IO error: lock hold by current process ... /LOCK: No locks available`
- `IO error: No such file or directory: while unlink() file: .../LOG.old.<ts>`

`RocksDbManager` now tracks closing databases in `closing_dbs` keyed by `DbName`;
both close paths register before spawning the shutdown and release afterwards, and
`open_db` waits on that registration first. The marker is a permit-less
`Semaphore` closed by the shutdown task, so a waiter that grabbed it before the
map entry was removed is still released. `finish_pending_close` compares by
pointer so it cannot clobber a newer cycle.

This is why `drop_partition_store` does not close the database itself: fail-fast
`Arc::try_unwrap` made that a no-op whenever anything else held the database (a
sibling partition, or a `PartitionStore` clone such as an in-flight datafusion
scan), so it could not be relied on.

## Test

`reopen_partition_after_background_close` drops and re-opens a partition ten
times; without the interlock it fails on the first round.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/5113).
* #5121
* #5120
* #5119
* #5114
* __->__ #5113
* #5116
* #5112
* #5109
* #5106