### PR TITLE
Harden rocksdb shutdown, fix sporadic SIGSEGV in tests

### DIFF
--- a/crates/partition-store/src/fsm_table/mod.rs
+++ b/crates/partition-store/src/fsm_table/mod.rs
@@ -8,11 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::TableKind::PartitionStateMachine;
-use crate::keys::{EncodeTableKey, KeyKind, define_table_key};
-use crate::{
-    PaddedPartitionId, PartitionDb, PartitionStore, PartitionStoreTransaction, StorageAccess,
-};
 use restate_limiter::RuleBook;
 use restate_storage_api::fsm_table::{
     CachedEpochMetadata, PartitionDurability, ReadFsmTable, SequenceNumber, WriteFsmTable,
@@ -27,6 +22,13 @@ use restate_types::partitions::StorageVersion;
 use restate_types::partitions::features::PersistedFeatures;
 use restate_types::schema::Schema;
 use restate_types::storage::{StorageCodec, StorageDecode};
+
+use crate::TableKind::PartitionStateMachine;
+use crate::keys::{EncodeTableKey, KeyKind, define_table_key};
+use crate::{
+    PaddedPartitionId, PartitionDb, PartitionSeal, PartitionStore, PartitionStoreTransaction,
+    StorageAccess,
+};
 
 define_table_key!(
     PartitionStateMachine,
@@ -101,6 +103,15 @@ pub(crate) mod fsm_variable {
     /// `VersionBarrierCommand` entries carrying feature changes.
     /// *Since v1.7.0*
     pub(crate) const STATE_MACHINE_FEATURES: u64 = 10;
+
+    /// A local marker (not replicated) written to indicate that the partition store
+    /// is unsafe and should be not used by processors. The data is json serialized
+    /// and contains the reason for the seal. The intention is to prevent processors
+    /// from using this partition store until it has been removed and replaced with
+    /// an unsealed safe one.
+    ///
+    /// *Since v1.7.3*
+    pub(crate) const SEAL_MARKER: u64 = 11;
 }
 
 fn get<T: PartitionStoreProtobufValue, S: StorageAccess>(
@@ -218,6 +229,38 @@ pub(crate) async fn put_jc_orphan_cleanup_done<S: StorageAccess>(
         fsm_variable::JC_ORPHAN_CLEANUP_DONE,
         &SequenceNumber::from(1u64),
     )
+}
+
+pub(crate) async fn get_partition_seal<S: StorageAccess>(
+    storage: &mut S,
+    partition_id: PartitionId,
+) -> Result<Option<PartitionSeal>> {
+    let key = PartitionStateMachineKey {
+        partition_id: partition_id.into(),
+        state_id: fsm_variable::SEAL_MARKER,
+    };
+
+    storage.get_kv_raw(key, |_k, v| {
+        v.map(|v| serde_json::from_slice(v).map_err(|e| StorageError::Conversion(e.into())))
+            .transpose()
+    })
+}
+
+pub(crate) async fn seal_partition<S: StorageAccess>(
+    storage: &mut S,
+    partition_id: PartitionId,
+    seal: &PartitionSeal,
+) -> Result<()> {
+    let key = PartitionStateMachineKey {
+        partition_id: partition_id.into(),
+        state_id: fsm_variable::SEAL_MARKER,
+    };
+
+    storage.put_kv_raw(
+        key,
+        serde_json::to_vec(seal).map_err(|e| StorageError::Conversion(e.into()))?,
+    )?;
+    Ok(())
 }
 
 /// Reads a `StorageCodec`-encoded value directly from the partition db's column family.

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -45,7 +45,9 @@ use restate_types::storage::StorageEncode;
 
 use restate_types::partitions::StorageVersion;
 
+use crate::fsm_table::get_partition_seal;
 use crate::fsm_table::put_storage_version;
+use crate::fsm_table::seal_partition;
 use crate::fsm_table::{
     get_locally_durable_lsn, get_storage_version_from_partition_db, is_jc_orphan_cleanup_done,
     put_jc_orphan_cleanup_done,
@@ -110,6 +112,20 @@ impl From<PaddedPartitionId> for PartitionId {
     fn from(value: PaddedPartitionId) -> Self {
         Self::from(u16::try_from(value.0).expect("partition_id must fit in u16"))
     }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, derive_more::Display)]
+#[serde(tag = "type")]
+pub enum PartitionSeal {
+    #[display(
+        "last applied LSN is ahead of the log, \
+        this indicates data-loss in the log. \
+        partition_applied_lsn: {partition_applied_lsn}, log_tail_lsn: {log_tail_lsn}"
+    )]
+    AheadOfLog {
+        partition_applied_lsn: Lsn,
+        log_tail_lsn: Lsn,
+    },
 }
 
 // Ensures that both types have the same length, this makes it possible to
