### PR TITLE
Add support for setting empty partition replica sets

### DIFF
--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -489,6 +489,7 @@ impl<T: TransportConnect> Scheduler<T> {
 
     /// Checks whether a pending reconfiguration should be completed. Conditions for doing this are:
     ///
+    /// * The next configuration is empty
     /// * All workers in the current configuration are disabled
     /// * Any of the partition processors in the next configuration is active (== caught up)
     ///
@@ -519,7 +520,7 @@ impl<T: TransportConnect> Scheduler<T> {
             legacy_cluster_state.is_partition_processor_active(&partition_id, node_id)
         });
 
-        all_current_workers_disabled || any_next_pp_active
+        next.replica_set().is_empty() || all_current_workers_disabled || any_next_pp_active
     }
 
     async fn load_partition_configuration(

--- a/release-notes/unreleased/partition-placement-control.md
+++ b/release-notes/unreleased/partition-placement-control.md
@@ -18,6 +18,18 @@ the cluster controller from creating or retargeting a pending replica set, but a
 reconfiguration to complete. Explicit `placement set` operations remain available as operator
 overrides.
 
+An explicit empty replica set can be used to stop all partition processors for a partition:
+
+```bash
+restatectl partitions placement set 0 --freeze --replicas
+```
+
+The command warns and asks for confirmation because the partition becomes unavailable while its
+replica set remains empty. Pass `--yes` for non-interactive use. Freezing placement keeps the
+replica set empty; without a freeze, the cluster controller may replace it with a non-empty set
+when enough eligible workers are available. Unfreezing an empty placement resumes automatic
+assignment. Stopping partition processors does not delete their local partition stores.
+
 Partition administration commands are now grouped under `partitions placement` and
 `partitions leadership`; the standalone `partitions reconfigure` command has been removed.
 

--- a/tools/restatectl/src/commands/partition/placement/set.rs
+++ b/tools/restatectl/src/commands/partition/placement/set.rs
@@ -13,7 +13,8 @@ use std::collections::HashMap;
 use anyhow::{anyhow, bail};
 use cling::prelude::*;
 
-use restate_cli_util::c_println;
+use restate_cli_util::ui::console::confirm_or_exit;
+use restate_cli_util::{c_println, c_warn};
 use restate_types::PlainNodeId;
 use restate_types::epoch::EpochMetadata;
 use restate_types::identifiers::PartitionId;
@@ -33,7 +34,13 @@ pub struct SetOpts {
     partition_id: PartitionId,
 
     /// Nodes that should run a partition processor replica (comma-separated)
-    #[arg(long, short = 'r', required = true, value_delimiter = ',')]
+    #[arg(
+        long,
+        short = 'r',
+        required = true,
+        value_delimiter = ',',
+        num_args = 0..
+    )]
     replicas: Vec<PlainNodeId>,
 
     /// Freeze automatic placement after setting the replicas
@@ -45,10 +52,6 @@ async fn set_placement(connection: &ConnectionInfo, opts: &SetOpts) -> anyhow::R
     let partition_table = connection.get_partition_table().await?;
     if !partition_table.contains(&opts.partition_id) {
         bail!("Partition {} does not exist.", opts.partition_id);
-    }
-
-    if opts.replicas.is_empty() {
-        bail!("At least one replica is required.");
     }
 
     let replicas: NodeSet = opts.replicas.iter().copied().collect();
@@ -63,13 +66,25 @@ async fn set_placement(connection: &ConnectionInfo, opts: &SetOpts) -> anyhow::R
         })?;
     }
 
-    let replication = u8::try_from(replicas.len())
-        .map_err(|_| anyhow!("Cannot configure more than {} replicas.", u8::MAX))?;
-    let placement = PartitionConfiguration::new(
-        ReplicationProperty::new_unchecked(replication),
-        replicas,
-        HashMap::default(),
-    );
+    let replication = if replicas.is_empty() {
+        c_warn!(
+            "An empty replica set stops all partition processors for partition {} once the \
+             configuration takes effect. Automatic placement may assign new replicas unless \
+             placement is frozen.",
+            opts.partition_id
+        );
+        confirm_or_exit(&format!(
+            "Set an empty replica set for partition {}?",
+            opts.partition_id
+        ))?;
+
+        partition_table.replication_property(&nodes_configuration)
+    } else {
+        let replication = u8::try_from(replicas.len())
+            .map_err(|_| anyhow!("Cannot configure more than {} replicas.", u8::MAX))?;
+        ReplicationProperty::new_unchecked(replication)
+    };
+    let placement = PartitionConfiguration::new(replication, replicas, HashMap::default());
 
     update_epoch_metadata(connection, opts.partition_id, |epoch_metadata| {
         apply_placement(epoch_metadata, placement.clone(), opts.freeze.as_deref())


### PR DESCRIPTION
Setting empty partition replica sets allows us to stop processing a given
partition. This is an expert configuration that should be used with care.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>