### PR TITLE
Extend restatectl RocksDB compaction controls 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3456,11 +3456,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]

--- a/crates/core/protobuf/node_ctl_svc.proto
+++ b/crates/core/protobuf/node_ctl_svc.proto
@@ -129,10 +129,24 @@ message EmbeddedMetadataClusterHealth {
 
 message TriggerCompactionRequest {
   repeated restate.common.DatabaseKind databases = 1;
+  ManualCompactionOptions options = 2;
 }
 
 message TriggerCompactionResponse {
   repeated DatabaseCompactionResult results = 1;
+}
+
+enum BottommostLevelCompaction {
+  BOTTOMMOST_LEVEL_COMPACTION_UNSPECIFIED = 0;
+  BOTTOMMOST_LEVEL_COMPACTION_SKIP = 1;
+  BOTTOMMOST_LEVEL_COMPACTION_IF_HAVE_COMPACTION_FILTER = 2;
+  BOTTOMMOST_LEVEL_COMPACTION_FORCE = 3;
+  BOTTOMMOST_LEVEL_COMPACTION_FORCE_OPTIMIZED = 4;
+}
+
+message ManualCompactionOptions {
+  BottommostLevelCompaction bottommost_level_compaction = 1;
+  bool recalculate_level = 2;
 }
 
 message DatabaseCompactionResult {

--- a/crates/core/src/protobuf.rs
+++ b/crates/core/src/protobuf.rs
@@ -33,6 +33,7 @@ pub mod cluster_ctrl_svc {
 pub mod node_ctl_svc {
     use enumset::EnumSet;
     use restate_types::nodes_config;
+    use restate_types::rocksdb as rocksdb_types;
     use tonic::codec::CompressionEncoding;
     use tonic::transport::Channel;
 
@@ -47,6 +48,59 @@ pub mod node_ctl_svc {
 
     pub const FILE_DESCRIPTOR_SET: &[u8] =
         tonic::include_file_descriptor_set!("node_ctl_svc_descriptor");
+
+    impl TryFrom<ManualCompactionOptions> for rocksdb_types::ManualCompactionOptions {
+        type Error = anyhow::Error;
+
+        fn try_from(value: ManualCompactionOptions) -> Result<Self, Self::Error> {
+            let bottommost_level_compaction = BottommostLevelCompaction::try_from(
+                value.bottommost_level_compaction,
+            )
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "unknown bottommost-level-compaction id {}",
+                    value.bottommost_level_compaction
+                )
+            })?;
+            let bottommost_level_compaction = match bottommost_level_compaction {
+                // We default to rocksdb_types::IfHaveCompactionFilter which is the default behavior
+                // of RocksDB if the default CompactOptions is specified.
+                BottommostLevelCompaction::Unspecified
+                | BottommostLevelCompaction::IfHaveCompactionFilter => {
+                    rocksdb_types::BottommostLevelCompaction::IfHaveCompactionFilter
+                }
+                BottommostLevelCompaction::Skip => rocksdb_types::BottommostLevelCompaction::Skip,
+                BottommostLevelCompaction::Force => rocksdb_types::BottommostLevelCompaction::Force,
+                BottommostLevelCompaction::ForceOptimized => {
+                    rocksdb_types::BottommostLevelCompaction::ForceOptimized
+                }
+            };
+
+            Ok(Self {
+                bottommost_level_compaction,
+                recalculate_level: value.recalculate_level,
+            })
+        }
+    }
+
+    impl From<rocksdb_types::ManualCompactionOptions> for ManualCompactionOptions {
+        fn from(value: rocksdb_types::ManualCompactionOptions) -> Self {
+            let bottommost_level_compaction = match value.bottommost_level_compaction {
+                rocksdb_types::BottommostLevelCompaction::Skip => BottommostLevelCompaction::Skip,
+                rocksdb_types::BottommostLevelCompaction::IfHaveCompactionFilter => {
+                    BottommostLevelCompaction::IfHaveCompactionFilter
+                }
+                rocksdb_types::BottommostLevelCompaction::Force => BottommostLevelCompaction::Force,
+                rocksdb_types::BottommostLevelCompaction::ForceOptimized => {
+                    BottommostLevelCompaction::ForceOptimized
+                }
+            };
+            Self {
+                bottommost_level_compaction: bottommost_level_compaction.into(),
+                recalculate_level: value.recalculate_level,
+            }
+        }
+    }
 
     impl ProvisionClusterResponse {
         pub fn dry_run(
@@ -144,6 +198,33 @@ pub mod node_ctl_svc {
 
             assert!(cluster_features_from_proto(&[ClusterFeature::Unknown as i32]).is_err());
             assert!(cluster_features_from_proto(&[i32::MAX]).is_err());
+        }
+
+        #[test]
+        fn manual_compaction_options_round_trip_and_validate() {
+            let options = rocksdb_types::ManualCompactionOptions {
+                bottommost_level_compaction:
+                    rocksdb_types::BottommostLevelCompaction::ForceOptimized,
+                recalculate_level: true,
+            };
+            let proto = ManualCompactionOptions::from(options);
+            assert_eq!(
+                rocksdb_types::ManualCompactionOptions::try_from(proto).unwrap(),
+                options
+            );
+
+            let defaults = rocksdb_types::ManualCompactionOptions::try_from(
+                ManualCompactionOptions::default(),
+            )
+            .unwrap();
+            assert_eq!(defaults, rocksdb_types::ManualCompactionOptions::default());
+            assert!(
+                rocksdb_types::ManualCompactionOptions::try_from(ManualCompactionOptions {
+                    bottommost_level_compaction: i32::MAX,
+                    recalculate_level: false,
+                })
+                .is_err()
+            );
         }
     }
 }

--- a/crates/node/src/network_server/grpc_svc_handler.rs
+++ b/crates/node/src/network_server/grpc_svc_handler.rs
@@ -12,9 +12,10 @@ use std::cmp::max_by_key;
 
 use anyhow::Context;
 use bytes::BytesMut;
+use tokio::sync::oneshot;
 use tonic::codec::CompressionEncoding;
 use tonic::{Request, Response, Status};
-use tracing::debug;
+use tracing::{debug, info, warn};
 
 use restate_metadata_server_grpc::grpc::new_metadata_server_client;
 use restate_metadata_store::protobuf::metadata_proxy_svc::metadata_proxy_svc_server::{
@@ -33,7 +34,7 @@ use restate_core::protobuf::node_ctl_svc::{
     ProvisionClusterResponse, TriggerCompactionRequest, TriggerCompactionResponse,
     cluster_features_from_proto,
 };
-use restate_core::{Identification, MetadataWriter};
+use restate_core::{Identification, MetadataWriter, TaskCenter, TaskKind};
 use restate_core::{Metadata, MetadataKind};
 use restate_metadata_store::{MetadataStoreClient, ReadError, WriteError};
 use restate_rocksdb::RocksDbManager;
@@ -46,6 +47,7 @@ use restate_types::nodes_config::{ClusterFeature, Role};
 use restate_types::protobuf::cluster::ClusterConfiguration as ProtoClusterConfiguration;
 use restate_types::protobuf::common::DatabaseKind;
 use restate_types::replication::ReplicationProperty;
+use restate_types::rocksdb::ManualCompactionOptions;
 use restate_types::storage::StorageCodec;
 
 use crate::{ClusterConfiguration, provision_cluster_metadata};
@@ -276,54 +278,87 @@ impl NodeCtlSvc for NodeCtlSvcHandler {
     ) -> Result<Response<TriggerCompactionResponse>, Status> {
         let request = request.into_inner();
 
-        // An empty databases list means compact all; otherwise filter to the requested kinds,
-        // ignoring any unspecified/unknown values.
         let compact_all = request.databases.is_empty();
         let requested_kinds: Vec<DatabaseKind> = request
             .databases
             .into_iter()
-            .filter_map(|k| DatabaseKind::try_from(k).ok())
-            .filter(|k| *k != DatabaseKind::Unspecified)
-            .collect();
+            .map(|raw| {
+                let kind = DatabaseKind::try_from(raw).map_err(|_| {
+                    Status::invalid_argument(format!("unknown database kind id {raw}"))
+                })?;
+                if kind == DatabaseKind::Unspecified {
+                    return Err(Status::invalid_argument(
+                        "database kind 'unspecified' is not a valid selection",
+                    ));
+                }
+                Ok(kind)
+            })
+            .collect::<Result<_, _>>()?;
+        let options: ManualCompactionOptions = request
+            .options
+            .map(TryInto::try_into)
+            .transpose()
+            .map_err(|err: anyhow::Error| Status::invalid_argument(err.to_string()))?
+            .unwrap_or_default();
 
         let Some(manager) = RocksDbManager::maybe_get() else {
             return Err(Status::unavailable("RocksDB manager not initialized"));
         };
 
         let all_dbs = manager.get_all_dbs();
-        let mut results = Vec::new();
+        let (result_tx, result_rx) = oneshot::channel();
+        TaskCenter::spawn(
+            TaskKind::Disposable,
+            "manual-rocksdb-compaction",
+            async move {
+                let mut results = Vec::new();
 
-        // Compactions run sequentially to avoid overwhelming the system with
-        // concurrent I/O from multiple databases.
-        for db in all_dbs {
-            let db_name = db.name().to_string();
-            let kind = db.kind();
+                // Compact sequentially to limit the I/O pressure on each node.
+                for db in all_dbs {
+                    let db_name = db.name().to_string();
+                    let kind = db.kind();
+                    let should_compact = compact_all
+                        || (kind != DatabaseKind::Unspecified
+                            && requested_kinds.contains(&kind));
 
-            let should_compact = compact_all
-                || (kind != DatabaseKind::Unspecified && requested_kinds.contains(&kind));
+                    if !should_compact {
+                        continue;
+                    }
 
-            if !should_compact {
-                continue;
-            }
+                    info!(db = %db_name, "Starting manual RocksDB compaction");
+                    let cf_count = db.cfs().len() as u32;
+                    match db.compact_all(options).await {
+                        Ok(()) => {
+                            info!(db = %db_name, "Manual RocksDB compaction task completed");
+                            results.push(DatabaseCompactionResult {
+                                db_name,
+                                success: true,
+                                error: None,
+                                column_families_compacted: cf_count,
+                            });
+                        }
+                        Err(e) => {
+                            warn!(db = %db_name, error = %e, "Manual RocksDB compaction task failed");
+                            results.push(DatabaseCompactionResult {
+                                db_name,
+                                success: false,
+                                error: Some(e.to_string()),
+                                column_families_compacted: 0,
+                            });
+                        }
+                    }
+                }
 
-            let cf_count = db.cfs().len() as u32;
-            match db.compact_all().await {
-                Ok(()) => results.push(DatabaseCompactionResult {
-                    db_name,
-                    success: true,
-                    error: None,
-                    column_families_compacted: cf_count,
-                }),
-                Err(e) => results.push(DatabaseCompactionResult {
-                    db_name,
-                    success: false,
-                    error: Some(e.to_string()),
-                    column_families_compacted: 0,
-                }),
-            }
-        }
+                let _ = result_tx.send(TriggerCompactionResponse { results });
+                Ok(())
+            },
+        )
+        .map_err(|_| Status::unavailable("node is shutting down"))?;
 
-        Ok(Response::new(TriggerCompactionResponse { results }))
+        result_rx
+            .await
+            .map(Response::new)
+            .map_err(|_| Status::unavailable("compaction task was aborted"))
     }
 }
 

--- a/crates/rocksdb/src/lib.rs
+++ b/crates/rocksdb/src/lib.rs
@@ -36,6 +36,7 @@ use rocksdb::statistics::Ticker;
 
 use restate_core::ShutdownError;
 use restate_types::protobuf::common::DatabaseKind;
+pub use restate_types::rocksdb::{BottommostLevelCompaction, ManualCompactionOptions};
 
 // re-exports
 pub use self::background::StorageTaskKind;
@@ -494,13 +495,16 @@ impl RocksDb {
     }
 
     #[tracing::instrument(skip_all, fields(db = %self.name()))]
-    pub async fn compact_all(self: Arc<Self>) -> Result<(), RocksError> {
+    pub async fn compact_all(
+        self: Arc<Self>,
+        options: ManualCompactionOptions,
+    ) -> Result<(), RocksError> {
         let manager = self.manager;
         let task = StorageTask::default()
             .kind(StorageTaskKind::Compaction)
             .op(move || {
                 let _x = RocksDbReadPerfGuard::new("manual-compaction");
-                self.db.compact_all();
+                self.db.compact_all(options);
             })
             .build()
             .unwrap();

--- a/crates/rocksdb/src/rock_access.rs
+++ b/crates/rocksdb/src/rock_access.rs
@@ -24,7 +24,7 @@ use crate::DbSpec;
 use crate::RawRocksDb;
 use crate::RocksError;
 use crate::configuration::create_default_cf_options;
-use crate::{CfName, RocksDbReadPerfGuard};
+use crate::{BottommostLevelCompaction, CfName, ManualCompactionOptions, RocksDbReadPerfGuard};
 use crate::{DbName, OpenMode};
 
 /// Operations in this wrapper can be IO blocking, prefer using [`crate::RocksDb`]
@@ -309,8 +309,19 @@ impl RocksAccess {
         Ok(self.db.flush_cfs_opt(&cf_refs, &flushopts)?)
     }
 
-    pub fn compact_all(&self) {
-        let opts = CompactOptions::default();
+    pub fn compact_all(&self, options: ManualCompactionOptions) {
+        let mut opts = CompactOptions::default();
+        opts.set_bottommost_level_compaction(match options.bottommost_level_compaction {
+            BottommostLevelCompaction::Skip => rocksdb::BottommostLevelCompaction::Skip,
+            BottommostLevelCompaction::IfHaveCompactionFilter => {
+                rocksdb::BottommostLevelCompaction::IfHaveCompactionFilter
+            }
+            BottommostLevelCompaction::Force => rocksdb::BottommostLevelCompaction::Force,
+            BottommostLevelCompaction::ForceOptimized => {
+                rocksdb::BottommostLevelCompaction::ForceOptimized
+            }
+        });
+        opts.set_change_level(options.recalculate_level);
         self.cfs()
             .iter()
             .filter_map(|name| self.cf_handle(name))

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -53,6 +53,7 @@ pub mod rate;
 pub mod replicated_loglet;
 pub mod replication;
 pub mod retries;
+pub mod rocksdb;
 pub mod schema;
 pub mod service_discovery;
 pub mod service_protocol;

--- a/crates/types/src/rocksdb.rs
+++ b/crates/types/src/rocksdb.rs
@@ -1,0 +1,32 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[cfg_attr(feature = "clap", clap(rename_all = "kebab-case"))]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum BottommostLevelCompaction {
+    /// Do not rewrite files already in the bottommost level.
+    Skip,
+    /// Rewrite bottommost files only when a compaction filter is configured. This is RocksDB's
+    /// default.
+    #[default]
+    IfHaveCompactionFilter,
+    /// Always rewrite the bottommost level, including files created earlier in this compaction.
+    Force,
+    /// Always rewrite existing bottommost files, but avoid rewriting files created earlier in this
+    /// compaction.
+    ForceOptimized,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ManualCompactionOptions {
+    pub bottommost_level_compaction: BottommostLevelCompaction,
+    pub recalculate_level: bool,
+}

--- a/release-notes/unreleased/manual-rocksdb-compaction-options.md
+++ b/release-notes/unreleased/manual-rocksdb-compaction-options.md
@@ -1,0 +1,31 @@
+# Release Notes: Control Manual RocksDB Compaction
+
+## New Feature
+
+### What Changed
+
+`restatectl storage compact` now lets operators control bottommost-level compaction with
+`--bottommost-level-compaction`. It preserves RocksDB's default behavior, which only rewrites the
+bottommost level when a compaction filter is configured. Use `force-optimized` to rewrite existing
+bottommost files after large deletions while avoiding files created during the same compaction.
+
+The `--recalculate-level` flag asks RocksDB to move compacted files to the minimum level capable of
+holding the resulting data. This is useful when compaction substantially reduces the data size.
+
+The command now waits up to 30 minutes by default, configurable with `--timeout`. Compactions
+accepted by a node continue in the background if the client times out. Any database, node, or
+request failure now causes a non-zero exit status after all available results have been printed.
+
+### Usage
+
+```bash
+restatectl storage compact -d partition-store
+restatectl storage compact --bottommost-level-compaction force-optimized
+restatectl storage compact --recalculate-level --timeout 1h
+```
+
+### Operational Note
+
+The current RocksDB Rust binding does not expose the native status returned by manual compaction.
+A successful result therefore confirms that the compaction task completed, but cannot report a
+native RocksDB compaction error.

--- a/server/src/signal.rs
+++ b/server/src/signal.rs
@@ -10,7 +10,7 @@
 
 use std::io::Write;
 
-use restate_rocksdb::RocksDbManager;
+use restate_rocksdb::{ManualCompactionOptions, RocksDbManager};
 use tokio::signal::unix::{SignalKind, signal};
 use tracing::{info, warn};
 
@@ -63,7 +63,7 @@ pub(super) async fn sighup_compact() {
                 ),
             };
             let db_name = db.name().to_owned();
-            match db.compact_all().await {
+            match db.compact_all(ManualCompactionOptions::default()).await {
                 Ok(()) => {
                     let _ = writeln!(
                         std::io::stderr(),

--- a/tools/restatectl/src/commands/storage/compact.rs
+++ b/tools/restatectl/src/commands/storage/compact.rs
@@ -8,20 +8,27 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::time::Duration;
+
 use cling::prelude::*;
 use tokio::task::JoinSet;
+use tonic::Code;
 use tracing::info;
 
 use restate_cli_util::_comfy_table::{Cell, Table};
 use restate_cli_util::ui::console::StyledTable;
-use restate_cli_util::{CliContext, c_println};
-use restate_core::protobuf::node_ctl_svc::{TriggerCompactionRequest, new_node_ctl_client};
+use restate_cli_util::{CliContext, c_eprintln, c_println};
+use restate_core::network::net_util::{DNSResolution, create_tonic_channel};
+use restate_core::protobuf::node_ctl_svc::{
+    ManualCompactionOptions as ProtoManualCompactionOptions, TriggerCompactionRequest,
+    TriggerCompactionResponse, new_node_ctl_client,
+};
 use restate_types::PlainNodeId;
 use restate_types::net::address::{AdvertisedAddress, FabricPort};
 use restate_types::protobuf::common::DatabaseKind;
+use restate_types::rocksdb::{BottommostLevelCompaction, ManualCompactionOptions};
 
 use crate::connection::ConnectionInfo;
-use crate::util::grpc_channel;
 
 #[derive(Run, Parser, Collect, Clone, Debug)]
 #[cling(run = "compact")]
@@ -34,6 +41,46 @@ pub struct CompactOpts {
     /// Target specific nodes by node ID (e.g. N1,N2). Defaults to all nodes in the cluster.
     #[arg(long, short = 'n', value_delimiter = ',')]
     node: Vec<PlainNodeId>,
+
+    /// Maximum time to wait for compaction results. Accepted compactions continue after timeout.
+    #[arg(long, default_value = "30m", value_parser = humantime::parse_duration)]
+    timeout: Duration,
+
+    /// Controls whether RocksDB rewrites files already in the bottommost level.
+    ///
+    /// Forcing bottommost-level compaction can reclaim space after large deletions, but causes
+    /// additional I/O and write amplification.
+    ///
+    /// See https://github.com/facebook/rocksdb/wiki/Manual-Compaction#compactrange.
+    #[arg(long, value_enum, default_value = "if-have-compaction-filter")]
+    bottommost_level_compaction: BottommostLevelCompaction,
+
+    /// Refit compacted files to the minimum level capable of holding the data.
+    ///
+    /// Use after compaction substantially reduces the data size and the current level is no longer
+    /// appropriate for the resulting files.
+    ///
+    /// See https://github.com/facebook/rocksdb/wiki/Manual-Compaction#compactrange.
+    #[arg(long)]
+    recalculate_level: bool,
+}
+
+impl From<&CompactOpts> for ProtoManualCompactionOptions {
+    fn from(value: &CompactOpts) -> Self {
+        ManualCompactionOptions {
+            bottommost_level_compaction: value.bottommost_level_compaction,
+            recalculate_level: value.recalculate_level,
+        }
+        .into()
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum TriggerCompactionError {
+    #[error("compaction request timed out after {0:?}")]
+    Timeout(Duration),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
 }
 
 fn parse_database_kind(s: &str) -> Result<DatabaseKind, String> {
@@ -52,6 +99,7 @@ fn parse_database_kind(s: &str) -> Result<DatabaseKind, String> {
 async fn compact(connection: &ConnectionInfo, opts: &CompactOpts) -> anyhow::Result<()> {
     // An empty list means "compact all" at the server side.
     let database_kinds: Vec<i32> = opts.database.iter().map(|k| *k as i32).collect();
+    let compaction_options = ProtoManualCompactionOptions::from(opts);
 
     // Resolve target node addresses from the cluster configuration.
     let nodes_config = connection.get_nodes_configuration().await?;
@@ -84,8 +132,10 @@ async fn compact(connection: &ConnectionInfo, opts: &CompactOpts) -> anyhow::Res
     let mut tasks = JoinSet::new();
     for address in addresses {
         let db_kinds = database_kinds.clone();
+        let timeout = opts.timeout;
         tasks.spawn(async move {
-            let result = trigger_compaction_on_node(&address, db_kinds).await;
+            let result =
+                trigger_compaction_on_node(&address, db_kinds, compaction_options, timeout).await;
             (address, result)
         });
     }
@@ -118,6 +168,12 @@ async fn compact(connection: &ConnectionInfo, opts: &CompactOpts) -> anyhow::Res
             }
             Ok((address, Err(err))) => {
                 total_failed += 1;
+                if let TriggerCompactionError::Timeout(timeout) = &err {
+                    c_eprintln!(
+                        "Compaction request to {address} timed out after {}. Any compaction request accepted by the node continues in the background; check the node logs before retrying.",
+                        humantime::format_duration(*timeout)
+                    );
+                }
                 results_table.add_row(vec![
                     Cell::new(address.to_string()),
                     Cell::new("-"),
@@ -134,33 +190,49 @@ async fn compact(connection: &ConnectionInfo, opts: &CompactOpts) -> anyhow::Res
 
     c_println!("{}", results_table);
     c_println!(
-        "Compaction complete: {} succeeded, {} failed",
+        "Compaction results: {} succeeded, {} failed",
         total_success,
         total_failed
     );
 
+    if total_failed > 0 {
+        anyhow::bail!("{total_failed} compaction operation(s) failed");
+    }
     Ok(())
 }
 
 async fn trigger_compaction_on_node(
     address: &AdvertisedAddress<FabricPort>,
     databases: Vec<i32>,
-) -> Result<restate_core::protobuf::node_ctl_svc::TriggerCompactionResponse, anyhow::Error> {
-    let channel = grpc_channel(address.clone());
-    let mut client = new_node_ctl_client(channel, &CliContext::get().network);
+    options: ProtoManualCompactionOptions,
+    timeout: Duration,
+) -> Result<TriggerCompactionResponse, TriggerCompactionError> {
+    let mut network = CliContext::get().network.clone();
+    network.request_timeout = timeout
+        .as_millis()
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("compaction timeout is too large"))?;
+    let channel = create_tonic_channel(address.clone(), &network, DNSResolution::Gai);
+    let mut client = new_node_ctl_client(channel, &network);
 
-    let timeout = CliContext::get().request_timeout();
-    let request = TriggerCompactionRequest { databases };
-    let response = tokio::time::timeout(timeout, client.trigger_compaction(request))
-        .await
-        .map_err(|_| anyhow::anyhow!("Compaction timed out after {:?}", timeout))?
-        .map_err(|e| anyhow::anyhow!("gRPC error: {}", e))?;
-
+    let request = TriggerCompactionRequest {
+        databases,
+        options: Some(options),
+    };
+    let response = client.trigger_compaction(request).await.map_err(|err| {
+        if err.code() == Code::DeadlineExceeded {
+            TriggerCompactionError::Timeout(timeout)
+        } else {
+            TriggerCompactionError::Other(anyhow::anyhow!("gRPC error: {err}"))
+        }
+    })?;
     Ok(response.into_inner())
 }
 
 #[cfg(test)]
 mod tests {
+    use restate_core::protobuf::node_ctl_svc::BottommostLevelCompaction as ProtoBottommostLevelCompaction;
+
     use super::*;
 
     #[test]
@@ -194,5 +266,22 @@ mod tests {
         assert!(super::parse_database_kind("all").is_err());
         assert!(super::parse_database_kind("").is_err());
         assert!(super::parse_database_kind("db").is_err());
+    }
+
+    #[test]
+    fn compaction_options_are_mapped() {
+        let opts = CompactOpts {
+            database: Vec::new(),
+            node: Vec::new(),
+            timeout: Duration::from_secs(30 * 60),
+            bottommost_level_compaction: BottommostLevelCompaction::ForceOptimized,
+            recalculate_level: true,
+        };
+        let requested = ProtoManualCompactionOptions::from(&opts);
+        assert_eq!(
+            requested.bottommost_level_compaction,
+            ProtoBottommostLevelCompaction::ForceOptimized as i32
+        );
+        assert!(requested.recalculate_level);
     }
 }


### PR DESCRIPTION
Expose bottommost-level compaction and level recalculation, using force-optimized compaction by default. Run accepted compactions independently of the RPC lifetime, add a 30-minute command timeout, and return a non-zero exit status for reported failures.