### PR TITLE
[worker] Introduce logging for high RPC queue latency and high PP arm loop latency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9216,6 +9216,7 @@ dependencies = [
  "restate-storage-query-datafusion",
  "restate-test-util",
  "restate-timer",
+ "restate-tracing",
  "restate-tracing-instrumentation",
  "restate-types",
  "restate-util-string",

--- a/crates/types/src/net/partition_processor.rs
+++ b/crates/types/src/net/partition_processor.rs
@@ -29,6 +29,7 @@ use crate::net::codec::{
 };
 use crate::net::{ProtocolVersion, ServiceTag};
 use crate::net::{default_wire_codec, define_rpc, define_service};
+use crate::time::MillisSinceEpoch;
 
 pub struct PartitionLeaderService;
 
@@ -50,6 +51,8 @@ default_wire_codec!(Result<PartitionProcessorRpcResponse, PartitionProcessorRpcE
 pub struct PartitionProcessorRpcRequest {
     pub request_id: PartitionProcessorRpcRequestId,
     pub partition_id: PartitionId,
+    /// Time at which the source node sent the request.
+    pub sent_at: Option<MillisSinceEpoch>,
     pub inner: PartitionProcessorRpcRequestInner,
 }
 

--- a/crates/worker-api/src/partition_processor_rpc_client.rs
+++ b/crates/worker-api/src/partition_processor_rpc_client.rs
@@ -39,6 +39,7 @@ use restate_types::net::partition_processor::{
     PartitionProcessorRpcRequest, PartitionProcessorRpcRequestInner, PartitionProcessorRpcResponse,
 };
 use restate_types::partition_table::{FindPartition, PartitionTable, PartitionTableError};
+use restate_types::time::MillisSinceEpoch;
 
 use crate::metric_definitions::{
     INVOCATION_CLIENT_REQUESTS, STATUS_COMPLETED, STATUS_INTERNAL_ERROR, STATUS_OVERLOADED_ERROR,
@@ -320,6 +321,7 @@ where
                 PartitionProcessorRpcRequest {
                     request_id,
                     partition_id,
+                    sent_at: Some(MillisSinceEpoch::now()),
                     inner: inner_request,
                 },
                 Some(*partition_id as u64),

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -46,6 +46,7 @@ restate-storage-query-datafusion = { workspace = true }
 restate-util-time = { workspace = true }
 restate-timer = { workspace = true }
 restate-tracing-instrumentation = { workspace = true }
+restate-tracing = { workspace = true }
 restate-types = { workspace = true }
 restate-util-string = { workspace = true }
 restate-vqueues = { workspace = true }

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -60,6 +60,7 @@ use restate_storage_api::deduplication_table::{
     DedupSequenceNumber, ProducerId, ReadDeduplicationTable,
 };
 use restate_storage_api::{StorageError, Transaction};
+use restate_tracing::warn_ratelimited;
 use restate_types::cluster::cluster_state::{PartitionProcessorStatus, RunMode};
 use restate_types::epoch::EpochMetadata;
 use restate_types::identifiers::LeaderEpoch;
@@ -111,6 +112,41 @@ pub struct LeadershipInfo {
     pub leader_epoch: LeaderEpoch,
     pub current_config: CurrentReplicaSetConfiguration,
     pub next_config: Option<NextReplicaSetConfiguration>,
+}
+
+const HIGH_RPC_QUEUE_LATENCY_THRESHOLD: Duration = Duration::from_secs(20);
+const SLOW_PARTITION_PROCESSOR_ARM_THRESHOLD: Duration = Duration::from_secs(10);
+
+struct SlowPartitionProcessorArmTracker {
+    partition_id: u32,
+    arm_label: &'static str,
+    // Using a low resolution clock here to optimize for perf, given that we're
+    // not that interested in accurate measurements.
+    started_at: MillisSinceEpoch,
+}
+
+impl SlowPartitionProcessorArmTracker {
+    fn new(partition_id: u32, arm_label: &'static str) -> Self {
+        Self {
+            partition_id,
+            arm_label,
+            started_at: MillisSinceEpoch::now(),
+        }
+    }
+}
+
+impl Drop for SlowPartitionProcessorArmTracker {
+    fn drop(&mut self) {
+        let duration = self.started_at.elapsed();
+        if duration > SLOW_PARTITION_PROCESSOR_ARM_THRESHOLD {
+            warn!(
+                partition_id = self.partition_id,
+                "Detected slow partition processor arm ({}) which has been running for {}",
+                self.arm_label,
+                duration.friendly()
+            );
+        }
+    }
 }
 
 impl From<EpochMetadata> for LeadershipInfo {
@@ -551,6 +587,7 @@ where
 
         let mut cloned_partition_store = self.partition_store.clone();
         let mut txn = cloned_partition_store.transaction();
+        let partition_id = self.ctx.partition_id().into();
 
         loop {
             let config = self.node_ctx.config.live_load();
@@ -561,21 +598,37 @@ where
 
             tokio::select! {
                 _ = self.target_leader_state_rx.changed() => {
+                    let _guard = SlowPartitionProcessorArmTracker::new(
+                        partition_id,
+                        "target_leader_state",
+                    );
                     let target_leader_state = self.target_leader_state_rx.borrow_and_update().clone();
                     self.on_target_leader_state(target_leader_state).await.context("failed handling target leader state change")?;
                     self.refresh_status(&mut durable_lsn_watch)?;
                 }
                 Ok(()) = watch_leader_changes.changed() => {
+                    let _guard = SlowPartitionProcessorArmTracker::new(
+                        partition_id,
+                        "leadership_state",
+                    );
                     // cloning to avoid holding the underlying RwLock.
                     let new_state = *watch_leader_changes.borrow_and_update();
                     self.leadership_state.maybe_step_down(&mut self.ctx, new_state.current_leader_epoch, new_state.current_leader).await;
                     self.refresh_status(&mut durable_lsn_watch)?;
                 }
                 Some(msg) = self.network_leader_svc_rx.next(), if network_processing_permit.is_some() => {
+                    let _guard = SlowPartitionProcessorArmTracker::new(
+                        partition_id,
+                        "network_leader_svc_rx",
+                    );
                     // todo: replace the live schema with the leader's consistent schema
                     self.on_rpc(msg, live_schemas.live_load(), &last_applied_lsn_watch, network_processing_permit.expect("guarded with is_some")).await;
                 }
                 _ = status_update_timer.tick() => {
+                    let _guard = SlowPartitionProcessorArmTracker::new(
+                        partition_id,
+                        "status_update_timer",
+                    );
                     // Update the status to ensure changes are observable
                     self.refresh_status(&mut durable_lsn_watch)?;
                 }
@@ -584,6 +637,10 @@ where
                 // Subsequent records are drained synchronously below (`now_or_never`), so the
                 // applied-but-uncommitted records can never be lost to select cancellation.
                 maybe_first = record_stream.next() => {
+                    let _guard = SlowPartitionProcessorArmTracker::new(
+                        partition_id,
+                        "record_stream",
+                    );
                     let Some(first) = maybe_first else {
                         return Err(ProcessorError::LogReadStreamTerminated);
                     };
@@ -665,9 +722,17 @@ where
                     self.ctx.vqueues_mut().try_compact();
                 },
                 result = self.leadership_state.run(&mut self.ctx) => {
+                    let _guard = SlowPartitionProcessorArmTracker::new(
+                        partition_id,
+                        "leadership_state.run",
+                    );
                     result?;
                 }
                 Some(leader_query_cmd) = self.leader_query_rx.recv() => {
+                    let _guard = SlowPartitionProcessorArmTracker::new(
+                        partition_id,
+                        "leader_query_rx",
+                    );
                     self.on_leader_query(leader_query_cmd);
                 }
             }
@@ -784,9 +849,21 @@ where
     ) {
         match msg {
             ServiceMessage::Rpc(msg) if msg.msg_type() == PartitionProcessorRpcRequest::TYPE => {
+                let dequeued_at = MillisSinceEpoch::now();
                 let msg = msg.into_typed::<PartitionProcessorRpcRequest>();
                 // note: split() decodes the payload
                 let (response_tx, body) = msg.split();
+                if let Some(sent_at) = body.sent_at
+                    && dequeued_at.duration_since(sent_at) > HIGH_RPC_QUEUE_LATENCY_THRESHOLD
+                {
+                    warn_ratelimited!(
+                        10,
+                        std::time::Duration::from_mins(1),
+                        partition_id = u32::from(self.ctx.partition_id()),
+                        "Detected high RPC queue latency of {}. This could indicate a slow partition processor loop.",
+                        sent_at.elapsed().friendly()
+                    );
+                }
                 self.on_pp_rpc_request(response_tx, body, schemas, permit)
                     .await;
             }

--- a/crates/worker/src/partition/rpc/mod.rs
+++ b/crates/worker/src/partition/rpc/mod.rs
@@ -119,6 +119,7 @@ where
         PartitionProcessorRpcRequest {
             request_id,
             partition_id: _,
+            sent_at: _,
             inner,
         }: PartitionProcessorRpcRequest,
     ) -> Decision {


### PR DESCRIPTION
This PR's outcome is two new ratelimited log lines that get logged if the PP is detected to be slow:
1. One log line for an RPC that has been queued for long since it was sent. Which required stamping a sent_at timestamp from the sender (backward compatible).
2. Re-introduces the per arm latency tracking for the PP loop but: 1) Uses `RoughtTimestamp` for efficient time tracking (it's only a single relaxed atomic load). 2) Doesn't report histograms, and instead logs only if it's above the slowness threshold. 3) Tracks the PP arm that might have introduced slowness.

This should be adding minimal runtime overhead, while still allowing us to see in the logs indications for unhealthiness in the PP loop. 

This will look something like this in the log:

```
2026-08-05T08:06:25.483420Z WARN restate_worker::partition
  Detected slow partition processor arm (record_stream) which has been running for 10s
    restate.logging.suppressed: 64
    partition_id: "3"
on rt:pp-3
  in restate_worker::partition::run
    partition_id: 3
```

---
[//]: # (BEGIN SAPLING FOOTER)
* __->__ #5134
* #5132
* #5126 
