### PR TITLE
[admin] Fix premature partition reconfiguration completion

### DIFF
--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -616,7 +616,12 @@ impl<T: TransportConnect> Scheduler<T> {
             .difference(partition_state.current.replica_set());
         let Some(first_newly_added) = newly_added.next() else {
             return next.replica_set().iter().any(|node_id| {
-                legacy_cluster_state.is_partition_processor_active(&partition_id, node_id)
+                is_partition_processor_active_on_current_generation(
+                    partition_id,
+                    *node_id,
+                    nodes_config,
+                    legacy_cluster_state,
+                )
             });
         };
         is_partition_processor_active_on_current_generation(
@@ -1275,6 +1280,34 @@ mod tests {
     }
 
     #[test]
+    fn reconfiguration_waits_for_added_follower_when_increasing_replication() {
+        let partition_id = PartitionId::MIN;
+        let state = reconfiguration_state(&[2, 1], Some(&[2, 1, 3]));
+        let nodes_config = nodes_configuration([(1, 1), (2, 1), (3, 1)]);
+
+        assert!(!should_complete(
+            partition_id,
+            &state,
+            &nodes_config,
+            [
+                (1, Some(ReplayStatus::Active)),
+                (2, Some(ReplayStatus::Active)),
+                (3, Some(ReplayStatus::Starting)),
+            ],
+        ));
+        assert!(should_complete(
+            partition_id,
+            &state,
+            &nodes_config,
+            [
+                (1, Some(ReplayStatus::Active)),
+                (2, Some(ReplayStatus::Active)),
+                (3, Some(ReplayStatus::Active)),
+            ],
+        ));
+    }
+
+    #[test]
     fn reconfiguration_requires_an_added_follower_to_be_active() {
         let partition_id = PartitionId::MIN;
         let state = reconfiguration_state(&[3, 2], Some(&[2, 1, 4]));
@@ -1340,7 +1373,7 @@ mod tests {
     #[test]
     fn reconfiguration_without_additions_requires_an_active_retained_follower() {
         let partition_id = PartitionId::MIN;
-        let nodes_config = nodes_configuration([(2, 1), (3, 1)]);
+        let nodes_config = nodes_configuration([(2, 2), (3, 1)]);
         let pure_removal = reconfiguration_state(&[3, 2], Some(&[2]));
 
         assert!(!should_complete(
@@ -1355,12 +1388,34 @@ mod tests {
             &nodes_config,
             [(2, Some(ReplayStatus::Starting))],
         ));
-        assert!(should_complete(
-            partition_id,
-            &pure_removal,
-            &nodes_config,
-            [(2, Some(ReplayStatus::Active))],
-        ));
+        let mut n2_active_from_old_generation =
+            reconfiguration_legacy_state(partition_id, [(2, Some(ReplayStatus::Active))]);
+        assert!(
+            !Scheduler::<FailingConnector>::should_complete_reconfiguration(
+                partition_id,
+                &nodes_config,
+                &pure_removal,
+                &n2_active_from_old_generation,
+            )
+        );
+
+        let NodeState::Alive(n2) = n2_active_from_old_generation
+            .nodes
+            .get_mut(&PlainNodeId::from(2))
+            .unwrap()
+        else {
+            unreachable!()
+        };
+        n2.generational_node_id = GenerationalNodeId::new(2, 2);
+
+        assert!(
+            Scheduler::<FailingConnector>::should_complete_reconfiguration(
+                partition_id,
+                &nodes_config,
+                &pure_removal,
+                &n2_active_from_old_generation,
+            )
+        );
         assert!(should_complete(
             partition_id,
             &reconfiguration_state(&[3, 2], Some(&[])),

--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -607,14 +607,15 @@ impl<T: TransportConnect> Scheduler<T> {
             return true;
         }
 
-        // Added processors start while `next` is pending, so there is no need to make them
-        // current before one is ready. Keeping the transition pending prevents an unready
-        // addition from entering leader election and lets placement reconsider `next` if the
-        // current replica set recovers first.
+        // Added processors start while `next` is pending. For transitions with additions,
+        // require readiness to be evidenced by at least one addition rather than retained
+        // overlap. This preserves the existing any-Active completion rule; other additions
+        // may still be warming when `next` becomes current.
         let mut newly_added = next
             .replica_set()
-            .difference(partition_state.current.replica_set());
-        let Some(first_newly_added) = newly_added.next() else {
+            .difference(partition_state.current.replica_set())
+            .peekable();
+        if newly_added.peek().is_none() {
             return next.replica_set().iter().any(|node_id| {
                 is_partition_processor_active_on_current_generation(
                     partition_id,
@@ -623,13 +624,8 @@ impl<T: TransportConnect> Scheduler<T> {
                     legacy_cluster_state,
                 )
             });
-        };
-        is_partition_processor_active_on_current_generation(
-            partition_id,
-            first_newly_added,
-            nodes_config,
-            legacy_cluster_state,
-        ) || newly_added.any(|node_id| {
+        }
+        newly_added.any(|node_id| {
             is_partition_processor_active_on_current_generation(
                 partition_id,
                 node_id,
@@ -1308,7 +1304,7 @@ mod tests {
     }
 
     #[test]
-    fn reconfiguration_requires_an_added_follower_to_be_active() {
+    fn reconfiguration_with_multiple_additions_requires_any_added_follower_to_be_active() {
         let partition_id = PartitionId::MIN;
         let state = reconfiguration_state(&[3, 2], Some(&[2, 1, 4]));
         let nodes_config = nodes_configuration([(1, 1), (2, 1), (3, 1), (4, 1)]);

--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -607,32 +607,29 @@ impl<T: TransportConnect> Scheduler<T> {
             return true;
         }
 
-        // If `next` adds processors to the replica set, wait for at least one addition to
-        // demonstrate readiness before making `next` current. Committing while every
-        // addition is still catching up admits unready replicas to leader election and,
-        // during replacement, can drop warm followers from the current replica set.
-        let mut newly_added = next
-            .replica_set()
-            .difference(partition_state.current.replica_set())
-            .peekable();
-        if newly_added.peek().is_none() {
-            return next.replica_set().iter().any(|node_id| {
-                is_partition_processor_active_on_current_generation(
-                    partition_id,
-                    *node_id,
-                    nodes_config,
-                    legacy_cluster_state,
-                )
-            });
-        }
-        newly_added.any(|node_id| {
+        let is_ready = |node_id| {
             is_partition_processor_active_on_current_generation(
                 partition_id,
                 node_id,
                 nodes_config,
                 legacy_cluster_state,
             )
-        })
+        };
+
+        let mut newly_added = next
+            .replica_set()
+            .difference(partition_state.current.replica_set())
+            .peekable();
+        if newly_added.peek().is_some() {
+            // If `next` adds processors to the replica set, wait for at least one addition to
+            // demonstrate readiness before making `next` current. Committing while every addition
+            // is still catching up admits unready replicas to leader election and, during
+            // replacement, can drop warm followers from the current replica set.
+            newly_added.any(is_ready)
+        } else {
+            // Removal-only: at least one retained member must be ready before we drop replicas
+            next.replica_set().iter().copied().any(is_ready)
+        }
     }
 
     async fn load_partition_configuration(
@@ -1099,6 +1096,14 @@ impl<T: TransportConnect> Scheduler<T> {
     }
 }
 
+/// Like [`LegacyClusterState::is_partition_processor_active`], but only trusts a status report
+/// coming from the node generation currently registered in the nodes configuration.
+///
+/// `LegacyClusterState` can retain a status observed from a previous incarnation of a node. After a
+/// restart (e.g. during a rolling update), a leftover `Active` report says nothing about the
+/// current process, which may still be restoring or replaying — so it must not certify
+/// reconfiguration completion. Any mismatch, in either direction, fails toward "not ready", which
+/// only delays completion by a refresh round.
 fn is_partition_processor_active_on_current_generation(
     partition_id: PartitionId,
     node_id: PlainNodeId,
@@ -1156,11 +1161,7 @@ mod tests {
     use super::*;
 
     fn configuration(node_id: u32) -> PartitionConfiguration {
-        PartitionConfiguration::new(
-            ReplicationProperty::new_unchecked(1),
-            [PlainNodeId::from(node_id)].into_iter().collect(),
-            HashMap::default(),
-        )
+        configuration_with_nodes([node_id])
     }
 
     fn configuration_with_nodes(node_ids: impl IntoIterator<Item = u32>) -> PartitionConfiguration {
@@ -1173,7 +1174,12 @@ mod tests {
         )
     }
 
-    fn reconfiguration_state(current: &[u32], next: Option<&[u32]>) -> PartitionState {
+    struct Reconfiguring<'a> {
+        current: &'a [u32],
+        next: Option<&'a [u32]>,
+    }
+
+    fn partition_state(Reconfiguring { current, next }: Reconfiguring<'_>) -> PartitionState {
         PartitionState::new(
             configuration_with_nodes(current.iter().copied()),
             next.map(|next| configuration_with_nodes(next.iter().copied())),
@@ -1200,6 +1206,7 @@ mod tests {
         nodes_config
     }
 
+    /// None = node reports alive but has no processor status for this partition.
     fn reconfiguration_legacy_state(
         partition_id: PartitionId,
         statuses: impl IntoIterator<Item = (u32, Option<ReplayStatus>)>,
@@ -1240,8 +1247,8 @@ mod tests {
 
     fn should_complete(
         partition_id: PartitionId,
-        state: &PartitionState,
         nodes_config: &NodesConfiguration,
+        state: &PartitionState,
         statuses: impl IntoIterator<Item = (u32, Option<ReplayStatus>)>,
     ) -> bool {
         Scheduler::<FailingConnector>::should_complete_reconfiguration(
@@ -1255,13 +1262,16 @@ mod tests {
     #[test]
     fn reconfiguration_waits_for_added_follower_to_be_active() {
         let partition_id = PartitionId::MIN;
-        let state = reconfiguration_state(&[3, 2], Some(&[2, 1]));
+        let state = partition_state(Reconfiguring {
+            current: &[3, 2],
+            next: Some(&[2, 1]),
+        });
         let nodes_config = nodes_configuration([(1, 1), (2, 1), (3, 1)]);
 
         assert!(!should_complete(
             partition_id,
-            &state,
             &nodes_config,
+            &state,
             [
                 (2, Some(ReplayStatus::Active)),
                 (1, Some(ReplayStatus::Starting)),
@@ -1269,22 +1279,26 @@ mod tests {
         ));
         assert!(should_complete(
             partition_id,
-            &state,
             &nodes_config,
+            &state,
             [(1, Some(ReplayStatus::Active))],
         ));
     }
 
     #[test]
-    fn reconfiguration_waits_for_added_follower_when_increasing_replication() {
+    fn reconfiguration_waits_for_added_follower_when_replacing_replica() {
         let partition_id = PartitionId::MIN;
-        let state = reconfiguration_state(&[2, 1], Some(&[2, 1, 3]));
+        // N1 and N2 are retained; N3 joins.
+        let state = partition_state(Reconfiguring {
+            current: &[2, 1],
+            next: Some(&[2, 1, 3]),
+        });
         let nodes_config = nodes_configuration([(1, 1), (2, 1), (3, 1)]);
 
         assert!(!should_complete(
             partition_id,
-            &state,
             &nodes_config,
+            &state,
             [
                 (1, Some(ReplayStatus::Active)),
                 (2, Some(ReplayStatus::Active)),
@@ -1293,8 +1307,8 @@ mod tests {
         ));
         assert!(should_complete(
             partition_id,
-            &state,
             &nodes_config,
+            &state,
             [
                 (1, Some(ReplayStatus::Active)),
                 (2, Some(ReplayStatus::Active)),
@@ -1304,15 +1318,19 @@ mod tests {
     }
 
     #[test]
-    fn reconfiguration_with_multiple_additions_requires_any_added_follower_to_be_active() {
+    fn reconfiguration_with_multiple_additions_completes_when_one_is_active() {
         let partition_id = PartitionId::MIN;
-        let state = reconfiguration_state(&[3, 2], Some(&[2, 1, 4]));
+        // N3 departs, N2 is retained, and N1 and N4 join.
+        let state = partition_state(Reconfiguring {
+            current: &[3, 2],
+            next: Some(&[2, 1, 4]),
+        });
         let nodes_config = nodes_configuration([(1, 1), (2, 1), (3, 1), (4, 1)]);
 
         assert!(!should_complete(
             partition_id,
-            &state,
             &nodes_config,
+            &state,
             [
                 (2, Some(ReplayStatus::Active)),
                 (1, Some(ReplayStatus::Starting)),
@@ -1321,8 +1339,8 @@ mod tests {
         ));
         assert!(should_complete(
             partition_id,
-            &state,
             &nodes_config,
+            &state,
             [
                 (1, Some(ReplayStatus::Active)),
                 (4, Some(ReplayStatus::Starting)),
@@ -1333,7 +1351,10 @@ mod tests {
     #[test]
     fn reconfiguration_requires_active_status_from_current_node_generation() {
         let partition_id = PartitionId::MIN;
-        let state = reconfiguration_state(&[3, 2], Some(&[2, 1]));
+        let state = partition_state(Reconfiguring {
+            current: &[3, 2],
+            next: Some(&[2, 1]),
+        });
         let nodes_config = nodes_configuration([(1, 2), (2, 1), (3, 1)]);
         let mut n1_active_from_old_generation =
             reconfiguration_legacy_state(partition_id, [(1, Some(ReplayStatus::Active))]);
@@ -1370,18 +1391,21 @@ mod tests {
     fn reconfiguration_without_additions_requires_an_active_retained_follower() {
         let partition_id = PartitionId::MIN;
         let nodes_config = nodes_configuration([(2, 2), (3, 1)]);
-        let pure_removal = reconfiguration_state(&[3, 2], Some(&[2]));
+        let pure_removal = partition_state(Reconfiguring {
+            current: &[3, 2],
+            next: Some(&[2]),
+        });
 
         assert!(!should_complete(
             partition_id,
-            &pure_removal,
             &nodes_config,
+            &pure_removal,
             [],
         ));
         assert!(!should_complete(
             partition_id,
-            &pure_removal,
             &nodes_config,
+            &pure_removal,
             [(2, Some(ReplayStatus::Starting))],
         ));
         let mut n2_active_from_old_generation =
@@ -1414,14 +1438,20 @@ mod tests {
         );
         assert!(should_complete(
             partition_id,
-            &reconfiguration_state(&[3, 2], Some(&[])),
             &nodes_config,
+            &partition_state(Reconfiguring {
+                current: &[3, 2],
+                next: Some(&[]),
+            }),
             [],
         ));
         assert!(!should_complete(
             partition_id,
-            &reconfiguration_state(&[3, 2], None),
             &nodes_config,
+            &partition_state(Reconfiguring {
+                current: &[3, 2],
+                next: None,
+            }),
             [],
         ));
     }

--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -22,7 +22,9 @@ use restate_core::{Metadata, MetadataWriter, ShutdownError, SyncError, TaskCente
 use restate_metadata_store::{
     MetadataStoreClient, ReadError, ReadModifyWriteError, ReadWriteError, WriteError,
 };
-use restate_types::cluster::cluster_state::LegacyClusterState;
+use restate_types::cluster::cluster_state::{
+    LegacyClusterState, NodeState as LegacyNodeState, ReplayStatus,
+};
 use restate_types::cluster_state::ClusterState;
 use restate_types::epoch::EpochMetadata;
 use restate_types::identifiers::PartitionId;
@@ -578,7 +580,8 @@ impl<T: TransportConnect> Scheduler<T> {
     ///
     /// * The next configuration is empty
     /// * All workers in the current configuration are disabled
-    /// * Any of the partition processors in the next configuration is active (== caught up)
+    /// * Any newly added partition processor is active (== caught up), or any processor in a
+    ///   removal-only next configuration is active
     ///
     /// Note: We don't complete the reconfiguration if all current nodes are dead for some time,
     /// because we might need any of them to send a partition store snapshot to the next nodes once
@@ -600,14 +603,35 @@ impl<T: TransportConnect> Scheduler<T> {
             .iter()
             .all(|node_id| nodes_config.get_worker_state(node_id) == WorkerState::Disabled);
 
-        // check whether we can transition from the current configuration to the next
-        // configuration, which is possible as soon as a single partition processor from the
-        // next configuration has become active
-        let any_next_pp_active = next.replica_set().iter().any(|node_id| {
-            legacy_cluster_state.is_partition_processor_active(&partition_id, node_id)
-        });
+        if next.replica_set().is_empty() || all_current_workers_disabled {
+            return true;
+        }
 
-        next.replica_set().is_empty() || all_current_workers_disabled || any_next_pp_active
+        // Added processors start while `next` is pending, so there is no need to make them
+        // current before one is ready. Keeping the transition pending prevents an unready
+        // addition from entering leader election and lets placement reconsider `next` if the
+        // current replica set recovers first.
+        let mut newly_added = next
+            .replica_set()
+            .difference(partition_state.current.replica_set());
+        let Some(first_newly_added) = newly_added.next() else {
+            return next.replica_set().iter().any(|node_id| {
+                legacy_cluster_state.is_partition_processor_active(&partition_id, node_id)
+            });
+        };
+        is_partition_processor_active_on_current_generation(
+            partition_id,
+            first_newly_added,
+            nodes_config,
+            legacy_cluster_state,
+        ) || newly_added.any(|node_id| {
+            is_partition_processor_active_on_current_generation(
+                partition_id,
+                node_id,
+                nodes_config,
+                legacy_cluster_state,
+            )
+        })
     }
 
     async fn load_partition_configuration(
@@ -1074,6 +1098,26 @@ impl<T: TransportConnect> Scheduler<T> {
     }
 }
 
+fn is_partition_processor_active_on_current_generation(
+    partition_id: PartitionId,
+    node_id: PlainNodeId,
+    nodes_config: &NodesConfiguration,
+    legacy_cluster_state: &LegacyClusterState,
+) -> bool {
+    let Ok(node_config) = nodes_config.find_node_by_id(node_id) else {
+        return false;
+    };
+    let Some(LegacyNodeState::Alive(node_state)) = legacy_cluster_state.nodes.get(&node_id) else {
+        return false;
+    };
+
+    node_state.generational_node_id == node_config.current_generation
+        && node_state
+            .partitions
+            .get(&partition_id)
+            .is_some_and(|status| status.replay_status == ReplayStatus::Active)
+}
+
 /// Returns `true` if the given node matches the leader affinity expression.
 fn matches_affinity(
     node_id: PlainNodeId,
@@ -1095,10 +1139,17 @@ fn matches_affinity(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+    use std::time::Duration;
+
     use restate_core::network::FailingConnector;
+    use restate_types::cluster::cluster_state::{
+        AliveNode, NodeState, PartitionProcessorStatus, ReplayStatus,
+    };
     use restate_types::metadata::Precondition;
-    use restate_types::nodes_config::{Role, WorkerConfig};
+    use restate_types::nodes_config::{NodeConfig, Role, WorkerConfig};
     use restate_types::partitions::placement_policy::{PlacementFreeze, PlacementPolicy};
+    use restate_types::time::MillisSinceEpoch;
     use restate_types::{GenerationalNodeId, RestateVersion};
 
     use super::*;
@@ -1109,6 +1160,219 @@ mod tests {
             [PlainNodeId::from(node_id)].into_iter().collect(),
             HashMap::default(),
         )
+    }
+
+    fn configuration_with_nodes(node_ids: impl IntoIterator<Item = u32>) -> PartitionConfiguration {
+        let replica_set: NodeSet = node_ids.into_iter().map(PlainNodeId::from).collect();
+        let replication_factor = u8::try_from(replica_set.len().max(1)).unwrap();
+        PartitionConfiguration::new(
+            ReplicationProperty::new_unchecked(replication_factor),
+            replica_set,
+            HashMap::default(),
+        )
+    }
+
+    fn reconfiguration_state(current: &[u32], next: Option<&[u32]>) -> PartitionState {
+        PartitionState::new(
+            configuration_with_nodes(current.iter().copied()),
+            next.map(|next| configuration_with_nodes(next.iter().copied())),
+            LeadershipPolicy::default(),
+            PlacementPolicy::default(),
+        )
+    }
+
+    fn nodes_configuration(
+        node_generations: impl IntoIterator<Item = (u32, u32)>,
+    ) -> NodesConfiguration {
+        let mut nodes_config = NodesConfiguration::new_for_testing();
+        for (node_id, generation) in node_generations {
+            nodes_config.upsert_node(
+                NodeConfig::builder()
+                    .name(format!("node-{node_id}"))
+                    .current_generation(GenerationalNodeId::new(node_id, generation))
+                    .address(format!("unix:/tmp/node-{node_id}").parse().unwrap())
+                    .roles(Role::Worker.into())
+                    .binary_version(RestateVersion::current())
+                    .build(),
+            );
+        }
+        nodes_config
+    }
+
+    fn reconfiguration_legacy_state(
+        partition_id: PartitionId,
+        statuses: impl IntoIterator<Item = (u32, Option<ReplayStatus>)>,
+    ) -> LegacyClusterState {
+        let nodes = statuses
+            .into_iter()
+            .map(|(node_id, replay_status)| {
+                let partitions = replay_status
+                    .map(|replay_status| {
+                        let status = PartitionProcessorStatus {
+                            replay_status,
+                            ..PartitionProcessorStatus::default()
+                        };
+                        (partition_id, status)
+                    })
+                    .into_iter()
+                    .collect();
+                (
+                    PlainNodeId::from(node_id),
+                    NodeState::Alive(AliveNode {
+                        last_heartbeat_at: MillisSinceEpoch::now(),
+                        generational_node_id: GenerationalNodeId::new(node_id, 1),
+                        partitions,
+                        uptime: Duration::ZERO,
+                    }),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+
+        LegacyClusterState {
+            last_refreshed: None,
+            nodes_config_version: Version::INVALID,
+            partition_table_version: Version::INVALID,
+            logs_metadata_version: Version::INVALID,
+            nodes,
+        }
+    }
+
+    fn should_complete(
+        partition_id: PartitionId,
+        state: &PartitionState,
+        nodes_config: &NodesConfiguration,
+        statuses: impl IntoIterator<Item = (u32, Option<ReplayStatus>)>,
+    ) -> bool {
+        Scheduler::<FailingConnector>::should_complete_reconfiguration(
+            partition_id,
+            nodes_config,
+            state,
+            &reconfiguration_legacy_state(partition_id, statuses),
+        )
+    }
+
+    #[test]
+    fn reconfiguration_waits_for_added_follower_to_be_active() {
+        let partition_id = PartitionId::MIN;
+        let state = reconfiguration_state(&[3, 2], Some(&[2, 1]));
+        let nodes_config = nodes_configuration([(1, 1), (2, 1), (3, 1)]);
+
+        assert!(!should_complete(
+            partition_id,
+            &state,
+            &nodes_config,
+            [
+                (2, Some(ReplayStatus::Active)),
+                (1, Some(ReplayStatus::Starting)),
+            ],
+        ));
+        assert!(should_complete(
+            partition_id,
+            &state,
+            &nodes_config,
+            [(1, Some(ReplayStatus::Active))],
+        ));
+    }
+
+    #[test]
+    fn reconfiguration_requires_an_added_follower_to_be_active() {
+        let partition_id = PartitionId::MIN;
+        let state = reconfiguration_state(&[3, 2], Some(&[2, 1, 4]));
+        let nodes_config = nodes_configuration([(1, 1), (2, 1), (3, 1), (4, 1)]);
+
+        assert!(!should_complete(
+            partition_id,
+            &state,
+            &nodes_config,
+            [
+                (2, Some(ReplayStatus::Active)),
+                (1, Some(ReplayStatus::Starting)),
+                (4, Some(ReplayStatus::Starting)),
+            ],
+        ));
+        assert!(should_complete(
+            partition_id,
+            &state,
+            &nodes_config,
+            [
+                (1, Some(ReplayStatus::Active)),
+                (4, Some(ReplayStatus::Starting)),
+            ],
+        ));
+    }
+
+    #[test]
+    fn reconfiguration_requires_active_status_from_current_node_generation() {
+        let partition_id = PartitionId::MIN;
+        let state = reconfiguration_state(&[3, 2], Some(&[2, 1]));
+        let nodes_config = nodes_configuration([(1, 2), (2, 1), (3, 1)]);
+        let mut n1_active_from_old_generation =
+            reconfiguration_legacy_state(partition_id, [(1, Some(ReplayStatus::Active))]);
+
+        assert!(
+            !Scheduler::<FailingConnector>::should_complete_reconfiguration(
+                partition_id,
+                &nodes_config,
+                &state,
+                &n1_active_from_old_generation,
+            )
+        );
+
+        let NodeState::Alive(n1) = n1_active_from_old_generation
+            .nodes
+            .get_mut(&PlainNodeId::from(1))
+            .unwrap()
+        else {
+            unreachable!()
+        };
+        n1.generational_node_id = GenerationalNodeId::new(1, 2);
+
+        assert!(
+            Scheduler::<FailingConnector>::should_complete_reconfiguration(
+                partition_id,
+                &nodes_config,
+                &state,
+                &n1_active_from_old_generation,
+            )
+        );
+    }
+
+    #[test]
+    fn reconfiguration_without_additions_requires_an_active_retained_follower() {
+        let partition_id = PartitionId::MIN;
+        let nodes_config = nodes_configuration([(2, 1), (3, 1)]);
+        let pure_removal = reconfiguration_state(&[3, 2], Some(&[2]));
+
+        assert!(!should_complete(
+            partition_id,
+            &pure_removal,
+            &nodes_config,
+            [],
+        ));
+        assert!(!should_complete(
+            partition_id,
+            &pure_removal,
+            &nodes_config,
+            [(2, Some(ReplayStatus::Starting))],
+        ));
+        assert!(should_complete(
+            partition_id,
+            &pure_removal,
+            &nodes_config,
+            [(2, Some(ReplayStatus::Active))],
+        ));
+        assert!(should_complete(
+            partition_id,
+            &reconfiguration_state(&[3, 2], Some(&[])),
+            &nodes_config,
+            [],
+        ));
+        assert!(!should_complete(
+            partition_id,
+            &reconfiguration_state(&[3, 2], None),
+            &nodes_config,
+            [],
+        ));
     }
 
     #[tokio::test]

--- a/crates/admin/src/cluster_controller/service/scheduler.rs
+++ b/crates/admin/src/cluster_controller/service/scheduler.rs
@@ -607,10 +607,10 @@ impl<T: TransportConnect> Scheduler<T> {
             return true;
         }
 
-        // Added processors start while `next` is pending. For transitions with additions,
-        // require readiness to be evidenced by at least one addition rather than retained
-        // overlap. This preserves the existing any-Active completion rule; other additions
-        // may still be warming when `next` becomes current.
+        // If `next` adds processors to the replica set, wait for at least one addition to
+        // demonstrate readiness before making `next` current. Committing while every
+        // addition is still catching up admits unready replicas to leader election and,
+        // during replacement, can drop warm followers from the current replica set.
         let mut newly_added = next
             .replica_set()
             .difference(partition_state.current.replica_set())

--- a/release-notes/unreleased/1326-wait-for-replacement-partition-replica.md
+++ b/release-notes/unreleased/1326-wait-for-replacement-partition-replica.md
@@ -1,0 +1,16 @@
+# Wait for a replacement partition replica to become ready
+
+## Bug Fix
+
+### What Changed
+
+Restate now waits for a newly added partition processor to catch up before completing a replica-set change.
+
+### Why This Matters
+
+During automatic replica replacement, a retained active member no longer makes the next configuration current while the replacement replays the log or restores a snapshot. This prevents the known-unready replacement from being selected for leadership.
+
+### Impact on Users
+
+- Rolling maintenance and node failures are less likely to select a replacement replica before it catches up.
+- No configuration or migration is required.


### PR DESCRIPTION
Partition leadership selection can, in certain circumstances, select cold followers to be partitionc leaders. This leads to large latency spikes or a temporarily leaderless partition.

The cause replica-set reconfiguration: the controller commits a pending replica-set transition as soon as *any* member of `next` reports `Active` - trivially satisfied by any retained member - and this can drop a departing warm replica from the leader-election set, even while the newly added replica is still catching up. This PR changes the replica-set reconfiguration to require **at least one newly added** processor (or, for removal-only transitions, a retained one) to report `Active` from its **current node generation** before `next` is committed. Until then, the old replica set keeps serving and the addition catches up outside the election set. Technically the current generation requirement is not strictly needed for the core scope of this fix, but it is good hygiene nonetheless; we haven't observed stale generation partition set being a problem in the wild.

Validated with focused tests on the gate plus a three-node cluster reproduction confirming that the handoff ordering flipped: the addition became `Active` before the departing replica stopped. Details are in the collapsed section below. Companion PR [#5149](https://github.com/restatedev/restate/pull/5149) adds partition leader-election diagnostics.

Additional [mostly] AI-generated context below.

## Scope

This change closes the handoff correctness gap only. It does not change gossip failure detection, guarantee continuous leadership while gossip excludes current replicas, or limit recovery fan-out. Increasing replication can still start many stale followers concurrently, causing trim-gap recovery, snapshot downloads, and resource pressure.

## How the unready replica entered leader election

A pending partition reconfiguration has a **current** and a **next** replica set. The worker manager runs processors in their union, allowing an added processor to restore and replay while the transition is pending. Leader election considers only the current set.

Before this change, the controller completed a transition as soon as *any* processor in `next` reported `Active`. For a replacement such as:

```text
current = [N3, N2]
next    = [N2, N1]
```

retained `N2` could satisfy the completion gate while newly added `N1` was absent, starting, replaying, or restoring a snapshot. Committing `next` then removed warm `N3` from the set used for leader election and admitted unready `N1` to it.

This was a two-stage failure. Notably, this is not a problem with leader scoring preferring a stale replica over a visible ready one. If the gossip failure detector later excluded retained `N2`, the unready `N1` could be the only eligible member of the completed current set. The other warm replica, `N3`, was no longer considered because premature completion had removed it from `current`. The legacy `GetNodeState` poll supplies processor status; it is the gossip failure-detector view that determines election eligibility here.

```mermaid
sequenceDiagram
    participant N3 as N3 departing warm replica
    participant CC as Cluster controller
    participant N2 as N2 retained warm replica
    participant N1 as N1 added replica

    Note over N3,N2: current = [N3, N2]
    CC->>CC: Propose next = [N2, N1]
    CC->>N1: Start as a pending processor
    N1-->>N1: Starting or recovering
    N2->>CC: Report Active
    CC->>CC: Old gate sees an Active member of next
    CC->>CC: Commit current = [N2, N1]
    CC->>N3: Stop processor removed by next
    Note over CC,N2: Gossip failure detector later excludes N2
    CC->>N1: Select the only eligible current member
    N1-->>CC: Fail to obtain a new leader epoch
```

## The same mechanism during an RF 2 -> 3 increase

A replication-factor increase does not remove a replica, but the old completion gate could still admit an unready addition:

```text
current = [N2, N1]
next    = [N2, N1, N3]
```

The following sanitized trace from one affected partition uses relative time and omits deployment and workload identifiers:

| Elapsed | Observed event |
|---:|---|
| T+0 | Added N3 starts about 26.5 million records behind and encounters a trim gap. |
| T+0.8 s | The controller commits RF 3 while N3 is stopped for fast-forward recovery. |
| T+74 s | N3's gossip failure-detector view excludes both retained replicas. |
| T+85 s | Recovering N3 receives a leader command and fails to obtain a new leader epoch. |
| T+114 s | N3 begins snapshot recovery. |
| T+151 s | N3 catches up. |

This trace shows the relevant ordering during a pure RF increase: the configuration committed while the addition was recovering, and that recovering addition later received a leader command after gossip excluded the retained replicas. It does not establish that every latency or error symptom observed during the broader recovery event came from stale promotion.

## The fix

For a transition that adds replicas, the completion gate now evaluates the set difference `next` - `current`. At least one newly added processor must report `ReplayStatus::Active`, and the report must match the node generation currently recorded in the nodes configuration. A retained processor or a stale status from a previous node incarnation can no longer certify that an addition is ready.

This deliberately preserves the existing any-Active completion semantics: one current-generation Active addition is sufficient evidence of new ready capacity; other additions may still be warming when `next` becomes current.

While the transition remains pending, the addition still starts and recovers through the existing union behavior, but leader election continues to use the unchanged current set. Once an added processor is current-generation `Active`, the controller may commit `next` and normal leader selection can include it.

Empty next configurations and the all-current-workers-disabled escape remain immediate. A non-empty removal-only transition requires a retained next-set processor to be `Active` on its current node generation.

```mermaid
sequenceDiagram
    participant N3 as N3 warm current replica
    participant CC as Cluster controller
    participant N1 as N1 added replica

    Note over N3: Remains current while N1 recovers
    CC->>N1: Start as a pending processor
    N1-->>N1: Restore snapshot and replay if needed
    N1->>CC: Report Active for current generation
    CC->>CC: Commit next as current
    CC->>N3: Stop if removed by next
```

## Validation (beyond the included tests)

A controlled three-node reproduction forced an added replica through a trim gap, snapshot restore, and replay. The fix reverses the handoff order: the departing warm replica must now outlive its replacement's catch-up, instead of being stopped before it.

| Build | Observed handoff | Window without a ready replacement |
|---|---|---|
| Before fix | departing replica stopped, addition became `Active` 1.68 s **later** | 1.68 s |
| With fix | addition became `Active`, departing replica stopped 1.01 s **later** | none |

(The 1.01 s is the controller's next instruction round after observing `Active` — expected control-loop latency, not a safety margin.)

The fixed run completed 400 sequential writes without an HTTP failure. This is integration evidence for the handoff ordering, not a formal end-to-end reproduction of every production-incident symptom.