### PR TITLE
[ci] Allow selecting the cargo profile for Docker image builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,11 +17,6 @@ on:
         required: false
         default: ""
         type: string
-      debug:
-        description: "include debug symbols in built image"
-        required: false
-        default: false
-        type: boolean
       parca:
         description: "split out debug symbols and upload to polar signals"
         required: false
@@ -36,6 +31,11 @@ on:
         description: "features to enable in the build"
         required: false
         default: ""
+        type: string
+      profile:
+        description: "cargo profile to build with (must exist in Cargo.toml)"
+        required: false
+        default: "release"
         type: string
       pushToDockerHub:
         description: "push image to DockerHub"
@@ -60,11 +60,6 @@ on:
         required: false
         default: ""
         type: string
-      debug:
-        description: "include debug symbols in built image"
-        required: false
-        default: false
-        type: boolean
       parca:
         description: "upload debug symbols to polar signals"
         required: false
@@ -79,6 +74,11 @@ on:
         description: "features to enable in the build"
         required: false
         default: ""
+        type: string
+      profile:
+        description: "cargo profile to build with (must exist in Cargo.toml)"
+        required: false
+        default: "release"
         type: string
       pushToDockerHub:
         description: "push image to DockerHub"
@@ -99,8 +99,8 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: ${{ (inputs.debug || inputs.parca) && 'warp-ubuntu-latest-x64-32x' || 'warp-ubuntu-latest-x64-16x' }}
-    timeout-minutes: ${{ (inputs.debug || inputs.parca) && 140 || 70 }}
+    runs-on: ${{ inputs.parca && 'warp-ubuntu-latest-x64-32x' || 'warp-ubuntu-latest-x64-16x' }}
+    timeout-minutes: ${{ inputs.parca && 140 || 70 }}
 
     steps:
       - name: Checkout repository
@@ -205,6 +205,18 @@ jobs:
             echo "This is not the latest version - will not update latest tag"
           fi
 
+      - name: Compute image tag prefix
+        id: prefix
+        env:
+          CARGO_PROFILE: ${{ inputs.profile }}
+        run: |
+          # Keep non-release-profile images from clobbering the regular tags.
+          # NB parca must not contribute a prefix; release builds use it and need plain tags.
+          PREFIX=""
+          if [[ "$CARGO_PROFILE" != "release" ]]; then PREFIX="${CARGO_PROFILE}-"; fi
+          echo "value=${PREFIX}" >> "$GITHUB_OUTPUT"
+          echo "Tag prefix: '${PREFIX}'"
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -215,7 +227,7 @@ jobs:
 
           flavor: |
             latest=${{ (steps.is-latest.outputs.is_latest == 'true') && 'true' || 'false' }}
