### PR TITLE
[tracing] introduce new ratelimited tracing utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8897,6 +8897,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "restate-tracing"
+version = "1.7.3-dev"
+dependencies = [
+ "restate-clock",
+ "restate-workspace-hack",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "restate-tracing-instrumentation"
 version = "1.7.3-dev"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ restate-util-time = { path = "util/time" }
 restate-test-util = { path = "crates/test-util" }
 restate-timer = { path = "crates/timer" }
 restate-timer-queue = { path = "crates/timer-queue" }
+restate-tracing = { path = "crates/tracing" }
 restate-tracing-instrumentation = { path = "crates/tracing-instrumentation" }
 restate-types = { path = "crates/types" }
 restate-utoipa = { path = "crates/utoipa" }

--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "restate-tracing"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+restate-workspace-hack = { workspace = true }
+
+restate-clock = { workspace = true }
+
+tracing = { workspace = true }
+
+[dev-dependencies]
+tracing-subscriber = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/tracing/src/lib.rs
+++ b/crates/tracing/src/lib.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A crate containing some tracing utilities.
+
+mod ratelimit;
+
+pub use ratelimit::*;

--- a/crates/tracing/src/ratelimit.rs
+++ b/crates/tracing/src/ratelimit.rs
@@ -1,0 +1,198 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! This module exports macros for rate-limiting log lines. Those macros will only log the event if the
+//! rate limit has not been exceeded.
+//!
+//! For example, for logging a log line at most 10 times per second:
+//!
+//! ```rust
+//! use std::time::Duration;
+//!
+//! use restate_tracing::info_ratelimited;
+//!
+//! info_ratelimited!(10, Duration::from_secs(1), "This event will be logged at most 10 times per second");
+//! ```
+//! After the first 10 log lines, new log lines will be suppressed. The first log line after the window expiry
+//! will get a label injected (`restate.logging.suppressed`) with the number of suppressed events in the previous
+//! window.
+//!
+//! Notes:
+//! - As with the tracing crate, if the event level is not enabled, field values won't be evaluated. Similarly, if
+//!   the rate limit is exceeded, the field values will also not be evaluated.
+//! - To reduce the overhead of this crate, if there are multiple concurrent calls to the same log line, only one
+//!   of them will be evaluated, and others will just move on (and not even get counted as suppressed). No caller
+//!   ever waits for the lock. This keeps the cost of this ratelimiting minimal (mostly two atomic operations), but
+//!   sacrifices on accuracy.
+
+#[doc(hidden)]
+pub mod __private {
+    use std::cell::UnsafeCell;
+    use std::num::NonZeroU32;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    pub use tracing;
+
+    use restate_clock::time::MillisSinceEpoch;
+
+    struct Inner {
+        current: u16,
+        period_start: MillisSinceEpoch,
+        suppressed: u32,
+    }
+
+    struct Unlock<'a>(&'a AtomicBool);
+
+    impl Drop for Unlock<'_> {
+        fn drop(&mut self) {
+            self.0.store(false, Ordering::Release);
+        }
+    }
+
+    pub struct RateLimiter {
+        // Max number of events to log per period
+        max: u16,
+        period_duration: &'static Duration,
+        locked: AtomicBool,
+        inner: UnsafeCell<Inner>,
+    }
+
+    // SAFETY: `inner` is only accessed after atomically acquiring `locked`, so at most one
+    // thread can access it at a time.
+    unsafe impl Sync for RateLimiter {}
+
+    impl RateLimiter {
+        pub const fn new(max: u16, period_duration: &'static Duration) -> Self {
+            Self {
+                max,
+                period_duration,
+                locked: AtomicBool::new(false),
+                inner: UnsafeCell::new(Inner {
+                    current: 0,
+                    period_start: MillisSinceEpoch::UNIX_EPOCH,
+                    suppressed: 0,
+                }),
+            }
+        }
+
+        /// Returns true if the log line should be logged (within the rate limit), and whether a supression
+        /// count label should be added to the log line.
+        ///
+        /// Supression count labels get added to the first log line after the rate limit window expires only
+        /// if there was at least one suppressed event in the previous window.
+        #[inline]
+        pub fn should_log(&self) -> (bool, Option<NonZeroU32>) {
+            if self
+                .locked
+                .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+                .is_err()
+            {
+                // Lock is already held, let's just skip this log line
+                return (false, None);
+            }
+            let _unlock = Unlock(&self.locked);
+            // SAFETY: the successful `compare_exchange` above grants this thread exclusive
+            // access to `inner` until `_unlock` is dropped.
+            let inner = unsafe { &mut *self.inner.get() };
+
+            let now = MillisSinceEpoch::now();
+
+            if inner.current == 0 || now.duration_since(inner.period_start) >= *self.period_duration
+            {
+                // First log line after the previous period expired, let's start a new period
+                // and reset the counter.
+                inner.current = 1;
+                inner.period_start = now;
+                // Using NonZeroU32::new returns None if the value is 0, which is what we want
+                let suppressed = NonZeroU32::new(std::mem::take(&mut inner.suppressed));
+                (true, suppressed)
+            } else if inner.current < self.max {
+                // We're still within the rate limit, the line should get logged.
+                inner.current += 1;
+                (true, None)
+            } else {
+                // We're exceeding the rate limit, the line should be suppressed.
+                inner.suppressed = inner.suppressed.saturating_add(1);
+                (false, None)
+            }
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! event_ratelimited {
+    ($lvl:expr, $count:expr, $dur:expr, $($field:tt)*) => {
+        {
+            if $crate::__private::tracing::event_enabled!(
+                $lvl,
+                restate.logging.suppressed =
+                    $crate::__private::tracing::field::Empty,
+                $($field)*
+            ) {
+                // Using const to force both the duration and the count to be constant
+                // at compile time for easier reasoning about the behavior.
+                const DUR: ::std::time::Duration = $dur;
+                const COUNT: u16 = $count;
+                static LIMIT: $crate::__private::RateLimiter =
+                    $crate::__private::RateLimiter::new(COUNT, &DUR);
+
+                // This branch will probably be optimized away at compile time given that
+                // COUNT is a compile-time constant.
+                if COUNT > 0 {
+                    let (should_log, suppressed) = LIMIT.should_log();
+                    if should_log {
+                        $crate::__private::tracing::event!(
+                            $lvl,
+                            restate.logging.suppressed = suppressed,
+                            $($field)*
+                        );
+                    }
+                }
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! info_ratelimited {
+    ($count:expr, $dur:expr, $($field:tt)*) => {
+        $crate::event_ratelimited!(
+            $crate::__private::tracing::Level::INFO,
+            $count,
+            $dur,
+            $($field)*
+        );
+    }
+}
+
+#[macro_export]
+macro_rules! warn_ratelimited {
+    ($count:expr, $dur:expr, $($field:tt)*) => {
+        $crate::event_ratelimited!(
+            $crate::__private::tracing::Level::WARN,
+            $count,
+            $dur,
+            $($field)*
+        );
+    }
+}
+
+#[macro_export]
+macro_rules! error_ratelimited {
+    ($count:expr, $dur:expr, $($field:tt)*) => {
+        $crate::event_ratelimited!(
+            $crate::__private::tracing::Level::ERROR,
+            $count,
+            $dur,
+            $($field)*
+        );
+    }
+}

--- a/crates/tracing/tests/macros.rs
+++ b/crates/tracing/tests/macros.rs
@@ -1,0 +1,160 @@
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tracing::field::{Field, Visit};
+use tracing::{Event, Level, Metadata, Subscriber};
+use tracing_subscriber::layer::{Context, SubscriberExt};
+use tracing_subscriber::{Layer, Registry};
+
+#[derive(Clone, Debug)]
+pub struct CapturedEvent {
+    pub metadata: &'static Metadata<'static>,
+    pub fields: BTreeMap<&'static str, String>,
+}
+
+#[derive(Clone, Default)]
+pub struct EventCapture {
+    events: Arc<Mutex<Vec<CapturedEvent>>>,
+}
+
+impl EventCapture {
+    pub fn layer(&self) -> CaptureLayer {
+        CaptureLayer {
+            capture: self.clone(),
+        }
+    }
+
+    pub fn with_default<T>(&self, f: impl FnOnce() -> T) -> T {
+        tracing::subscriber::with_default(Registry::default().with(self.layer()), f)
+    }
+
+    pub fn events(&self) -> Vec<CapturedEvent> {
+        self.events.lock().expect("event capture poisoned").clone()
+    }
+
+    pub fn take_events(&self) -> Vec<CapturedEvent> {
+        std::mem::take(&mut *self.events.lock().expect("event capture poisoned"))
+    }
+}
+
+pub struct CaptureLayer {
+    capture: EventCapture,
+}
+
+impl<S> Layer<S> for CaptureLayer
+where
+    S: Subscriber,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = FieldVisitor::default();
+        event.record(&mut visitor);
+
+        self.capture
+            .events
+            .lock()
+            .expect("event capture poisoned")
+            .push(CapturedEvent {
+                metadata: event.metadata(),
+                fields: visitor.fields,
+            });
+    }
+}
+
+#[derive(Default)]
+struct FieldVisitor {
+    fields: BTreeMap<&'static str, String>,
+}
+
+impl Visit for FieldVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.fields.insert(field.name(), format!("{value:?}"));
+    }
+}
+
+#[test]
+fn limits_events_per_callsite() {
+    let capture = EventCapture::default();
+
+    capture.with_default(|| {
+        for attempt in 0..3 {
+            restate_tracing::info_ratelimited!(
+                2,
+                Duration::MAX,
+                attempt = attempt,
+                "rate-limited event"
+            );
+        }
+    });
+
+    let events = capture.events();
+
+    assert_eq!(events.len(), 2);
+    assert!(
+        events
+            .iter()
+            .all(|event| event.metadata.level() == &Level::INFO)
+    );
+    assert_eq!(events[0].fields["attempt"], "0");
+    assert_eq!(events[1].fields["attempt"], "1");
+}
+
+#[test]
+fn supression_label() {
+    let capture = EventCapture::default();
+
+    capture.with_default(|| {
+        for _ in 0..2 {
+            for attempt in 0..20 {
+                restate_tracing::info_ratelimited!(
+                    2,
+                    Duration::from_millis(100),
+                    attempt = attempt,
+                    "rate-limited event"
+                );
+            }
+            std::thread::sleep(Duration::from_millis(110));
+        }
+    });
+
+    let events = capture.events();
+
+    assert_eq!(events.len(), 4);
+    assert!(
+        events
+            .iter()
+            .all(|event| event.metadata.level() == &Level::INFO)
+    );
+    assert_eq!(events[0].fields["attempt"], "0");
+    assert_eq!(events[0].fields.get("restate.logging.suppressed"), None);
+
+    assert_eq!(events[1].fields["attempt"], "1");
+    assert_eq!(events[1].fields.get("restate.logging.suppressed"), None);
+
+    // Only first event after period expiry, gets a label with the number of suppressed events
+    assert_eq!(events[2].fields["attempt"], "0");
+    assert_eq!(events[2].fields["restate.logging.suppressed"], "18");
+
+    assert_eq!(events[3].fields["attempt"], "1");
+    assert_eq!(events[3].fields.get("restate.logging.suppressed"), None);
+}
+
+#[test]
+fn max_zero() {
+    let capture = EventCapture::default();
+
+    capture.with_default(|| {
+        for attempt in 0..20 {
+            restate_tracing::info_ratelimited!(
+                0,
+                Duration::from_millis(100),
+                attempt = attempt,
+                "rate-limited event"
+            );
+        }
+    });
+
+    let events = capture.events();
+    assert_eq!(events.len(), 0);
+}


### PR DESCRIPTION
This PR introduces a new crate for tracing utils, and implements its first module which is a ratelimited logging module.

This allows for an efficient "log at most X times every Y seconds" kind of logging, to help reduce log spam. Prior art on this is folly's `LOG_EVERY_*` macros ([link](https://github.com/facebook/folly/blob/4963d7c505eeb18322eefb35d80a853a3edcaf99/folly/logging/xlog.h#L133)) and LogDevice's `RATELIMIT_*` ([link](https://github.com/facebookarchive/LogDevice/blob/ce7726050edc49a1e15d9160e81c890736b779e2/logdevice/common/debug.h#L272)) from which this implementation is inspired.

Usage example would be:
```rust
info_ratelimit!(1, Duration::from_secs(10), field1="test", "my message");
```

This will get logged only once every 10s. The first log line after the period expires will also have the `restate.logging.supressed` field which indicates how many calls were suppressed in the last period. We're also sacrficing on accuracy here in favor of perf, by skipping concurrent logging attempts for the same log line.

---
[//]: # (BEGIN SAPLING FOOTER)
* __->__ #5132
* #5126