@@ -614,6 +630,14 @@ impl PartitionStore {
 
     pub fn partition(&self) -> &Arc<Partition> {
         self.db.partition()
+    }
+
+    pub async fn get_seal_marker(&mut self) -> Result<Option<PartitionSeal>> {
+        get_partition_seal(self, self.partition_id()).await
+    }
+
+    pub async fn seal(&mut self, seal: &PartitionSeal) -> Result<()> {
+        seal_partition(self, self.partition_id(), seal).await
     }
 
     /// Returns `true` if the one-time cleanup of orphaned `jc` index entries has not yet been

--- a/crates/rocksdb/src/db_manager.rs
+++ b/crates/rocksdb/src/db_manager.rs
@@ -268,6 +268,16 @@ impl RocksDbManager {
 
     /// Ask all databases to shut down cleanly
     pub async fn shutdown(&'static self) {
+        // Stop accepting new work. Submitters using the `*_unchecked` variants can still get
+        // through, which is why we join the pools below instead of relying on this alone.
+        self.shutting_down
+            .store(true, std::sync::atomic::Ordering::Release);
+
+        // Wait for storage tasks that are already running before draining `self.dbs`: a database
+        // that is still being opened has not been registered there yet (see `open_db`), so it
+        // would otherwise escape the close loop entirely.
+        self.join_storage_pools().await;
+
         self.close_db_tasks.close();
         for (name, db) in self.dbs.write().drain() {
             let Some(db) = db.upgrade() else {
@@ -281,8 +291,37 @@ impl RocksDbManager {
         }
         // wait for all tasks to complete
         self.close_db_tasks.wait().await;
+
+        // No storage task may still be inside rocksdb when we return. The process can begin
+        // running C++ static destructors right after this, and a task still in `DB::Open` would
+        // then read a freed option-registry static and crash with SIGSEGV.
+        self.join_storage_pools().await;
         self.env.clone().join_all_threads();
         info!("Rocksdb manager shutdown completed");
+    }
+
+    /// Waits until neither storage pool has queued or running jobs.
+    ///
+    /// Bounded by the configured shutdown grace period: a stalled write is not a reason to hang
+    /// the process forever, even though returning early re-opens the window described in
+    /// [`Self::shutdown`].
+    async fn join_storage_pools(&'static self) {
+        let grace_period = Configuration::pinned().common.shutdown_grace_period();
+
+        // `ThreadPool::join` blocks, so it must not run on a runtime worker.
+        let join = tokio::task::spawn_blocking(move || {
+            self.high_pri_pool.join();
+            self.low_pri_pool.join();
+        });
+
+        match tokio::time::timeout(grace_period, join).await {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => warn!("Failed to join rocksdb storage thread pools: {err}"),
+            Err(_) => warn!(
+                "Rocksdb storage thread pools are still busy after {:?}, continuing shutdown",
+                grace_period
+            ),
+        }
     }
 
     /// Emergency shutdown is ongoing, this will ensure rocksdb's wal is fsynced.

--- a/crates/storage-query-datafusion/src/partition_state/row.rs
+++ b/crates/storage-query-datafusion/src/partition_state/row.rs
@@ -46,7 +46,14 @@ pub(crate) fn append_partition_row(
         row.last_record_applied_at(ts.as_u64() as i64);
     }
 
-    row.fmt_replay_status(state.replay_status);
+    if state.is_broken() {
+        // A parked processor is not replaying anything. Leave the column NULL rather than
+        // reporting the default `starting`, which would read as progress.
+        row.fmt_broken_reason(state.broken_reason);
+    } else {
+        row.fmt_replay_status(state.replay_status);
+    }
+
     if let Some(lsn) = state.durable_lsn {
         row.durable_log_lsn(lsn.into());
     }

--- a/crates/storage-query-datafusion/src/partition_state/schema.rs
+++ b/crates/storage-query-datafusion/src/partition_state/schema.rs
@@ -45,7 +45,7 @@ define_table!(
         /// Last record applied at
         last_record_applied_at: TimestampMillisecond,
 
-        /// Replay status
+        /// Replay status. NULL if the processor is broken, since it is not replaying
         replay_status: DataType::Utf8,
 
         /// Durable log LSN
@@ -70,5 +70,9 @@ define_table!(
         /// Partition-store on-disk storage version (StorageVersion discriminant).
         /// Set once on partition open.
         storage_version: DataType::UInt32,
+
+        /// Why the node gave up on running this partition processor, if it did.
+        /// NULL while the processor is healthy.
+        broken_reason: DataType::Utf8,
     )
 );

--- a/crates/types/build.rs
+++ b/crates/types/build.rs
@@ -116,6 +116,11 @@ fn build_restate_proto(out_dir: &Path) -> std::io::Result<()> {
             "DetailedRunMode",
             "#[derive(::strum::Display, ::restate_encoding::NetSerde, ::bilrost::Enumeration)]",
         )
+        .enum_attribute(
+            "BrokenReason",
+            "#[derive(::strum::Display, ::restate_encoding::NetSerde, ::bilrost::Enumeration)]",
+        )
+        .enum_attribute("BrokenReason", "#[strum(serialize_all = \"snake_case\")]")
         .btree_map([
             ".restate.cluster.ClusterState",
             ".restate.cluster.AliveNode",

--- a/crates/types/protobuf/restate/cluster.proto
+++ b/crates/types/protobuf/restate/cluster.proto
@@ -70,6 +70,18 @@ enum ReplayStatus {
   CATCHING_UP = 3;
 }
 
+// Why a partition processor has been parked on a node. A parked processor is
+// not retried automatically; it needs operator intervention to recover.
+// Since v1.7.3
+enum BrokenReason {
+  // The partition processor is not broken.
+  BrokenReason_NOT_BROKEN = 0;
+  // The local partition store's applied LSN is ahead of the log tail, which
+  // indicates data loss in the log. The store has been sealed and must be
+  // replaced before this node can run the partition again.
+  BrokenReason_AHEAD_OF_LOG = 1;
+}
+
 message PartitionProcessorStatus {
   reserved 8;
   google.protobuf.Timestamp updated_at = 1;
@@ -93,6 +105,9 @@ message PartitionProcessorStatus {
   // Partition-store on-disk storage version (StorageVersion discriminant).
   optional uint32 storage_version = 16;
   DetailedRunMode detailed_effective_mode = 17;
+  // Set when this node has parked the partition processor instead of retrying
+  // it. All other fields carry their defaults in that case.
+  BrokenReason broken_reason = 18;
 }
 
 message ReplicationProperty { string replication_property = 1; }

--- a/crates/types/src/cluster/cluster_state.rs
+++ b/crates/types/src/cluster/cluster_state.rs
@@ -19,7 +19,7 @@ use crate::identifiers::{LeaderEpoch, PartitionId};
 use crate::logs::Lsn;
 use crate::partitions::StorageVersion;
 use crate::partitions::features::PersistedFeatures;
-pub use crate::protobuf::cluster::DetailedRunMode;
+pub use crate::protobuf::cluster::{BrokenReason, DetailedRunMode};
 use crate::time::MillisSinceEpoch;
 use crate::{GenerationalNodeId, PlainNodeId, Version};
 
@@ -211,9 +211,22 @@ pub struct PartitionProcessorStatus {
     /// Since v1.7.3 (if Unknown, use effective_mode)
     #[bilrost(17)]
     pub detailed_effective_mode: DetailedRunMode,
+
+    /// Set when the node has parked this partition processor instead of retrying it.
+    /// All other fields carry their defaults in that case.
+    ///
+    /// Since v1.7.3
+    #[bilrost(18)]
+    pub broken_reason: BrokenReason,
 }
 
 impl PartitionProcessorStatus {
+    /// The node running this processor gave up on it and will not retry until an
+    /// operator intervenes.
+    pub fn is_broken(&self) -> bool {
+        self.broken_reason != BrokenReason::NotBroken
+    }
+
     pub fn effective_mode(&self) -> DetailedRunMode {
         match self.detailed_effective_mode {
             DetailedRunMode::Unknown => self.effective_mode.into(),
@@ -269,6 +282,7 @@ impl Default for PartitionProcessorStatus {
             last_applied_schema_version: None,
             enabled_features: PersistedFeatures::default(),
             storage_version: None,
+            broken_reason: BrokenReason::NotBroken,
         }
     }
 }

--- a/crates/worker/src/metric_definitions.rs
+++ b/crates/worker/src/metric_definitions.rs
@@ -28,6 +28,7 @@ pub const LEADER_LABEL_FOLLOWER: &str = "0";
 //                     not configured.
 pub const PARTITION_BLOCKED_FLARE: &str = "restate.partition.blocked_flare";
 pub const FLARE_REASON_VERSION_BARRIER: &str = "version_barrier";
+pub const FLARE_REASON_AHEAD_OF_LOG: &str = "ahead_of_log";
 pub const FLARE_REASON_MIGRATION_BARRIER: &str = "migration_barrier";
 pub const FLARE_REASON_SNAPSHOT_UNAVAILABLE: &str = "snapshot-unavailable";
 

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -53,7 +53,7 @@ use restate_core::network::{
 use restate_core::{Metadata, ShutdownError, TaskCenter, TaskKind, cancellation_token};
 use restate_ingestion_client::IngestionClient;
 use restate_partition_store::{
-    MigrationError, PartitionDb, PartitionStore, PartitionStoreTransaction,
+    MigrationError, PartitionDb, PartitionSeal, PartitionStore, PartitionStoreTransaction,
 };
 use restate_platform::memory::EstimatedMemorySize;
 use restate_storage_api::deduplication_table::{
@@ -300,6 +300,20 @@ pub enum ProcessorError {
     Other(#[from] anyhow::Error),
 }
 
+impl From<PartitionSeal> for ProcessorError {
+    fn from(value: PartitionSeal) -> Self {
+        match value {
+            PartitionSeal::AheadOfLog {
+                partition_applied_lsn,
+                log_tail_lsn,
+            } => ProcessorError::PartitionAheadOfLog {
+                partition_applied_lsn,
+                log_tail_lsn,
+            },
+        }
+    }
+}
+
 /// OrderedOperations are scheduled operations that
 /// will only get executed once the partition read up to
 /// the bifrost tail that was found once the operation
@@ -425,15 +439,6 @@ where
         let partition_id = self.ctx.partition_id();
         let my_node = self.node_ctx.my_node_id().as_plain();
 
-        let mut durable_lsn_watch = self.partition_store.get_durable_lsn().await?;
-        let durable_lsn = durable_lsn_watch
-            .borrow_and_update()
-            .unwrap_or(Lsn::INVALID);
-
-        self.node_ctx
-            .replica_set_states
-            .note_durable_lsn(partition_id, my_node, durable_lsn);
-
         // If the underlying log is not provisioned, now is the time to provision it.
         // We'll retry a few times before giving back control to PPM
         //
@@ -476,13 +481,34 @@ where
         // If our `last_applied_lsn` is at or beyond the tail, this is a strong indicator
         // that the log has reverted backwards.
         if self.ctx.fsm().last_applied_lsn() >= current_tail.offset() {
+            let partition_applied_lsn = self.ctx.fsm().last_applied_lsn();
+            let log_tail_lsn = current_tail.offset();
+            self.partition_store
+                .seal(&PartitionSeal::AheadOfLog {
+                    partition_applied_lsn,
+                    log_tail_lsn,
+                })
+                .await?;
+
             return Err(ProcessorError::PartitionAheadOfLog {
-                partition_applied_lsn: self.ctx.fsm().last_applied_lsn(),
-                log_tail_lsn: current_tail.offset(),
+                partition_applied_lsn,
+                log_tail_lsn,
             });
         }
 
+        let mut durable_lsn_watch = self.partition_store.get_durable_lsn().await?;
+        let durable_lsn = durable_lsn_watch
+            .borrow_and_update()
+            .unwrap_or(Lsn::INVALID);
+
+        self.node_ctx
+            .replica_set_states
+            .note_durable_lsn(partition_id, my_node, durable_lsn);
+
         self.ctx.status_mut().set_started_at(Instant::now());
+        // Note that before this point, we will not allow taking snapshots of this partition store
+        // and it's important that we perform the seal check before we update the replay status to
+        // avoid taking snapshots of a sealed partition store.
         self.ctx.set_catchup_lsn(current_tail.offset());
         debug!(
             last_applied_lsn = %self.ctx.fsm().last_applied_lsn(),

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -57,7 +57,7 @@ use restate_partition_store::snapshots::{
 use restate_partition_store::{SnapshotError, SnapshotErrorKind};
 use restate_types::GenerationalNodeId;
 use restate_types::cluster::cluster_state::ReplayStatus;
-use restate_types::cluster::cluster_state::{PartitionProcessorStatus, RunMode};
+use restate_types::cluster::cluster_state::{BrokenReason, PartitionProcessorStatus, RunMode};
 use restate_types::config::Configuration;
 use restate_types::epoch::EpochMetadata;
 use restate_types::health::HealthStatus;
@@ -146,6 +146,14 @@ type SnapshotResultInternal = Result<(PartitionId, PartitionSnapshotStatus), Sna
 struct PendingSnapshotTask {
     snapshot_id: SnapshotId,
     sender: Option<oneshot::Sender<SnapshotResult>>,
+}
+
+/// What to do with a partition once its processor's runtime task has terminated.
+enum PostStopAction {
+    Restart(RestartDelay),
+    /// Give up on the partition: retrying cannot fix the failure, so we park the processor
+    /// in [`ProcessorState::Broken`] until an operator intervenes.
+    Park(BrokenReason),
 }
 
 enum RestartDelay {
@@ -393,6 +401,10 @@ where
             task.cancel();
         }
 
+        // broken processors have no runtime task left to await, so drop them upfront to keep
+        // `await_processors_termination` from waiting on an event that can never arrive
+        self.processor_states.retain(|_, state| !state.is_broken());
+
         // stop all running processors
         for processor_state in self.processor_states.values_mut() {
             processor_state.stop();
@@ -559,6 +571,16 @@ where
                                     runtime_handle.cancel();
                                     self.await_runtime_task_result(partition_id, runtime_handle);
                                 }
+                                ProcessorState::Broken { .. } => {
+                                    // Unreachable in practice: we only park a processor as
+                                    // broken after its runtime task reported termination.
+                                    // Stop the new one and stay broken.
+                                    debug!(
+                                        "Started partition processor for a partition we gave up on. Stopping it."
+                                    );
+                                    runtime_handle.cancel();
+                                    self.await_runtime_task_result(partition_id, runtime_handle);
+                                }
                             }
                         } else {
                             debug!("Started partition processor is no longer needed. Stopping it.");
@@ -582,18 +604,18 @@ where
             }
             EventKind::Stopped(result) => {
                 self.unregister_pp_rpc_shard(partition_id);
-                let delay = match self.processor_states.remove(&partition_id) {
+                let action = match self.processor_states.remove(&partition_id) {
                     None => {
                         debug!("Stopped partition processor which is no longer running.");
                         // immediately try to restart if we are still part of the partition's membership
                         counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => NORMAL_STOP).increment(1);
-                        RestartDelay::Immediate
+                        PostStopAction::Restart(RestartDelay::Immediate)
                     }
                     Some(processor_state) => match processor_state {
                         ProcessorState::Starting { .. } => {
                             counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => STARTUP_ERROR_STOP).increment(1);
                             warn!(%partition_id, "Partition processor failed to start: {result:?}");
-                            RestartDelay::Fixed
+                            PostStopAction::Restart(RestartDelay::Fixed)
                         }
                         ProcessorState::Started {
                             processor,
@@ -613,19 +635,24 @@ where
                                     counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => ERROR_STOP).increment(1);
                                     gauge!(PARTITION_BLOCKED_FLARE, PARTITION_LABEL => partition_id.to_string(), REASON_LABEL => FLARE_REASON_VERSION_BARRIER).set(1);
                                     error!(%partition_id, "Partition processor start error: {e}");
-                                    RestartDelay::MaxBackoff
+                                    PostStopAction::Restart(RestartDelay::MaxBackoff)
                                 }
                                 Err(e @ ProcessorError::MigrationBarrier { .. }) => {
                                     counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => ERROR_STOP).increment(1);
                                     gauge!(PARTITION_BLOCKED_FLARE, PARTITION_LABEL => partition_id.to_string(), REASON_LABEL => FLARE_REASON_MIGRATION_BARRIER).set(1);
                                     error!(%partition_id, "Partition processor start error: {e}");
-                                    RestartDelay::MaxBackoff
+                                    PostStopAction::Restart(RestartDelay::MaxBackoff)
                                 }
                                 Err(e @ ProcessorError::PartitionAheadOfLog { .. }) => {
                                     counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => ERROR_STOP).increment(1);
                                     gauge!(PARTITION_BLOCKED_FLARE, PARTITION_LABEL => partition_id.to_string(), REASON_LABEL => FLARE_REASON_AHEAD_OF_LOG).set(1);
-                                    error!(%partition_id, "Partition processor start error: {e}");
-                                    RestartDelay::MaxBackoff
+                                    error!(
+                                        %partition_id,
+                                        "Partition processor start error: {e}. The local partition store \
+                                        is sealed; this node will not run this partition again until the \
+                                        store has been dropped and replaced by a safe snapshot",
+                                    );
+                                    PostStopAction::Park(BrokenReason::AheadOfLog)
                                 }
                                 Err(ProcessorError::TrimGapEncountered {
                                     read_pointer: sequence_number,
@@ -644,7 +671,7 @@ where
                                         );
                                         self.fast_forward_on_startup.insert(partition_id, *to_lsn);
 
-                                        RestartDelay::Immediate
+                                        PostStopAction::Restart(RestartDelay::Immediate)
                                     } else {
                                         error!(
                                             %partition_id,
@@ -653,7 +680,7 @@ where
                                         );
                                         gauge!(PARTITION_BLOCKED_FLARE, PARTITION_LABEL => partition_id.to_string(), REASON_LABEL => FLARE_REASON_SNAPSHOT_UNAVAILABLE).set(1);
                                         // configuration problem; until we have peer-to-peer state exchange we can only wait
-                                        RestartDelay::MaxBackoff
+                                        PostStopAction::Restart(RestartDelay::MaxBackoff)
                                     }
                                 }
                                 Err(err) => {
@@ -663,12 +690,12 @@ where
                                     };
                                     counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => ERROR_STOP).increment(1);
                                     error!(%partition_id, %err, "Partition processor exited unexpectedly, {}", next_delay);
-                                    next_delay
+                                    PostStopAction::Restart(next_delay)
                                 }
                                 Ok(_) => {
                                     counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => NORMAL_STOP).increment(1);
                                     info!(%partition_id, "Partition processor stopped");
-                                    RestartDelay::Immediate
+                                    PostStopAction::Restart(RestartDelay::Immediate)
                                 }
                             }
                         }
@@ -678,13 +705,28 @@ where
                                     .unregister_all(processor.key_range());
                             }
                             counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => NORMAL_STOP).increment(1);
-                            RestartDelay::Immediate
+                            PostStopAction::Restart(RestartDelay::Immediate)
                         }
+                        // Unreachable in practice: a broken processor has no runtime task that
+                        // could report back. Stay broken rather than silently restarting.
+                        ProcessorState::Broken { reason, .. } => PostStopAction::Park(reason),
                     },
                 };
 
