### PR TITLE
Add `restatectl partition drop-store`

### DIFF
--- a/crates/admin/src/cluster_controller/grpc_svc_handler.rs
+++ b/crates/admin/src/cluster_controller/grpc_svc_handler.rs
@@ -25,13 +25,14 @@ use restate_bifrost::loglet::FindTailOptions;
 use restate_bifrost::{Bifrost, Error as BiforstError};
 use restate_core::protobuf::cluster_ctrl_svc::{
     ClusterStateRequest, ClusterStateResponse, CreatePartitionSnapshotRequest,
-    CreatePartitionSnapshotResponse, DescribeLogRequest, DescribeLogResponse, FindTailRequest,
-    FindTailResponse, GetClusterConfigurationRequest, GetClusterConfigurationResponse,
-    ListLogsRequest, ListLogsResponse, MigrateMetadataRequest, MigrateMetadataResponse,
-    QueryRequest, QueryResponse, QueryWarning, SealAndExtendChainRequest,
-    SealAndExtendChainResponse, SealChainRequest, SealChainResponse, SealedSegment,
-    SetClusterConfigurationRequest, SetClusterConfigurationResponse, SyncEpochMetadataRequest,
-    SyncEpochMetadataResponse, TailState, TrimLogRequest,
+    CreatePartitionSnapshotResponse, DescribeLogRequest, DescribeLogResponse,
+    DropPartitionStoreRequest, DropPartitionStoreResponse, FindTailRequest, FindTailResponse,
+    GetClusterConfigurationRequest, GetClusterConfigurationResponse, ListLogsRequest,
+    ListLogsResponse, MigrateMetadataRequest, MigrateMetadataResponse, QueryRequest, QueryResponse,
+    QueryWarning, SealAndExtendChainRequest, SealAndExtendChainResponse, SealChainRequest,
+    SealChainResponse, SealedSegment, SetClusterConfigurationRequest,
+    SetClusterConfigurationResponse, SyncEpochMetadataRequest, SyncEpochMetadataResponse,
+    TailState, TrimLogRequest,
     cluster_ctrl_svc_server::{ClusterCtrlSvc, ClusterCtrlSvcServer},
 };
 use restate_core::{Metadata, MetadataWriter};
@@ -45,14 +46,14 @@ use restate_types::logs::{LogId, Lsn, SequenceNumber};
 use restate_types::metadata::{GlobalMetadata, Precondition};
 use restate_types::metadata_store::keys::{NODES_CONFIG_KEY, partition_processor_epoch_key};
 use restate_types::net::connect_opts::GrpcConnectionOptions;
-use restate_types::net::partition_processor_manager::Snapshot;
+use restate_types::net::partition_processor_manager::{DropPartitionStoreOutcome, Snapshot};
 use restate_types::nodes_config::{NodesConfiguration, Role};
 use restate_types::partitions::PartitionTable;
 use restate_types::partitions::state::PartitionReplicaSetStates;
 use restate_types::protobuf::cluster::ClusterConfiguration;
 use restate_types::schema::Schema;
 use restate_types::storage::{StorageCodec, StorageEncode};
-use restate_types::{PlainNodeId, Version, Versioned};
+use restate_types::{NodeId, PlainNodeId, Version, Versioned};
 
 use crate::query_utils::WriteRecordBatchStream;
 
@@ -224,6 +225,42 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
                 snapshot_id: snapshot_id.to_string(),
                 log_id: log_id.into(),
                 min_applied_lsn: min_applied_lsn.as_u64(),
+            })),
+        }
+    }
+
+    /// Handles requests from `restatectl partition drop-store` to delete a single node's local
+    /// copy of a partition. Implemented as an RPC call to the targeted worker node.
+    async fn drop_partition_store(
+        &self,
+        request: Request<DropPartitionStoreRequest>,
+    ) -> Result<Response<DropPartitionStoreResponse>, Status> {
+        let request = request.into_inner();
+        let partition_id = PartitionId::from(
+            u16::try_from(request.partition_id)
+                .map_err(|id| Status::invalid_argument(format!("Invalid partition id: {id}")))?,
+        );
+        // the generation is irrelevant here: we target whichever generation of the node is
+        // currently alive
+        let node_id = NodeId::from(
+            request
+                .node_id
+                .ok_or_else(|| Status::invalid_argument("node_id is required"))?,
+        )
+        .id();
+
+        match self
+            .controller_handle
+            .drop_partition_store(partition_id, node_id, request.force)
+            .await
+            .map_err(|_| Status::aborted("Node is shutting down"))?
+        {
+            Err(err) => {
+                info!("Failed to drop partition store: {err}");
+                Err(Status::internal(err.to_string()))
+            }
+            Ok(outcome) => Ok(Response::new(DropPartitionStoreResponse {
+                dropped: matches!(outcome, DropPartitionStoreOutcome::Dropped),
             })),
         }
     }

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -50,7 +50,9 @@ use restate_types::logs::metadata::{
 };
 use restate_types::logs::{self, LogId, LogletId, Lsn};
 use restate_types::net::node::NodeState;