-            ${{ inputs.debug && 'prefix=debug-,onlatest=true' || '' }}
+            ${{ steps.prefix.outputs.value != '' && format('prefix={0},onlatest=true', steps.prefix.outputs.value) || '' }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -262,15 +274,15 @@ jobs:
           platforms: ${{ github.ref == 'refs/heads/main' && 'linux/arm64,linux/amd64' || (inputs.platforms || 'linux/arm64,linux/amd64') }}
           network: host
           build-args: |
-            CARGO_PROFILE_RELEASE_DEBUG=${{ inputs.debug || inputs.parca }}
+            CARGO_PROFILE=${{ inputs.profile }}
             BUILD_INDIVIDUALLY=${{ inputs.buildIndividually }}
             UPLOAD_DEBUGINFO=${{ inputs.parca }}
             RESTATE_FEATURES=${{ inputs.features || '' }}
           secrets: |
             parca=${{ secrets.PARCA_TOKEN }}
           cache-from: type=gha,url=http://127.0.0.1:49160/,version=1
-          # don't cache debug/parca builds, it's just too big
-          cache-to: ${{ (!inputs.debug && !inputs.parca) && 'type=gha,url=http://127.0.0.1:49160/,mode=max,version=1' || '' }}
+          # don't cache parca builds, they're too big
+          cache-to: ${{ !inputs.parca && 'type=gha,url=http://127.0.0.1:49160/,mode=max,version=1' || '' }}
 
       - name: Upload docker image tar as artifact
         if: ${{ inputs.uploadImageAsTarball != '' }}
@@ -292,7 +304,7 @@ jobs:
           network: host
           outputs: type=local,dest=./debug-symbols
           build-args: |
-            CARGO_PROFILE_RELEASE_DEBUG=true
+            CARGO_PROFILE=${{ inputs.profile }}
             BUILD_INDIVIDUALLY=${{ inputs.buildIndividually }}
             UPLOAD_DEBUGINFO=true
             RESTATE_FEATURES=${{ inputs.features || '' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,6 +33,11 @@ on:
         required: false
         default: ""
         type: string
+      profile:
+        description: "cargo profile to build with (must exist in Cargo.toml)"
+        required: false
+        default: "release"
+        type: string
       pushToDockerHub:
         description: "push image to DockerHub"
         required: false
@@ -71,6 +76,15 @@ on:
         required: false
         default: ""
         type: string
+      profile:
+        description: "cargo profile to build with"
+        required: false
+        default: "release"
+        type: choice
+        options:
+          - release
+          - release-lite
+          - release-debug
       pushToDockerHub:
         description: "push image to DockerHub"
         required: false
@@ -191,6 +205,17 @@ jobs:
             echo "This is not the latest version - will not update latest tag"
           fi
 
+      - name: Compute image tag prefix
+        id: prefix
+        run: |
+          # Keep non-release-profile and debug images from clobbering the regular tags.
+          # NB parca must not contribute a prefix; release builds use it and need plain tags.
+          PREFIX=""
+          if [[ "${{ inputs.debug }}" == "true" ]]; then PREFIX="debug-"; fi
+          if [[ "${{ inputs.profile }}" != "release" ]]; then PREFIX="${PREFIX}${{ inputs.profile }}-"; fi
+          echo "value=${PREFIX}" >> $GITHUB_OUTPUT
+          echo "Tag prefix: '${PREFIX}'"
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -201,7 +226,7 @@ jobs:
 
           flavor: |
             latest=${{ (steps.is-latest.outputs.is_latest == 'true') && 'true' || 'false' }}
-            ${{ inputs.debug && 'prefix=debug-,onlatest=true' || '' }}
+            ${{ steps.prefix.outputs.value != '' && format('prefix={0},onlatest=true', steps.prefix.outputs.value) || '' }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -228,7 +253,8 @@ jobs:
           platforms: ${{ github.ref == 'refs/heads/main' && 'linux/arm64,linux/amd64' || (inputs.platforms || 'linux/arm64,linux/amd64') }}
           network: host
           build-args: |
-            CARGO_PROFILE_RELEASE_DEBUG=${{ inputs.debug || inputs.parca }}
+            CARGO_PROFILE=${{ inputs.profile }}
+            CARGO_PROFILE_DEBUG=${{ (inputs.debug || inputs.parca) && 'true' || '' }}
             BUILD_INDIVIDUALLY=${{ inputs.buildIndividually }}
             UPLOAD_DEBUGINFO=${{ inputs.parca }}
             RESTATE_FEATURES=${{ inputs.features || '' }}
@@ -258,7 +284,8 @@ jobs:
           network: host
           outputs: type=local,dest=./debug-symbols
           build-args: |
-            CARGO_PROFILE_RELEASE_DEBUG=true
+            CARGO_PROFILE=${{ inputs.profile }}
+            CARGO_PROFILE_DEBUG=true
             BUILD_INDIVIDUALLY=${{ inputs.buildIndividually }}
             UPLOAD_DEBUGINFO=true
             RESTATE_FEATURES=${{ inputs.features || '' }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,6 +29,7 @@ ARG SCCACHE_SERVER_PORT=4227
 FROM base-$TARGETARCH AS builder
 ARG SCCACHE_SERVER_PORT
 ARG TARGETARCH
+ARG UPLOAD_DEBUGINFO
 
 ENV RUSTC_WRAPPER=/usr/bin/sccache
 ENV SCCACHE_DIR=/var/cache/sccache
@@ -47,51 +48,61 @@ ENV ac_cv_printf_positional=yes
 # Set sasl2-sys cross-compilation env variables (because we cannot run cross compiled tests)
 ENV ac_cv_gssapi_supports_spnego=yes
 
-# Overrides the behaviour of the release profile re including debug symbols, which in our repo is not to include them.
-# Should be set to 'false' or 'true'. See https://doc.rust-lang.org/cargo/reference/environment-variables.html
-ARG CARGO_PROFILE_RELEASE_DEBUG=false
+# Cargo profile to build with. Must be a profile defined in the workspace Cargo.toml
+# (e.g. release, release-lite, release-debug).
+ARG CARGO_PROFILE=release
 # Avoids feature unification by building the three binaries individually
 ARG BUILD_INDIVIDUALLY=false
 ARG RESTATE_FEATURES=''
-RUN if [ "$BUILD_INDIVIDUALLY" = "true" ]; then \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES chef-cook --release -p restate-cli && \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES chef-cook --release -p restate-server && \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES chef-cook --release -p restatectl; \
+RUN if [ "$UPLOAD_DEBUGINFO" = "true" ]; then \
+    profile_env=$(printf '%s' "$CARGO_PROFILE" | tr '[:lower:]-' '[:upper:]_') && \
+    export "CARGO_PROFILE_${profile_env}_DEBUG=true"; \
+    fi && \
+    if [ "$BUILD_INDIVIDUALLY" = "true" ]; then \
+    just arch="$TARGETARCH" libc=gnu features="$RESTATE_FEATURES" chef-cook --profile="$CARGO_PROFILE" -p restate-cli && \
+    just arch="$TARGETARCH" libc=gnu features="$RESTATE_FEATURES" chef-cook --profile="$CARGO_PROFILE" -p restate-server && \
+    just arch="$TARGETARCH" libc=gnu features="$RESTATE_FEATURES" chef-cook --profile="$CARGO_PROFILE" -p restatectl; \
     else \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES chef-cook --release -p restate-cli -p restate-server -p restatectl; \
+    just arch="$TARGETARCH" libc=gnu features="$RESTATE_FEATURES" chef-cook --profile="$CARGO_PROFILE" -p restate-cli -p restate-server -p restatectl; \
     fi
 COPY . .
 
 FROM builder AS upload-false
 RUN --mount=type=cache,target=/var/cache/sccache \
     if [ "$BUILD_INDIVIDUALLY" = "true" ]; then \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --release -p restate-cli && \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --release -p restate-server && \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --release -p restatectl; \
+    just arch="$TARGETARCH" libc=gnu features="$RESTATE_FEATURES" build --profile="$CARGO_PROFILE" -p restate-cli && \
+    just arch="$TARGETARCH" libc=gnu features="$RESTATE_FEATURES" build --profile="$CARGO_PROFILE" -p restate-server && \
+    just arch="$TARGETARCH" libc=gnu features="$RESTATE_FEATURES" build --profile="$CARGO_PROFILE" -p restatectl; \
     else \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --release -p restate-cli -p restate-server -p restatectl; \
+    just arch="$TARGETARCH" libc=gnu features="$RESTATE_FEATURES" build --profile="$CARGO_PROFILE" -p restate-cli -p restate-server -p restatectl; \
     fi && \
     just notice-file && \
-    mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restate-server target/restate-server && \
-    mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restatectl target/restatectl && \
-    mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restate target/restate
+    case "$CARGO_PROFILE" in dev|test) profile_dir=debug ;; release|bench) profile_dir=release ;; *) profile_dir="$CARGO_PROFILE" ;; esac && \
+    target_dir="target/$(just arch="$TARGETARCH" libc=gnu print-target)/$profile_dir" && \
+    mv "$target_dir/restate-server" target/restate-server && \
+    mv "$target_dir/restatectl" target/restatectl && \
+    mv "$target_dir/restate" target/restate
 RUN cp docker/scripts/no-restate-debug-symbols.sh target/download-restate-debug-symbols.sh
 
 FROM builder AS upload-true
 RUN --mount=type=secret,id=parca --mount=type=cache,target=/var/cache/sccache \
     # useful so that binaries can tell if they actually were compiled with debug symbols
     export DEBUG_STRIPPED="true" && \
+    profile_env=$(printf '%s' "$CARGO_PROFILE" | tr '[:lower:]-' '[:upper:]_') && \
+    export "CARGO_PROFILE_${profile_env}_DEBUG=true" && \
     if [ "$BUILD_INDIVIDUALLY" = "true" ]; then \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --release -p restate-cli && \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --release -p restate-server && \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --release -p restatectl; \
+    just arch="$TARGETARCH" libc=gnu features="$RESTATE_FEATURES" build --profile="$CARGO_PROFILE" -p restate-cli && \
+    just arch="$TARGETARCH" libc=gnu features="$RESTATE_FEATURES" build --profile="$CARGO_PROFILE" -p restate-server && \
+    just arch="$TARGETARCH" libc=gnu features="$RESTATE_FEATURES" build --profile="$CARGO_PROFILE" -p restatectl; \
     else \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --release -p restate-cli -p restate-server -p restatectl; \
+    just arch="$TARGETARCH" libc=gnu features="$RESTATE_FEATURES" build --profile="$CARGO_PROFILE" -p restate-cli -p restate-server -p restatectl; \
     fi && \
     just notice-file && \
-    mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restate-server target/restate-server && \
-    mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restatectl target/restatectl && \
-    mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restate target/restate && \
+    case "$CARGO_PROFILE" in dev|test) profile_dir=debug ;; release|bench) profile_dir=release ;; *) profile_dir="$CARGO_PROFILE" ;; esac && \
+    target_dir="target/$(just arch="$TARGETARCH" libc=gnu print-target)/$profile_dir" && \
+    mv "$target_dir/restate-server" target/restate-server && \
+    mv "$target_dir/restatectl" target/restatectl && \
+    mv "$target_dir/restate" target/restate && \
     $(just --set arch $TARGETARCH --evaluate _arch)-linux-gnu-objcopy --only-keep-debug target/restate-server target/restate-server.debug && \
     $(just --set arch $TARGETARCH --evaluate _arch)-linux-gnu-objcopy --strip-debug target/restate-server && \
     $(just --set arch $TARGETARCH --evaluate _arch)-linux-gnu-objcopy --add-gnu-debuglink=target/restate-server.debug target/restate-server && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,51 +47,59 @@ ENV ac_cv_printf_positional=yes
 # Set sasl2-sys cross-compilation env variables (because we cannot run cross compiled tests)
 ENV ac_cv_gssapi_supports_spnego=yes
 