-                if !self.restart_partition_processor_if_replica(partition_id, delay) {
-                    debug!("Partition processor stopped: {result:?}");
+                match action {
+                    PostStopAction::Restart(delay) => {
+                        if !self.restart_partition_processor_if_replica(partition_id, delay) {
+                            debug!("Partition processor stopped: {result:?}");
+                        }
+                    }
+                    PostStopAction::Park(reason) => {
+                        if self.should_run_processor(partition_id) {
+                            self.processor_states
+                                .insert(partition_id, ProcessorState::broken(reason));
+                        } else {
+                            debug!("Partition processor stopped: {result:?}");
+                        }
+                    }
                 }
 
                 gauge!(NUM_ACTIVE_PARTITIONS).set(self.processor_states.len() as f64);
@@ -1338,7 +1380,16 @@ where
         // All the remaining running processors are no longer part of the observed partition
         // configuration. Let's terminate them.
         for partition_id in running_processors.into_iter() {
-            if let Some(processor) = self.processor_states.get_mut(&partition_id) {
+            let Some(processor) = self.processor_states.get_mut(&partition_id) else {
+                continue;
+            };
+
+            if processor.is_broken() {
+                // A broken processor has no runtime task that would report its termination,
+                // so drop it right away instead of waiting for a `Stopped` event.
+                debug!(%partition_id, "Forget broken partition processor because it is no longer a member of the partition configuration");
+                self.processor_states.remove(&partition_id);
+            } else {
                 debug!(%partition_id, "Stop partition processor because it is no longer a member of the partition configuration");
                 processor.stop();
 
@@ -1347,11 +1398,21 @@ where
                         "Partition processor stop requested with snapshot task result outstanding"
                     );
                 }
-                self.latest_snapshots.remove(&partition_id);
             }
+            self.latest_snapshots.remove(&partition_id);
         }
 
         gauge!(NUM_ACTIVE_PARTITIONS).set(self.processor_states.len() as f64);
