### PR TITLE
Improve partition lifecycle observability

### DIFF
--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -723,11 +723,11 @@ impl<T: TransportConnect> Scheduler<T> {
             Ok(epoch_metadata) => {
                 info!(
                     %partition_id,
-                    old_replica_set = %partition_state.current.replica_set(),
-                    new_replica_set = %epoch_metadata.current().replica_set(),
-                    "Transitioned from partition configuration {current_version} to {expected_next_version}");
-                let (_, _, current, next, leadership_policy, placement_policy) =
-                    epoch_metadata.into_inner();
+                    "Partition configuration transition: {current_version} {} -> {expected_next_version} {}",
+                    partition_state.current.replica_set(),
+                    epoch_metadata.current().replica_set(),
+                    );
+                let (_, _, current, next, leadership_policy, placement_policy) = epoch_metadata.into_inner();
                 Ok(PartitionConfigurationUpdate {
                     current,
                     next,

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -403,7 +403,7 @@ impl BifrostInner {
                             .await
                         {
                             Ok(lsn) => {
-                                info!(%log_id, "Chain is sealed at lsn={lsn}, will attempt finding the tail again");
+                                debug!(%log_id, "Chain is sealed at lsn={lsn}, will attempt finding the tail again");
                                 continue;
                             }
                             Err(err) => {

--- a/crates/types/src/partitions/state.rs
+++ b/crates/types/src/partitions/state.rs
@@ -506,6 +506,16 @@ impl MembershipState {
         self.current_leader.subscribe()
     }
 
+    /// Iterates over node IDs in the current and next replica-set configurations.
+    ///
+    /// A node present in both configurations is yielded twice.
+    pub fn replica_set_union(&self) -> impl Iterator<Item = PlainNodeId> {
+        std::iter::once(&self.observed_current_membership)
+            .chain(self.observed_next_membership.iter())
+            .flat_map(|membership| membership.members.iter())
+            .map(|member| member.node_id)
+    }
+
     /// Returns the first alive node from `observed_current_membership` by overlaying it with the
     /// current cluster state.
     pub fn first_alive_node(&self, cluster_state: &ClusterState) -> Option<GenerationalNodeId> {

--- a/crates/worker/src/partition/leadership/leader_state.rs
+++ b/crates/worker/src/partition/leadership/leader_state.rs
@@ -22,6 +22,7 @@ use futures::stream::FuturesUnordered;
 use futures::{FutureExt, StreamExt, stream};
 use itertools::Itertools;
 use metrics::counter;
+use tokio::time::Instant;
 use tokio_stream::wrappers::{ReceiverStream, WatchStream};
 use tracing::{debug, trace};
 
@@ -79,6 +80,7 @@ const NETWORK_EVENTS_BUFFER_SIZE: usize = 1;
 
 pub struct LeaderState {
     pub(crate) partition_id: PartitionId,
+    pub at: Instant,
     pub leader_epoch: LeaderEpoch,
     // only needed for proposing TruncateOutbox to ourselves
     partition_key_range: KeyRange,
@@ -151,6 +153,7 @@ impl LeaderState {
         let (network_events_tx, network_events_rx) =
             tokio::sync::mpsc::channel(NETWORK_EVENTS_BUFFER_SIZE);
         LeaderState {
+            at: Instant::now(),
             partition_id,
             leader_epoch,
             partition_key_range,

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -24,7 +24,7 @@ use futures::{StreamExt, TryStreamExt};
 use tokio::sync::mpsc;
 use tokio::time::Instant;
 use tokio_stream::wrappers::ReceiverStream;
-use tracing::{debug, instrument, warn};
+use tracing::{debug, info, instrument, warn};
 
 use restate_core::network::{Oneshot, Reciprocal, TransportConnect};
 use restate_core::{Metadata, ShutdownError, TaskCenter, TaskKind};
@@ -61,6 +61,7 @@ use restate_types::partitions::PartitionFeatureChange;
 use restate_types::protobuf::cluster::DetailedRunMode;
 use restate_types::schema::Schema;
 use restate_types::storage::{StorageDecodeError, StorageEncodeError};
+use restate_util_string::format_restring;
 use restate_util_time::DurationExt;
 use restate_vqueues::context::{HasVQueues, HasVQueuesMut};
 use restate_vqueues::scheduler::{self};
@@ -179,11 +180,6 @@ pub(crate) enum NetworkServiceEvent {
 enum State {
     Follower,
     Candidate {
-        at: Instant,
-        /// When this node started campaigning for leadership. Unlike `at`, which is reset on
-        /// each state transition to time the current phase, this is preserved across a
-        /// `BecomingLeader` detour so the readiness event can report the full
-        /// candidacy-to-effective-leadership duration.
         campaign_started_at: Instant,
         leader_epoch: LeaderEpoch,
         // to be able to move out of it
@@ -199,17 +195,6 @@ enum State {
         self_proposer: Option<SelfProposer>,
     },
     Leader(Box<LeaderState>),
-}
-
-/// Readiness recorded when `become_leader` installs `State::Leader`: the epoch it became
-/// leader for, and how long it took to get there, measured from when this node started
-/// campaigning for leadership until it reached effective leadership. This spans the
-/// `AnnounceLeader` log round-trip and, on feature-enabling transitions, the intervening
-/// `BecomingLeader` version-barrier round-trip. It excludes only the leader-epoch acquisition
-/// that precedes the campaign.
-pub(crate) struct EffectiveLeadershipReadiness {
-    pub(crate) leader_epoch: LeaderEpoch,
-    pub(crate) time_to_effective_leadership: Duration,
 }
 
 impl State {
@@ -229,11 +214,6 @@ pub(crate) struct LeadershipState<T> {
     partition_id: PartitionId,
     ingestion_client: IngestionClient<T, Envelope>,
     leader_query_tx: LeaderQuerySender,
-
-    /// Set when `become_leader` installs `State::Leader`, cleared by
-    /// `take_effective_leadership_readiness` once the enclosing batch has been successfully
-    /// committed locally and the readiness log can be safely emitted.
-    became_effective_leader: Option<EffectiveLeadershipReadiness>,
 }
 
 impl<T> LeadershipState<T>
@@ -250,26 +230,11 @@ where
             partition_id,
             ingestion_client,
             leader_query_tx,
-            became_effective_leader: None,
         }
     }
 
     pub(crate) fn is_leader(&self) -> bool {
         matches!(self.state, State::Leader(_) | State::BecomingLeader { .. })
-    }
-
-    pub(crate) fn is_effective_leader(&self) -> bool {
-        matches!(self.state, State::Leader(_))
-    }
-
-    /// Returns and consumes the readiness recorded when `become_leader` installed
-    /// `State::Leader`, but only if the processor is still an effective leader. The token is
-    /// consumed even after a same-batch step-down, so it can never be observed twice.
-    pub(crate) fn take_effective_leadership_readiness(
-        &mut self,
-    ) -> Option<EffectiveLeadershipReadiness> {
-        let readiness = self.became_effective_leader.take()?;
-        self.is_effective_leader().then_some(readiness)
     }
 
     pub(crate) fn partition_id(&self) -> PartitionId {
@@ -353,7 +318,6 @@ where
         self_proposer.self_propose_unaccounted(ctx.key_range().start(), announce_leader)?;
 
         self.state = State::Candidate {
-            at: Instant::now(),
             campaign_started_at,
             leader_epoch,
             self_proposer: Some(self_proposer),
@@ -384,12 +348,17 @@ where
 
         let planned_mode = match &self.state {
             State::Follower => RunMode::Follower,
-            State::Candidate { leader_epoch, .. } => {
+            State::Candidate {
+                campaign_started_at,
+                leader_epoch,
+                ..
+            } => {
                 match leader_epoch.cmp(&new_leader_epoch) {
                     Ordering::Less => {
-                        debug!(
-                            "Lost leadership campaign. Conceding to {} at epoch {}",
-                            new_leader_node, new_leader_epoch
+                        info!(
+                            campaign_duration = %campaign_started_at.elapsed().friendly(),
+                            partition_id = %self.partition_id,
+                            "Lost leadership campaign. Conceding to {new_leader_node} at epoch {new_leader_epoch}",
                         );
                         self.become_follower().await;
                         RunMode::Follower
@@ -400,14 +369,17 @@ where
                     }
                 }
             }
-            State::BecomingLeader { leader_epoch, .. } => {
+            State::BecomingLeader {
+                at, leader_epoch, ..
+            } => {
                 match leader_epoch.cmp(&new_leader_epoch) {
                     Ordering::Less => {
-                        debug!(
+                        info!(
                             my_leadership_epoch = %leader_epoch,
-                            %new_leader_epoch,
-                            "Every reign must end. Stepping down and becoming an conceding to {} at epoch {}",
-                            new_leader_node, new_leader_epoch
+                            partition_id = %self.partition_id,
+                            "Every reign must end. Spent {} as {}. Conceding to {new_leader_node} at epoch {new_leader_epoch}",
+                            at.elapsed().friendly(),
+                            self.detailed_effective_mode(),
                         );
                         self.become_follower().await;
                         RunMode::Follower
@@ -420,11 +392,12 @@ where
             }
             State::Leader(leader_state) => match leader_state.leader_epoch.cmp(&new_leader_epoch) {
                 Ordering::Less => {
-                    debug!(
+                    info!(
                         my_leadership_epoch = %leader_state.leader_epoch,
-                        %new_leader_epoch,
-                        "Every reign must end. Stepping down and becoming an conceding to {} at epoch {}",
-                        new_leader_node, new_leader_epoch
+                        partition_id = %self.partition_id,
+                        "Every reign must end. Spent {} as {}. Conceding to {new_leader_node} at epoch {new_leader_epoch}",
+                        leader_state.at.elapsed().friendly(),
+                        self.detailed_effective_mode(),
                     );
                     self.become_follower().await;
                     RunMode::Follower
@@ -521,17 +494,16 @@ where
         let prev_mode = self.detailed_effective_mode();
 
         if let State::Candidate {
-            at,
             campaign_started_at,
             leader_epoch,
-            self_proposer,
+            ref mut self_proposer,
         }
         | State::BecomingLeader {
-            at,
             campaign_started_at,
             leader_epoch,
-            self_proposer,
-        } = &mut self.state
+            ref mut self_proposer,
+            ..
+        } = self.state
         {
             let live_config = &mut node_ctx.config;
             let config = live_config.live_load();
@@ -599,24 +571,13 @@ where
                     .max(processor.fsm().min_restate_version())
                     .clone();
 
-                debug!(
-                    "Proposing VersionBarrier command to enable state-machine features {}",
-                    feature_changes
-                        .iter()
-                        .map(|c| {
-                            let name: &'static str = c.into();
-                            name
-                        })
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                );
                 self_proposer.self_propose_unaccounted(
                     processor.key_range().start(),
                     Command::VersionBarrier(VersionBarrierCommand {
                         version: barrier_version,
                         partition_key_range: Keys::RangeInclusive(processor.key_range().into()),
                         human_reason: Some("Apply state-machine feature changes".to_owned()),
-                        feature_changes: feature_changes.into_iter().map(|c| c.id()).collect(),
+                        feature_changes: feature_changes.iter().map(|c| c.id()).collect(),
                     }),
                 )?;
 
@@ -631,16 +592,26 @@ where
                 // we actually observe the VersionBarrier command back from the log. But we also
                 // don't expect any other commands other than AnnounceLeader (from preemptions) or
                 // VersionBarrier (our own self-proposal) to be next in the log.
-                debug!(
-                    "Transitioning from {prev_mode} -> {}. Spent {} in {prev_mode} mode.",
+                info!(
+                    partition_id = %processor.partition_id(),
+                    leader_epoch = %leader_epoch,
+                    campaign_duration = %campaign_started_at.elapsed().friendly(),
+                    "Processor transitioned into {}. Will propose a `VersionBarrier` to enable [{}]",
                     DetailedRunMode::BecomingLeader,
-                    at.elapsed().friendly(),
+                    feature_changes
+                        .iter()
+                        .map(|c| {
+                            let name: &'static str = c.into();
+                            name
+                        })
+                        .collect::<Vec<_>>()
+                        .join(", ")
                 );
 
                 self.state = State::BecomingLeader {
                     at: Instant::now(),
-                    campaign_started_at: *campaign_started_at,
-                    leader_epoch: *leader_epoch,
+                    campaign_started_at,
+                    leader_epoch,
                     self_proposer: Some(self_proposer),
                 };
 
@@ -691,7 +662,7 @@ where
                 .leader_handles_registry
                 .register_leader_query(processor.key_range(), self.leader_query_tx.clone());
 
-            let invoker_name = Arc::from(format!("invoker-{}", processor.partition_id()));
+            let invoker_name = format_restring!("invoker-{}", processor.partition_id());
             let invoker_config = Configuration::live().map(|c| &c.worker.invoker);
             let invoker_task_guard =
                 TaskCenter::spawn_unmanaged(TaskKind::SystemService, invoker_name, async move {
@@ -733,7 +704,7 @@ where
             let (shuffle_tx, shuffle_rx) = tokio::sync::watch::channel(None);
 
             let shuffle = Shuffle::new(
-                ShuffleMetadata::new(processor.partition_id(), *leader_epoch),
+                ShuffleMetadata::new(processor.partition_id(), leader_epoch),
                 OutboxReader::from(partition_store.clone()),
                 shuffle_tx,
                 config.worker.internal_queue_length(),
@@ -770,14 +741,34 @@ where
                 Duration::from_secs(5).add_jitter(0.5),
             );
 
-            debug!(
-                "Transitioning from {prev_mode} -> {}. Spent {} in {prev_mode} mode.",
-                DetailedRunMode::Leader,
-                at.elapsed().friendly(),
-            );
+            match self.state {
+                State::Candidate {
+                    campaign_started_at,
+                    ..
+                } => {
+                    info!(
+                        campaign_duration = %campaign_started_at.elapsed().friendly(),
+                        partition_id = %processor.partition_id(),
+                        "Processor became {} of epoch {leader_epoch}",
+                        DetailedRunMode::Leader,
+                    );
+                }
+                State::BecomingLeader {
+                    at,
+                    campaign_started_at,
+                    ..
+                } => {
+                    info!(
+                        campaign_duration = %campaign_started_at.elapsed().friendly(),
+                        partition_id = %processor.partition_id(),
+                        "Processor became {} of epoch {leader_epoch}. Spent {} as {prev_mode}",
+                        DetailedRunMode::Leader,
+                        at.elapsed().friendly(),
+                    );
+                }
+                _ => unreachable!(),
+            }
 
-            let leader_epoch = *leader_epoch;
-            let campaign_started_at = *campaign_started_at;
             self.state = State::Leader(Box::new(LeaderState::new(
                 processor.partition_id(),
                 leader_epoch,
@@ -799,11 +790,6 @@ where
                 leader_query_guard,
                 node_ctx.rule_book_cache.subscribe(),
             )));
-
-            self.became_effective_leader = Some(EffectiveLeadershipReadiness {
-                leader_epoch,
-                time_to_effective_leadership: campaign_started_at.elapsed(),
-            });
 
             Ok(())
         } else {
@@ -1144,7 +1130,6 @@ mod tests {
         // the journal-v2 default; the processor stays `BecomingLeader` until that barrier
         // is applied.
         assert!(matches!(state.state, State::BecomingLeader { .. }));
-        assert!(!state.is_effective_leader());
 
         let record = reader.next().await.unwrap()?;
         let envelope = record.try_decode::<Envelope>().unwrap()?;
@@ -1166,19 +1151,6 @@ mod tests {
             .await?;
 
         assert!(matches!(state.state, State::Leader(_)));
-        assert!(state.is_effective_leader());
-
-        // become_leader() only records the transition; the caller (the partition
-        // processor's run loop) is responsible for emitting the readiness log, and only
-        // after the enclosing batch has been successfully committed locally.
-        let readiness = state
-            .take_effective_leadership_readiness()
-            .expect("become_leader records the transition to effective leadership");
-        assert_eq!(readiness.leader_epoch, leader_epoch);
-        // Measured from candidacy, so it spans the AnnounceLeader and BecomingLeader
-        // round-trips this test walked through, not just the final become_leader body.
-        assert!(!readiness.time_to_effective_leadership.is_zero());
-        assert!(state.take_effective_leadership_readiness().is_none());
 
         state.step_down().await;
 

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -43,7 +43,7 @@ use futures::{FutureExt, StreamExt};
 use metrics::histogram;
 use tokio::sync::watch;
 use tokio::time::{Instant, MissedTickBehavior};
-use tracing::{debug, error, info, instrument, trace, warn};
+use tracing::{debug, error, instrument, trace, warn};
 
 use restate_bifrost::loglet::FindTailOptions;
 use restate_bifrost::{DataRecord, DataRecordError, LogEntry};
@@ -663,15 +663,6 @@ where
                     // compact while applying the WAL commands as this could remove vqueue meta entries
                     // which are required by the scheduler when applying the scheduler events.
                     self.ctx.vqueues_mut().try_compact();
-
-                    if let Some(readiness) = self.leadership_state.take_effective_leadership_readiness() {
-                        info!(
-                            partition_id = %self.ctx.partition_id(),
-                            leader_epoch = %readiness.leader_epoch,
-                            time_to_effective_leadership_seconds = readiness.time_to_effective_leadership.as_secs_f64(),
-                            "Partition processor reached effective leadership"
-                        );
-                    }
                 },
                 result = self.leadership_state.run(&mut self.ctx) => {
                     result?;

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -10,6 +10,7 @@
 
 mod introspection;
 mod processor_state;
+mod reconciliation;
 mod spawn_processor_task;
 
 pub use introspection::{LeaderQueryGuard, PartitionLeaderHandlesRegistry};
@@ -96,6 +97,7 @@ use crate::partition::{LeadershipInfo, NodeContext, ProcessorError};
 use crate::partition_processor_manager::processor_state::{
     LeaderEpochToken, ProcessorState, StartedProcessor,
 };
+use crate::partition_processor_manager::reconciliation::{ReconciliationPlan, StopDisposition};
 use crate::partition_processor_manager::spawn_processor_task::SpawnPartitionProcessorTask;
 use crate::rule_book_cache::{RuleBookCache, RuleBookCacheHandle};
 
@@ -1365,41 +1367,33 @@ where
 
     fn on_replica_set_state_changes(&mut self, replica_set_states: &PartitionReplicaSetStates) {
         let my_node_id = Metadata::with_current(|m| m.my_node_id().as_plain());
-        let mut running_processors: HashSet<_> = self.processor_states.keys().copied().collect();
+        let plan =
+            ReconciliationPlan::build(&self.processor_states, replica_set_states, my_node_id);
 
-        // Not ideal to have to iterate over all replica states. An index per node id could help.
-        // In practice, this is probably not a problem because the replica sets won't change that
-        // often.
-        for (partition_id, membership_state) in replica_set_states.iter() {
-            if membership_state.contains(my_node_id) {
-                if !self.processor_states.contains_key(&partition_id) {
-                    self.start_partition_processor(partition_id, None);
-                }
-
-                running_processors.remove(&partition_id);
-            }
+        if !plan.is_empty() {
+            info!("Reconciling partition processors: {plan}");
         }
 
-        // All the remaining running processors are no longer part of the observed partition
-        // configuration. Let's terminate them.
-        for partition_id in running_processors.into_iter() {
-            let Some(processor) = self.processor_states.get_mut(&partition_id) else {
-                continue;
-            };
+        for partition_id in plan.starts.keys().copied() {
+            self.start_partition_processor(partition_id, None);
+        }
 
-            if processor.is_broken() {
-                // A broken processor has no runtime task that would report its termination,
-                // so drop it right away instead of waiting for a `Stopped` event.
-                debug!(%partition_id, "Forget broken partition processor because it is no longer a member of the partition configuration");
-                self.processor_states.remove(&partition_id);
-            } else {
-                debug!(%partition_id, "Stop partition processor because it is no longer a member of the partition configuration");
-                processor.stop();
+        for (&partition_id, planned_stop) in &plan.stops {
+            match planned_stop.disposition() {
+                StopDisposition::RequestStop => {
+                    let Some(processor) = self.processor_states.get_mut(&partition_id) else {
+                        continue;
+                    };
+                    processor.stop();
 
-                if self.pending_snapshots.contains_key(&partition_id) {
-                    info!(%partition_id,
-                        "Partition processor stop requested with snapshot task result outstanding"
-                    );
+                    if self.pending_snapshots.contains_key(&partition_id) {
+                        info!(%partition_id,
+                            "Partition processor stop requested with snapshot task result outstanding"
+                        );
+                    }
+                }
+                StopDisposition::ForgetBroken => {
+                    self.processor_states.remove(&partition_id);
                 }
             }
             self.latest_snapshots.remove(&partition_id);

--- a/crates/worker/src/partition_processor_manager/reconciliation.rs
+++ b/crates/worker/src/partition_processor_manager/reconciliation.rs
@@ -1,0 +1,231 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use restate_types::identifiers::PartitionId;
+use restate_types::partitions::state::{MembershipState, PartitionReplicaSetStates};
+use restate_types::replication::NodeSet;
+use restate_types::{PlainNodeId, Version};
+
+use super::processor_state::ProcessorState;
+
+/// Processor starts and stops needed to match observed replica-set membership.
+#[derive(Default)]
+pub(super) struct ReconciliationPlan {
+    pub(super) starts: BTreeMap<PartitionId, MembershipSnapshot>,
+    pub(super) stops: BTreeMap<PartitionId, PlannedStop>,
+}
+
+impl fmt::Display for ReconciliationPlan {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("starts=[")?;
+        let mut separator = "";
+        for (partition_id, start) in &self.starts {
+            write!(f, "{separator}P{partition_id}({start})")?;
+            separator = ", ";
+        }
+
+        f.write_str("] stops=[")?;
+        separator = "";
+        for (partition_id, stop) in &self.stops {
+            write!(f, "{separator}P{partition_id}({stop})")?;
+            separator = ", ";
+        }
+        f.write_str("]")
+    }
+}
+
+impl ReconciliationPlan {
+    pub(super) fn build(
+        processor_states: &BTreeMap<PartitionId, ProcessorState>,
+        replica_set_states: &PartitionReplicaSetStates,
+        my_node_id: PlainNodeId,
+    ) -> Self {
+        let mut plan = Self {
+            starts: BTreeMap::new(),
+            stops: processor_states
+                .iter()
+                .map(|(&partition_id, processor_state)| {
+                    let disposition = if processor_state.is_broken() {
+                        StopDisposition::ForgetBroken
+                    } else {
+                        StopDisposition::RequestStop
+                    };
+                    (
+                        partition_id,
+                        PlannedStop {
+                            reason: StopReason::NoObservedReplicaSet,
+                            disposition,
+                        },
+                    )
+                })
+                .collect(),
+        };
+
+        for (partition_id, membership) in replica_set_states.iter() {
+            if membership.contains(my_node_id) {
+                plan.stops.remove(&partition_id);
+                if !processor_states.contains_key(&partition_id) {
+                    plan.starts.insert(partition_id, (&membership).into());
+                }
+            } else if let Some(planned_stop) = plan.stops.get_mut(&partition_id) {
+                planned_stop.reason = StopReason::NotInObservedReplicaSet((&membership).into());
+            }
+        }
+
+        plan
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.starts.is_empty() && self.stops.is_empty()
+    }
+}
+
+pub(super) struct MembershipSnapshot {
+    current_version: Version,
+    next_version: Option<Version>,
+    replica_set: NodeSet,
+}
+
+impl fmt::Display for MembershipSnapshot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.current_version)?;
+        if let Some(next_version) = self.next_version {
+            write!(f, "->{next_version}")?;
+        }
+        write!(f, " {:#}", self.replica_set)
+    }
+}
+
+impl From<&MembershipState> for MembershipSnapshot {
+    fn from(membership: &MembershipState) -> Self {
+        Self {
+            current_version: membership.observed_current_membership.version,
+            next_version: membership
+                .observed_next_membership
+                .as_ref()
+                .map(|membership| membership.version),
+            replica_set: membership.replica_set_union().collect(),
+        }
+    }
+}
+
+enum StopReason {
+    NotInObservedReplicaSet(MembershipSnapshot),
+    NoObservedReplicaSet,
+}
+
+impl fmt::Display for StopReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotInObservedReplicaSet(membership) => membership.fmt(f),
+            Self::NoObservedReplicaSet => f.write_str("unobserved"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum StopDisposition {
+    RequestStop,
+    ForgetBroken,
+}
+
+pub(super) struct PlannedStop {
+    reason: StopReason,
+    disposition: StopDisposition,
+}
+
+impl fmt::Display for PlannedStop {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.reason.fmt(f)?;
+        if self.disposition == StopDisposition::ForgetBroken {
+            f.write_str("; forget-broken")?;
+        }
+        Ok(())
+    }
+}
+
+impl PlannedStop {
+    pub(super) fn disposition(&self) -> StopDisposition {
+        self.disposition
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use restate_types::cluster::cluster_state::{BrokenReason, RunMode};
+    use restate_types::logs::{Lsn, SequenceNumber};
+    use restate_types::partitions::state::{LeadershipState, MemberState, ReplicaSetState};
+
+    use super::*;
+
+    fn replica_set(version: Version, members: &[PlainNodeId]) -> ReplicaSetState {
+        ReplicaSetState {
+            version,
+            members: members
+                .iter()
+                .map(|&node_id| MemberState {
+                    node_id,
+                    durable_lsn: Lsn::INVALID,
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn plans_membership_reconciliation_with_reasons() {
+        let my_node_id = PlainNodeId::from(1);
+        let other_node_id = PlainNodeId::from(2);
+        let retained = PartitionId::from(0);
+        let stopped = PartitionId::from(1);
+        let forgotten = PartitionId::from(2);
+        let not_observed = PartitionId::from(3);
+        let started = PartitionId::from(4);
+        let irrelevant = PartitionId::from(5);
+
+        let processor_states = BTreeMap::from([
+            (retained, ProcessorState::starting(RunMode::Follower, None)),
+            (stopped, ProcessorState::starting(RunMode::Follower, None)),
+            (forgotten, ProcessorState::broken(BrokenReason::AheadOfLog)),
+            (
+                not_observed,
+                ProcessorState::starting(RunMode::Follower, None),
+            ),
+        ]);
+        let replica_set_states = PartitionReplicaSetStates::default();
+
+        for (partition_id, members) in [
+            (retained, &[my_node_id][..]),
+            (stopped, &[other_node_id][..]),
+            (forgotten, &[other_node_id][..]),
+            (started, &[other_node_id][..]),
+            (irrelevant, &[other_node_id][..]),
+        ] {
+            let current = replica_set(Version::MIN, members);
+            let next =
+                (partition_id == started).then(|| replica_set(Version::MIN.next(), &[my_node_id]));
+            replica_set_states.note_observed_membership(
+                partition_id,
+                LeadershipState::default(),
+                &current,
+                &next,
+            );
+        }
+
+        let plan = ReconciliationPlan::build(&processor_states, &replica_set_states, my_node_id);
+
+        assert_eq!(
+            plan.to_string(),
+            "starts=[P4(v1->v2 [N1, N2])] stops=[P1(v1 [N2]), P2(v1 [N2]; forget-broken), P3(unobserved)]"
+        );
+    }
+}


### PR DESCRIPTION

Replace delayed effective-leadership readiness logs with transition-specific events and durations.
Aggregate replica-set reconciliation starts and stops into a compact action plan.
Clarify partition configuration transitions and demote noisy sealed-chain retries to debug.

Aggregated PPM reconciliations example:

```
2026-07-31T15:31:23.010181Z INFO restate_worker::partition_processor_manager
  Reconciling partition processors: starts=[P5(v5 [N1, N3]), P6(v5 [N1, N3]), P7(v5 [N1, N3]), P10(v5 [N1, N3]), P15(v5 [N1, N3]), P17(v5 [N1, N3])] stops=[]
on rs:worker-4
```

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/5120).
* #5121
* __->__ #5120
* #5119
* #5114
* #5113
* #5116
* #5112
* #5109
* #5106