### PR TITLE
Add rules and user_limits tables to docs

### DIFF
--- a/crates/storage-query-datafusion/src/table_docs.rs
+++ b/crates/storage-query-datafusion/src/table_docs.rs
@@ -10,8 +10,8 @@
 
 use crate::{
     deployment, inbox, invocation_state, invocation_status, journal, journal_events,
-    keyed_service_status, promise, scheduler_status, service, state, vqueue_entry_status,
-    vqueue_meta, vqueues,
+    keyed_service_status, promise, rules, scheduler_status, service, state, user_limits,
+    vqueue_entry_status, vqueue_meta, vqueues,
 };
 use std::borrow::Cow;
 
@@ -25,9 +25,11 @@ pub const ALL_TABLE_DOCS: &[StaticTableDocs] = &[
     journal_events::schema::TABLE_DOCS,
     keyed_service_status::schema::TABLE_DOCS,
     promise::schema::TABLE_DOCS,
+    rules::schema::TABLE_DOCS,
     scheduler_status::schema::TABLE_DOCS,
     service::schema::TABLE_DOCS,
     state::schema::TABLE_DOCS,
+    user_limits::schema::TABLE_DOCS,
     vqueue_entry_status::schema::TABLE_DOCS,
     vqueue_meta::schema::TABLE_DOCS,
     vqueues::schema::TABLE_DOCS,


### PR DESCRIPTION
The `sys_rules` and `sys_user_limits` tables were not exposed in the table docs. 
This PR adds them, so they show up in [the introspection docs](https://docs.restate.dev/references/sql-introspection).