+    }
+
+    /// Whether this node should be running a processor for the given partition, i.e. we are
+    /// part of its replica set and the manager itself is not shutting down.
+    fn should_run_processor(&self, partition_id: PartitionId) -> bool {
+        !restate_core::is_cancellation_requested()
+            && self
+                .replica_set_states
+                .membership_state(partition_id)
+                .contains(Metadata::with_current(|m| m.my_node_id().as_plain()))
     }
 
     /// Starts a partition processor if this node is part of the replica set of the given partition.
@@ -1361,24 +1422,12 @@ where
         partition_id: PartitionId,
         delay: RestartDelay,
     ) -> bool {
-        // only restart partition processors if the partition processor manager is still supposed to run
-        if restate_core::is_cancellation_requested() {
+        if !self.should_run_processor(partition_id) {
             return false;
         }
 
-        if self
-            .replica_set_states
-            .membership_state(partition_id)
-            .contains(Metadata::with_current(|m| m.my_node_id().as_plain()))
-        {
-            self.start_partition_processor(
-                partition_id,
-                delay.next_delay().map(|d| d.add_jitter(0.3)),
-            );
-            true
-        } else {
-            false
-        }
+        self.start_partition_processor(partition_id, delay.next_delay().map(|d| d.add_jitter(0.3)));
+        true
     }
 
     #[instrument(level = "info", skip_all, fields(partition_id = %partition_id))]

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -85,9 +85,10 @@ use restate_worker_api::invoker::capacity::InvokerCapacity;
 use restate_worker_api::{ProcessorsManagerCommand, ProcessorsManagerHandle};
 
 use crate::metric_definitions::{
-    ERROR_STOP, FLARE_REASON_MIGRATION_BARRIER, FLARE_REASON_SNAPSHOT_UNAVAILABLE,
-    FLARE_REASON_VERSION_BARRIER, GAP_STOP, PARTITION_BLOCKED_FLARE, PARTITION_IS_EFFECTIVE_LEADER,
-    PARTITION_START, REASON_LABEL, STARTUP_ERROR_STOP, TYPE_LABEL,
+    ERROR_STOP, FLARE_REASON_AHEAD_OF_LOG, FLARE_REASON_MIGRATION_BARRIER,
+    FLARE_REASON_SNAPSHOT_UNAVAILABLE, FLARE_REASON_VERSION_BARRIER, GAP_STOP,
+    PARTITION_BLOCKED_FLARE, PARTITION_IS_EFFECTIVE_LEADER, PARTITION_START, REASON_LABEL,
+    STARTUP_ERROR_STOP, TYPE_LABEL,
 };
 use crate::metric_definitions::{NORMAL_STOP, PARTITION_TIME_SINCE_LAST_STATUS_UPDATE};
 use crate::metric_definitions::{NUM_ACTIVE_PARTITIONS, PARTITION_APPLIED_LSN_LAG};
@@ -617,6 +618,12 @@ where
                                 Err(e @ ProcessorError::MigrationBarrier { .. }) => {
                                     counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => ERROR_STOP).increment(1);
                                     gauge!(PARTITION_BLOCKED_FLARE, PARTITION_LABEL => partition_id.to_string(), REASON_LABEL => FLARE_REASON_MIGRATION_BARRIER).set(1);
+                                    error!(%partition_id, "Partition processor start error: {e}");
+                                    RestartDelay::MaxBackoff
+                                }
+                                Err(e @ ProcessorError::PartitionAheadOfLog { .. }) => {
+                                    counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => ERROR_STOP).increment(1);
+                                    gauge!(PARTITION_BLOCKED_FLARE, PARTITION_LABEL => partition_id.to_string(), REASON_LABEL => FLARE_REASON_AHEAD_OF_LOG).set(1);
                                     error!(%partition_id, "Partition processor start error: {e}");
                                     RestartDelay::MaxBackoff
                                 }