-use restate_types::net::partition_processor_manager::{CreateSnapshotRequest, Snapshot};
+use restate_types::net::partition_processor_manager::{
+    CreateSnapshotRequest, DropPartitionStoreOutcome, DropPartitionStoreRequest, Snapshot,
+};
 use restate_types::nodes_config::{NodesConfiguration, StorageState};
 use restate_types::partition_table::{
     self, PartitionReplication, PartitionTable, PartitionTableBuilder,
@@ -60,7 +62,7 @@ use restate_types::partitions::state::{MembershipState, PartitionReplicaSetState
 use restate_types::protobuf::common::AdminStatus;
 use restate_types::replicated_loglet::ReplicatedLogletParams;
 use restate_types::replication::{NodeSet, NodeSetChecker, ReplicationProperty};
-use restate_types::{GenerationalNodeId, NodeId, Version};
+use restate_types::{GenerationalNodeId, NodeId, PlainNodeId, Version};
 
 use crate::cluster_controller::cluster_state_refresher::ClusterStateRefresher;
 use crate::cluster_controller::grpc_svc_handler::ClusterCtrlSvcHandler;
@@ -197,6 +199,12 @@ enum ClusterControllerCommand {
         min_target_lsn: Option<Lsn>,
         response_tx: oneshot::Sender<anyhow::Result<Snapshot>>,
     },
+    DropPartitionStore {
+        partition_id: PartitionId,
+        node_id: PlainNodeId,
+        force: bool,
+        response_tx: oneshot::Sender<anyhow::Result<DropPartitionStoreOutcome>>,
+    },
     UpdateClusterConfiguration {
         partition_replication: Option<ReplicationProperty>,
         default_provider: ProviderConfiguration,
@@ -292,6 +300,28 @@ impl ClusterControllerHandle {
         }
 
         Ok(create_snapshot_response)
+    }
+
+    /// Asks a specific node to delete its local copy of a partition.
+    pub async fn drop_partition_store(
+        &self,
+        partition_id: PartitionId,
+        node_id: PlainNodeId,
+        force: bool,
+    ) -> Result<anyhow::Result<DropPartitionStoreOutcome>, ShutdownError> {
+        let (response_tx, response_rx) = oneshot::channel();
+
+        let _ = self
+            .tx
+            .send(ClusterControllerCommand::DropPartitionStore {
+                partition_id,
+                node_id,
+                force,
+                response_tx,
+            })
+            .await;
+
+        response_rx.await.map_err(|_| ShutdownError)
     }
 
     pub async fn update_cluster_configuration(
@@ -494,6 +524,44 @@ impl<T: TransportConnect> Service<T> {
         };
     }
 
+    /// Asks the given node to delete its local copy of the partition. Unlike snapshotting, the
+    /// target node is chosen by the operator: only that node's copy is affected.
+    fn spawn_drop_partition_store_task(
+        &self,
+        partition_id: PartitionId,
+        node_id: PlainNodeId,
+        force: bool,
+        response_tx: oneshot::Sender<anyhow::Result<DropPartitionStoreOutcome>>,
+    ) {
+        let node = self
+            .cluster_state_refresher
+            .get_cluster_state()
+            .alive_nodes()
+            .find(|node| node.generational_node_id.as_plain() == node_id)
+            .map(|node| node.generational_node_id);
+
+        let Some(node_id) = node else {
+            let _ = response_tx.send(Err(anyhow::anyhow!(
+                "Node {node_id} is not alive, cannot drop its partition store"
+            )));
+            return;
+        };
+
+        let node_rpc_client = self.processor_manager_client.clone();
+        let _ = TaskCenter::spawn_child(
+            TaskKind::Disposable,
+            "drop-partition-store-response",
+            async move {
+                let _ = response_tx.send(
+                    node_rpc_client
+                        .drop_partition_store(node_id, partition_id, force)
+                        .await,
+                );
+                Ok(())
+            },
+        );
+    }
+
     fn on_cluster_cmd(&self, command: ClusterControllerCommand, state: &ClusterControllerState) {
         match command {
             ClusterControllerCommand::GetClusterState(tx) => {
@@ -530,6 +598,20 @@ impl<T: TransportConnect> Service<T> {
                     min_target_lsn,
                     response_tx,
                 );
+            }
+            ClusterControllerCommand::DropPartitionStore {
+                partition_id,
+                node_id,
+                force,
+                response_tx,
+            } => {
+                warn!(
+                    ?partition_id,
+                    %node_id,
+                    %force,
+                    "Drop partition store command received"
+                );
+                self.spawn_drop_partition_store_task(partition_id, node_id, force, response_tx);
             }
             ClusterControllerCommand::UpdateClusterConfiguration {
                 partition_replication,
@@ -783,6 +865,28 @@ where
             .await?
             .result
             .map_err(|e| anyhow!("Failed to create snapshot: {:?}", e))
+    }
+
+    pub async fn drop_partition_store(
+        &self,
+        node_id: GenerationalNodeId,
+        partition_id: PartitionId,
+        force: bool,
+    ) -> anyhow::Result<DropPartitionStoreOutcome> {
+        self.network_sender
+            .call_rpc(
+                node_id,
+                Swimlane::default(),
+                DropPartitionStoreRequest {
+                    partition_id,
+                    force,
+                },
+                Some(partition_id.into()),
+                None,
+            )
+            .await?
+            .result
+            .map_err(|e| anyhow!("{node_id} refused to drop its partition store: {e}"))
     }
 }
 

--- a/crates/core/protobuf/cluster_ctrl_svc.proto
+++ b/crates/core/protobuf/cluster_ctrl_svc.proto
@@ -27,6 +27,9 @@ service ClusterCtrlSvc {
   rpc CreatePartitionSnapshot(CreatePartitionSnapshotRequest)
       returns (CreatePartitionSnapshotResponse);
 
+  rpc DropPartitionStore(DropPartitionStoreRequest)
+      returns (DropPartitionStoreResponse);
+
   rpc SealAndExtendChain(SealAndExtendChainRequest)
       returns (SealAndExtendChainResponse);
 
@@ -117,6 +120,24 @@ message CreatePartitionSnapshotResponse {
   uint32 log_id = 2;
   // Minimum LSN (inclusive) which is guaranteed to be covered by the snapshot
   uint64 min_applied_lsn = 3;
+}
+
+// Deletes a single node's local copy of a partition. All data the node holds
+// for this partition is lost; it can only be recovered from a snapshot or by
+// replaying the log. This is intended for recovering a node whose partition
+// store has been sealed (see BrokenReason).
+message DropPartitionStoreRequest {
+  uint32 partition_id = 1;
+  // The node to delete the partition store from
+  restate.common.NodeId node_id = 2;
+  // Stop a running partition processor before deleting. Without this, the node
+  // rejects the request unless it has already given up on the partition.
+  bool force = 3;
+}
+
+message DropPartitionStoreResponse {
+  // False if the node had no local partition store to delete
+  bool dropped = 1;
 }
 
 message ChainExtension {

--- a/crates/types/src/net/partition_processor_manager.rs
+++ b/crates/types/src/net/partition_processor_manager.rs
@@ -93,3 +93,51 @@ pub struct Snapshot {
 pub enum SnapshotError {
     SnapshotCreationFailed(String),
 }
+
+define_rpc! {
+    @request = DropPartitionStoreRequest,
+    @response = DropPartitionStoreResponse,
+    @service = PartitionManagerService,
+}
+
+default_wire_codec!(DropPartitionStoreRequest);
+default_wire_codec!(DropPartitionStoreResponse);
+
+/// Asks a node to delete its local copy of a partition's data.
+///
+/// The node refuses unless it has given up on running the partition (see
+/// [`crate::cluster::cluster_state::BrokenReason`]) or isn't running it at all, so that a healthy
+/// processor can never have its store pulled out from under it. `force` overrides that check by
+/// stopping the processor first.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DropPartitionStoreRequest {
+    pub partition_id: PartitionId,
+    pub force: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DropPartitionStoreResponse {
+    pub result: Result<DropPartitionStoreOutcome, DropPartitionStoreError>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, derive_more::Display)]
+pub enum DropPartitionStoreOutcome {
+    #[display("the local partition store was dropped")]
+    Dropped,
+    #[display("this node has no local partition store for this partition")]
+    NoStoreFound,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, derive_more::Display)]
+pub enum DropPartitionStoreError {
+    #[display(
+        "a partition processor is running on this node and the partition does not look broken"
+    )]
+    ProcessorRunning,
+    #[display("another drop request for this partition is already in progress")]
+    DropInProgress,
+    #[display("the partition is not in this node's partition table")]
+    UnknownPartition,
+    #[display("failed to drop the local partition store: {_0}")]
+    Internal(String),
+}

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -70,7 +70,9 @@ use restate_types::net::metadata::MetadataKind;
 use restate_types::net::partition_processor::PartitionLeaderService;
 use restate_types::net::partition_processor_manager::{
     ControlProcessor, ControlProcessors, CreateSnapshotRequest, CreateSnapshotResponse,
-    PartitionManagerService, ProcessorCommand, Snapshot, SnapshotError as NetSnapshotError,
+    DropPartitionStoreError, DropPartitionStoreOutcome, DropPartitionStoreRequest,
+    DropPartitionStoreResponse, PartitionManagerService, ProcessorCommand, Snapshot,
+    SnapshotError as NetSnapshotError,
 };
 use restate_types::net::{RpcRequest as _, UnaryMessage};
 use restate_types::nodes_config::{NodesConfigError, NodesConfiguration, WorkerState};
@@ -121,6 +123,7 @@ pub struct PartitionProcessorManager<T> {
 
     asynchronous_operations: JoinSet<AsynchronousEvent>,
 
+    pending_drops: HashMap<PartitionId, PendingDrop>,
     pending_snapshots: HashMap<PartitionId, PendingSnapshotTask>,
     latest_snapshots: HashMap<PartitionId, PartitionSnapshotStatus>,
     pending_snapshot_status_refreshes: HashSet<PartitionId>,
@@ -146,6 +149,18 @@ type SnapshotResultInternal = Result<(PartitionId, PartitionSnapshotStatus), Sna
 struct PendingSnapshotTask {
     snapshot_id: SnapshotId,
     sender: Option<oneshot::Sender<SnapshotResult>>,
+}
+
+type DropResult = Result<DropPartitionStoreOutcome, DropPartitionStoreError>;
+
+/// An in-flight request to delete this node's local copy of a partition.
+///
+/// While one of these exists for a partition, the manager will not start a processor for it,
+/// so that we never race the drop against a fresh `open()`.
+struct PendingDrop {
+    /// Set while we are waiting for a running processor to terminate before we can drop.
+    awaiting_stop: bool,
+    sender: oneshot::Sender<DropResult>,
 }
 
 /// What to do with a partition once its processor's runtime task has terminated.
@@ -272,6 +287,7 @@ where
             target_tail_lsns: HashMap::default(),
             leader_handles_registry: PartitionLeaderHandlesRegistry::default(),
             asynchronous_operations: JoinSet::default(),
+            pending_drops: HashMap::default(),
             pending_snapshots: HashMap::default(),
             latest_snapshots: HashMap::default(),
             pending_snapshot_status_refreshes: HashSet::default(),
@@ -401,6 +417,13 @@ where
             task.cancel();
         }
 
+        // abandon in-flight drop requests for partitions still awaiting stop rather than deleting data
+        // on the way down; the requester sees its RPC fail and can retry against the restarted node.
+        //
+        // Leave the ones that already have an in-flight task dropping them so that the caller gets
+        // its result back (this is best-effort though as we don't wait for the pending_drops on shutdown).
+        self.pending_drops.retain(|_, val| !val.awaiting_stop);
+
         // broken processors have no runtime task left to await, so drop them upfront to keep
         // `await_processors_termination` from waiting on an event that can never arrive
         self.processor_states.retain(|_, state| !state.is_broken());
@@ -444,6 +467,10 @@ where
             ServiceMessage::Rpc(msg) if msg.msg_type() == CreateSnapshotRequest::TYPE => {
                 let request = msg.into_typed::<CreateSnapshotRequest>();
                 self.handle_create_snapshot_request(request);
+            }
+            ServiceMessage::Rpc(msg) if msg.msg_type() == DropPartitionStoreRequest::TYPE => {
+                let request = msg.into_typed::<DropPartitionStoreRequest>();
+                self.handle_drop_partition_store_request(request);
             }
             msg => {
                 msg.fail(Verdict::MessageUnrecognized);
@@ -598,6 +625,11 @@ where
                             partition_id,
                             RestartDelay::Fixed,
                         );
+                        // no runtime task was created, so no `Stopped` event will follow: a drop
+                        // waiting for this processor to go away has to be resumed from here
+                        if self.take_pending_drop_stop_wait(partition_id) {
+                            self.spawn_drop_partition_store_task(partition_id);
+                        }
                     }
                 }
                 gauge!(NUM_ACTIVE_PARTITIONS).set(self.processor_states.len() as f64);