-# Overrides the behaviour of the release profile re including debug symbols, which in our repo is not to include them.
-# Should be set to 'false' or 'true'. See https://doc.rust-lang.org/cargo/reference/environment-variables.html
-ARG CARGO_PROFILE_RELEASE_DEBUG=false
+# Cargo profile to build with. Must be a profile defined in the workspace Cargo.toml
+# (e.g. release, release-lite, release-debug).
+ARG CARGO_PROFILE=release
+# Overrides the behaviour of the selected profile re including debug symbols, which for 'release'
+# in our repo is not to include them. Leave empty to keep whatever the profile itself defines
+# (release-lite and release-debug already set debug = true).
+# Should be set to '', 'false' or 'true'. See https://doc.rust-lang.org/cargo/reference/environment-variables.html
+ARG CARGO_PROFILE_DEBUG=''
 # Avoids feature unification by building the three binaries individually
 ARG BUILD_INDIVIDUALLY=false
 ARG RESTATE_FEATURES=''
-RUN if [ "$BUILD_INDIVIDUALLY" = "true" ]; then \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES chef-cook --release -p restate-cli && \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES chef-cook --release -p restate-server && \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES chef-cook --release -p restatectl; \
+RUN if [ -n "$CARGO_PROFILE_DEBUG" ]; then export CARGO_PROFILE_$(echo "$CARGO_PROFILE" | tr 'a-z-' 'A-Z_')_DEBUG="$CARGO_PROFILE_DEBUG"; fi && \
+    if [ "$BUILD_INDIVIDUALLY" = "true" ]; then \
+    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES chef-cook --profile=$CARGO_PROFILE -p restate-cli && \
+    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES chef-cook --profile=$CARGO_PROFILE -p restate-server && \
+    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES chef-cook --profile=$CARGO_PROFILE -p restatectl; \
     else \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES chef-cook --release -p restate-cli -p restate-server -p restatectl; \