--- a/crates/worker/src/partition_processor_manager/processor_state.rs
+++ b/crates/worker/src/partition_processor_manager/processor_state.rs
@@ -16,10 +16,13 @@ use tracing::debug;
 use ulid::Ulid;
 
 use restate_core::network::ShardSender;
-use restate_types::cluster::cluster_state::{PartitionProcessorStatus, ReplayStatus, RunMode};
+use restate_types::cluster::cluster_state::{
+    BrokenReason, PartitionProcessorStatus, ReplayStatus, RunMode,
+};
 use restate_types::identifiers::LeaderEpoch;
 use restate_types::net::partition_processor::PartitionLeaderService;
 use restate_types::sharding::KeyRange;
+use restate_types::time::MillisSinceEpoch;
 
 use crate::partition::{LeadershipInfo, TargetLeaderState};
 
@@ -48,6 +51,13 @@ pub enum ProcessorState {
     Stopping {
         processor: Option<StartedProcessor>,
     },
+    /// The processor hit a failure that retrying cannot resolve, so this node gave up on
+    /// running it. There is no runtime task backing this state; it is only cleared by an
+    /// operator action (see `restatectl`) or by losing membership of the partition.
+    Broken {
+        reason: BrokenReason,
+        since: MillisSinceEpoch,
+    },
 }
 
 impl ProcessorState {
@@ -57,6 +67,17 @@ impl ProcessorState {
             start_time: Instant::now(),
             delay,
         }
+    }
+
+    pub fn broken(reason: BrokenReason) -> Self {
+        Self::Broken {
+            reason,
+            since: MillisSinceEpoch::now(),
+        }
+    }
+
+    pub fn is_broken(&self) -> bool {
+        matches!(self, ProcessorState::Broken { .. })
     }
 
     pub fn stopping(processor: StartedProcessor) -> Self {
@@ -94,6 +115,11 @@ impl ProcessorState {
             ProcessorState::Stopping { .. } => {
                 // already stopping
             }
+            ProcessorState::Broken { .. } => {
+                // Nothing to stop; there is no runtime task that would report back a
+                // `Stopped` event. Callers that want to get rid of a broken processor must
+                // drop the state instead of waiting for it to terminate.
+            }
         };
     }
 