@@ -713,6 +745,11 @@ where
                     },
                 };
 
+                // A pending drop was waiting for this processor to release the store. Note that
+                // `should_run_processor` reports false while a drop is pending, so neither branch
+                // below revives the processor we just stopped.
+                let resume_drop = self.take_pending_drop_stop_wait(partition_id);
+
                 match action {
                     PostStopAction::Restart(delay) => {
                         if !self.restart_partition_processor_if_replica(partition_id, delay) {
@@ -727,6 +764,10 @@ where
                             debug!("Partition processor stopped: {result:?}");
                         }
                     }
+                }
+
+                if resume_drop {
+                    self.spawn_drop_partition_store_task(partition_id);
                 }
 
                 gauge!(NUM_ACTIVE_PARTITIONS).set(self.processor_states.len() as f64);
@@ -780,6 +821,9 @@ where
             EventKind::SnapshotStatusUpdateSkipped => {
                 self.pending_snapshot_status_refreshes.remove(&partition_id);
                 // No-op: no snapshot found or error fetching status (logged upstream)
+            }
+            EventKind::PartitionStoreDropped(result) => {
+                self.on_partition_store_dropped(partition_id, result);
             }
         }
     }
@@ -1335,6 +1379,143 @@ where
         Ok(Box::new(epoch.into()))
     }
 
