### PR TITLE
[invocation client] relax retry policy and add metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9154,6 +9154,7 @@ dependencies = [
  "derive_more",
  "futures",
  "gardal",
+ "metrics",
  "restate-clock",
  "restate-core",
  "restate-errors",

--- a/crates/ingress-http/src/handler/error.rs
+++ b/crates/ingress-http/src/handler/error.rs
@@ -130,11 +130,8 @@ pub enum ErrorResponse {
 }
 
 impl HandlerError {
-    pub(crate) fn fill_builder<B: http_body::Body + Default + From<Bytes>>(
-        self,
-        res_builder: http::response::Builder,
-    ) -> Response<B> {
-        let status_code = match &self {
+    pub(crate) fn status_code(&self) -> StatusCode {
+        match self {
             HandlerError::NotFound
             | HandlerError::ServiceNotFound(_)
             | HandlerError::ServiceHandlerNotFound(_, _)
@@ -176,7 +173,14 @@ impl HandlerError {
                 StatusCode::from_u16(e.code().into()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
             }
             HandlerError::NotReady => StatusCode::from_u16(470).unwrap(),
-        };
+        }
+    }
+
+    pub(crate) fn fill_builder<B: http_body::Body + Default + From<Bytes>>(
+        self,
+        res_builder: http::response::Builder,
+    ) -> Response<B> {
+        let status_code = self.status_code();
 
         let error_response = match self {
             HandlerError::Invocation(e) => ErrorResponse::Invocation(e),

--- a/crates/ingress-http/src/handler/service_handler.rs
+++ b/crates/ingress-http/src/handler/service_handler.rs
@@ -44,7 +44,10 @@ use super::tracing::prepare_tracing_span;
 use super::{APPLICATION_JSON, Handler};
 use crate::RequestDispatcher;
 use crate::handler::responses::{IDEMPOTENCY_EXPIRES, X_RESTATE_ID};
-use crate::metric_definitions::{INGRESS_REQUEST_DURATION, INGRESS_REQUESTS, REQUEST_COMPLETED};
+use crate::metric_definitions::{
+    INGRESS_REQUEST_DURATION, INGRESS_REQUESTS, REQUEST_COMPLETED, REQUEST_ERROR,
+    REQUEST_INGRESS_ERROR, REQUEST_INVOCATION_ERROR,
+};
 
 pub(crate) const IDEMPOTENCY_KEY: HeaderName = HeaderName::from_static("idempotency-key");
 const LIMIT_KEY_HEADER: HeaderName = HeaderName::from_static("x-restate-limit-key");
@@ -74,6 +77,20 @@ pub(crate) struct SendResponse {
     status: SendStatus,
 }
 
+fn request_metric_status(result: &Result<Response<Full<Bytes>>, HandlerError>) -> &'static str {
+    match result {
+        Ok(response)
+            if response.status().is_client_error() || response.status().is_server_error() =>
+        {
+            REQUEST_INVOCATION_ERROR
+        }
+        Ok(_) => REQUEST_COMPLETED,
+        Err(HandlerError::Invocation(_)) => REQUEST_INVOCATION_ERROR,
+        Err(error) if error.status_code().is_client_error() => REQUEST_ERROR,
+        Err(_) => REQUEST_INGRESS_ERROR,
+    }
+}
+
 impl<Schemas, Dispatcher> Handler<Schemas, Dispatcher>
 where
     Schemas: InvocationTargetResolver + Clone + Send + Sync + 'static,
@@ -88,7 +105,36 @@ where
         <B as http_body::Body>::Error: Into<GenericError>,
     {
         let start_time = Instant::now();
+        let service_name_label = service_request.name.to_string();
+        let invoke_ty_label = service_request.invoke_ty.as_static_str();
 
+        let result = self.process_service_request(req, service_request).await;
+
+        histogram!(
+            INGRESS_REQUEST_DURATION,
+            "rpc.service" => service_name_label.clone(),
+            "rpc.type" => invoke_ty_label,
+        )
+        .record(start_time.elapsed());
+
+        counter!(
+            INGRESS_REQUESTS,
+            "status" => request_metric_status(&result),
+            "rpc.service" => service_name_label,
+            "rpc.type" => invoke_ty_label,
+        )
+        .increment(1);
+        result
+    }
+
+    async fn process_service_request<B: http_body::Body>(
+        self,
+        req: Request<B>,
+        service_request: ServiceRequestType,
+    ) -> Result<Response<Full<Bytes>>, HandlerError>
+    where
+        <B as http_body::Body>::Error: Into<GenericError>,
+    {
         let ServiceRequestType {
             name: service_name,
             handler: handler_name,
@@ -204,9 +250,8 @@ where
         .with_scope(scope);
 
         let invocation_id = InvocationId::generate(&invocation_target, idempotency_key.as_deref());
-        let invoke_ty_str = invoke_ty.as_static_str();
 
-        let result = async move {
+        async move {
             let ingress_span_context =
                 prepare_tracing_span(&invocation_id, &invocation_target, &req);
 
@@ -293,25 +338,7 @@ where
                 }
             }
         }
-        .await;
-
-        // Note that we only record (mostly) successful requests here. We might want to
-        // change this in the _near_ future.
-        histogram!(
-            INGRESS_REQUEST_DURATION,
-            "rpc.service" => service_name.to_string(),
-            "rpc.type" => invoke_ty_str,
-        )
-        .record(start_time.elapsed());
-
-        counter!(
-            INGRESS_REQUESTS,
-            "status" => REQUEST_COMPLETED,
-            "rpc.service" => service_name.to_string(),
-            "rpc.type" => invoke_ty_str,
-        )
-        .increment(1);
-        result
+        .await
     }
 
     async fn handle_service_call(

--- a/crates/ingress-http/src/metric_definitions.rs
+++ b/crates/ingress-http/src/metric_definitions.rs
@@ -19,6 +19,9 @@ pub const INGRESS_REQUESTS: &str = "restate.ingress.requests.total";
 // values of label `status` in INGRESS_REQUEST
 pub const REQUEST_ADMITTED: &str = "admitted";
 pub const REQUEST_COMPLETED: &str = "completed";
+pub const REQUEST_ERROR: &str = "request_error";
+pub const REQUEST_INGRESS_ERROR: &str = "ingress_error";
+pub const REQUEST_INVOCATION_ERROR: &str = "invocation_error";
 pub const REQUEST_RATE_LIMITED: &str = "rate-limited";
 
 pub const INGRESS_REQUEST_DURATION: &str = "restate.ingress.request_duration.seconds";

--- a/crates/ingress-http/src/rpc_request_dispatcher.rs
+++ b/crates/ingress-http/src/rpc_request_dispatcher.rs
@@ -41,8 +41,12 @@ impl<IC> InvocationClientRequestDispatcher<IC> {
     pub fn new(invocation_client: IC) -> Self {
         Self {
             invocation_client,
-            // TODO figure out how to tune this?
-            retry_policy: RetryPolicy::fixed_delay(Duration::from_millis(50), None),
+            retry_policy: RetryPolicy::exponential(
+                Duration::from_millis(50),
+                2.0,
+                None,                         // max attempts
+                Some(Duration::from_secs(1)), // max interval
+            ),
         }
     }
 

--- a/crates/worker-api/Cargo.toml
+++ b/crates/worker-api/Cargo.toml
@@ -30,6 +30,7 @@ futures = { workspace = true }
 gardal = { workspace = true, features = ["tokio"] }
 serde = { workspace = true, optional = true }
 derive_more = { workspace = true, features = ["display"] }
+metrics = { workspace = true }
 serde_with = { workspace = true, optional = true }
 smallvec = { workspace = true }
 strum = { workspace = true }

--- a/crates/worker-api/src/lib.rs
+++ b/crates/worker-api/src/lib.rs
@@ -13,6 +13,7 @@ pub mod processor;
 pub mod resources;
 
 mod leader_query;
+mod metric_definitions;
 mod partition_processor_manager;
 mod partition_processor_rpc_client;
 mod scheduler_status;

--- a/crates/worker-api/src/metric_definitions.rs
+++ b/crates/worker-api/src/metric_definitions.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use metrics::{Unit, describe_counter};
+
+pub const INVOCATION_CLIENT_REQUESTS: &str = "restate.invocation_client.requests.total";
+
+// Values of label `status` in INVOCATION_CLIENT_REQUESTS.
+pub const STATUS_COMPLETED: &str = "completed";
+pub const STATUS_INTERNAL_ERROR: &str = "internal_error";
+pub const STATUS_OVERLOADED_ERROR: &str = "overloaded_error";
+pub const STATUS_PROTOCOL_ERROR: &str = "protocol_error";
+pub const STATUS_ROUTING_ERROR: &str = "routing_error";
+pub const STATUS_SHUTDOWN: &str = "shutdown";
+pub const STATUS_UNAVAILABLE_ERROR: &str = "unavailable_error";
+
+pub fn describe_metrics() {
+    describe_counter!(
+        INVOCATION_CLIENT_REQUESTS,
+        Unit::Count,
+        "Total partition processor RPC attempts made by the invocation client"
+    );
+}

--- a/crates/worker-api/src/partition_processor_rpc_client.rs
+++ b/crates/worker-api/src/partition_processor_rpc_client.rs
@@ -8,8 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::HashMap;
+use std::fmt;
 use std::sync::Arc;
 
+use metrics::counter;
 use tracing::trace;
 
 use restate_core::ShutdownError;
@@ -18,7 +21,6 @@ use restate_core::network::{NetworkSender, RpcReplyError, Swimlane};
 use restate_core::network::{Networking, TransportConnect};
 use restate_core::partitions::PartitionRouting;
 use restate_types::NodeId;
-use restate_types::errors::GenericError;
 use restate_types::identifiers::{
     EntryIndex, InvocationId, PartitionId, PartitionProcessorRpcRequestId, WithPartitionKey,
 };
@@ -37,6 +39,12 @@ use restate_types::net::partition_processor::{
     PartitionProcessorRpcRequest, PartitionProcessorRpcRequestInner, PartitionProcessorRpcResponse,
 };
 use restate_types::partition_table::{FindPartition, PartitionTable, PartitionTableError};
+
+use crate::metric_definitions::{
+    INVOCATION_CLIENT_REQUESTS, STATUS_COMPLETED, STATUS_INTERNAL_ERROR, STATUS_OVERLOADED_ERROR,
+    STATUS_PROTOCOL_ERROR, STATUS_ROUTING_ERROR, STATUS_SHUTDOWN, STATUS_UNAVAILABLE_ERROR,
+    describe_metrics,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum PartitionProcessorInvocationClientError {
@@ -61,18 +69,43 @@ pub struct RpcError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum RpcErrorKind {
-    #[error(transparent)]
     Connect(#[from] ConnectError),
-    #[error("failed sending request: {0}")]
-    SendFailed(GenericError),
-    #[error("not leader")]
-    NotLeader,
-    #[error("lost leadership")]
-    LostLeadership,
-    #[error("rejecting rpc because the partition is too busy")]
-    Busy,
-    #[error("internal error: {0}")]
-    Internal(String),
+    ConnectionClosedBeforeSend,
+    Encode(#[from] EncodeError),
+    Reply(#[from] RpcReplyError),
+    Processor(#[from] PartitionProcessorRpcError),
+}
+
+// Note: Those are customer facing errors (e.g. in http invocation response errors), so try to keep
+// stable as much as possible.
+impl fmt::Display for RpcErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RpcErrorKind::Connect(err) => err.fmt(f),
+            RpcErrorKind::ConnectionClosedBeforeSend => {
+                f.write_str("failed sending request: Connection lost")
+            }
+            RpcErrorKind::Encode(err) => write!(f, "failed sending request: {err}"),
+            RpcErrorKind::Reply(
+                RpcReplyError::ServiceNotFound
+                | RpcReplyError::SortCodeNotFound
+                | RpcReplyError::ServiceStopped,
+            )
+            | RpcErrorKind::Processor(PartitionProcessorRpcError::NotLeader(_)) => {
+                f.write_str("not leader")
+            }
+            RpcErrorKind::Reply(RpcReplyError::LoadShedding | RpcReplyError::ServiceNotReady) => {
+                f.write_str("rejecting rpc because the partition is too busy")
+            }
+            RpcErrorKind::Reply(err) => write!(f, "internal error: {err}"),
+            RpcErrorKind::Processor(PartitionProcessorRpcError::LostLeadership(_)) => {
+                f.write_str("lost leadership")
+            }
+            RpcErrorKind::Processor(PartitionProcessorRpcError::Internal(msg)) => {
+                write!(f, "internal error: {msg}")
+            }
+        }
+    }
 }
 
 impl PartitionProcessorInvocationClientError {
@@ -89,6 +122,52 @@ impl PartitionProcessorInvocationClientError {
             _ => false,
         }
     }
+
+    fn as_metric_label(&self) -> &'static str {
+        match self {
+            PartitionProcessorInvocationClientError::UnknownPartition(_)
+            | PartitionProcessorInvocationClientError::UnknownNode(_) => STATUS_ROUTING_ERROR,
+            PartitionProcessorInvocationClientError::Shutdown(_) => STATUS_SHUTDOWN,
+            PartitionProcessorInvocationClientError::Rpc(err) => err.source.as_metric_label(),
+        }
+    }
+}
+
+impl RpcErrorKind {
+    fn as_metric_label(&self) -> &'static str {
+        match self {
+            RpcErrorKind::Connect(ConnectError::Shutdown(_)) => STATUS_SHUTDOWN,
+            RpcErrorKind::Connect(ConnectError::Discovery(_))
+            | RpcErrorKind::Reply(
+                RpcReplyError::ServiceNotFound
+                | RpcReplyError::ServiceStopped
+                | RpcReplyError::SortCodeNotFound,
+            )
+            | RpcErrorKind::Processor(
+                PartitionProcessorRpcError::NotLeader(_)
+                | PartitionProcessorRpcError::LostLeadership(_),
+            ) => STATUS_ROUTING_ERROR,
+            RpcErrorKind::Reply(RpcReplyError::LoadShedding) => STATUS_OVERLOADED_ERROR,
+            RpcErrorKind::Connect(
+                ConnectError::Handshake(_)
+                | ConnectError::Throttled(_)
+                | ConnectError::Transport(_),
+            )
+            | RpcErrorKind::ConnectionClosedBeforeSend
+            | RpcErrorKind::Reply(
+                RpcReplyError::Dropped
+                | RpcReplyError::ConnectionClosed(_)
+                | RpcReplyError::ServiceNotReady,
+            ) => STATUS_UNAVAILABLE_ERROR,
+            RpcErrorKind::Encode(_)
+            | RpcErrorKind::Reply(RpcReplyError::Unknown(_) | RpcReplyError::MessageUnrecognized) => {
+                STATUS_PROTOCOL_ERROR
+            }
+            RpcErrorKind::Processor(PartitionProcessorRpcError::Internal(_)) => {
+                STATUS_INTERNAL_ERROR
+            }
+        }
+    }
 }
 
 impl RpcError {
@@ -101,16 +180,20 @@ impl RpcError {
     }
 
     fn is_safe_to_retry(&self) -> bool {
-        match self.source {
+        match &self.source {
             RpcErrorKind::Connect(_)
-            | RpcErrorKind::NotLeader
-            | RpcErrorKind::Busy
-            | RpcErrorKind::SendFailed(_) => {
+            | RpcErrorKind::ConnectionClosedBeforeSend
+            | RpcErrorKind::Encode(_) => {
                 // These are pre-flight error that we can distinguish,
                 // and for which we know for certain that no message was proposed yet to the log.
                 true
             }
-            _ => false,
+            RpcErrorKind::Reply(err) => !err.maybe_processed(),
+            RpcErrorKind::Processor(PartitionProcessorRpcError::NotLeader(_)) => true,
+            RpcErrorKind::Processor(
+                PartitionProcessorRpcError::LostLeadership(_)
+                | PartitionProcessorRpcError::Internal(_),
+            ) => false,
         }
     }
 }
@@ -122,42 +205,11 @@ impl From<PartitionProcessorInvocationClientError> for InvocationClientError {
     }
 }
 
-impl From<EncodeError> for RpcErrorKind {
-    fn from(value: EncodeError) -> Self {
-        Self::SendFailed(value.into())
-    }
-}
-
-impl From<RpcReplyError> for RpcErrorKind {
-    fn from(value: RpcReplyError) -> Self {
-        match value {
-            e @ RpcReplyError::Unknown(_) => Self::Internal(e.to_string()),
-            e @ RpcReplyError::Dropped => Self::Internal(e.to_string()),
-            // todo: perhaps this should be an explicit error
-            e @ RpcReplyError::ConnectionClosed(_) => Self::Internal(e.to_string()),
-            e @ RpcReplyError::MessageUnrecognized => Self::Internal(e.to_string()),
-            RpcReplyError::ServiceNotFound | RpcReplyError::SortCodeNotFound => Self::NotLeader,
-            RpcReplyError::LoadShedding => Self::Busy,
-            RpcReplyError::ServiceNotReady => Self::Busy,
-            RpcReplyError::ServiceStopped => Self::NotLeader,
-        }
-    }
-}
-
-impl From<PartitionProcessorRpcError> for RpcErrorKind {
-    fn from(value: PartitionProcessorRpcError) -> Self {
-        match value {
-            PartitionProcessorRpcError::NotLeader(_) => RpcErrorKind::NotLeader,
-            PartitionProcessorRpcError::LostLeadership(_) => RpcErrorKind::LostLeadership,
-            PartitionProcessorRpcError::Internal(msg) => RpcErrorKind::Internal(msg),
-        }
-    }
-}
-
 pub struct PartitionProcessorInvocationClient<C> {
     networking: Networking<C>,
     partition_table: Live<PartitionTable>,
     partition_routing: PartitionRouting,
+    partition_id_labels: Arc<HashMap<PartitionId, Arc<str>>>,
 }
 
 impl<C: Clone> Clone for PartitionProcessorInvocationClient<C> {
@@ -166,6 +218,7 @@ impl<C: Clone> Clone for PartitionProcessorInvocationClient<C> {
             networking: self.networking.clone(),
             partition_table: self.partition_table.clone(),
             partition_routing: self.partition_routing.clone(),
+            partition_id_labels: self.partition_id_labels.clone(),
         }
     }
 }
@@ -176,10 +229,18 @@ impl<C> PartitionProcessorInvocationClient<C> {
         partition_table: Live<PartitionTable>,
         partition_routing: PartitionRouting,
     ) -> Self {
+        describe_metrics();
+        let partition_id_labels = partition_table
+            .pinned()
+            .iter_ids()
+            .map(|partition_id| (*partition_id, Arc::<str>::from(partition_id.to_string())))
+            .collect();
+
         Self {
             networking,
             partition_table,
             partition_routing,
+            partition_id_labels: Arc::new(partition_id_labels),
         }
     }
 }
@@ -196,8 +257,42 @@ where
         let partition_id = self
             .partition_table
             .pinned()
-            .find_partition_id(inner_request.partition_key())?;
+            .find_partition_id(inner_request.partition_key());
+        let partition_id_label: metrics::SharedString = match partition_id.as_ref() {
+            Ok(partition_id) => match self.partition_id_labels.get(partition_id) {
+                Some(label) => label.clone().into(),
+                None => partition_id.to_string().into(),
+            },
+            Err(_) => "unknown".into(),
+        };
 
+        let res = match partition_id {
+            Ok(partition_id) => {
+                self.send_to_partition(request_id, partition_id, inner_request)
+                    .await
+            }
+            Err(err) => Err(err.into()),
+        };
+
+        counter!(
+            INVOCATION_CLIENT_REQUESTS,
+            "partition_id" => partition_id_label,
+            "status" => match &res {
+                Ok(_) => STATUS_COMPLETED,
+                Err(err) => err.as_metric_label(),
+            },
+        )
+        .increment(1);
+
+        res
+    }
+
+    async fn send_to_partition(
+        &self,
+        request_id: PartitionProcessorRpcRequestId,
+        partition_id: PartitionId,
+        inner_request: PartitionProcessorRpcRequestInner,
+    ) -> Result<PartitionProcessorRpcResponse, PartitionProcessorInvocationClientError> {
         let node_id = NodeId::from(
             self.partition_routing
                 .get_node_by_partition(partition_id)
@@ -217,7 +312,7 @@ where
             RpcError::from_err(
                 partition_id,
                 node_id,
-                RpcErrorKind::SendFailed("Connection lost".into()),
+                RpcErrorKind::ConnectionClosedBeforeSend,
             )
         })?;
         let rpc_result = permit

--- a/monitoring/grafana/restate-internals.json
+++ b/monitoring/grafana/restate-internals.json
@@ -736,7 +736,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "sum by (rpc_service) (rate(restate_ingress_requests_total{cluster_name=\"$cluster\", node_name=~\"$node\", status=\"completed\"}[$__rate_interval]))",
+          "expr": "sum by (rpc_service) (rate(restate_ingress_requests_total{cluster_name=\"$cluster\", node_name=~\"$node\", status=~\"completed|request_error|invocation_error|ingress_error\"}[$__rate_interval]))",
           "legendFormat": "{{rpc_service}}",
           "refId": "A"
         },
@@ -745,7 +745,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(restate_ingress_requests_total{cluster_name=\"$cluster\", node_name=~\"$node\", status=\"completed\"}[$__rate_interval]))",
+          "expr": "sum(rate(restate_ingress_requests_total{cluster_name=\"$cluster\", node_name=~\"$node\", status=~\"completed|request_error|invocation_error|ingress_error\"}[$__rate_interval]))",
           "legendFormat": "Total",
           "refId": "B"
         }

--- a/monitoring/grafana/restate-overview.json
+++ b/monitoring/grafana/restate-overview.json
@@ -1527,7 +1527,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (rpc_service) (rate(restate_ingress_requests_total{cluster_name=\"$cluster\", node_name=~\"$node\", status=\"completed\"}[$__rate_interval]))",
+          "expr": "sum by (rpc_service) (rate(restate_ingress_requests_total{cluster_name=\"$cluster\", node_name=~\"$node\", status=~\"completed|request_error|invocation_error|ingress_error\"}[$__rate_interval]))",
           "legendFormat": "{{rpc_service}}",
           "refId": "A"
         },
@@ -1536,7 +1536,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(restate_ingress_requests_total{cluster_name=\"$cluster\", node_name=~\"$node\", status=\"completed\"}[$__rate_interval]))",
+          "expr": "sum(rate(restate_ingress_requests_total{cluster_name=\"$cluster\", node_name=~\"$node\", status=~\"completed|request_error|invocation_error|ingress_error\"}[$__rate_interval]))",
           "legendFormat": "Total",
           "refId": "B"
         },

--- a/release-notes/unreleased/invocation-client-retry-and-metrics.md
+++ b/release-notes/unreleased/invocation-client-retry-and-metrics.md
@@ -1,0 +1,35 @@
+# Release Notes: Reduce invocation-client retry pressure and improve ingress observability
+
+## Improvement
+
+### What Changed
+
+HTTP ingress requests now retry retryable invocation-client failures with exponential backoff,
+starting at 50 milliseconds and capped at one second between attempts. Previously, retries used a
+fixed 50-millisecond delay.
+
+A new `restate.invocation_client.requests.total` counter records partition-processor RPC attempts
+by `partition_id` and `status`. Status values distinguish completed requests from routing,
+availability, overload, protocol, internal, and shutdown errors.
+
+The `status` label on `restate.ingress.requests.total` now distinguishes `completed`,
+`request_error`, `invocation_error`, and `ingress_error` outcomes. Ingress request duration is also
+recorded for unsuccessful requests.
+
+### Why This Matters
+
+Exponential backoff reduces repeated traffic to stale partition leaders during leadership changes.
+The new metric and status labels make it easier to identify retry pressure and distinguish invalid
+requests, invocation failures, and failures within Restate's ingress processing.
+
+### Impact on Users
+
+- Existing and new deployments adopt the new retry behavior automatically.
+- Custom dashboards and alerts can use the new statuses to separate application-level invocation
+  failures from ingress failures.
+
+### Migration Guidance
+
+rometheus queries that use `status="completed"` to calculate the total
+processed ingress request rate should include `request_error`, `invocation_error`, and
+`ingress_error` as appropriate.


### PR DESCRIPTION

Invocation client retry policy:
Currently, the invocation client has an extremely aggressive retry policy. Fixed, 50ms forever. During leader transitions, it's expected that until the leader claims leadership, the partition routing information would be stale. The unlucky node that just forfeited its leadership will be hammered pretty aggressively (due to the retry policy) with potentially large payloads until the new leader emerges. This is obviously undesierable. So this PR changes the retry policy to use expontential backoff starting from the 50ms and all the way up to a second to reduce the pressure a bit.

Invocation client attempts metrics:
To give us some observability on the retry behavior, this PR adds a counter for each invocation client attempt, and its result. This required maintaining the underlying error in the RpcErrorKind for better metric labels. To avoid changing the existing error messages, I've implemented a custom Display that maps to the old code. This metric is admittely high cardinality (num nodes * num partitions * num error labels), some labels are rare (e.g. protocol errors) but still it's worth calling it out in case there are concerns about it.

Ingress status classification:
Currently, the ingress' request metric has a status that's either `admitted` or `completed`. We're currently not exposing any metric about whether the requests are succeeding or failing. This PR expands the status label with `request_error` (bad request from the user), `invocation_error` (invocation failed), and `ingress_error` (server failed to to process the request, e.g. due to a non retryable error). This can help us distinguish 5XX caused by a restate problem versus 5XX returned by the customer deployment for example.

---
[//]: # (BEGIN SAPLING FOOTER)
* #5132
* __->__ #5126