@@ -124,6 +150,9 @@ impl ProcessorState {
             }
             ProcessorState::Stopping { .. } => {
                 // we first need to stop before we check whether we should run again
+            }
+            ProcessorState::Broken { .. } => {
+                // a broken processor cannot run in any mode
             }
         }
     }
@@ -177,6 +206,10 @@ impl ProcessorState {
             }
             ProcessorState::Stopping { .. } => {
                 // we first need to stop before we check whether we should run again
+                None
+            }
+            ProcessorState::Broken { .. } => {
+                debug!("Ignoring leadership request for a broken partition processor.");
                 None
             }
         }
@@ -234,6 +267,9 @@ impl ProcessorState {
             ProcessorState::Stopping { .. } => {
                 debug!("Received leader epoch while stopping partition processor. Ignoring.");
             }
+            ProcessorState::Broken { .. } => {
+                debug!("Received leader epoch for a broken partition processor. Ignoring.");
+            }
         }
     }
 
@@ -243,7 +279,7 @@ impl ProcessorState {
             ProcessorState::Started { leader_state, .. } => {
                 matches!(leader_state, LeaderState::AwaitingLeaderEpoch(token) if *token == leader_epoch_token)
             }
-            ProcessorState::Stopping { .. } => false,
+            ProcessorState::Stopping { .. } | ProcessorState::Broken { .. } => false,
         }
     }
 
@@ -301,6 +337,13 @@ impl ProcessorState {
                 // todo report stopping status back to the cluster controller
                 None
             }
+            ProcessorState::Broken { reason, since } => Some(PartitionProcessorStatus {
+                broken_reason: *reason,
+                // report when we gave up rather than "now", so that operators can see how
+                // long the partition has been sitting broken.
+                updated_at: *since,
+                ..Default::default()
+            }),
         }
     }
 

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -128,6 +128,17 @@ where
 
                     let mut partition_store = partition_store?;
 
+                    // verify that this partition store is not sealed
+                    if let Some(seal) = partition_store.get_seal_marker().await? {
+                        warn!("Local partition store for partition {} is sealed due to {}. The \
+                        partition store is not safe to use by this node and will need to be replaced \
+                        by a safe snapshot before continuing!",
+                        partition.partition_id,
+                        seal,
+                        );
+                        return Err(ProcessorError::from(seal));
+                    }
+
                     // One-time background cleanup of orphaned jc index entries left behind
                     // by a bug in delete_journal that used the wrong scan prefix.
                     // Runs on a blocking thread so it doesn't starve the tokio runtime.