+    /// Deletes this node's local copy of a partition, on operator request.
+    ///
+    /// We only touch the store once we are sure that no processor is using it: either this node
+    /// already gave up on the partition, or it isn't a replica of it, or - with `force` - we stop
+    /// the running processor and wait for it to terminate first. [`Self::pending_drops`] keeps the
+    /// manager from starting a new processor in the meantime.
+    #[instrument(level = "info", skip_all, fields(partition_id = %partition_id, force = %force))]
+    fn on_drop_partition_store(
+        &mut self,
+        partition_id: PartitionId,
+        force: bool,
+        sender: oneshot::Sender<DropResult>,
+    ) {
+        if self.pending_drops.contains_key(&partition_id) {
+            let _ = sender.send(Err(DropPartitionStoreError::DropInProgress));
+            return;
+        }
+
+        if !self.partition_table.live_load().contains(&partition_id) {
+            // without the partition's metadata we don't know which column family to drop
+            let _ = sender.send(Err(DropPartitionStoreError::UnknownPartition));
+            return;
+        }
+
+        let awaiting_stop = match self.processor_states.get_mut(&partition_id) {
+            // this node isn't running the partition; nothing can race us
+            None => false,
+            Some(state) if state.is_broken() => {
+                // no runtime task to await, the processor is already gone
+                self.processor_states.remove(&partition_id);
+                false
+            }
+            Some(_) if !force => {
+                let _ = sender.send(Err(DropPartitionStoreError::ProcessorRunning));
+                return;
+            }
+            Some(state) => {
+                warn!("Stopping a running partition processor to drop its local store");
+                state.stop();
+                true
+            }
+        };
+
+        self.pending_drops.insert(
+            partition_id,
+            PendingDrop {
+                awaiting_stop,
+                sender,
+            },
+        );
+
+        if !awaiting_stop {
+            self.spawn_drop_partition_store_task(partition_id);
+        }
+    }
+
+    /// Clears the "waiting for the processor to terminate" flag of a pending drop. Returns true
+    /// if a drop was waiting, and is now ready to run.
+    fn take_pending_drop_stop_wait(&mut self, partition_id: PartitionId) -> bool {
+        self.pending_drops
+            .get_mut(&partition_id)
+            .is_some_and(|pending| std::mem::take(&mut pending.awaiting_stop))
+    }
+
+    fn spawn_drop_partition_store_task(&mut self, partition_id: PartitionId) {
+        let partition = self.partition_table.live_load().get(&partition_id).cloned();
+        let psm = self.partition_store_manager.clone();
+
+        self.asynchronous_operations
+            .build_task()
+            .name(&format!("drop-partition-store-{partition_id}"))
+            .spawn(
+                async move {
+                    let result = match partition {
+                        None => Err(DropPartitionStoreError::UnknownPartition),
+                        Some(partition) => psm
+                            .drop_partition_store(&partition)
+                            .await
+                            .map(|dropped| {
+                                if dropped {
+                                    DropPartitionStoreOutcome::Dropped
+                                } else {
+                                    DropPartitionStoreOutcome::NoStoreFound
+                                }
+                            })
+                            .map_err(|err| DropPartitionStoreError::Internal(err.to_string())),
+                    };
+
+                    AsynchronousEvent {
+                        partition_id,
+                        inner: EventKind::PartitionStoreDropped(result),
+                    }
+                }
+                .in_current_tc(),
+            )
+            .expect("to spawn drop partition store task");
+    }
+
+    fn on_partition_store_dropped(&mut self, partition_id: PartitionId, result: DropResult) {
+        match &result {
+            Ok(outcome) => {
+                info!(%partition_id, "Drop partition store request completed: {outcome}");
+                // the partition can only have been blocked on data we just deleted
+                gauge!(PARTITION_BLOCKED_FLARE, PARTITION_LABEL => partition_id.to_string(), REASON_LABEL => FLARE_REASON_AHEAD_OF_LOG).set(0);
+            }
+            Err(err) => {
+                warn!(%partition_id, "Drop partition store request failed: {err}");
+            }
+        }
+
+        if let Some(pending) = self.pending_drops.remove(&partition_id) {
+            let _ = pending.sender.send(result);
+        }
+
+        // now that the drop is no longer pending, resume normal operation: if we are still a
+        // replica of this partition the processor starts over from a snapshot or an empty store
+        self.restart_partition_processor_if_replica(partition_id, RestartDelay::Immediate);
+        gauge!(NUM_ACTIVE_PARTITIONS).set(self.processor_states.len() as f64);
+    }
+
+    fn handle_drop_partition_store_request(
+        &mut self,
+        request: Incoming<Rpc<DropPartitionStoreRequest>>,
+    ) {
+        let (sender, rx) = oneshot::channel();
+        let (reciprocal, body) = request.split();
+        self.on_drop_partition_store(body.partition_id, body.force, sender);
+        tokio::spawn(async move {
+            let Ok(result) = rx.await else {
+                // dropping the reciprocal will notify the sender that the request will not
+                // complete.
+                return;
+            };
+            reciprocal.send(DropPartitionStoreResponse { result });
+        });
+    }
+
     fn handle_create_snapshot_request(&mut self, request: Incoming<Rpc<CreateSnapshotRequest>>) {
         let (sender, rx) = oneshot::channel();
         let (reciprocal, body) = request.split();
@@ -1406,9 +1587,11 @@ where
     }
 
     /// Whether this node should be running a processor for the given partition, i.e. we are
