### PR TITLE
Aggregate partition configuration transition logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9236,6 +9236,7 @@ dependencies = [
  "derive_more",
  "futures",
  "gardal",
+ "metrics",
  "restate-clock",
  "restate-core",
  "restate-errors",

--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -13,7 +13,7 @@ use std::collections::BTreeMap;
 use std::collections::hash_map::Entry;
 
 use ahash::HashMap;
-use futures::{StreamExt, TryStreamExt};
+use futures::StreamExt;
 use tracing::{debug, info, trace};
 
 use restate_core::network::{NetworkSender as _, Networking, Swimlane, TransportConnect};
@@ -34,7 +34,8 @@ use restate_types::partition_table::PartitionTable;
 use restate_types::partitions::leadership_policy::{LeaderAffinity, LeadershipPolicy};
 use restate_types::partitions::placement_policy::PlacementPolicy;
 use restate_types::partitions::state::{
-    ObservedPartitionReplicaSetVersion, PartitionReplicaSetStates, ReplicaSetState,
+    MembershipUpdateBatch, ObservedPartitionReplicaSetVersion, PartitionReplicaSetStates,
+    ReplicaSetState,
 };
 use restate_types::partitions::{PartitionConfiguration, worker_candidate_filter};
 use restate_types::replication::balanced_spread_selector::{
@@ -220,18 +221,15 @@ impl<T: TransportConnect> Scheduler<T> {
         };
 
         if updated {
-            Self::note_observed_membership_update(
-                partition_id,
-                occupied_entry.get(),
-                &self.replica_set_states,
-            );
+            let mut batch = self.replica_set_states.membership_update_batch();
+            Self::note_observed_membership_update(partition_id, occupied_entry.get(), &mut batch);
         }
     }
 
     fn note_observed_membership_update(
         partition_id: PartitionId,
         partition_state: &PartitionState,
-        replica_set_states: &PartitionReplicaSetStates,
+        batch: &mut MembershipUpdateBatch,
     ) {
         let current_membership =
             ReplicaSetState::from_partition_configuration(&partition_state.current);
@@ -243,7 +241,7 @@ impl<T: TransportConnect> Scheduler<T> {
         // the leadership epoch has been acquired or not. The leadership state will only be
         // updated when either the actual leader or any of the followers has observed the
         // leader epoch as being the winner of the elections.
-        replica_set_states.note_observed_membership(
+        batch.note_observed_membership(
             partition_id,
             Default::default(),
             &current_membership,
@@ -300,7 +298,7 @@ impl<T: TransportConnect> Scheduler<T> {
         &mut self,
         partition_table: &PartitionTable,
     ) -> Result<(), Error> {
-        self.partitions = futures::stream::iter(partition_table.iter_ids().cloned().map(
+        let mut partition_configs = futures::stream::iter(partition_table.iter_ids().cloned().map(
             async |partition_id| {
                 Result::<_, Error>::Ok((
                     partition_id,
@@ -313,23 +311,32 @@ impl<T: TransportConnect> Scheduler<T> {
             },
         ))
         // load partitions concurrently - we choose 24 to match the default partition count
-        .buffer_unordered(24)
-        .try_filter_map(
-            async |(partition_id, partition_state)| match partition_state {
-                Some(partition_state) => {
+        .buffer_unordered(24);
+
+        let mut partitions = HashMap::default();
+        let mut batch = self.replica_set_states.membership_update_batch();
+        let mut first_error = None;
+        while let Some(val) = partition_configs.next().await {
+            match val {
+                Ok((partition_id, Some(partition_state))) => {
                     Self::note_observed_membership_update(
                         partition_id,
                         &partition_state,
-                        &self.replica_set_states,
+                        &mut batch,
                     );
-
-                    Ok(Some((partition_id, partition_state)))
+                    partitions.insert(partition_id, partition_state);
                 }
-                None => Ok(None),
-            },
-        )
-        .try_collect::<HashMap<_, _>>()
-        .await?;
+                Ok((_partition_id, None)) => {}
+                Err(err) => {
+                    first_error.get_or_insert(err);
+                }
+            }
+        }
+
+        if let Some(err) = first_error {
+            return Err(err);
+        }
+        self.partitions = partitions;
 
         Ok(())
     }
@@ -359,6 +366,8 @@ impl<T: TransportConnect> Scheduler<T> {
         nodes_config: &NodesConfiguration,
         partition_table: &PartitionTable,
     ) -> Result<(), Error> {
+        let mut membership_updates = self.replica_set_states.membership_update_batch();
+
         for partition_id in partition_table.iter_ids().copied() {
             let entry = self.partitions.entry(partition_id);
 
@@ -406,7 +415,7 @@ impl<T: TransportConnect> Scheduler<T> {
                                 Self::note_observed_membership_update(
                                     partition_id,
                                     entry.get(),
-                                    &self.replica_set_states,
+                                    &mut membership_updates,
                                 );
                             }
                         }
@@ -436,7 +445,7 @@ impl<T: TransportConnect> Scheduler<T> {
                         Self::note_observed_membership_update(
                             partition_id,
                             occupied_entry.get(),
-                            &self.replica_set_states,
+                            &mut membership_updates,
                         );
                         occupied_entry
                     } else {
@@ -470,7 +479,7 @@ impl<T: TransportConnect> Scheduler<T> {
                     Self::note_observed_membership_update(
                         partition_id,
                         occupied_entry.get(),
-                        &self.replica_set_states,
+                        &mut membership_updates,
                     );
                 }
             }

--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -723,11 +723,11 @@ impl<T: TransportConnect> Scheduler<T> {
             Ok(epoch_metadata) => {
                 info!(
                     %partition_id,
-                    old_replica_set = %partition_state.current.replica_set(),
-                    new_replica_set = %epoch_metadata.current().replica_set(),
-                    "Transitioned from partition configuration {current_version} to {expected_next_version}");
-                let (_, _, current, next, leadership_policy, placement_policy) =
-                    epoch_metadata.into_inner();
+                    "Partition configuration transition: {current_version} {} -> {expected_next_version} {}",
+                    partition_state.current.replica_set(),
+                    epoch_metadata.current().replica_set(),
+                    );
+                let (_, _, current, next, leadership_policy, placement_policy) = epoch_metadata.into_inner();
                 Ok(PartitionConfigurationUpdate {
                     current,
                     next,

--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -11,6 +11,7 @@
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::collections::hash_map::Entry;
+use std::fmt;
 
 use ahash::HashMap;
 use futures::StreamExt;
@@ -165,6 +166,50 @@ struct PartitionConfigurationUpdate {
     next: Option<PartitionConfiguration>,
     leadership_policy: LeadershipPolicy,
     placement_policy: PlacementPolicy,
+}
+
+struct CompleteReconfigurationResult {
+    configuration: PartitionConfigurationUpdate,
+    transition: Option<PartitionConfigurationTransition>,
+}
+
+struct PartitionConfigurationTransition {
+    current_version: Version,
+    current_replica_set: NodeSet,
+    next_version: Version,
+    next_replica_set: NodeSet,
+}
+
+#[derive(Default)]
+struct PartitionConfigurationTransitions(BTreeMap<PartitionId, PartitionConfigurationTransition>);
+
+impl PartitionConfigurationTransitions {
+    fn insert(&mut self, partition_id: PartitionId, transition: PartitionConfigurationTransition) {
+        self.0.insert(partition_id, transition);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl fmt::Display for PartitionConfigurationTransitions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[")?;
+        let mut separator = "";
+        for (partition_id, transition) in &self.0 {
+            write!(
+                f,
+                "{separator}P{partition_id}({} {:#} -> {} {:#})",
+                transition.current_version,
+                transition.current_replica_set,
+                transition.next_version,
+                transition.next_replica_set,
+            )?;
+            separator = ", ";
+        }
+        f.write_str("]")
+    }
 }
 
 pub struct Scheduler<T> {
@@ -366,6 +411,32 @@ impl<T: TransportConnect> Scheduler<T> {
         nodes_config: &NodesConfiguration,
         partition_table: &PartitionTable,
     ) -> Result<(), Error> {
+        let mut transitions = PartitionConfigurationTransitions::default();
+        let result = self
+            .ensure_valid_partition_configuration_inner(
+                cluster_state,
+                legacy_cluster_state,
+                nodes_config,
+                partition_table,
+                &mut transitions,
+            )
+            .await;
+
+        if !transitions.is_empty() {
+            info!("Partition configuration transitions: {transitions}");
+        }
+
+        result
+    }
+
+    async fn ensure_valid_partition_configuration_inner(
+        &mut self,
+        cluster_state: &ClusterState,
+        legacy_cluster_state: &LegacyClusterState,
+        nodes_config: &NodesConfiguration,
+        partition_table: &PartitionTable,
+        transitions: &mut PartitionConfigurationTransitions,
+    ) -> Result<(), Error> {
         let mut membership_updates = self.replica_set_states.membership_update_batch();
 
         for partition_id in partition_table.iter_ids().copied() {
@@ -463,12 +534,19 @@ impl<T: TransportConnect> Scheduler<T> {
                 partition_state,
                 legacy_cluster_state,
             ) {
-                let partition_configuration_update = Self::complete_reconfiguration(
+                let CompleteReconfigurationResult {
+                    configuration: partition_configuration_update,
+                    transition,
+                } = Self::complete_reconfiguration(
                     self.metadata_writer.raw_metadata_store_client(),
                     partition_id,
                     occupied_entry.get(),
                 )
                 .await?;
+
+                if let Some(transition) = transition {
+                    transitions.insert(partition_id, transition);
+                }
 
                 if occupied_entry.get_mut().update(
                     partition_configuration_update.current,
@@ -679,7 +757,7 @@ impl<T: TransportConnect> Scheduler<T> {
         metadata_store_client: &MetadataStoreClient,
         partition_id: PartitionId,
         partition_state: &PartitionState,
-    ) -> Result<PartitionConfigurationUpdate, Error> {
+    ) -> Result<CompleteReconfigurationResult, Error> {
         let current_version = partition_state.current.version();
         let expected_next_version = partition_state
             .next
@@ -721,22 +799,28 @@ impl<T: TransportConnect> Scheduler<T> {
             }
         }).await {
             Ok(epoch_metadata) => {
-                info!(
-                    %partition_id,
-                    "Partition configuration transition: {current_version} {} -> {expected_next_version} {}",
-                    partition_state.current.replica_set(),
-                    epoch_metadata.current().replica_set(),
-                    );
+                let transition = PartitionConfigurationTransition {
+                    current_version,
+                    current_replica_set: partition_state.current.replica_set().clone(),
+                    next_version: expected_next_version,
+                    next_replica_set: epoch_metadata.current().replica_set().clone(),
+                };
                 let (_, _, current, next, leadership_policy, placement_policy) = epoch_metadata.into_inner();
-                Ok(PartitionConfigurationUpdate {
-                    current,
-                    next,
-                    leadership_policy,
-                    placement_policy,
+                Ok(CompleteReconfigurationResult {
+                    configuration: PartitionConfigurationUpdate {
+                        current,
+                        next,
+                        leadership_policy,
+                        placement_policy,
+                    },
+                    transition: Some(transition),
                 })
             }
             Err(ReadModifyWriteError::FailedOperation(concurrent_update)) => {
-                Ok(*concurrent_update)
+                Ok(CompleteReconfigurationResult {
+                    configuration: *concurrent_update,
+                    transition: None,
+                })
             }
             Err(ReadModifyWriteError::ReadWrite(err)) => {
                 Err(err.into())
@@ -1188,10 +1272,10 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(
-            completed.current.replica_set(),
+            completed.configuration.current.replica_set(),
             configuration(2).replica_set()
         );
-        assert!(completed.next.is_none());
-        assert_eq!(completed.placement_policy, policy);
+        assert!(completed.configuration.next.is_none());
+        assert_eq!(completed.configuration.placement_policy, policy);
     }
 }

--- a/crates/bifrost/src/bifrost.rs
+++ b/crates/bifrost/src/bifrost.rs
@@ -403,7 +403,7 @@ impl BifrostInner {
                             .await
                         {
                             Ok(lsn) => {
-                                info!(%log_id, "Chain is sealed at lsn={lsn}, will attempt finding the tail again");
+                                debug!(%log_id, "Chain is sealed at lsn={lsn}, will attempt finding the tail again");
                                 continue;
                             }
                             Err(err) => {

--- a/crates/ingress-http/src/handler/error.rs
+++ b/crates/ingress-http/src/handler/error.rs
@@ -130,11 +130,8 @@ pub enum ErrorResponse {
 }
 
 impl HandlerError {
-    pub(crate) fn fill_builder<B: http_body::Body + Default + From<Bytes>>(
-        self,
-        res_builder: http::response::Builder,
-    ) -> Response<B> {
-        let status_code = match &self {
+    pub(crate) fn status_code(&self) -> StatusCode {
+        match self {
             HandlerError::NotFound
             | HandlerError::ServiceNotFound(_)
             | HandlerError::ServiceHandlerNotFound(_, _)
@@ -176,7 +173,14 @@ impl HandlerError {
                 StatusCode::from_u16(e.code().into()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
             }
             HandlerError::NotReady => StatusCode::from_u16(470).unwrap(),
-        };
+        }
+    }
+
+    pub(crate) fn fill_builder<B: http_body::Body + Default + From<Bytes>>(
+        self,
+        res_builder: http::response::Builder,
+    ) -> Response<B> {
+        let status_code = self.status_code();
 
         let error_response = match self {
             HandlerError::Invocation(e) => ErrorResponse::Invocation(e),

--- a/crates/ingress-http/src/handler/service_handler.rs
+++ b/crates/ingress-http/src/handler/service_handler.rs
@@ -44,7 +44,10 @@ use super::tracing::prepare_tracing_span;
 use super::{APPLICATION_JSON, Handler};
 use crate::RequestDispatcher;
 use crate::handler::responses::{IDEMPOTENCY_EXPIRES, X_RESTATE_ID};
-use crate::metric_definitions::{INGRESS_REQUEST_DURATION, INGRESS_REQUESTS, REQUEST_COMPLETED};
+use crate::metric_definitions::{
+    INGRESS_REQUEST_DURATION, INGRESS_REQUESTS, REQUEST_COMPLETED, REQUEST_ERROR,
+    REQUEST_INGRESS_ERROR, REQUEST_INVOCATION_ERROR,
+};
 
 pub(crate) const IDEMPOTENCY_KEY: HeaderName = HeaderName::from_static("idempotency-key");
 const LIMIT_KEY_HEADER: HeaderName = HeaderName::from_static("x-restate-limit-key");
@@ -74,6 +77,20 @@ pub(crate) struct SendResponse {
     status: SendStatus,
 }
 
+fn request_metric_status(result: &Result<Response<Full<Bytes>>, HandlerError>) -> &'static str {
+    match result {
+        Ok(response)
+            if response.status().is_client_error() || response.status().is_server_error() =>
+        {
+            REQUEST_INVOCATION_ERROR
+        }
+        Ok(_) => REQUEST_COMPLETED,
+        Err(HandlerError::Invocation(_)) => REQUEST_INVOCATION_ERROR,
+        Err(error) if error.status_code().is_client_error() => REQUEST_ERROR,
+        Err(_) => REQUEST_INGRESS_ERROR,
+    }
+}
+
 impl<Schemas, Dispatcher> Handler<Schemas, Dispatcher>
 where
     Schemas: InvocationTargetResolver + Clone + Send + Sync + 'static,
@@ -88,7 +105,36 @@ where
         <B as http_body::Body>::Error: Into<GenericError>,
     {
         let start_time = Instant::now();
+        let service_name_label = service_request.name.to_string();
+        let invoke_ty_label = service_request.invoke_ty.as_static_str();
 
+        let result = self.process_service_request(req, service_request).await;
+
+        histogram!(
+            INGRESS_REQUEST_DURATION,
+            "rpc.service" => service_name_label.clone(),
+            "rpc.type" => invoke_ty_label,
+        )
+        .record(start_time.elapsed());
+
+        counter!(
+            INGRESS_REQUESTS,
+            "status" => request_metric_status(&result),
+            "rpc.service" => service_name_label,
+            "rpc.type" => invoke_ty_label,
+        )
+        .increment(1);
+        result
+    }
+
+    async fn process_service_request<B: http_body::Body>(
+        self,
+        req: Request<B>,
+        service_request: ServiceRequestType,
+    ) -> Result<Response<Full<Bytes>>, HandlerError>
+    where
+        <B as http_body::Body>::Error: Into<GenericError>,
+    {
         let ServiceRequestType {
             name: service_name,
             handler: handler_name,
@@ -204,9 +250,8 @@ where
         .with_scope(scope);
 
         let invocation_id = InvocationId::generate(&invocation_target, idempotency_key.as_deref());
-        let invoke_ty_str = invoke_ty.as_static_str();
 
-        let result = async move {
+        async move {
             let ingress_span_context =
                 prepare_tracing_span(&invocation_id, &invocation_target, &req);
 
@@ -293,25 +338,7 @@ where
                 }
             }
         }
-        .await;
-
-        // Note that we only record (mostly) successful requests here. We might want to
-        // change this in the _near_ future.
-        histogram!(
-            INGRESS_REQUEST_DURATION,
-            "rpc.service" => service_name.to_string(),
-            "rpc.type" => invoke_ty_str,
-        )
-        .record(start_time.elapsed());
-
-        counter!(
-            INGRESS_REQUESTS,
-            "status" => REQUEST_COMPLETED,
-            "rpc.service" => service_name.to_string(),
-            "rpc.type" => invoke_ty_str,
-        )
-        .increment(1);
-        result
+        .await
     }
 
     async fn handle_service_call(

--- a/crates/ingress-http/src/metric_definitions.rs
+++ b/crates/ingress-http/src/metric_definitions.rs
@@ -19,6 +19,9 @@ pub const INGRESS_REQUESTS: &str = "restate.ingress.requests.total";
 // values of label `status` in INGRESS_REQUEST
 pub const REQUEST_ADMITTED: &str = "admitted";
 pub const REQUEST_COMPLETED: &str = "completed";
+pub const REQUEST_ERROR: &str = "request_error";
+pub const REQUEST_INGRESS_ERROR: &str = "ingress_error";
+pub const REQUEST_INVOCATION_ERROR: &str = "invocation_error";
 pub const REQUEST_RATE_LIMITED: &str = "rate-limited";
 
 pub const INGRESS_REQUEST_DURATION: &str = "restate.ingress.request_duration.seconds";

--- a/crates/ingress-http/src/rpc_request_dispatcher.rs
+++ b/crates/ingress-http/src/rpc_request_dispatcher.rs
@@ -41,8 +41,12 @@ impl<IC> InvocationClientRequestDispatcher<IC> {
     pub fn new(invocation_client: IC) -> Self {
         Self {
             invocation_client,
-            // TODO figure out how to tune this?
-            retry_policy: RetryPolicy::fixed_delay(Duration::from_millis(50), None),
+            retry_policy: RetryPolicy::exponential(
+                Duration::from_millis(50),
+                2.0,
+                None,                         // max attempts
+                Some(Duration::from_secs(1)), // max interval
+            ),
         }
     }
 

--- a/crates/partition-store/src/fsm_table/mod.rs
+++ b/crates/partition-store/src/fsm_table/mod.rs
@@ -8,11 +8,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::TableKind::PartitionStateMachine;
-use crate::keys::{EncodeTableKey, KeyKind, define_table_key};
-use crate::{
-    PaddedPartitionId, PartitionDb, PartitionStore, PartitionStoreTransaction, StorageAccess,
-};
 use restate_limiter::RuleBook;
 use restate_storage_api::fsm_table::{
     CachedEpochMetadata, PartitionDurability, ReadFsmTable, SequenceNumber, WriteFsmTable,
@@ -27,6 +22,13 @@ use restate_types::partitions::StorageVersion;
 use restate_types::partitions::features::PersistedFeatures;
 use restate_types::schema::Schema;
 use restate_types::storage::{StorageCodec, StorageDecode};
+
+use crate::TableKind::PartitionStateMachine;
+use crate::keys::{EncodeTableKey, KeyKind, define_table_key};
+use crate::{
+    PaddedPartitionId, PartitionDb, PartitionSeal, PartitionStore, PartitionStoreTransaction,
+    StorageAccess,
+};
 
 define_table_key!(
     PartitionStateMachine,
@@ -101,6 +103,15 @@ pub(crate) mod fsm_variable {
     /// `VersionBarrierCommand` entries carrying feature changes.
     /// *Since v1.7.0*
     pub(crate) const STATE_MACHINE_FEATURES: u64 = 10;
+
+    /// A local marker (not replicated) written to indicate that the partition store
+    /// is unsafe and should be not used by processors. The data is json serialized
+    /// and contains the reason for the seal. The intention is to prevent processors
+    /// from using this partition store until it has been removed and replaced with
+    /// an unsealed safe one.
+    ///
+    /// *Since v1.7.3*
+    pub(crate) const SEAL_MARKER: u64 = 11;
 }
 
 fn get<T: PartitionStoreProtobufValue, S: StorageAccess>(
@@ -218,6 +229,38 @@ pub(crate) async fn put_jc_orphan_cleanup_done<S: StorageAccess>(
         fsm_variable::JC_ORPHAN_CLEANUP_DONE,
         &SequenceNumber::from(1u64),
     )
+}
+
+pub(crate) async fn get_partition_seal<S: StorageAccess>(
+    storage: &mut S,
+    partition_id: PartitionId,
+) -> Result<Option<PartitionSeal>> {
+    let key = PartitionStateMachineKey {
+        partition_id: partition_id.into(),
+        state_id: fsm_variable::SEAL_MARKER,
+    };
+
+    storage.get_kv_raw(key, |_k, v| {
+        v.map(|v| serde_json::from_slice(v).map_err(|e| StorageError::Conversion(e.into())))
+            .transpose()
+    })
+}
+
+pub(crate) async fn seal_partition<S: StorageAccess>(
+    storage: &mut S,
+    partition_id: PartitionId,
+    seal: &PartitionSeal,
+) -> Result<()> {
+    let key = PartitionStateMachineKey {
+        partition_id: partition_id.into(),
+        state_id: fsm_variable::SEAL_MARKER,
+    };
+
+    storage.put_kv_raw(
+        key,
+        serde_json::to_vec(seal).map_err(|e| StorageError::Conversion(e.into()))?,
+    )?;
+    Ok(())
 }
 
 /// Reads a `StorageCodec`-encoded value directly from the partition db's column family.

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -45,7 +45,9 @@ use restate_types::storage::StorageEncode;
 
 use restate_types::partitions::StorageVersion;
 
+use crate::fsm_table::get_partition_seal;
 use crate::fsm_table::put_storage_version;
+use crate::fsm_table::seal_partition;
 use crate::fsm_table::{
     get_locally_durable_lsn, get_storage_version_from_partition_db, is_jc_orphan_cleanup_done,
     put_jc_orphan_cleanup_done,
@@ -110,6 +112,20 @@ impl From<PaddedPartitionId> for PartitionId {
     fn from(value: PaddedPartitionId) -> Self {
         Self::from(u16::try_from(value.0).expect("partition_id must fit in u16"))
     }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, derive_more::Display)]
+#[serde(tag = "type")]
+pub enum PartitionSeal {
+    #[display(
+        "last applied LSN is ahead of the log, \
+        this indicates data-loss in the log. \
+        partition_applied_lsn: {partition_applied_lsn}, log_tail_lsn: {log_tail_lsn}"
+    )]
+    AheadOfLog {
+        partition_applied_lsn: Lsn,
+        log_tail_lsn: Lsn,
+    },
 }
 
 // Ensures that both types have the same length, this makes it possible to
@@ -614,6 +630,14 @@ impl PartitionStore {
 
     pub fn partition(&self) -> &Arc<Partition> {
         self.db.partition()
+    }
+
+    pub async fn get_seal_marker(&mut self) -> Result<Option<PartitionSeal>> {
+        get_partition_seal(self, self.partition_id()).await
+    }
+
+    pub async fn seal(&mut self, seal: &PartitionSeal) -> Result<()> {
+        seal_partition(self, self.partition_id(), seal).await
     }
 
     /// Returns `true` if the one-time cleanup of orphaned `jc` index entries has not yet been

--- a/crates/storage-query-datafusion/src/partition_state/row.rs
+++ b/crates/storage-query-datafusion/src/partition_state/row.rs
@@ -46,7 +46,14 @@ pub(crate) fn append_partition_row(
         row.last_record_applied_at(ts.as_u64() as i64);
     }
 
-    row.fmt_replay_status(state.replay_status);
+    if state.is_broken() {
+        // A parked processor is not replaying anything. Leave the column NULL rather than
+        // reporting the default `starting`, which would read as progress.
+        row.fmt_broken_reason(state.broken_reason);
+    } else {
+        row.fmt_replay_status(state.replay_status);
+    }
+
     if let Some(lsn) = state.durable_lsn {
         row.durable_log_lsn(lsn.into());
     }

--- a/crates/storage-query-datafusion/src/partition_state/schema.rs
+++ b/crates/storage-query-datafusion/src/partition_state/schema.rs
@@ -45,7 +45,7 @@ define_table!(
         /// Last record applied at
         last_record_applied_at: TimestampMillisecond,
 
-        /// Replay status
+        /// Replay status. NULL if the processor is broken, since it is not replaying
         replay_status: DataType::Utf8,
 
         /// Durable log LSN
@@ -70,5 +70,9 @@ define_table!(
         /// Partition-store on-disk storage version (StorageVersion discriminant).
         /// Set once on partition open.
         storage_version: DataType::UInt32,
+
+        /// Why the node gave up on running this partition processor, if it did.
+        /// NULL while the processor is healthy.
+        broken_reason: DataType::Utf8,
     )
 );

--- a/crates/types/build.rs
+++ b/crates/types/build.rs
@@ -116,6 +116,11 @@ fn build_restate_proto(out_dir: &Path) -> std::io::Result<()> {
             "DetailedRunMode",
             "#[derive(::strum::Display, ::restate_encoding::NetSerde, ::bilrost::Enumeration)]",
         )
+        .enum_attribute(
+            "BrokenReason",
+            "#[derive(::strum::Display, ::restate_encoding::NetSerde, ::bilrost::Enumeration)]",
+        )
+        .enum_attribute("BrokenReason", "#[strum(serialize_all = \"snake_case\")]")
         .btree_map([
             ".restate.cluster.ClusterState",
             ".restate.cluster.AliveNode",

--- a/crates/types/protobuf/restate/cluster.proto
+++ b/crates/types/protobuf/restate/cluster.proto
@@ -70,6 +70,18 @@ enum ReplayStatus {
   CATCHING_UP = 3;
 }
 
+// Why a partition processor has been parked on a node. A parked processor is
+// not retried automatically; it needs operator intervention to recover.
+// Since v1.7.3
+enum BrokenReason {
+  // The partition processor is not broken.
+  BrokenReason_NOT_BROKEN = 0;
+  // The local partition store's applied LSN is ahead of the log tail, which
+  // indicates data loss in the log. The store has been sealed and must be
+  // replaced before this node can run the partition again.
+  BrokenReason_AHEAD_OF_LOG = 1;
+}
+
 message PartitionProcessorStatus {
   reserved 8;
   google.protobuf.Timestamp updated_at = 1;
@@ -93,6 +105,9 @@ message PartitionProcessorStatus {
   // Partition-store on-disk storage version (StorageVersion discriminant).
   optional uint32 storage_version = 16;
   DetailedRunMode detailed_effective_mode = 17;
+  // Set when this node has parked the partition processor instead of retrying
+  // it. All other fields carry their defaults in that case.
+  BrokenReason broken_reason = 18;
 }
 
 message ReplicationProperty { string replication_property = 1; }

--- a/crates/types/src/cluster/cluster_state.rs
+++ b/crates/types/src/cluster/cluster_state.rs
@@ -19,7 +19,7 @@ use crate::identifiers::{LeaderEpoch, PartitionId};
 use crate::logs::Lsn;
 use crate::partitions::StorageVersion;
 use crate::partitions::features::PersistedFeatures;
-pub use crate::protobuf::cluster::DetailedRunMode;
+pub use crate::protobuf::cluster::{BrokenReason, DetailedRunMode};
 use crate::time::MillisSinceEpoch;
 use crate::{GenerationalNodeId, PlainNodeId, Version};
 
@@ -211,9 +211,22 @@ pub struct PartitionProcessorStatus {
     /// Since v1.7.3 (if Unknown, use effective_mode)
     #[bilrost(17)]
     pub detailed_effective_mode: DetailedRunMode,
+
+    /// Set when the node has parked this partition processor instead of retrying it.
+    /// All other fields carry their defaults in that case.
+    ///
+    /// Since v1.7.3
+    #[bilrost(18)]
+    pub broken_reason: BrokenReason,
 }
 
 impl PartitionProcessorStatus {
+    /// The node running this processor gave up on it and will not retry until an
+    /// operator intervenes.
+    pub fn is_broken(&self) -> bool {
+        self.broken_reason != BrokenReason::NotBroken
+    }
+
     pub fn effective_mode(&self) -> DetailedRunMode {
         match self.detailed_effective_mode {
             DetailedRunMode::Unknown => self.effective_mode.into(),
@@ -269,6 +282,7 @@ impl Default for PartitionProcessorStatus {
             last_applied_schema_version: None,
             enabled_features: PersistedFeatures::default(),
             storage_version: None,
+            broken_reason: BrokenReason::NotBroken,
         }
     }
 }

--- a/crates/types/src/partitions/state.rs
+++ b/crates/types/src/partitions/state.rs
@@ -506,6 +506,16 @@ impl MembershipState {
         self.current_leader.subscribe()
     }
 
+    /// Iterates over node IDs in the current and next replica-set configurations.
+    ///
+    /// A node present in both configurations is yielded twice.
+    pub fn replica_set_union(&self) -> impl Iterator<Item = PlainNodeId> {
+        std::iter::once(&self.observed_current_membership)
+            .chain(self.observed_next_membership.iter())
+            .flat_map(|membership| membership.members.iter())
+            .map(|member| member.node_id)
+    }
+
     /// Returns the first alive node from `observed_current_membership` by overlaying it with the
     /// current cluster state.
     pub fn first_alive_node(&self, cluster_state: &ClusterState) -> Option<GenerationalNodeId> {

--- a/crates/types/src/partitions/state.rs
+++ b/crates/types/src/partitions/state.rs
@@ -30,6 +30,39 @@ pub struct PartitionReplicaSetStates {
     inner: Arc<Inner>,
 }
 
+/// Batches notifications for observed membership updates.
+pub struct MembershipUpdateBatch {
+    states: PartitionReplicaSetStates,
+    changed: bool,
+    membership_changed: bool,
+}
+
+impl MembershipUpdateBatch {
+    pub fn note_observed_membership(
+        &mut self,
+        partition_id: PartitionId,
+        current_leader: LeadershipState,
+        current_membership: &ReplicaSetState,
+        next_membership: &Option<ReplicaSetState>,
+    ) {
+        let modified = self.states.merge_observed_membership(
+            partition_id,
+            current_leader,
+            current_membership,
+            next_membership,
+        );
+        self.changed |= modified.changed();
+        self.membership_changed |= modified.membership_changed;
+    }
+}
+
+impl Drop for MembershipUpdateBatch {
+    fn drop(&mut self) {
+        self.states
+            .notify_observed_membership_changes(self.changed, self.membership_changed);
+    }
+}
+
 #[derive(Default)]
 struct Inner {
     partitions: DashMap<PartitionId, MembershipState>,
@@ -86,7 +119,31 @@ impl PartitionReplicaSetStates {
         current_membership: &ReplicaSetState,
         next_membership: &Option<ReplicaSetState>,
     ) {
-        let modified = match self.inner.partitions.entry(partition_id) {
+        let modified = self.merge_observed_membership(
+            partition_id,
+            current_leader,
+            current_membership,
+            next_membership,
+        );
+        self.notify_observed_membership_changes(modified.changed(), modified.membership_changed);
+    }
+
+    pub fn membership_update_batch(&self) -> MembershipUpdateBatch {
+        MembershipUpdateBatch {
+            states: self.clone(),
+            changed: false,
+            membership_changed: false,
+        }
+    }
+
+    fn merge_observed_membership(
+        &self,
+        partition_id: PartitionId,
+        current_leader: LeadershipState,
+        current_membership: &ReplicaSetState,
+        next_membership: &Option<ReplicaSetState>,
+    ) -> MembershipMergeResult {
+        match self.inner.partitions.entry(partition_id) {
             Entry::Occupied(mut occupied_entry) => {
                 occupied_entry
                     .get_mut()
@@ -100,12 +157,14 @@ impl PartitionReplicaSetStates {
                 });
                 MembershipMergeResult::all_changed()
             }
-        };
+        }
+    }
 
-        if modified.changed() {
+    fn notify_observed_membership_changes(&self, changed: bool, membership_changed: bool) {
+        if changed {
             self.inner.global_notify.notify_waiters();
         }
-        if modified.membership_changed {
+        if membership_changed {
             self.inner.membership_notify.notify_waiters();
         }
     }
@@ -567,6 +626,33 @@ mod tests {
                 },
                 &None,
             );
+
+            assert!(changed.now_or_never().is_some());
+            assert!(membership_changed.now_or_never().is_some());
+        }
+
+        // Batched updates are immediately visible but notify only after the batch closes.
+        {
+            let mut changed = Box::pin(states.changed());
+            let mut membership_changed = Box::pin(states.membership_changed());
+            {
+                let mut batch = states.membership_update_batch();
+                for partition_id in [PartitionId::from(1), PartitionId::from(2)] {
+                    batch.note_observed_membership(
+                        partition_id,
+                        LeadershipState::default(),
+                        &ReplicaSetState {
+                            version: Version::from(1),
+                            members: Default::default(),
+                        },
+                        &None,
+                    );
+                }
+
+                assert_eq!(states.iter().count(), 3);
+                assert!(changed.as_mut().now_or_never().is_none());
+                assert!(membership_changed.as_mut().now_or_never().is_none());
+            }
 
             assert!(changed.now_or_never().is_some());
             assert!(membership_changed.now_or_never().is_some());

--- a/crates/worker-api/Cargo.toml
+++ b/crates/worker-api/Cargo.toml
@@ -30,6 +30,7 @@ futures = { workspace = true }
 gardal = { workspace = true, features = ["tokio"] }
 serde = { workspace = true, optional = true }
 derive_more = { workspace = true, features = ["display"] }
+metrics = { workspace = true }
 serde_with = { workspace = true, optional = true }
 smallvec = { workspace = true }
 strum = { workspace = true }

--- a/crates/worker-api/src/lib.rs
+++ b/crates/worker-api/src/lib.rs
@@ -13,6 +13,7 @@ pub mod processor;
 pub mod resources;
 
 mod leader_query;
+mod metric_definitions;
 mod partition_processor_manager;
 mod partition_processor_rpc_client;
 mod scheduler_status;

--- a/crates/worker-api/src/metric_definitions.rs
+++ b/crates/worker-api/src/metric_definitions.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use metrics::{Unit, describe_counter};
+
+pub const INVOCATION_CLIENT_REQUESTS: &str = "restate.invocation_client.requests.total";
+
+// Values of label `status` in INVOCATION_CLIENT_REQUESTS.
+pub const STATUS_COMPLETED: &str = "completed";
+pub const STATUS_INTERNAL_ERROR: &str = "internal_error";
+pub const STATUS_OVERLOADED_ERROR: &str = "overloaded_error";
+pub const STATUS_PROTOCOL_ERROR: &str = "protocol_error";
+pub const STATUS_ROUTING_ERROR: &str = "routing_error";
+pub const STATUS_SHUTDOWN: &str = "shutdown";
+pub const STATUS_UNAVAILABLE_ERROR: &str = "unavailable_error";
+
+pub fn describe_metrics() {
+    describe_counter!(
+        INVOCATION_CLIENT_REQUESTS,
+        Unit::Count,
+        "Total partition processor RPC attempts made by the invocation client"
+    );
+}

--- a/crates/worker-api/src/partition_processor_rpc_client.rs
+++ b/crates/worker-api/src/partition_processor_rpc_client.rs
@@ -8,8 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::HashMap;
+use std::fmt;
 use std::sync::Arc;
 
+use metrics::counter;
 use tracing::trace;
 
 use restate_core::ShutdownError;
@@ -18,7 +21,6 @@ use restate_core::network::{NetworkSender, RpcReplyError, Swimlane};
 use restate_core::network::{Networking, TransportConnect};
 use restate_core::partitions::PartitionRouting;
 use restate_types::NodeId;
-use restate_types::errors::GenericError;
 use restate_types::identifiers::{
     EntryIndex, InvocationId, PartitionId, PartitionProcessorRpcRequestId, WithPartitionKey,
 };
@@ -37,6 +39,12 @@ use restate_types::net::partition_processor::{
     PartitionProcessorRpcRequest, PartitionProcessorRpcRequestInner, PartitionProcessorRpcResponse,
 };
 use restate_types::partition_table::{FindPartition, PartitionTable, PartitionTableError};
+
+use crate::metric_definitions::{
+    INVOCATION_CLIENT_REQUESTS, STATUS_COMPLETED, STATUS_INTERNAL_ERROR, STATUS_OVERLOADED_ERROR,
+    STATUS_PROTOCOL_ERROR, STATUS_ROUTING_ERROR, STATUS_SHUTDOWN, STATUS_UNAVAILABLE_ERROR,
+    describe_metrics,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum PartitionProcessorInvocationClientError {
@@ -61,18 +69,43 @@ pub struct RpcError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum RpcErrorKind {
-    #[error(transparent)]
     Connect(#[from] ConnectError),
-    #[error("failed sending request: {0}")]
-    SendFailed(GenericError),
-    #[error("not leader")]
-    NotLeader,
-    #[error("lost leadership")]
-    LostLeadership,
-    #[error("rejecting rpc because the partition is too busy")]
-    Busy,
-    #[error("internal error: {0}")]
-    Internal(String),
+    ConnectionClosedBeforeSend,
+    Encode(#[from] EncodeError),
+    Reply(#[from] RpcReplyError),
+    Processor(#[from] PartitionProcessorRpcError),
+}
+
+// Note: Those are customer facing errors (e.g. in http invocation response errors), so try to keep
+// stable as much as possible.
+impl fmt::Display for RpcErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RpcErrorKind::Connect(err) => err.fmt(f),
+            RpcErrorKind::ConnectionClosedBeforeSend => {
+                f.write_str("failed sending request: Connection lost")
+            }
+            RpcErrorKind::Encode(err) => write!(f, "failed sending request: {err}"),
+            RpcErrorKind::Reply(
+                RpcReplyError::ServiceNotFound
+                | RpcReplyError::SortCodeNotFound
+                | RpcReplyError::ServiceStopped,
+            )
+            | RpcErrorKind::Processor(PartitionProcessorRpcError::NotLeader(_)) => {
+                f.write_str("not leader")
+            }
+            RpcErrorKind::Reply(RpcReplyError::LoadShedding | RpcReplyError::ServiceNotReady) => {
+                f.write_str("rejecting rpc because the partition is too busy")
+            }
+            RpcErrorKind::Reply(err) => write!(f, "internal error: {err}"),
+            RpcErrorKind::Processor(PartitionProcessorRpcError::LostLeadership(_)) => {
+                f.write_str("lost leadership")
+            }
+            RpcErrorKind::Processor(PartitionProcessorRpcError::Internal(msg)) => {
+                write!(f, "internal error: {msg}")
+            }
+        }
+    }
 }
 
 impl PartitionProcessorInvocationClientError {
@@ -89,6 +122,52 @@ impl PartitionProcessorInvocationClientError {
             _ => false,
         }
     }
+
+    fn as_metric_label(&self) -> &'static str {
+        match self {
+            PartitionProcessorInvocationClientError::UnknownPartition(_)
+            | PartitionProcessorInvocationClientError::UnknownNode(_) => STATUS_ROUTING_ERROR,
+            PartitionProcessorInvocationClientError::Shutdown(_) => STATUS_SHUTDOWN,
+            PartitionProcessorInvocationClientError::Rpc(err) => err.source.as_metric_label(),
+        }
+    }
+}
+
+impl RpcErrorKind {
+    fn as_metric_label(&self) -> &'static str {
+        match self {
+            RpcErrorKind::Connect(ConnectError::Shutdown(_)) => STATUS_SHUTDOWN,
+            RpcErrorKind::Connect(ConnectError::Discovery(_))
+            | RpcErrorKind::Reply(
+                RpcReplyError::ServiceNotFound
+                | RpcReplyError::ServiceStopped
+                | RpcReplyError::SortCodeNotFound,
+            )
+            | RpcErrorKind::Processor(
+                PartitionProcessorRpcError::NotLeader(_)
+                | PartitionProcessorRpcError::LostLeadership(_),
+            ) => STATUS_ROUTING_ERROR,
+            RpcErrorKind::Reply(RpcReplyError::LoadShedding) => STATUS_OVERLOADED_ERROR,
+            RpcErrorKind::Connect(
+                ConnectError::Handshake(_)
+                | ConnectError::Throttled(_)
+                | ConnectError::Transport(_),
+            )
+            | RpcErrorKind::ConnectionClosedBeforeSend
+            | RpcErrorKind::Reply(
+                RpcReplyError::Dropped
+                | RpcReplyError::ConnectionClosed(_)
+                | RpcReplyError::ServiceNotReady,
+            ) => STATUS_UNAVAILABLE_ERROR,
+            RpcErrorKind::Encode(_)
+            | RpcErrorKind::Reply(RpcReplyError::Unknown(_) | RpcReplyError::MessageUnrecognized) => {
+                STATUS_PROTOCOL_ERROR
+            }
+            RpcErrorKind::Processor(PartitionProcessorRpcError::Internal(_)) => {
+                STATUS_INTERNAL_ERROR
+            }
+        }
+    }
 }
 
 impl RpcError {
@@ -101,16 +180,20 @@ impl RpcError {
     }
 
     fn is_safe_to_retry(&self) -> bool {
-        match self.source {
+        match &self.source {
             RpcErrorKind::Connect(_)
-            | RpcErrorKind::NotLeader
-            | RpcErrorKind::Busy
-            | RpcErrorKind::SendFailed(_) => {
+            | RpcErrorKind::ConnectionClosedBeforeSend
+            | RpcErrorKind::Encode(_) => {
                 // These are pre-flight error that we can distinguish,
                 // and for which we know for certain that no message was proposed yet to the log.
                 true
             }
-            _ => false,
+            RpcErrorKind::Reply(err) => !err.maybe_processed(),
+            RpcErrorKind::Processor(PartitionProcessorRpcError::NotLeader(_)) => true,
+            RpcErrorKind::Processor(
+                PartitionProcessorRpcError::LostLeadership(_)
+                | PartitionProcessorRpcError::Internal(_),
+            ) => false,
         }
     }
 }
@@ -122,42 +205,11 @@ impl From<PartitionProcessorInvocationClientError> for InvocationClientError {
     }
 }
 
-impl From<EncodeError> for RpcErrorKind {
-    fn from(value: EncodeError) -> Self {
-        Self::SendFailed(value.into())
-    }
-}
-
-impl From<RpcReplyError> for RpcErrorKind {
-    fn from(value: RpcReplyError) -> Self {
-        match value {
-            e @ RpcReplyError::Unknown(_) => Self::Internal(e.to_string()),
-            e @ RpcReplyError::Dropped => Self::Internal(e.to_string()),
-            // todo: perhaps this should be an explicit error
-            e @ RpcReplyError::ConnectionClosed(_) => Self::Internal(e.to_string()),
-            e @ RpcReplyError::MessageUnrecognized => Self::Internal(e.to_string()),
-            RpcReplyError::ServiceNotFound | RpcReplyError::SortCodeNotFound => Self::NotLeader,
-            RpcReplyError::LoadShedding => Self::Busy,
-            RpcReplyError::ServiceNotReady => Self::Busy,
-            RpcReplyError::ServiceStopped => Self::NotLeader,
-        }
-    }
-}
-
-impl From<PartitionProcessorRpcError> for RpcErrorKind {
-    fn from(value: PartitionProcessorRpcError) -> Self {
-        match value {
-            PartitionProcessorRpcError::NotLeader(_) => RpcErrorKind::NotLeader,
-            PartitionProcessorRpcError::LostLeadership(_) => RpcErrorKind::LostLeadership,
-            PartitionProcessorRpcError::Internal(msg) => RpcErrorKind::Internal(msg),
-        }
-    }
-}
-
 pub struct PartitionProcessorInvocationClient<C> {
     networking: Networking<C>,
     partition_table: Live<PartitionTable>,
     partition_routing: PartitionRouting,
+    partition_id_labels: Arc<HashMap<PartitionId, Arc<str>>>,
 }
 
 impl<C: Clone> Clone for PartitionProcessorInvocationClient<C> {
@@ -166,6 +218,7 @@ impl<C: Clone> Clone for PartitionProcessorInvocationClient<C> {
             networking: self.networking.clone(),
             partition_table: self.partition_table.clone(),
             partition_routing: self.partition_routing.clone(),
+            partition_id_labels: self.partition_id_labels.clone(),
         }
     }
 }
@@ -176,10 +229,18 @@ impl<C> PartitionProcessorInvocationClient<C> {
         partition_table: Live<PartitionTable>,
         partition_routing: PartitionRouting,
     ) -> Self {
+        describe_metrics();
+        let partition_id_labels = partition_table
+            .pinned()
+            .iter_ids()
+            .map(|partition_id| (*partition_id, Arc::<str>::from(partition_id.to_string())))
+            .collect();
+
         Self {
             networking,
             partition_table,
             partition_routing,
+            partition_id_labels: Arc::new(partition_id_labels),
         }
     }
 }
@@ -196,8 +257,42 @@ where
         let partition_id = self
             .partition_table
             .pinned()
-            .find_partition_id(inner_request.partition_key())?;
+            .find_partition_id(inner_request.partition_key());
+        let partition_id_label: metrics::SharedString = match partition_id.as_ref() {
+            Ok(partition_id) => match self.partition_id_labels.get(partition_id) {
+                Some(label) => label.clone().into(),
+                None => partition_id.to_string().into(),
+            },
+            Err(_) => "unknown".into(),
+        };
 
+        let res = match partition_id {
+            Ok(partition_id) => {
+                self.send_to_partition(request_id, partition_id, inner_request)
+                    .await
+            }
+            Err(err) => Err(err.into()),
+        };
+
+        counter!(
+            INVOCATION_CLIENT_REQUESTS,
+            "partition_id" => partition_id_label,
+            "status" => match &res {
+                Ok(_) => STATUS_COMPLETED,
+                Err(err) => err.as_metric_label(),
+            },
+        )
+        .increment(1);
+
+        res
+    }
+
+    async fn send_to_partition(
+        &self,
+        request_id: PartitionProcessorRpcRequestId,
+        partition_id: PartitionId,
+        inner_request: PartitionProcessorRpcRequestInner,
+    ) -> Result<PartitionProcessorRpcResponse, PartitionProcessorInvocationClientError> {
         let node_id = NodeId::from(
             self.partition_routing
                 .get_node_by_partition(partition_id)
@@ -217,7 +312,7 @@ where
             RpcError::from_err(
                 partition_id,
                 node_id,
-                RpcErrorKind::SendFailed("Connection lost".into()),
+                RpcErrorKind::ConnectionClosedBeforeSend,
             )
         })?;
         let rpc_result = permit

--- a/crates/worker/src/metric_definitions.rs
+++ b/crates/worker/src/metric_definitions.rs
@@ -28,6 +28,7 @@ pub const LEADER_LABEL_FOLLOWER: &str = "0";
 //                     not configured.
 pub const PARTITION_BLOCKED_FLARE: &str = "restate.partition.blocked_flare";
 pub const FLARE_REASON_VERSION_BARRIER: &str = "version_barrier";
+pub const FLARE_REASON_AHEAD_OF_LOG: &str = "ahead_of_log";
 pub const FLARE_REASON_MIGRATION_BARRIER: &str = "migration_barrier";
 pub const FLARE_REASON_SNAPSHOT_UNAVAILABLE: &str = "snapshot-unavailable";
 

--- a/crates/worker/src/partition/leadership/leader_state.rs
+++ b/crates/worker/src/partition/leadership/leader_state.rs
@@ -22,6 +22,7 @@ use futures::stream::FuturesUnordered;
 use futures::{FutureExt, StreamExt, stream};
 use itertools::Itertools;
 use metrics::counter;
+use tokio::time::Instant;
 use tokio_stream::wrappers::{ReceiverStream, WatchStream};
 use tracing::{debug, trace};
 
@@ -79,6 +80,7 @@ const NETWORK_EVENTS_BUFFER_SIZE: usize = 1;
 
 pub struct LeaderState {
     pub(crate) partition_id: PartitionId,
+    pub at: Instant,
     pub leader_epoch: LeaderEpoch,
     // only needed for proposing TruncateOutbox to ourselves
     partition_key_range: KeyRange,
@@ -151,6 +153,7 @@ impl LeaderState {
         let (network_events_tx, network_events_rx) =
             tokio::sync::mpsc::channel(NETWORK_EVENTS_BUFFER_SIZE);
         LeaderState {
+            at: Instant::now(),
             partition_id,
             leader_epoch,
             partition_key_range,

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -24,7 +24,7 @@ use futures::{StreamExt, TryStreamExt};
 use tokio::sync::mpsc;
 use tokio::time::Instant;
 use tokio_stream::wrappers::ReceiverStream;
-use tracing::{debug, instrument, warn};
+use tracing::{debug, info, instrument, warn};
 
 use restate_core::network::{Oneshot, Reciprocal, TransportConnect};
 use restate_core::{Metadata, ShutdownError, TaskCenter, TaskKind};
@@ -61,6 +61,7 @@ use restate_types::partitions::PartitionFeatureChange;
 use restate_types::protobuf::cluster::DetailedRunMode;
 use restate_types::schema::Schema;
 use restate_types::storage::{StorageDecodeError, StorageEncodeError};
+use restate_util_string::format_restring;
 use restate_util_time::DurationExt;
 use restate_vqueues::context::{HasVQueues, HasVQueuesMut};
 use restate_vqueues::scheduler::{self};
@@ -179,11 +180,6 @@ pub(crate) enum NetworkServiceEvent {
 enum State {
     Follower,
     Candidate {
-        at: Instant,
-        /// When this node started campaigning for leadership. Unlike `at`, which is reset on
-        /// each state transition to time the current phase, this is preserved across a
-        /// `BecomingLeader` detour so the readiness event can report the full
-        /// candidacy-to-effective-leadership duration.
         campaign_started_at: Instant,
         leader_epoch: LeaderEpoch,
         // to be able to move out of it
@@ -199,17 +195,6 @@ enum State {
         self_proposer: Option<SelfProposer>,
     },
     Leader(Box<LeaderState>),
-}
-
-/// Readiness recorded when `become_leader` installs `State::Leader`: the epoch it became
-/// leader for, and how long it took to get there, measured from when this node started
-/// campaigning for leadership until it reached effective leadership. This spans the
-/// `AnnounceLeader` log round-trip and, on feature-enabling transitions, the intervening
-/// `BecomingLeader` version-barrier round-trip. It excludes only the leader-epoch acquisition
-/// that precedes the campaign.
-pub(crate) struct EffectiveLeadershipReadiness {
-    pub(crate) leader_epoch: LeaderEpoch,
-    pub(crate) time_to_effective_leadership: Duration,
 }
 
 impl State {
@@ -229,11 +214,6 @@ pub(crate) struct LeadershipState<T> {
     partition_id: PartitionId,
     ingestion_client: IngestionClient<T, Envelope>,
     leader_query_tx: LeaderQuerySender,
-
-    /// Set when `become_leader` installs `State::Leader`, cleared by
-    /// `take_effective_leadership_readiness` once the enclosing batch has been successfully
-    /// committed locally and the readiness log can be safely emitted.
-    became_effective_leader: Option<EffectiveLeadershipReadiness>,
 }
 
 impl<T> LeadershipState<T>
@@ -250,26 +230,11 @@ where
             partition_id,
             ingestion_client,
             leader_query_tx,
-            became_effective_leader: None,
         }
     }
 
     pub(crate) fn is_leader(&self) -> bool {
         matches!(self.state, State::Leader(_) | State::BecomingLeader { .. })
-    }
-
-    pub(crate) fn is_effective_leader(&self) -> bool {
-        matches!(self.state, State::Leader(_))
-    }
-
-    /// Returns and consumes the readiness recorded when `become_leader` installed
-    /// `State::Leader`, but only if the processor is still an effective leader. The token is
-    /// consumed even after a same-batch step-down, so it can never be observed twice.
-    pub(crate) fn take_effective_leadership_readiness(
-        &mut self,
-    ) -> Option<EffectiveLeadershipReadiness> {
-        let readiness = self.became_effective_leader.take()?;
-        self.is_effective_leader().then_some(readiness)
     }
 
     pub(crate) fn partition_id(&self) -> PartitionId {
@@ -353,7 +318,6 @@ where
         self_proposer.self_propose_unaccounted(ctx.key_range().start(), announce_leader)?;
 
         self.state = State::Candidate {
-            at: Instant::now(),
             campaign_started_at,
             leader_epoch,
             self_proposer: Some(self_proposer),
@@ -384,12 +348,17 @@ where
 
         let planned_mode = match &self.state {
             State::Follower => RunMode::Follower,
-            State::Candidate { leader_epoch, .. } => {
+            State::Candidate {
+                campaign_started_at,
+                leader_epoch,
+                ..
+            } => {
                 match leader_epoch.cmp(&new_leader_epoch) {
                     Ordering::Less => {
-                        debug!(
-                            "Lost leadership campaign. Conceding to {} at epoch {}",
-                            new_leader_node, new_leader_epoch
+                        info!(
+                            campaign_duration = %campaign_started_at.elapsed().friendly(),
+                            partition_id = %self.partition_id,
+                            "Lost leadership campaign. Conceding to {new_leader_node} at epoch {new_leader_epoch}",
                         );
                         self.become_follower().await;
                         RunMode::Follower
@@ -400,14 +369,17 @@ where
                     }
                 }
             }
-            State::BecomingLeader { leader_epoch, .. } => {
+            State::BecomingLeader {
+                at, leader_epoch, ..
+            } => {
                 match leader_epoch.cmp(&new_leader_epoch) {
                     Ordering::Less => {
-                        debug!(
+                        info!(
                             my_leadership_epoch = %leader_epoch,
-                            %new_leader_epoch,
-                            "Every reign must end. Stepping down and becoming an conceding to {} at epoch {}",
-                            new_leader_node, new_leader_epoch
+                            partition_id = %self.partition_id,
+                            "Every reign must end. Spent {} as {}. Conceding to {new_leader_node} at epoch {new_leader_epoch}",
+                            at.elapsed().friendly(),
+                            self.detailed_effective_mode(),
                         );
                         self.become_follower().await;
                         RunMode::Follower
@@ -420,11 +392,12 @@ where
             }
             State::Leader(leader_state) => match leader_state.leader_epoch.cmp(&new_leader_epoch) {
                 Ordering::Less => {
-                    debug!(
+                    info!(
                         my_leadership_epoch = %leader_state.leader_epoch,
-                        %new_leader_epoch,
-                        "Every reign must end. Stepping down and becoming an conceding to {} at epoch {}",
-                        new_leader_node, new_leader_epoch
+                        partition_id = %self.partition_id,
+                        "Every reign must end. Spent {} as {}. Conceding to {new_leader_node} at epoch {new_leader_epoch}",
+                        leader_state.at.elapsed().friendly(),
+                        self.detailed_effective_mode(),
                     );
                     self.become_follower().await;
                     RunMode::Follower
@@ -521,17 +494,16 @@ where
         let prev_mode = self.detailed_effective_mode();
 
         if let State::Candidate {
-            at,
             campaign_started_at,
             leader_epoch,
-            self_proposer,
+            ref mut self_proposer,
         }
         | State::BecomingLeader {
-            at,
             campaign_started_at,
             leader_epoch,
-            self_proposer,
-        } = &mut self.state
+            ref mut self_proposer,
+            ..
+        } = self.state
         {
             let live_config = &mut node_ctx.config;
             let config = live_config.live_load();
@@ -599,24 +571,13 @@ where
                     .max(processor.fsm().min_restate_version())
                     .clone();
 
-                debug!(
-                    "Proposing VersionBarrier command to enable state-machine features {}",
-                    feature_changes
-                        .iter()
-                        .map(|c| {
-                            let name: &'static str = c.into();
-                            name
-                        })
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                );
                 self_proposer.self_propose_unaccounted(
                     processor.key_range().start(),
                     Command::VersionBarrier(VersionBarrierCommand {
                         version: barrier_version,
                         partition_key_range: Keys::RangeInclusive(processor.key_range().into()),
                         human_reason: Some("Apply state-machine feature changes".to_owned()),
-                        feature_changes: feature_changes.into_iter().map(|c| c.id()).collect(),
+                        feature_changes: feature_changes.iter().map(|c| c.id()).collect(),
                     }),
                 )?;
 
@@ -631,16 +592,26 @@ where
                 // we actually observe the VersionBarrier command back from the log. But we also
                 // don't expect any other commands other than AnnounceLeader (from preemptions) or
                 // VersionBarrier (our own self-proposal) to be next in the log.
-                debug!(
-                    "Transitioning from {prev_mode} -> {}. Spent {} in {prev_mode} mode.",
+                info!(
+                    partition_id = %processor.partition_id(),
+                    leader_epoch = %leader_epoch,
+                    campaign_duration = %campaign_started_at.elapsed().friendly(),
+                    "Processor transitioned into {}. Will propose a `VersionBarrier` to enable [{}]",
                     DetailedRunMode::BecomingLeader,
-                    at.elapsed().friendly(),
+                    feature_changes
+                        .iter()
+                        .map(|c| {
+                            let name: &'static str = c.into();
+                            name
+                        })
+                        .collect::<Vec<_>>()
+                        .join(", ")
                 );
 
                 self.state = State::BecomingLeader {
                     at: Instant::now(),
-                    campaign_started_at: *campaign_started_at,
-                    leader_epoch: *leader_epoch,
+                    campaign_started_at,
+                    leader_epoch,
                     self_proposer: Some(self_proposer),
                 };
 
@@ -691,7 +662,7 @@ where
                 .leader_handles_registry
                 .register_leader_query(processor.key_range(), self.leader_query_tx.clone());
 
-            let invoker_name = Arc::from(format!("invoker-{}", processor.partition_id()));
+            let invoker_name = format_restring!("invoker-{}", processor.partition_id());
             let invoker_config = Configuration::live().map(|c| &c.worker.invoker);
             let invoker_task_guard =
                 TaskCenter::spawn_unmanaged(TaskKind::SystemService, invoker_name, async move {
@@ -733,7 +704,7 @@ where
             let (shuffle_tx, shuffle_rx) = tokio::sync::watch::channel(None);
 
             let shuffle = Shuffle::new(
-                ShuffleMetadata::new(processor.partition_id(), *leader_epoch),
+                ShuffleMetadata::new(processor.partition_id(), leader_epoch),
                 OutboxReader::from(partition_store.clone()),
                 shuffle_tx,
                 config.worker.internal_queue_length(),
@@ -770,14 +741,34 @@ where
                 Duration::from_secs(5).add_jitter(0.5),
             );
 
-            debug!(
-                "Transitioning from {prev_mode} -> {}. Spent {} in {prev_mode} mode.",
-                DetailedRunMode::Leader,
-                at.elapsed().friendly(),
-            );
+            match self.state {
+                State::Candidate {
+                    campaign_started_at,
+                    ..
+                } => {
+                    info!(
+                        campaign_duration = %campaign_started_at.elapsed().friendly(),
+                        partition_id = %processor.partition_id(),
+                        "Processor became {} of epoch {leader_epoch}",
+                        DetailedRunMode::Leader,
+                    );
+                }
+                State::BecomingLeader {
+                    at,
+                    campaign_started_at,
+                    ..
+                } => {
+                    info!(
+                        campaign_duration = %campaign_started_at.elapsed().friendly(),
+                        partition_id = %processor.partition_id(),
+                        "Processor became {} of epoch {leader_epoch}. Spent {} as {prev_mode}",
+                        DetailedRunMode::Leader,
+                        at.elapsed().friendly(),
+                    );
+                }
+                _ => unreachable!(),
+            }
 
-            let leader_epoch = *leader_epoch;
-            let campaign_started_at = *campaign_started_at;
             self.state = State::Leader(Box::new(LeaderState::new(
                 processor.partition_id(),
                 leader_epoch,
@@ -799,11 +790,6 @@ where
                 leader_query_guard,
                 node_ctx.rule_book_cache.subscribe(),
             )));
-
-            self.became_effective_leader = Some(EffectiveLeadershipReadiness {
-                leader_epoch,
-                time_to_effective_leadership: campaign_started_at.elapsed(),
-            });
 
             Ok(())
         } else {
@@ -1144,7 +1130,6 @@ mod tests {
         // the journal-v2 default; the processor stays `BecomingLeader` until that barrier
         // is applied.
         assert!(matches!(state.state, State::BecomingLeader { .. }));
-        assert!(!state.is_effective_leader());
 
         let record = reader.next().await.unwrap()?;
         let envelope = record.try_decode::<Envelope>().unwrap()?;
@@ -1166,19 +1151,6 @@ mod tests {
             .await?;
 
         assert!(matches!(state.state, State::Leader(_)));
-        assert!(state.is_effective_leader());
-
-        // become_leader() only records the transition; the caller (the partition
-        // processor's run loop) is responsible for emitting the readiness log, and only
-        // after the enclosing batch has been successfully committed locally.
-        let readiness = state
-            .take_effective_leadership_readiness()
-            .expect("become_leader records the transition to effective leadership");
-        assert_eq!(readiness.leader_epoch, leader_epoch);
-        // Measured from candidacy, so it spans the AnnounceLeader and BecomingLeader
-        // round-trips this test walked through, not just the final become_leader body.
-        assert!(!readiness.time_to_effective_leadership.is_zero());
-        assert!(state.take_effective_leadership_readiness().is_none());
 
         state.step_down().await;
 

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -43,7 +43,7 @@ use futures::{FutureExt, StreamExt};
 use metrics::histogram;
 use tokio::sync::watch;
 use tokio::time::{Instant, MissedTickBehavior};
-use tracing::{debug, error, info, instrument, trace, warn};
+use tracing::{debug, error, instrument, trace, warn};
 
 use restate_bifrost::loglet::FindTailOptions;
 use restate_bifrost::{DataRecord, DataRecordError, LogEntry};
@@ -663,15 +663,6 @@ where
                     // compact while applying the WAL commands as this could remove vqueue meta entries
                     // which are required by the scheduler when applying the scheduler events.
                     self.ctx.vqueues_mut().try_compact();
-
-                    if let Some(readiness) = self.leadership_state.take_effective_leadership_readiness() {
-                        info!(
-                            partition_id = %self.ctx.partition_id(),
-                            leader_epoch = %readiness.leader_epoch,
-                            time_to_effective_leadership_seconds = readiness.time_to_effective_leadership.as_secs_f64(),
-                            "Partition processor reached effective leadership"
-                        );
-                    }
                 },
                 result = self.leadership_state.run(&mut self.ctx) => {
                     result?;

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -53,7 +53,7 @@ use restate_core::network::{
 use restate_core::{Metadata, ShutdownError, TaskCenter, TaskKind, cancellation_token};
 use restate_ingestion_client::IngestionClient;
 use restate_partition_store::{
-    MigrationError, PartitionDb, PartitionStore, PartitionStoreTransaction,
+    MigrationError, PartitionDb, PartitionSeal, PartitionStore, PartitionStoreTransaction,
 };
 use restate_platform::memory::EstimatedMemorySize;
 use restate_storage_api::deduplication_table::{
@@ -300,6 +300,20 @@ pub enum ProcessorError {
     Other(#[from] anyhow::Error),
 }
 
+impl From<PartitionSeal> for ProcessorError {
+    fn from(value: PartitionSeal) -> Self {
+        match value {
+            PartitionSeal::AheadOfLog {
+                partition_applied_lsn,
+                log_tail_lsn,
+            } => ProcessorError::PartitionAheadOfLog {
+                partition_applied_lsn,
+                log_tail_lsn,
+            },
+        }
+    }
+}
+
 /// OrderedOperations are scheduled operations that
 /// will only get executed once the partition read up to
 /// the bifrost tail that was found once the operation
@@ -425,15 +439,6 @@ where
         let partition_id = self.ctx.partition_id();
         let my_node = self.node_ctx.my_node_id().as_plain();
 
-        let mut durable_lsn_watch = self.partition_store.get_durable_lsn().await?;
-        let durable_lsn = durable_lsn_watch
-            .borrow_and_update()
-            .unwrap_or(Lsn::INVALID);
-
-        self.node_ctx
-            .replica_set_states
-            .note_durable_lsn(partition_id, my_node, durable_lsn);
-
         // If the underlying log is not provisioned, now is the time to provision it.
         // We'll retry a few times before giving back control to PPM
         //
@@ -476,13 +481,34 @@ where
         // If our `last_applied_lsn` is at or beyond the tail, this is a strong indicator
         // that the log has reverted backwards.
         if self.ctx.fsm().last_applied_lsn() >= current_tail.offset() {
+            let partition_applied_lsn = self.ctx.fsm().last_applied_lsn();
+            let log_tail_lsn = current_tail.offset();
+            self.partition_store
+                .seal(&PartitionSeal::AheadOfLog {
+                    partition_applied_lsn,
+                    log_tail_lsn,
+                })
+                .await?;
+
             return Err(ProcessorError::PartitionAheadOfLog {
-                partition_applied_lsn: self.ctx.fsm().last_applied_lsn(),
-                log_tail_lsn: current_tail.offset(),
+                partition_applied_lsn,
+                log_tail_lsn,
             });
         }
 
+        let mut durable_lsn_watch = self.partition_store.get_durable_lsn().await?;
+        let durable_lsn = durable_lsn_watch
+            .borrow_and_update()
+            .unwrap_or(Lsn::INVALID);
+
+        self.node_ctx
+            .replica_set_states
+            .note_durable_lsn(partition_id, my_node, durable_lsn);
+
         self.ctx.status_mut().set_started_at(Instant::now());
+        // Note that before this point, we will not allow taking snapshots of this partition store
+        // and it's important that we perform the seal check before we update the replay status to
+        // avoid taking snapshots of a sealed partition store.
         self.ctx.set_catchup_lsn(current_tail.offset());
         debug!(
             last_applied_lsn = %self.ctx.fsm().last_applied_lsn(),

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -10,6 +10,7 @@
 
 mod introspection;
 mod processor_state;
+mod reconciliation;
 mod spawn_processor_task;
 
 pub use introspection::{LeaderQueryGuard, PartitionLeaderHandlesRegistry};
@@ -96,6 +97,7 @@ use crate::partition::{LeadershipInfo, NodeContext, ProcessorError};
 use crate::partition_processor_manager::processor_state::{
     LeaderEpochToken, ProcessorState, StartedProcessor,
 };
+use crate::partition_processor_manager::reconciliation::{ReconciliationPlan, StopDisposition};
 use crate::partition_processor_manager::spawn_processor_task::SpawnPartitionProcessorTask;
 use crate::rule_book_cache::{RuleBookCache, RuleBookCacheHandle};
 
@@ -1365,41 +1367,33 @@ where
 
     fn on_replica_set_state_changes(&mut self, replica_set_states: &PartitionReplicaSetStates) {
         let my_node_id = Metadata::with_current(|m| m.my_node_id().as_plain());
-        let mut running_processors: HashSet<_> = self.processor_states.keys().copied().collect();
+        let plan =
+            ReconciliationPlan::build(&self.processor_states, replica_set_states, my_node_id);
 
-        // Not ideal to have to iterate over all replica states. An index per node id could help.
-        // In practice, this is probably not a problem because the replica sets won't change that
-        // often.
-        for (partition_id, membership_state) in replica_set_states.iter() {
-            if membership_state.contains(my_node_id) {
-                if !self.processor_states.contains_key(&partition_id) {
-                    self.start_partition_processor(partition_id, None);
-                }
-
-                running_processors.remove(&partition_id);
-            }
+        if !plan.is_empty() {
+            info!("Reconciling partition processors: {plan}");
         }
 
-        // All the remaining running processors are no longer part of the observed partition
-        // configuration. Let's terminate them.
-        for partition_id in running_processors.into_iter() {
-            let Some(processor) = self.processor_states.get_mut(&partition_id) else {
-                continue;
-            };
+        for partition_id in plan.starts.keys().copied() {
+            self.start_partition_processor(partition_id, None);
+        }
 
-            if processor.is_broken() {
-                // A broken processor has no runtime task that would report its termination,
-                // so drop it right away instead of waiting for a `Stopped` event.
-                debug!(%partition_id, "Forget broken partition processor because it is no longer a member of the partition configuration");
-                self.processor_states.remove(&partition_id);
-            } else {
-                debug!(%partition_id, "Stop partition processor because it is no longer a member of the partition configuration");
-                processor.stop();
+        for (&partition_id, planned_stop) in &plan.stops {
+            match planned_stop.disposition() {
+                StopDisposition::RequestStop => {
+                    let Some(processor) = self.processor_states.get_mut(&partition_id) else {
+                        continue;
+                    };
+                    processor.stop();
 
-                if self.pending_snapshots.contains_key(&partition_id) {
-                    info!(%partition_id,
-                        "Partition processor stop requested with snapshot task result outstanding"
-                    );
+                    if self.pending_snapshots.contains_key(&partition_id) {
+                        info!(%partition_id,
+                            "Partition processor stop requested with snapshot task result outstanding"
+                        );
+                    }
+                }
+                StopDisposition::ForgetBroken => {
+                    self.processor_states.remove(&partition_id);
                 }
             }
             self.latest_snapshots.remove(&partition_id);

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -57,7 +57,7 @@ use restate_partition_store::snapshots::{
 use restate_partition_store::{SnapshotError, SnapshotErrorKind};
 use restate_types::GenerationalNodeId;
 use restate_types::cluster::cluster_state::ReplayStatus;
-use restate_types::cluster::cluster_state::{PartitionProcessorStatus, RunMode};
+use restate_types::cluster::cluster_state::{BrokenReason, PartitionProcessorStatus, RunMode};
 use restate_types::config::Configuration;
 use restate_types::epoch::EpochMetadata;
 use restate_types::health::HealthStatus;
@@ -144,6 +144,14 @@ type SnapshotResultInternal = Result<(PartitionId, PartitionSnapshotStatus), Sna
 struct PendingSnapshotTask {
     snapshot_id: SnapshotId,
     sender: Option<oneshot::Sender<SnapshotResult>>,
+}
+
+/// What to do with a partition once its processor's runtime task has terminated.
+enum PostStopAction {
+    Restart(RestartDelay),
+    /// Give up on the partition: retrying cannot fix the failure, so we park the processor
+    /// in [`ProcessorState::Broken`] until an operator intervenes.
+    Park(BrokenReason),
 }
 
 enum RestartDelay {
@@ -391,6 +399,10 @@ where
             task.cancel();
         }
 
+        // broken processors have no runtime task left to await, so drop them upfront to keep
+        // `await_processors_termination` from waiting on an event that can never arrive
+        self.processor_states.retain(|_, state| !state.is_broken());
+
         // stop all running processors
         for processor_state in self.processor_states.values_mut() {
             processor_state.stop();
@@ -557,6 +569,16 @@ where
                                     runtime_handle.cancel();
                                     self.await_runtime_task_result(partition_id, runtime_handle);
                                 }
+                                ProcessorState::Broken { .. } => {
+                                    // Unreachable in practice: we only park a processor as
+                                    // broken after its runtime task reported termination.
+                                    // Stop the new one and stay broken.
+                                    debug!(
+                                        "Started partition processor for a partition we gave up on. Stopping it."
+                                    );
+                                    runtime_handle.cancel();
+                                    self.await_runtime_task_result(partition_id, runtime_handle);
+                                }
                             }
                         } else {
                             debug!("Started partition processor is no longer needed. Stopping it.");
@@ -579,18 +601,18 @@ where
             }
             EventKind::Stopped(result) => {
                 self.unregister_pp_rpc_shard(partition_id);
-                let delay = match self.processor_states.remove(&partition_id) {
+                let action = match self.processor_states.remove(&partition_id) {
                     None => {
                         debug!("Stopped partition processor which is no longer running.");
                         // immediately try to restart if we are still part of the partition's membership
                         counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => NORMAL_STOP).increment(1);
-                        RestartDelay::Immediate
+                        PostStopAction::Restart(RestartDelay::Immediate)
                     }
                     Some(processor_state) => match processor_state {
                         ProcessorState::Starting { .. } => {
                             counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => STARTUP_ERROR_STOP).increment(1);
                             warn!(%partition_id, "Partition processor failed to start: {result:?}");
-                            RestartDelay::Fixed
+                            PostStopAction::Restart(RestartDelay::Fixed)
                         }
                         ProcessorState::Started {
                             processor,
@@ -610,19 +632,24 @@ where
                                     counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => ERROR_STOP).increment(1);
                                     gauge!(PARTITION_BLOCKED_FLARE, PARTITION_LABEL => partition_id.to_string(), REASON_LABEL => FLARE_REASON_VERSION_BARRIER).set(1);
                                     error!(%partition_id, "Partition processor start error: {e}");
-                                    RestartDelay::MaxBackoff
+                                    PostStopAction::Restart(RestartDelay::MaxBackoff)
                                 }
                                 Err(e @ ProcessorError::MigrationBarrier { .. }) => {
                                     counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => ERROR_STOP).increment(1);
                                     gauge!(PARTITION_BLOCKED_FLARE, PARTITION_LABEL => partition_id.to_string(), REASON_LABEL => FLARE_REASON_MIGRATION_BARRIER).set(1);
                                     error!(%partition_id, "Partition processor start error: {e}");
-                                    RestartDelay::MaxBackoff
+                                    PostStopAction::Restart(RestartDelay::MaxBackoff)
                                 }
                                 Err(e @ ProcessorError::PartitionAheadOfLog { .. }) => {
                                     counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => ERROR_STOP).increment(1);
                                     gauge!(PARTITION_BLOCKED_FLARE, PARTITION_LABEL => partition_id.to_string(), REASON_LABEL => FLARE_REASON_AHEAD_OF_LOG).set(1);
-                                    error!(%partition_id, "Partition processor start error: {e}");
-                                    RestartDelay::MaxBackoff
+                                    error!(
+                                        %partition_id,
+                                        "Partition processor start error: {e}. The local partition store \
+                                        is sealed; this node will not run this partition again until the \
+                                        store has been dropped and replaced by a safe snapshot",
+                                    );
+                                    PostStopAction::Park(BrokenReason::AheadOfLog)
                                 }
                                 Err(ProcessorError::TrimGapEncountered {
                                     read_pointer: sequence_number,
@@ -641,7 +668,7 @@ where
                                         );
                                         self.fast_forward_on_startup.insert(partition_id, *to_lsn);
 
-                                        RestartDelay::Immediate
+                                        PostStopAction::Restart(RestartDelay::Immediate)
                                     } else {
                                         error!(
                                             %partition_id,
@@ -650,7 +677,7 @@ where
                                         );
                                         gauge!(PARTITION_BLOCKED_FLARE, PARTITION_LABEL => partition_id.to_string(), REASON_LABEL => FLARE_REASON_SNAPSHOT_UNAVAILABLE).set(1);
                                         // configuration problem; until we have peer-to-peer state exchange we can only wait
-                                        RestartDelay::MaxBackoff
+                                        PostStopAction::Restart(RestartDelay::MaxBackoff)
                                     }
                                 }
                                 Err(err) => {
@@ -660,12 +687,12 @@ where
                                     };
                                     counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => ERROR_STOP).increment(1);
                                     error!(%partition_id, %err, "Partition processor exited unexpectedly, {}", next_delay);
-                                    next_delay
+                                    PostStopAction::Restart(next_delay)
                                 }
                                 Ok(_) => {
                                     counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => NORMAL_STOP).increment(1);
                                     info!(%partition_id, "Partition processor stopped");
-                                    RestartDelay::Immediate
+                                    PostStopAction::Restart(RestartDelay::Immediate)
                                 }
                             }
                         }
@@ -675,13 +702,28 @@ where
                                     .unregister_all(processor.key_range());
                             }
                             counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => NORMAL_STOP).increment(1);
-                            RestartDelay::Immediate
+                            PostStopAction::Restart(RestartDelay::Immediate)
                         }
+                        // Unreachable in practice: a broken processor has no runtime task that
+                        // could report back. Stay broken rather than silently restarting.
+                        ProcessorState::Broken { reason, .. } => PostStopAction::Park(reason),
                     },
                 };
 
-                if !self.restart_partition_processor_if_replica(partition_id, delay) {
-                    debug!("Partition processor stopped: {result:?}");
+                match action {
+                    PostStopAction::Restart(delay) => {
+                        if !self.restart_partition_processor_if_replica(partition_id, delay) {
+                            debug!("Partition processor stopped: {result:?}");
+                        }
+                    }
+                    PostStopAction::Park(reason) => {
+                        if self.should_run_processor(partition_id) {
+                            self.processor_states
+                                .insert(partition_id, ProcessorState::broken(reason));
+                        } else {
+                            debug!("Partition processor stopped: {result:?}");
+                        }
+                    }
                 }
             }
             EventKind::NewLeaderEpoch {
@@ -1341,7 +1383,16 @@ where
         // All the remaining running processors are no longer part of the observed partition
         // configuration. Let's terminate them.
         for partition_id in running_processors.into_iter() {
-            if let Some(processor) = self.processor_states.get_mut(&partition_id) {
+            let Some(processor) = self.processor_states.get_mut(&partition_id) else {
+                continue;
+            };
+
+            if processor.is_broken() {
+                // A broken processor has no runtime task that would report its termination,
+                // so drop it right away instead of waiting for a `Stopped` event.
+                debug!(%partition_id, "Forget broken partition processor because it is no longer a member of the partition configuration");
+                self.processor_states.remove(&partition_id);
+            } else {
                 debug!(%partition_id, "Stop partition processor because it is no longer a member of the partition configuration");
                 processor.stop();
 
@@ -1350,9 +1401,19 @@ where
                         "Partition processor stop requested with snapshot task result outstanding"
                     );
                 }
-                self.latest_snapshots.remove(&partition_id);
             }
+            self.latest_snapshots.remove(&partition_id);
         }
+    }
+
+    /// Whether this node should be running a processor for the given partition, i.e. we are
+    /// part of its replica set and the manager itself is not shutting down.
+    fn should_run_processor(&self, partition_id: PartitionId) -> bool {
+        !restate_core::is_cancellation_requested()
+            && self
+                .replica_set_states
+                .membership_state(partition_id)
+                .contains(Metadata::with_current(|m| m.my_node_id().as_plain()))
     }
 
     /// Starts a partition processor if this node is part of the replica set of the given partition.
@@ -1362,24 +1423,12 @@ where
         partition_id: PartitionId,
         delay: RestartDelay,
     ) -> bool {
-        // only restart partition processors if the partition processor manager is still supposed to run
-        if restate_core::is_cancellation_requested() {
+        if !self.should_run_processor(partition_id) {
             return false;
         }
 
-        if self
-            .replica_set_states
-            .membership_state(partition_id)
-            .contains(Metadata::with_current(|m| m.my_node_id().as_plain()))
-        {
-            self.start_partition_processor(
-                partition_id,
-                delay.next_delay().map(|d| d.add_jitter(0.3)),
-            );
-            true
-        } else {
-            false
-        }
+        self.start_partition_processor(partition_id, delay.next_delay().map(|d| d.add_jitter(0.3)));
+        true
     }
 
     #[instrument(level = "info", skip_all, fields(partition_id = %partition_id))]

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -85,12 +85,12 @@ use restate_worker_api::invoker::capacity::InvokerCapacity;
 use restate_worker_api::{ProcessorsManagerCommand, ProcessorsManagerHandle};
 
 use crate::metric_definitions::{
-    ERROR_STOP, FLARE_REASON_MIGRATION_BARRIER, FLARE_REASON_SNAPSHOT_UNAVAILABLE,
-    FLARE_REASON_VERSION_BARRIER, GAP_STOP, NORMAL_STOP, NUM_ACTIVE_PARTITION_LEADERS,
-    NUM_ACTIVE_PARTITIONS, NUM_PARTITIONS, PARTITION_APPLIED_LSN_LAG, PARTITION_BLOCKED_FLARE,
-    PARTITION_LABEL, PARTITION_NUM_UNKNOWN_APPLIED_LSN_LAG, PARTITION_START, PARTITION_STOP,
-    PARTITION_TIME_SINCE_LAST_STATUS_UPDATE, REASON_LABEL, SNAPSHOT_AGE, STARTUP_ERROR_STOP,
-    TYPE_LABEL,
+    ERROR_STOP, FLARE_REASON_AHEAD_OF_LOG, FLARE_REASON_MIGRATION_BARRIER,
+    FLARE_REASON_SNAPSHOT_UNAVAILABLE, FLARE_REASON_VERSION_BARRIER, GAP_STOP, NORMAL_STOP,
+    NUM_ACTIVE_PARTITION_LEADERS, NUM_ACTIVE_PARTITIONS, NUM_PARTITIONS, PARTITION_APPLIED_LSN_LAG,
+    PARTITION_BLOCKED_FLARE, PARTITION_LABEL, PARTITION_NUM_UNKNOWN_APPLIED_LSN_LAG,
+    PARTITION_START, PARTITION_STOP, PARTITION_TIME_SINCE_LAST_STATUS_UPDATE, REASON_LABEL,
+    SNAPSHOT_AGE, STARTUP_ERROR_STOP, TYPE_LABEL,
 };
 use crate::partition::{LeadershipInfo, NodeContext, ProcessorError};
 use crate::partition_processor_manager::processor_state::{
@@ -615,6 +615,12 @@ where
                                 Err(e @ ProcessorError::MigrationBarrier { .. }) => {
                                     counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => ERROR_STOP).increment(1);
                                     gauge!(PARTITION_BLOCKED_FLARE, PARTITION_LABEL => partition_id.to_string(), REASON_LABEL => FLARE_REASON_MIGRATION_BARRIER).set(1);
+                                    error!(%partition_id, "Partition processor start error: {e}");
+                                    RestartDelay::MaxBackoff
+                                }
+                                Err(e @ ProcessorError::PartitionAheadOfLog { .. }) => {
+                                    counter!(PARTITION_STOP, PARTITION_LABEL => partition_id.to_string(), TYPE_LABEL => ERROR_STOP).increment(1);
+                                    gauge!(PARTITION_BLOCKED_FLARE, PARTITION_LABEL => partition_id.to_string(), REASON_LABEL => FLARE_REASON_AHEAD_OF_LOG).set(1);
                                     error!(%partition_id, "Partition processor start error: {e}");
                                     RestartDelay::MaxBackoff
                                 }

--- a/crates/worker/src/partition_processor_manager/processor_state.rs
+++ b/crates/worker/src/partition_processor_manager/processor_state.rs
@@ -16,10 +16,13 @@ use tracing::debug;
 use ulid::Ulid;
 
 use restate_core::network::ShardSender;
-use restate_types::cluster::cluster_state::{PartitionProcessorStatus, ReplayStatus, RunMode};
+use restate_types::cluster::cluster_state::{
+    BrokenReason, PartitionProcessorStatus, ReplayStatus, RunMode,
+};
 use restate_types::identifiers::LeaderEpoch;
 use restate_types::net::partition_processor::PartitionLeaderService;
 use restate_types::sharding::KeyRange;
+use restate_types::time::MillisSinceEpoch;
 
 use crate::partition::{LeadershipInfo, TargetLeaderState};
 
@@ -48,6 +51,13 @@ pub enum ProcessorState {
     Stopping {
         processor: Option<StartedProcessor>,
     },
+    /// The processor hit a failure that retrying cannot resolve, so this node gave up on
+    /// running it. There is no runtime task backing this state; it is only cleared by an
+    /// operator action (see `restatectl`) or by losing membership of the partition.
+    Broken {
+        reason: BrokenReason,
+        since: MillisSinceEpoch,
+    },
 }
 
 impl ProcessorState {
@@ -57,6 +67,17 @@ impl ProcessorState {
             start_time: Instant::now(),
             delay,
         }
+    }
+
+    pub fn broken(reason: BrokenReason) -> Self {
+        Self::Broken {
+            reason,
+            since: MillisSinceEpoch::now(),
+        }
+    }
+
+    pub fn is_broken(&self) -> bool {
+        matches!(self, ProcessorState::Broken { .. })
     }
 
     pub fn stopping(processor: StartedProcessor) -> Self {
@@ -94,6 +115,11 @@ impl ProcessorState {
             ProcessorState::Stopping { .. } => {
                 // already stopping
             }
+            ProcessorState::Broken { .. } => {
+                // Nothing to stop; there is no runtime task that would report back a
+                // `Stopped` event. Callers that want to get rid of a broken processor must
+                // drop the state instead of waiting for it to terminate.
+            }
         };
     }
 
@@ -124,6 +150,9 @@ impl ProcessorState {
             }
             ProcessorState::Stopping { .. } => {
                 // we first need to stop before we check whether we should run again
+            }
+            ProcessorState::Broken { .. } => {
+                // a broken processor cannot run in any mode
             }
         }
     }
@@ -177,6 +206,10 @@ impl ProcessorState {
             }
             ProcessorState::Stopping { .. } => {
                 // we first need to stop before we check whether we should run again
+                None
+            }
+            ProcessorState::Broken { .. } => {
+                debug!("Ignoring leadership request for a broken partition processor.");
                 None
             }
         }
@@ -234,6 +267,9 @@ impl ProcessorState {
             ProcessorState::Stopping { .. } => {
                 debug!("Received leader epoch while stopping partition processor. Ignoring.");
             }
+            ProcessorState::Broken { .. } => {
+                debug!("Received leader epoch for a broken partition processor. Ignoring.");
+            }
         }
     }
 
@@ -243,7 +279,7 @@ impl ProcessorState {
             ProcessorState::Started { leader_state, .. } => {
                 matches!(leader_state, LeaderState::AwaitingLeaderEpoch(token) if *token == leader_epoch_token)
             }
-            ProcessorState::Stopping { .. } => false,
+            ProcessorState::Stopping { .. } | ProcessorState::Broken { .. } => false,
         }
     }
 
@@ -301,6 +337,13 @@ impl ProcessorState {
                 // todo report stopping status back to the cluster controller
                 None
             }
+            ProcessorState::Broken { reason, since } => Some(PartitionProcessorStatus {
+                broken_reason: *reason,
+                // report when we gave up rather than "now", so that operators can see how
+                // long the partition has been sitting broken.
+                updated_at: *since,
+                ..Default::default()
+            }),
         }
     }
 

--- a/crates/worker/src/partition_processor_manager/reconciliation.rs
+++ b/crates/worker/src/partition_processor_manager/reconciliation.rs
@@ -1,0 +1,231 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use restate_types::identifiers::PartitionId;
+use restate_types::partitions::state::{MembershipState, PartitionReplicaSetStates};
+use restate_types::replication::NodeSet;
+use restate_types::{PlainNodeId, Version};
+
+use super::processor_state::ProcessorState;
+
+/// Processor starts and stops needed to match observed replica-set membership.
+#[derive(Default)]
+pub(super) struct ReconciliationPlan {
+    pub(super) starts: BTreeMap<PartitionId, MembershipSnapshot>,
+    pub(super) stops: BTreeMap<PartitionId, PlannedStop>,
+}
+
+impl fmt::Display for ReconciliationPlan {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("starts=[")?;
+        let mut separator = "";
+        for (partition_id, start) in &self.starts {
+            write!(f, "{separator}P{partition_id}({start})")?;
+            separator = ", ";
+        }
+
+        f.write_str("] stops=[")?;
+        separator = "";
+        for (partition_id, stop) in &self.stops {
+            write!(f, "{separator}P{partition_id}({stop})")?;
+            separator = ", ";
+        }
+        f.write_str("]")
+    }
+}
+
+impl ReconciliationPlan {
+    pub(super) fn build(
+        processor_states: &BTreeMap<PartitionId, ProcessorState>,
+        replica_set_states: &PartitionReplicaSetStates,
+        my_node_id: PlainNodeId,
+    ) -> Self {
+        let mut plan = Self {
+            starts: BTreeMap::new(),
+            stops: processor_states
+                .iter()
+                .map(|(&partition_id, processor_state)| {
+                    let disposition = if processor_state.is_broken() {
+                        StopDisposition::ForgetBroken
+                    } else {
+                        StopDisposition::RequestStop
+                    };
+                    (
+                        partition_id,
+                        PlannedStop {
+                            reason: StopReason::NoObservedReplicaSet,
+                            disposition,
+                        },
+                    )
+                })
+                .collect(),
+        };
+
+        for (partition_id, membership) in replica_set_states.iter() {
+            if membership.contains(my_node_id) {
+                plan.stops.remove(&partition_id);
+                if !processor_states.contains_key(&partition_id) {
+                    plan.starts.insert(partition_id, (&membership).into());
+                }
+            } else if let Some(planned_stop) = plan.stops.get_mut(&partition_id) {
+                planned_stop.reason = StopReason::NotInObservedReplicaSet((&membership).into());
+            }
+        }
+
+        plan
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.starts.is_empty() && self.stops.is_empty()
+    }
+}
+
+pub(super) struct MembershipSnapshot {
+    current_version: Version,
+    next_version: Option<Version>,
+    replica_set: NodeSet,
+}
+
+impl fmt::Display for MembershipSnapshot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.current_version)?;
+        if let Some(next_version) = self.next_version {
+            write!(f, "->{next_version}")?;
+        }
+        write!(f, " {:#}", self.replica_set)
+    }
+}
+
+impl From<&MembershipState> for MembershipSnapshot {
+    fn from(membership: &MembershipState) -> Self {
+        Self {
+            current_version: membership.observed_current_membership.version,
+            next_version: membership
+                .observed_next_membership
+                .as_ref()
+                .map(|membership| membership.version),
+            replica_set: membership.replica_set_union().collect(),
+        }
+    }
+}
+
+enum StopReason {
+    NotInObservedReplicaSet(MembershipSnapshot),
+    NoObservedReplicaSet,
+}
+
+impl fmt::Display for StopReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotInObservedReplicaSet(membership) => membership.fmt(f),
+            Self::NoObservedReplicaSet => f.write_str("unobserved"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum StopDisposition {
+    RequestStop,
+    ForgetBroken,
+}
+
+pub(super) struct PlannedStop {
+    reason: StopReason,
+    disposition: StopDisposition,
+}
+
+impl fmt::Display for PlannedStop {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.reason.fmt(f)?;
+        if self.disposition == StopDisposition::ForgetBroken {
+            f.write_str("; forget-broken")?;
+        }
+        Ok(())
+    }
+}
+
+impl PlannedStop {
+    pub(super) fn disposition(&self) -> StopDisposition {
+        self.disposition
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use restate_types::cluster::cluster_state::{BrokenReason, RunMode};
+    use restate_types::logs::{Lsn, SequenceNumber};
+    use restate_types::partitions::state::{LeadershipState, MemberState, ReplicaSetState};
+
+    use super::*;
+
+    fn replica_set(version: Version, members: &[PlainNodeId]) -> ReplicaSetState {
+        ReplicaSetState {
+            version,
+            members: members
+                .iter()
+                .map(|&node_id| MemberState {
+                    node_id,
+                    durable_lsn: Lsn::INVALID,
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn plans_membership_reconciliation_with_reasons() {
+        let my_node_id = PlainNodeId::from(1);
+        let other_node_id = PlainNodeId::from(2);
+        let retained = PartitionId::from(0);
+        let stopped = PartitionId::from(1);
+        let forgotten = PartitionId::from(2);
+        let not_observed = PartitionId::from(3);
+        let started = PartitionId::from(4);
+        let irrelevant = PartitionId::from(5);
+
+        let processor_states = BTreeMap::from([
+            (retained, ProcessorState::starting(RunMode::Follower, None)),
+            (stopped, ProcessorState::starting(RunMode::Follower, None)),
+            (forgotten, ProcessorState::broken(BrokenReason::AheadOfLog)),
+            (
+                not_observed,
+                ProcessorState::starting(RunMode::Follower, None),
+            ),
+        ]);
+        let replica_set_states = PartitionReplicaSetStates::default();
+
+        for (partition_id, members) in [
+            (retained, &[my_node_id][..]),
+            (stopped, &[other_node_id][..]),
+            (forgotten, &[other_node_id][..]),
+            (started, &[other_node_id][..]),
+            (irrelevant, &[other_node_id][..]),
+        ] {
+            let current = replica_set(Version::MIN, members);
+            let next =
+                (partition_id == started).then(|| replica_set(Version::MIN.next(), &[my_node_id]));
+            replica_set_states.note_observed_membership(
+                partition_id,
+                LeadershipState::default(),
+                &current,
+                &next,
+            );
+        }
+
+        let plan = ReconciliationPlan::build(&processor_states, &replica_set_states, my_node_id);
+
+        assert_eq!(
+            plan.to_string(),
+            "starts=[P4(v1->v2 [N1, N2])] stops=[P1(v1 [N2]), P2(v1 [N2]; forget-broken), P3(unobserved)]"
+        );
+    }
+}

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -128,6 +128,17 @@ where
 
                     let mut partition_store = partition_store?;
 
+                    // verify that this partition store is not sealed
+                    if let Some(seal) = partition_store.get_seal_marker().await? {
+                        warn!("Local partition store for partition {} is sealed due to {}. The \
+                        partition store is not safe to use by this node and will need to be replaced \
+                        by a safe snapshot before continuing!",
+                        partition.partition_id,
+                        seal,
+                        );
+                        return Err(ProcessorError::from(seal));
+                    }
+
                     // One-time background cleanup of orphaned jc index entries left behind
                     // by a bug in delete_journal that used the wrong scan prefix.
                     // Runs on a blocking thread so it doesn't starve the tokio runtime.

--- a/monitoring/grafana/restate-internals.json
+++ b/monitoring/grafana/restate-internals.json
@@ -736,7 +736,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum by (rpc_service) (rate(restate_ingress_requests_total{cluster_name=\"$cluster\", node_name=~\"$node\", status=\"completed\"}[$__rate_interval]))",
+          "expr": "sum by (rpc_service) (rate(restate_ingress_requests_total{cluster_name=\"$cluster\", node_name=~\"$node\", status=~\"completed|request_error|invocation_error|ingress_error\"}[$__rate_interval]))",
           "legendFormat": "{{rpc_service}}",
           "refId": "A"
         },
@@ -745,7 +745,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(restate_ingress_requests_total{cluster_name=\"$cluster\", node_name=~\"$node\", status=\"completed\"}[$__rate_interval]))",
+          "expr": "sum(rate(restate_ingress_requests_total{cluster_name=\"$cluster\", node_name=~\"$node\", status=~\"completed|request_error|invocation_error|ingress_error\"}[$__rate_interval]))",
           "legendFormat": "Total",
           "refId": "B"
         }

--- a/monitoring/grafana/restate-overview.json
+++ b/monitoring/grafana/restate-overview.json
@@ -1527,7 +1527,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (rpc_service) (rate(restate_ingress_requests_total{cluster_name=\"$cluster\", node_name=~\"$node\", status=\"completed\"}[$__rate_interval]))",
+          "expr": "sum by (rpc_service) (rate(restate_ingress_requests_total{cluster_name=\"$cluster\", node_name=~\"$node\", status=~\"completed|request_error|invocation_error|ingress_error\"}[$__rate_interval]))",
           "legendFormat": "{{rpc_service}}",
           "refId": "A"
         },
@@ -1536,7 +1536,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(restate_ingress_requests_total{cluster_name=\"$cluster\", node_name=~\"$node\", status=\"completed\"}[$__rate_interval]))",
+          "expr": "sum(rate(restate_ingress_requests_total{cluster_name=\"$cluster\", node_name=~\"$node\", status=~\"completed|request_error|invocation_error|ingress_error\"}[$__rate_interval]))",
           "legendFormat": "Total",
           "refId": "B"
         },

--- a/release-notes/unreleased/invocation-client-retry-and-metrics.md
+++ b/release-notes/unreleased/invocation-client-retry-and-metrics.md
@@ -1,0 +1,35 @@
+# Release Notes: Reduce invocation-client retry pressure and improve ingress observability
+
+## Improvement
+
+### What Changed
+
+HTTP ingress requests now retry retryable invocation-client failures with exponential backoff,
+starting at 50 milliseconds and capped at one second between attempts. Previously, retries used a
+fixed 50-millisecond delay.
+
+A new `restate.invocation_client.requests.total` counter records partition-processor RPC attempts
+by `partition_id` and `status`. Status values distinguish completed requests from routing,
+availability, overload, protocol, internal, and shutdown errors.
+
+The `status` label on `restate.ingress.requests.total` now distinguishes `completed`,
+`request_error`, `invocation_error`, and `ingress_error` outcomes. Ingress request duration is also
+recorded for unsuccessful requests.
+
+### Why This Matters
+
+Exponential backoff reduces repeated traffic to stale partition leaders during leadership changes.
+The new metric and status labels make it easier to identify retry pressure and distinguish invalid
+requests, invocation failures, and failures within Restate's ingress processing.
+
+### Impact on Users
+
+- Existing and new deployments adopt the new retry behavior automatically.
+- Custom dashboards and alerts can use the new statuses to separate application-level invocation
+  failures from ingress failures.
+
+### Migration Guidance
+
+rometheus queries that use `status="completed"` to calculate the total
+processed ingress request rate should include `request_error`, `invocation_error`, and
+`ingress_error` as appropriate.

--- a/release-notes/unreleased/park-broken-partition-processors.md
+++ b/release-notes/unreleased/park-broken-partition-processors.md
@@ -1,0 +1,36 @@
+# Release Notes: Partition processors are parked instead of retried when the local store is sealed
+
+## Behavioral Change
+
+### What Changed
+
+When a partition processor fails because its local partition store is sealed (the store's applied
+LSN is ahead of the log tail, which indicates data loss in the log), the node no longer retries the
+processor on a backoff. It parks the processor and reports it as **broken**:
+
+- `restatectl partition list` shows `Broken (ahead-of-log)` in the `STATUS` column.
+- `restatectl status` counts broken processors separately, e.g. `2 (1 broken)` under `FOLLOWERS`.
+- The `partition_state` SQL table has a new `broken_reason` column (`NULL` while healthy). Its
+  `replay_status` is `NULL` for a broken processor, since there is no replay in progress.
+- The `restate.partition.blocked_flare{reason="ahead_of_log"}` gauge is still raised.
+
+Other blocked states (version barrier, migration barrier, missing snapshot) are unchanged and keep
+retrying, because a cluster upgrade or a newly published snapshot can resolve them on its own.
+
+### Why This Matters
+
+A sealed store cannot be repaired by retrying: the local data must be discarded and replaced from a
+snapshot. Retrying every 30 seconds only produced log noise and made it impossible to tell a
+transiently failing processor from one that will never recover.
+
+### Impact on Users
+
+- A parked processor stays down until an operator intervenes, the node restarts, or the node leaves
+  the partition's replica set. Previously it would keep retrying (and keep failing).
+- Nothing to do for healthy deployments; the new state is only reachable via a sealed partition
+  store.
+
+### Migration Guidance
+
+None. Older `restatectl` builds ignore the new field and render a broken processor as a follower
+that never becomes active.

--- a/tools/restate-doctor/src/util/decode_value.rs
+++ b/tools/restate-doctor/src/util/decode_value.rs
@@ -16,6 +16,7 @@
 use bilrost::OwnedMessage;
 
 use restate_limiter::RuleBook;
+use restate_partition_store::PartitionSeal;
 use restate_partition_store::fsm_table::PartitionStateMachineKey;
 use restate_partition_store::keys::{DecodeTableKey, KeyKind};
 use restate_partition_store::vqueue_table::{EntryStatusKey, InputPayloadKey};
@@ -56,6 +57,8 @@ mod fsm_variable {
     pub const RULE_BOOK: u64 = 9;
     /// *Since v1.7.0*
     pub const STATE_MACHINE_FEATURES: u64 = 10;
+    /// *Since v1.7.3*
+    pub const SEAL_MARKER: u64 = 11;
 }
 
 /// Result of decoding a value, including codec metadata
@@ -390,6 +393,11 @@ fn decode_fsm_value(key: &[u8], value: &[u8]) -> DecodedValue {
         }
     };
 
+    // The seal marker is plain json, it is not wrapped in a StorageCodec envelope.
+    if state_id == fsm_variable::SEAL_MARKER {
+        return decode_fsm_seal_marker(value);
+    }
+
     // Read codec byte
     let codec_byte = value[0];
     let codec = StorageCodecKind::try_from(codec_byte).ok();
@@ -451,6 +459,28 @@ fn decode_fsm_value(key: &[u8], value: &[u8]) -> DecodedValue {
             payload_size,
             format!("<unknown state_id={unknown}, {} bytes>", payload_size),
         ),
+    }
+}
+
+/// Decode the partition seal marker.
+///
+/// Unlike every other FSM variable, the seal marker is stored as plain json bytes without a
+/// [`StorageCodec`] envelope, so there is no codec byte to strip. Values written by a newer
+/// version may carry a [`PartitionSeal`] variant we don't know about; in that case we fall back to
+/// echoing the raw json instead of reporting a decode error.
+fn decode_fsm_seal_marker(value: &[u8]) -> DecodedValue {
+    let payload_size = value.len();
+
+    match serde_json::from_slice::<PartitionSeal>(value) {
+        Ok(seal) => DecodedValue::decoded(None, payload_size, format!("PartitionSeal({seal:?})")),
+        Err(err) => match serde_json::from_slice::<serde_json::Value>(value) {
+            Ok(raw) => DecodedValue::decoded(
+                None,
+                payload_size,
+                format!("PartitionSeal(<unrecognized> {raw})"),
+            ),
+            Err(_) => DecodedValue::error(None, payload_size, format!("{err}")),
+        },
     }
 }
 
@@ -564,6 +594,7 @@ mod tests {
     use restate_partition_store::PaddedPartitionId;
     use restate_partition_store::fsm_table::PartitionStateMachineKey;
     use restate_partition_store::keys::EncodeTableKeyPrefix;
+    use restate_types::logs::Lsn;
     use restate_types::storage::StorageCodec;
 
     use super::*;
@@ -615,6 +646,30 @@ mod tests {
         assert!(
             matches!(&decoded.content, DecodedContent::Decoded(s) if s.contains("JcOrphanCleanupDone(1)")),
             "jc-orphan-cleanup flag should decode, got: {decoded}"
+        );
+
+        // Seal marker: plain json, no StorageCodec envelope
+        let value = serde_json::to_vec(&PartitionSeal::AheadOfLog {
+            partition_applied_lsn: Lsn::new(10),
+            log_tail_lsn: Lsn::new(5),
+        })
+        .unwrap();
+        let decoded = decode_value(KeyKind::Fsm, &fsm_key(fsm_variable::SEAL_MARKER), &value);
+        assert_eq!(decoded.codec, None);
+        assert!(
+            matches!(&decoded.content, DecodedContent::Decoded(s) if s.contains("AheadOfLog")),
+            "seal marker should decode, got: {decoded}"
+        );
+
+        // A variant written by a newer version falls back to the raw json
+        let decoded = decode_value(
+            KeyKind::Fsm,
+            &fsm_key(fsm_variable::SEAL_MARKER),
+            br#"{"type":"SomethingNew"}"#,
+        );
+        assert!(
+            matches!(&decoded.content, DecodedContent::Decoded(s) if s.contains("<unrecognized>")),
+            "unknown seal variant should fall back to raw json, got: {decoded}"
         );
     }
 }

--- a/tools/restatectl/src/commands/partition/list.rs
+++ b/tools/restatectl/src/commands/partition/list.rs
@@ -21,7 +21,8 @@ use restate_core::protobuf::cluster_ctrl_svc::{ClusterStateRequest, new_cluster_
 use restate_types::logs::Lsn;
 use restate_types::nodes_config::Role;
 use restate_types::protobuf::cluster::{
-    DeadNode, DetailedRunMode, PartitionProcessorStatus, ReplayStatus, RunMode, node_state,
+    BrokenReason, DeadNode, DetailedRunMode, PartitionProcessorStatus, ReplayStatus, RunMode,
+    node_state,
 };
 use restate_types::{GenerationalNodeId, PlainNodeId, Version};
 
@@ -184,6 +185,7 @@ pub async fn list_partitions(
                 render_replay_status(
                     processor.status.effective_mode(),
                     processor.status.replay_status(),
+                    processor.status.broken_reason(),
                     processor.status.target_tail_lsn.map(Into::into),
                 ),
                 Cell::new(
@@ -309,7 +311,22 @@ fn render_mode(
     }
 }
 
-fn render_replay_status(effective: RunMode, status: ReplayStatus, target_lsn: Option<Lsn>) -> Cell {
+fn render_replay_status(
+    effective: RunMode,
+    status: ReplayStatus,
+    broken_reason: BrokenReason,
+    target_lsn: Option<Lsn>,
+) -> Cell {
+    // A broken processor isn't running at all, so its replay status carries no information.
+    match broken_reason {
+        BrokenReason::NotBroken => {}
+        BrokenReason::AheadOfLog => {
+            return Cell::new("Broken (ahead-of-log)")
+                .fg(Color::Red)
+                .add_attribute(Attribute::Bold);
+        }
+    }
+
     match (status, effective) {
         (ReplayStatus::Unknown, _) => Cell::new("UNKNOWN").fg(Color::Red),
         (ReplayStatus::Starting, _) => Cell::new("Starting").fg(Color::Yellow),

--- a/tools/restatectl/src/commands/status.rs
+++ b/tools/restatectl/src/commands/status.rs
@@ -26,7 +26,7 @@ use restate_types::health::MetadataServerStatus;
 use restate_types::logs::metadata::Logs;
 use restate_types::nodes_config::{NodeConfig, NodesConfiguration, Role};
 use restate_types::protobuf::cluster::node_state::State;
-use restate_types::protobuf::cluster::{AliveNode, RunMode};
+use restate_types::protobuf::cluster::{AliveNode, BrokenReason, RunMode};
 use restate_types::{GenerationalNodeId, NodeId};
 use restate_util_time::DurationExt;
 
@@ -158,6 +158,12 @@ async fn alive_node_status(
     let counter = alive_node.partitions.values().fold(
         PartitionCounter::default(),
         |mut counter, partition_status| {
+            // a broken processor is neither leading nor following, it isn't running at all
+            if partition_status.broken_reason() != BrokenReason::NotBroken {
+                counter.broken += 1;
+                return counter;
+            }
+
             let effective =
                 RunMode::try_from(partition_status.effective_mode).expect("valid effective mode");
             let planned =
@@ -251,6 +257,7 @@ struct PartitionCounter {
     followers: u16,
     upgrading: u16,
     downgrading: u16,
+    broken: u16,
 }
 
 impl PartitionCounter {
@@ -273,6 +280,9 @@ impl PartitionCounter {
         write!(buf, "{}", self.followers).expect("must succeed");
         if self.downgrading > 0 {
             write!(buf, "+{}", self.downgrading).expect("must succeed");
+        }
+        if self.broken > 0 {
+            write!(buf, " ({} broken)", self.broken).expect("must succeed");
         }
 
         buf


### PR DESCRIPTION

Collect successful transitions during each scheduler pass and emit one compact summary.
Preserve visibility of partial successes when a later partition update fails.

Example:

```
2026-07-31T15:30:53.756559Z INFO restate_admin::cluster_controller::service::scheduler
  Partition configuration transitions: [P0(v2 [N1, N2] -> v3 [N1, N3]), P2(v3 [N1, N2] -> v4 [N2, N3]), P4(v2 [N1, N2] -> v3 [N1, N3]), P5(v3 [N1, N2] -> v4 [N2, N3]), P6(v3 [N1, N2] -> v4 [N2, N3]), P7(v3 [N1, N2] -> v4 [N2, N3]), P10(v3 [N1, N2] -> v4 [N2, N3]), P11(v2 [N1, N2] -> v3 [N1, N3]), P14(v2 [N1, N2] -> v3 [N1, N3]), P15(v3 [N1, N2] -> v4 [N2, N3]), P17(v3 [N1, N2] -> v4 [N2, N3]), P18(v2 [N1, N2] -> v3 [N1, N3]), P21(v2 [N1, N2] -> v3 [N1, N3])]
on rs:worker-10
```

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/restatedev/restate/pull/5121).
* __->__ #5121
* #5120
* #5119
* #5114
* #5113
* #5116
* #5112
* #5109
* #5106