### PR TITLE
Github Actions: use non-deprecated CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       RUSTFLAGS: -D warnings
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - name: Install cargo-hakari
         uses: taiki-e/install-action@v2
@@ -49,7 +49,7 @@ jobs:
       # - name: Install liburing
       #   run: sudo apt-get update && sudo apt-get install -y liburing-dev
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-2x
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: EmbarkStudios/cargo-deny-action@v2
       with:
         command: check advisories
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 10
     runs-on: warp-ubuntu-latest-x64-2x
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: EmbarkStudios/cargo-deny-action@v2
       with:
         command: check bans licenses sources

--- a/.github/workflows/docker-refresh.yml
+++ b/.github/workflows/docker-refresh.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Determine latest stable release
         id: latest-release

--- a/.github/workflows/docker-tools.yml
+++ b/.github/workflows/docker-tools.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install cargo-hakari
         if: ${{ hashFiles('.config/hakari.toml') != '' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -90,7 +90,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install cargo-hakari
         if: ${{ hashFiles('.config/hakari.toml') != '' }}

--- a/.github/workflows/hack-clippy.yml
+++ b/.github/workflows/hack-clippy.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       RUST_BACKTRACE: full
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: warp-ubuntu-latest-x64-2x
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref }}
       - name: Write release version

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -21,7 +21,7 @@ jobs:
       GITHUB_USER: "Restate bot"
       GITHUB_EMAIL: "code+bot@restate.dev"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           repository: "restatedev/homebrew-tap"
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: "Download GitHub Artifacts"
         uses: actions/download-artifact@v4

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: actions/setup-node@v4
         with:
@@ -117,7 +117,7 @@ jobs:
             binary: restate-server
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -19,7 +19,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
           submodules: recursive
@@ -119,7 +119,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
           submodules: recursive
@@ -246,7 +246,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
           submodules: recursive
@@ -310,7 +310,7 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
           submodules: recursive
@@ -435,7 +435,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
           submodules: recursive


### PR DESCRIPTION
Workflows currently get an annotation on all workflows of:

	Node.js 20 is deprecated. The following actions target
	Node.js 20 but are being forced to run on Node.js 24:
		 actions/checkout@v4.
	For more information see:
		https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners

This is a house-keeping commit to remove the annoying message.