-    /// part of its replica set and the manager itself is not shutting down.
+    /// part of its replica set, its local store is not being dropped, and the manager itself is
+    /// not shutting down.
     fn should_run_processor(&self, partition_id: PartitionId) -> bool {
         !restate_core::is_cancellation_requested()
+            && !self.pending_drops.contains_key(&partition_id)
             && self
                 .replica_set_states
                 .membership_state(partition_id)
@@ -1432,6 +1615,12 @@ where
 
     #[instrument(level = "info", skip_all, fields(partition_id = %partition_id))]
     fn start_partition_processor(&mut self, partition_id: PartitionId, delay: Option<Duration>) {
+        if self.pending_drops.contains_key(&partition_id) {
+            // dropping the column family under a starting processor would corrupt it
+            debug!("Not starting partition processor while its local store is being dropped");
+            return;
+        }
+
         let Some(partition) = self.partition_table.live_load().get(&partition_id).cloned() else {
             debug!(
                 "Cannot start partition processor because it is not contained in the partition table. Waiting for a partition table update."
@@ -1611,6 +1800,7 @@ enum EventKind {
         snapshot_status: PartitionSnapshotStatus,
     },
     SnapshotStatusUpdateSkipped,
+    PartitionStoreDropped(DropResult),
 }
 
 #[cfg(test)]

--- a/release-notes/unreleased/drop-partition-store.md
+++ b/release-notes/unreleased/drop-partition-store.md
@@ -1,0 +1,40 @@
+# Release Notes: `restatectl partition drop-store`
+
+## New Feature
+
+### What Changed
+
+A new command deletes a single node's local copy of a partition:
+
+```shell
+restatectl partition drop-store <PARTITION_ID> --node N3
+```
+
+The request goes through the cluster controller (`ClusterCtrlSvc.DropPartitionStore`) to the
+targeted node's partition processor manager, which deletes the partition's RocksDB column
+family. Once dropped, the node restarts the processor and re-bootstraps from the latest
+snapshot, or from the log if no snapshot repository is configured.
+
+The node **rejects** the request while it is running a partition processor for that partition,
+unless it has already given up on it (reported as `Broken (ahead-of-log)` in
+`restatectl partition list`). Passing `--force` overrides that: the node stops the running
+processor, waits for it to terminate, and only then deletes the store. `restatectl` prints the
+node's reported state and asks for confirmation before sending either variant.
+
+### Why This Matters
+
+A partition store that is ahead of its log is sealed and can never be used again. Until now the
+only way to clear it was to stop the node and delete files by hand. This makes the recovery a
+single, guarded command.
+
+### Impact on Users
+
+- **Destructive.** All of the targeted node's data for that partition is deleted. Other replicas
+  are untouched. Dropping the store of the last remaining replica loses the partition's data
+  unless a snapshot exists.
+- Requires the targeted node to be alive.
+- Confirmation is skipped with `--yes` or when `CI` is set, as with other `restatectl` commands.
+
+### Migration Guidance
+
+None; this is a new command.

--- a/tools/restatectl/src/commands/partition/drop_store.rs
+++ b/tools/restatectl/src/commands/partition/drop_store.rs
@@ -1,0 +1,153 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::bail;
+use cling::prelude::*;
+
+use restate_cli_util::ui::console::confirm_or_exit;
+use restate_cli_util::{CliContext, c_println, c_warn};
+use restate_core::protobuf::cluster_ctrl_svc::{
+    ClusterStateRequest, DropPartitionStoreRequest, new_cluster_ctrl_client,
+};
+use restate_types::PlainNodeId;
+use restate_types::identifiers::PartitionId;
+use restate_types::nodes_config::Role;
+use restate_types::protobuf::cluster::{BrokenReason, node_state};
+
+use crate::connection::ConnectionInfo;
+
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[cling(run = "drop_partition_store")]
+#[command(
+    after_long_help = "Deletes one node's local copy of a partition. All data that node \
+    holds for the partition is lost; it recovers by downloading a snapshot or by replaying the \
+    log. This is meant for nodes whose partition store has been sealed, which the node reports \
+    as a broken partition processor (see `restatectl partition list`)."
+)]
+pub struct DropStoreOpts {
+    /// The partition whose local store should be deleted
+    #[arg(required = true)]
+    partition_id: PartitionId,
+
+    /// The node to delete the partition store from
+    #[arg(long, short = 'n', required = true)]
+    node: PlainNodeId,
+
+    /// Stop a running partition processor before deleting. Without this, the node only accepts
+    /// the request if it has already given up on the partition.
+    #[arg(long)]
+    force: bool,
+}
+
+async fn drop_partition_store(
+    connection: &ConnectionInfo,
+    opts: &DropStoreOpts,
+) -> anyhow::Result<()> {
+    let cluster_state = connection
+        .try_each(Some(Role::Admin), |channel| async {
+            new_cluster_ctrl_client(channel, &CliContext::get().network)
+                .get_cluster_state(ClusterStateRequest::default())
+                .await
+        })
+        .await?
+        .into_inner()
+        .cluster_state;
+
+    let Some(node_state) = cluster_state
+        .and_then(|state| state.nodes.get(&u32::from(opts.node)).cloned())
+        .and_then(|node| node.state)
+    else {
+        bail!("Node {} is not known to the cluster.", opts.node);
+    };
+
+    let node_state::State::Alive(alive_node) = node_state else {
+        bail!(
+            "Node {} is not alive. Its partition store can only be dropped while it is running.",
+            opts.node
+        );
+    };
+
+    let reported_state = alive_node
+        .partitions
+        .get(&u32::from(u16::from(opts.partition_id)));
+
+    let broken_reason = reported_state.map(|status| status.broken_reason());
+
+    match broken_reason {
+        Some(BrokenReason::AheadOfLog) => {
+            c_println!(
+                "Node {} reports partition {} as broken: its local store is sealed because the \
+                applied LSN is ahead of the log tail.",
+                opts.node,
+                opts.partition_id,
+            );
+        }
+        Some(BrokenReason::NotBroken) if !opts.force => {
+            bail!(
+                "Node {} is running a partition processor for partition {} and does not report it \
+                as broken. Re-run with --force to stop the processor and delete its store anyway.",
+                opts.node,
+                opts.partition_id,
+            );
+        }
+        Some(BrokenReason::NotBroken) => {
+            c_warn!(
+                "Node {} does not report partition {} as broken. Forcing the drop will stop a \
+                running partition processor and destroy the only copy of the partition this node \
+                holds.",
+                opts.node,
+                opts.partition_id,
+            );
+        }
+        None => {
+            c_println!(
+                "Node {} is not running a partition processor for partition {}.",
+                opts.node,
+                opts.partition_id,
+            );
+        }
+    }
+
+    confirm_or_exit(&format!(
+        "Delete node {}'s local copy of partition {}? This cannot be undone",
+        opts.node, opts.partition_id
+    ))?;
+
+    let request = DropPartitionStoreRequest {
+        partition_id: u32::from(u16::from(opts.partition_id)),
+        node_id: Some(opts.node.into()),
+        force: opts.force,
+    };
+
+    let response = connection
+        .try_each(Some(Role::Admin), |channel| async {
+            new_cluster_ctrl_client(channel, &CliContext::get().network)
+                .drop_partition_store(request)
+                .await
+        })
+        .await?
+        .into_inner();
+
+    if response.dropped {
+        c_println!(
+            "✅ Dropped node {}'s local copy of partition {}",
+            opts.node,
+            opts.partition_id
+        );
+    } else {
+        c_println!(
+            "✅ Node {} had no local copy of partition {} to drop",
+            opts.node,
+            opts.partition_id
+        );
+    }
+
+    Ok(())
+}

--- a/tools/restatectl/src/commands/partition/mod.rs
+++ b/tools/restatectl/src/commands/partition/mod.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod drop_store;
 mod gen_metadata;
 mod leader;
 pub mod list;
@@ -27,4 +28,6 @@ pub enum Partitions {
     /// Control leader election policy for partitions
     #[clap(subcommand)]
     Leader(leader::Leader),
+    /// Delete a node's local copy of a partition
+    DropStore(drop_store::DropStoreOpts),
 }


### PR DESCRIPTION

Deletes one node's local copy of a partition, so an operator can clear a sealed
partition store without stopping the node and removing files by hand:

```
restatectl partition drop-store <PARTITION_ID> --node N3 [--force]
```

## Flow

`restatectl` -> `ClusterCtrlSvc.DropPartitionStore` -> the targeted node's
partition processor manager -> `PartitionStoreManager::drop_partition_store`.
Unlike snapshotting, the operator picks the node; only that node's copy is
affected. Afterwards the processor restarts and re-bootstraps from a snapshot, or
from the log if no snapshot repository is configured.

## Guard

The node refuses while it is running a processor for the partition, unless it has
already parked it as broken or is not a replica at all. `--force` stops the
running processor and waits for its runtime task to terminate before deleting.
`pending_drops` blocks `start_partition_processor` for the whole window, so a
restart can never re-provision the column family mid-drop, and drops are abandoned
on shutdown rather than deleting data on the way down.

`restatectl` reports the node's view of the partition, warns when `--force`
targets one that does not look broken, and asks for confirmation.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/5114).
* #5121
* #5120
* #5119
* __->__ #5114
* #5113
* #5116
* #5112
* #5109
* #5106