### PR TITLE
DF: service key of scoped services is scope, not target_service_key

### DIFF
--- a/crates/storage-query-datafusion/src/invocation_status/table.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/table.rs
@@ -61,7 +61,7 @@ pub(crate) fn register_self(
         sys_invocation_status_sort_order(),
         remote_scanner_manager.create_distributed_scanner(NAME, local_scanner),
         FirstMatchingPartitionKeyExtractor::default()
-            .with_service_key("target_service_key")
+            .with_scope_or_service_key("scope", "target_service_key")
             .with_grouped_invocation_id("id"),
     )
     .with_statistics(statistics.build());


### PR DESCRIPTION

When VQueues is enabled, the partition key is computed from the invocation
scope, and not the service key.

This PR makes sure DF can select the correct partition to scan based on the
if vqueues feature is enabled or not