--- a/release-notes/unreleased/park-broken-partition-processors.md
+++ b/release-notes/unreleased/park-broken-partition-processors.md
@@ -1,0 +1,36 @@
+# Release Notes: Partition processors are parked instead of retried when the local store is sealed
+
+## Behavioral Change
+
+### What Changed
+
+When a partition processor fails because its local partition store is sealed (the store's applied
+LSN is ahead of the log tail, which indicates data loss in the log), the node no longer retries the
+processor on a backoff. It parks the processor and reports it as **broken**:
+
+- `restatectl partition list` shows `Broken (ahead-of-log)` in the `STATUS` column.
+- `restatectl status` counts broken processors separately, e.g. `2 (1 broken)` under `FOLLOWERS`.
+- The `partition_state` SQL table has a new `broken_reason` column (`NULL` while healthy). Its
+  `replay_status` is `NULL` for a broken processor, since there is no replay in progress.
+- The `restate.partition.blocked_flare{reason="ahead_of_log"}` gauge is still raised.
+
+Other blocked states (version barrier, migration barrier, missing snapshot) are unchanged and keep
+retrying, because a cluster upgrade or a newly published snapshot can resolve them on its own.
+
+### Why This Matters
+
+A sealed store cannot be repaired by retrying: the local data must be discarded and replaced from a
+snapshot. Retrying every 30 seconds only produced log noise and made it impossible to tell a
+transiently failing processor from one that will never recover.
+
+### Impact on Users
+
+- A parked processor stays down until an operator intervenes, the node restarts, or the node leaves
+  the partition's replica set. Previously it would keep retrying (and keep failing).
+- Nothing to do for healthy deployments; the new state is only reachable via a sealed partition
+  store.
+
+### Migration Guidance
+
+None. Older `restatectl` builds ignore the new field and render a broken processor as a follower
+that never becomes active.

--- a/tools/restate-doctor/src/util/decode_value.rs
+++ b/tools/restate-doctor/src/util/decode_value.rs
@@ -16,6 +16,7 @@
 use bilrost::OwnedMessage;
 
 use restate_limiter::RuleBook;
+use restate_partition_store::PartitionSeal;
 use restate_partition_store::fsm_table::PartitionStateMachineKey;
 use restate_partition_store::keys::{DecodeTableKey, KeyKind};
 use restate_partition_store::vqueue_table::{EntryStatusKey, InputPayloadKey};
@@ -56,6 +57,8 @@ mod fsm_variable {
     pub const RULE_BOOK: u64 = 9;
     /// *Since v1.7.0*
     pub const STATE_MACHINE_FEATURES: u64 = 10;
+    /// *Since v1.7.3*
+    pub const SEAL_MARKER: u64 = 11;
 }
 
 /// Result of decoding a value, including codec metadata
@@ -390,6 +393,11 @@ fn decode_fsm_value(key: &[u8], value: &[u8]) -> DecodedValue {
         }
     };
 
+    // The seal marker is plain json, it is not wrapped in a StorageCodec envelope.
+    if state_id == fsm_variable::SEAL_MARKER {
+        return decode_fsm_seal_marker(value);
+    }
+
     // Read codec byte
     let codec_byte = value[0];
     let codec = StorageCodecKind::try_from(codec_byte).ok();
@@ -451,6 +459,28 @@ fn decode_fsm_value(key: &[u8], value: &[u8]) -> DecodedValue {
             payload_size,
             format!("<unknown state_id={unknown}, {} bytes>", payload_size),
         ),
+    }
+}
+
+/// Decode the partition seal marker.
+///
+/// Unlike every other FSM variable, the seal marker is stored as plain json bytes without a
+/// [`StorageCodec`] envelope, so there is no codec byte to strip. Values written by a newer
+/// version may carry a [`PartitionSeal`] variant we don't know about; in that case we fall back to
+/// echoing the raw json instead of reporting a decode error.
+fn decode_fsm_seal_marker(value: &[u8]) -> DecodedValue {
+    let payload_size = value.len();
+
+    match serde_json::from_slice::<PartitionSeal>(value) {
+        Ok(seal) => DecodedValue::decoded(None, payload_size, format!("PartitionSeal({seal:?})")),
+        Err(err) => match serde_json::from_slice::<serde_json::Value>(value) {
+            Ok(raw) => DecodedValue::decoded(
+                None,
+                payload_size,
+                format!("PartitionSeal(<unrecognized> {raw})"),
+            ),
+            Err(_) => DecodedValue::error(None, payload_size, format!("{err}")),
+        },
     }
 }
 
@@ -564,6 +594,7 @@ mod tests {
     use restate_partition_store::PaddedPartitionId;
     use restate_partition_store::fsm_table::PartitionStateMachineKey;
     use restate_partition_store::keys::EncodeTableKeyPrefix;
+    use restate_types::logs::Lsn;
     use restate_types::storage::StorageCodec;
 
     use super::*;
@@ -615,6 +646,30 @@ mod tests {
         assert!(
             matches!(&decoded.content, DecodedContent::Decoded(s) if s.contains("JcOrphanCleanupDone(1)")),
             "jc-orphan-cleanup flag should decode, got: {decoded}"
+        );
+
+        // Seal marker: plain json, no StorageCodec envelope
+        let value = serde_json::to_vec(&PartitionSeal::AheadOfLog {
+            partition_applied_lsn: Lsn::new(10),
+            log_tail_lsn: Lsn::new(5),
+        })
+        .unwrap();
+        let decoded = decode_value(KeyKind::Fsm, &fsm_key(fsm_variable::SEAL_MARKER), &value);
+        assert_eq!(decoded.codec, None);
+        assert!(
+            matches!(&decoded.content, DecodedContent::Decoded(s) if s.contains("AheadOfLog")),
+            "seal marker should decode, got: {decoded}"
+        );
+
+        // A variant written by a newer version falls back to the raw json
+        let decoded = decode_value(
+            KeyKind::Fsm,
+            &fsm_key(fsm_variable::SEAL_MARKER),
+            br#"{"type":"SomethingNew"}"#,
+        );
+        assert!(
+            matches!(&decoded.content, DecodedContent::Decoded(s) if s.contains("<unrecognized>")),
+            "unknown seal variant should fall back to raw json, got: {decoded}"
         );
     }
 }