+    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES chef-cook --profile=$CARGO_PROFILE -p restate-cli -p restate-server -p restatectl; \
     fi
 COPY . .
 
 FROM builder AS upload-false
 RUN --mount=type=cache,target=/var/cache/sccache \
+    if [ -n "$CARGO_PROFILE_DEBUG" ]; then export CARGO_PROFILE_$(echo "$CARGO_PROFILE" | tr 'a-z-' 'A-Z_')_DEBUG="$CARGO_PROFILE_DEBUG"; fi && \
     if [ "$BUILD_INDIVIDUALLY" = "true" ]; then \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --release -p restate-cli && \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --release -p restate-server && \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --release -p restatectl; \
+    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --profile=$CARGO_PROFILE -p restate-cli && \
+    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --profile=$CARGO_PROFILE -p restate-server && \
+    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --profile=$CARGO_PROFILE -p restatectl; \
     else \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --release -p restate-cli -p restate-server -p restatectl; \
+    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --profile=$CARGO_PROFILE -p restate-cli -p restate-server -p restatectl; \
     fi && \
     just notice-file && \
-    mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restate-server target/restate-server && \
-    mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restatectl target/restatectl && \
-    mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restate target/restate
+    mv target/$(just arch=$TARGETARCH libc=gnu print-target)/$CARGO_PROFILE/restate-server target/restate-server && \
+    mv target/$(just arch=$TARGETARCH libc=gnu print-target)/$CARGO_PROFILE/restatectl target/restatectl && \
+    mv target/$(just arch=$TARGETARCH libc=gnu print-target)/$CARGO_PROFILE/restate target/restate
 RUN cp docker/scripts/no-restate-debug-symbols.sh target/download-restate-debug-symbols.sh
 
 FROM builder AS upload-true
 RUN --mount=type=secret,id=parca --mount=type=cache,target=/var/cache/sccache \
     # useful so that binaries can tell if they actually were compiled with debug symbols
     export DEBUG_STRIPPED="true" && \