--- a/tools/restatectl/src/commands/partition/list.rs
+++ b/tools/restatectl/src/commands/partition/list.rs
@@ -21,7 +21,8 @@ use restate_core::protobuf::cluster_ctrl_svc::{ClusterStateRequest, new_cluster_
 use restate_types::logs::Lsn;
 use restate_types::nodes_config::Role;
 use restate_types::protobuf::cluster::{
-    DeadNode, DetailedRunMode, PartitionProcessorStatus, ReplayStatus, RunMode, node_state,
+    BrokenReason, DeadNode, DetailedRunMode, PartitionProcessorStatus, ReplayStatus, RunMode,
+    node_state,
 };
 use restate_types::{GenerationalNodeId, PlainNodeId, Version};
 
@@ -184,6 +185,7 @@ pub async fn list_partitions(
                 render_replay_status(
                     processor.status.effective_mode(),
                     processor.status.replay_status(),
+                    processor.status.broken_reason(),
                     processor.status.target_tail_lsn.map(Into::into),
                 ),
                 Cell::new(
@@ -309,7 +311,22 @@ fn render_mode(
     }
 }
 
-fn render_replay_status(effective: RunMode, status: ReplayStatus, target_lsn: Option<Lsn>) -> Cell {
+fn render_replay_status(
+    effective: RunMode,
+    status: ReplayStatus,
+    broken_reason: BrokenReason,
+    target_lsn: Option<Lsn>,
+) -> Cell {
+    // A broken processor isn't running at all, so its replay status carries no information.
+    match broken_reason {
+        BrokenReason::NotBroken => {}
+        BrokenReason::AheadOfLog => {
+            return Cell::new("Broken (ahead-of-log)")
+                .fg(Color::Red)
+                .add_attribute(Attribute::Bold);
+        }
+    }
+
     match (status, effective) {
         (ReplayStatus::Unknown, _) => Cell::new("UNKNOWN").fg(Color::Red),
         (ReplayStatus::Starting, _) => Cell::new("Starting").fg(Color::Yellow),

--- a/tools/restatectl/src/commands/status.rs
+++ b/tools/restatectl/src/commands/status.rs
@@ -26,7 +26,7 @@ use restate_types::health::MetadataServerStatus;
 use restate_types::logs::metadata::Logs;
 use restate_types::nodes_config::{NodeConfig, NodesConfiguration, Role};
 use restate_types::protobuf::cluster::node_state::State;
-use restate_types::protobuf::cluster::{AliveNode, RunMode};
+use restate_types::protobuf::cluster::{AliveNode, BrokenReason, RunMode};
 use restate_types::{GenerationalNodeId, NodeId};
 use restate_util_time::DurationExt;
 
@@ -158,6 +158,12 @@ async fn alive_node_status(
     let counter = alive_node.partitions.values().fold(
         PartitionCounter::default(),
         |mut counter, partition_status| {
+            // a broken processor is neither leading nor following, it isn't running at all
+            if partition_status.broken_reason() != BrokenReason::NotBroken {
+                counter.broken += 1;
+                return counter;
+            }
+
             let effective =
                 RunMode::try_from(partition_status.effective_mode).expect("valid effective mode");
             let planned =
@@ -251,6 +257,7 @@ struct PartitionCounter {
     followers: u16,
     upgrading: u16,
     downgrading: u16,
+    broken: u16,
 }
 
 impl PartitionCounter {
@@ -273,6 +280,9 @@ impl PartitionCounter {
         write!(buf, "{}", self.followers).expect("must succeed");
         if self.downgrading > 0 {
             write!(buf, "+{}", self.downgrading).expect("must succeed");
+        }
+        if self.broken > 0 {
+            write!(buf, " ({} broken)", self.broken).expect("must succeed");
         }
 
         buf


### PR DESCRIPTION

## Why

Storage-pool threads could still be inside `rocksdb::DBImpl::Open` when the
process called `exit()`. C++ static destructors then freed rocksdb's
option-registry statics - the enum lookup maps that `OptionTypeInfo` holds by
pointer - and the in-flight open read freed memory while re-parsing the
`OPTIONS-*` file it had just written. The result was a SIGSEGV on an `rs:io-lo`
thread, seen as `proper_partition_processor_lifecycle` crashing roughly 1 run in
15 under parallel load.

`shutdown()` did not prevent this. It closed the databases in `self.dbs`, waited
for `close_db_tasks`, and joined rocksdb's *env* threads, but never joined our own
storage pools. A database that is still being opened is also not yet registered in
`self.dbs` - `open_db` inserts it only after `RocksDb::open` returns - so it
escaped the close loop as well.

## What

- `shutdown()` sets `shutting_down` itself instead of relying on `DbWatchdog`
  having observed the TaskCenter shutdown watch first. Direct callers (tests,
  `lite`) never set it, so opens were still being accepted.
- New `join_storage_pools()` runs before draining `self.dbs`, so in-flight opens
  complete and register their database in time to be closed, and again after the
  close tasks, so no storage task is inside rocksdb when `shutdown()` returns.
- Bounded by `Configuration::common.shutdown_grace_period()` (default 60s). On
  timeout it warns and continues: a stalled write should not hang the process,
  even though returning early re-opens the window.

Note this makes shutdown wait for in-flight storage IO where it previously did
not, so a busy node can take longer to stop.

## Evidence

0 failures and 0 new crash reports over 60 runs of the reproducing loop, against
1 in 15 before. Beyond that, no pool job can be queued or running once
`shutdown()` returns, which is the precondition the crash needs.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/5116).
* #5121
* #5120
* #5119
* #5114
* #5113
* __->__ #5116
* #5112
* #5109
* #5106