+    if [ -n "$CARGO_PROFILE_DEBUG" ]; then export CARGO_PROFILE_$(echo "$CARGO_PROFILE" | tr 'a-z-' 'A-Z_')_DEBUG="$CARGO_PROFILE_DEBUG"; fi && \
     if [ "$BUILD_INDIVIDUALLY" = "true" ]; then \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --release -p restate-cli && \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --release -p restate-server && \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --release -p restatectl; \
+    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --profile=$CARGO_PROFILE -p restate-cli && \
+    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --profile=$CARGO_PROFILE -p restate-server && \
+    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --profile=$CARGO_PROFILE -p restatectl; \
     else \
-    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --release -p restate-cli -p restate-server -p restatectl; \
+    just arch=$TARGETARCH libc=gnu features=$RESTATE_FEATURES build --profile=$CARGO_PROFILE -p restate-cli -p restate-server -p restatectl; \
     fi && \
     just notice-file && \
-    mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restate-server target/restate-server && \
-    mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restatectl target/restatectl && \
-    mv target/$(just arch=$TARGETARCH libc=gnu print-target)/release/restate target/restate && \
+    mv target/$(just arch=$TARGETARCH libc=gnu print-target)/$CARGO_PROFILE/restate-server target/restate-server && \
+    mv target/$(just arch=$TARGETARCH libc=gnu print-target)/$CARGO_PROFILE/restatectl target/restatectl && \
+    mv target/$(just arch=$TARGETARCH libc=gnu print-target)/$CARGO_PROFILE/restate target/restate && \
     $(just --set arch $TARGETARCH --evaluate _arch)-linux-gnu-objcopy --only-keep-debug target/restate-server target/restate-server.debug && \
     $(just --set arch $TARGETARCH --evaluate _arch)-linux-gnu-objcopy --strip-debug target/restate-server && \
     $(just --set arch $TARGETARCH --evaluate _arch)-linux-gnu-objcopy --add-gnu-debuglink=target/restate-server.debug target/restate-server && \

--- a/docs/dev/build-and-ci.md
+++ b/docs/dev/build-and-ci.md
@@ -194,11 +194,11 @@ A **reusable workflow** called by this repo and many others in the restatedev or
 **Inputs:**
 - `uploadImageAsTarball`: Save image as artifact for downstream jobs
 - `platforms`: Target platforms (default: `linux/arm64,linux/amd64`)
-- `debug`: Include debug symbols
 - `parca`: Split debug symbols and upload to Polar Signals
 - `buildIndividually`: Build binaries separately to avoid feature unification
 - `features`: Cargo features to enable
 - `pushToDockerHub`: Push to Docker Hub in addition to GHCR
+- `profile`: Select which Cargo profile to build
 
 **Build optimizations:**
 - Uses `sccache` with WarpBuild cache

--- a/justfile
+++ b/justfile
@@ -27,6 +27,7 @@ features := ""
 libc := "gnu"
 arch := "" # use the default architecture
 os := "" # use the default os
+profile := "release" # cargo profile used by the `docker` recipe
 
 _features := if features == "all" {
         "--all-features"
@@ -179,7 +180,7 @@ verify: lint test doctest
 
 docker:
     # podman builds do not work without --platform set, even though it claims to default to host arch
-    docker buildx build . --platform linux/{{ _docker_arch }} --file docker/Dockerfile --tag={{ docker_image }} --progress='{{ DOCKER_PROGRESS }}' --build-arg RESTATE_FEATURES={{ features }} --load
+    docker buildx build . --platform linux/{{ _docker_arch }} --file docker/Dockerfile --tag={{ docker_image }} --progress='{{ DOCKER_PROGRESS }}' --build-arg RESTATE_FEATURES={{ features }} --build-arg CARGO_PROFILE={{ profile }} --load
 
 docker-debug:
     # podman builds do not work without --platform set, even though it claims to default to host arch


### PR DESCRIPTION
Allow reusable and manually dispatched Docker builds to select any Cargo profile, and propagate it through cargo-chef, compilation, artifact lookup, and local just builds.

Handle Cargo's historical output directories for built-in profiles while preserving custom profile directories. Prefix non-release image tags so profile builds cannot overwrite regular release tags.

Remove the redundant debug workflow input and use profile configuration as the source of debug settings. Parca builds still force debug information for the selected profile and retain the larger runner, timeout, and uncached build path.