### PR TITLE
[admin] `/deployments?include=status` API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7494,6 +7494,7 @@ version = "1.8.0-dev"
 dependencies = [
  "ahash",
  "anyhow",
+ "arc-swap",
  "assert2",
  "axum",
  "bytes",

--- a/crates/admin-rest-model/src/deployments.rs
+++ b/crates/admin-rest-model/src/deployments.rs
@@ -285,6 +285,16 @@ pub struct ListDeploymentsResponse {
 }
 
 #[cfg_attr(feature = "schema", derive(utoipa::ToSchema))]
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DeploymentStatus {
+    /// Active means the deployment is either currently handling in-flight information
+    #[default]
+    Active,
+    Drained,
+}
+
+#[cfg_attr(feature = "schema", derive(utoipa::ToSchema))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DeploymentResponse {
@@ -293,6 +303,15 @@ pub enum DeploymentResponse {
     Http {
         /// # Deployment ID
         id: DeploymentId,
+
+        /// # Status
+        ///
+        /// Whether this deployment is active or fully drained.
+        ///
+        /// This will be returned only if explicitly requested with `include=status`.
+        /// This information is periodically refreshed and cached, it might not be accurate.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        status: Option<DeploymentStatus>,
 
         /// # Deployment URI
         ///
@@ -369,6 +388,15 @@ pub enum DeploymentResponse {
     Lambda {
         /// # Deployment ID
         id: DeploymentId,
+
+        /// # Status
+        ///
+        /// Whether this deployment is active or fully drained.
+        ///
+        /// This will be returned only if explicitly requested with `include=status`.
+        /// This information is periodically refreshed and cached, it might not be accurate.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        status: Option<DeploymentStatus>,
 
         /// # Lambda ARN
         ///
@@ -452,6 +480,15 @@ pub enum DetailedDeploymentResponse {
         /// # Deployment ID
         id: DeploymentId,
 
+        /// # Status
+        ///
+        /// Whether this deployment is active or fully drained.
+        ///
+        /// This will be returned only if explicitly requested with `include=status`.
+        /// This information is periodically refreshed and cached, it might not be accurate.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        status: Option<DeploymentStatus>,
+
         /// # Deployment URI
         ///
         /// URI used to invoke this service deployment.
@@ -525,6 +562,15 @@ pub enum DetailedDeploymentResponse {
     Lambda {
         /// # Deployment ID
         id: DeploymentId,
+
+        /// # Status
+        ///
+        /// Whether this deployment is active or fully drained.
+        ///
+        /// This will be returned only if explicitly requested with `include=status`.
+        /// This information is periodically refreshed and cached, it might not be accurate.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        status: Option<DeploymentStatus>,
 
         /// # Lambda ARN
         ///

--- a/crates/admin-rest-model/src/deployments.rs
+++ b/crates/admin-rest-model/src/deployments.rs
@@ -288,9 +288,12 @@ pub struct ListDeploymentsResponse {
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum DeploymentStatus {
-    /// Active means the deployment is either currently handling in-flight information
+    /// Active means the deployment is either currently handling in-flight invocations and/or
+    /// it serves the latest service revisions for some/all its services.
     #[default]
     Active,
+    /// Drained means the deployment is not handling in-flight invocations,
+    /// and it's serving outdated service revisions for all its services.
     Drained,
 }
 
@@ -310,7 +313,7 @@ pub enum DeploymentResponse {
         ///
         /// This will be returned only if explicitly requested with `include=status`.
         /// This information is periodically refreshed and cached, it might not be accurate.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[serde(skip_serializing_if = "Option::is_none")]
         status: Option<DeploymentStatus>,
 
         /// # Deployment URI
@@ -395,7 +398,7 @@ pub enum DeploymentResponse {
         ///
         /// This will be returned only if explicitly requested with `include=status`.
         /// This information is periodically refreshed and cached, it might not be accurate.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[serde(skip_serializing_if = "Option::is_none")]
         status: Option<DeploymentStatus>,
 
         /// # Lambda ARN
@@ -486,7 +489,7 @@ pub enum DetailedDeploymentResponse {
         ///
         /// This will be returned only if explicitly requested with `include=status`.
         /// This information is periodically refreshed and cached, it might not be accurate.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[serde(skip_serializing_if = "Option::is_none")]
         status: Option<DeploymentStatus>,
 
         /// # Deployment URI
@@ -569,7 +572,7 @@ pub enum DetailedDeploymentResponse {
         ///
         /// This will be returned only if explicitly requested with `include=status`.
         /// This information is periodically refreshed and cached, it might not be accurate.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[serde(skip_serializing_if = "Option::is_none")]
         status: Option<DeploymentStatus>,
 
         /// # Lambda ARN

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -43,6 +43,7 @@ restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", o
 
 ahash = { workspace = true }
 anyhow = { workspace = true }
+arc-swap = { workspace = true }
 assert2 = { workspace = true }
 axum = { workspace = true, features = ["json", "query"] }
 bytes = { workspace = true }
@@ -84,6 +85,7 @@ restate-types = { workspace = true, features = ["test-util"] }
 
 googletest = { workspace = true }
 test-log = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 tracing = { workspace = true }
 
 [lints]

--- a/crates/admin/src/cache.rs
+++ b/crates/admin/src/cache.rs
@@ -148,8 +148,9 @@ impl DeploymentStatusCache {
                 Ok(guard) => {
                     // Drop current to avoid holding lock.
                     drop(current);
-                    self.refresh_locked(source, requested_at, guard).await
-                },
+                    self.refresh_locked(source, requested_at, false, guard)
+                        .await
+                }
                 Err(_) => Ok(Arc::clone(current_ref)),
             };
         }
@@ -159,7 +160,8 @@ impl DeploymentStatusCache {
 
         // Cold start (nothing to serve) or a forced refresh: wait our turn, then refresh.
         let guard = self.inner.refresh.lock().await;
-        self.refresh_locked(source, requested_at, guard).await
+        self.refresh_locked(source, requested_at, force_refresh, guard)
+            .await
     }
 
     /// Recomputes the cache entry while holding the refresh lock, stores it, and returns it.
@@ -167,10 +169,12 @@ impl DeploymentStatusCache {
         &self,
         source: &S,
         requested_at: Instant,
+        force_refresh: bool,
         _guard: MutexGuard<'_, ()>,
     ) -> anyhow::Result<Arc<CachedDeploymentStatuses>> {
         // Another caller may have refreshed while we entered the lock, skip refreshing in that case.
-        if let Some(current) = self.inner.value.load().as_ref()
+        if !force_refresh
+            && let Some(current) = self.inner.value.load().as_ref()
             && current.computed_at >= requested_at
             && current.schema_version == source.schema_version()
         {

--- a/crates/admin/src/cache.rs
+++ b/crates/admin/src/cache.rs
@@ -247,7 +247,7 @@ where
              AND deployment IN ({not_latest_deployments_in_clause})"
                 )
             } else {
-                // TODO remove this once vqueues are enabled by default
+                // TODO v1.8.0 remove this once vqueues are enabled by default
                 format!(
                     "SELECT DISTINCT pinned_deployment_id FROM sys_invocation_status \
              WHERE status != 'completed' AND pinned_deployment_id IN ({not_latest_deployments_in_clause})"

--- a/crates/admin/src/cache.rs
+++ b/crates/admin/src/cache.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
 // All rights reserved.
 //
 // Use of this software is governed by the Business Source License
@@ -135,20 +135,27 @@ impl DeploymentStatusCache {
             .into();
         let current = self.inner.value.load();
 
-        if !force_refresh && let Some(current) = current.as_ref() {
+        if !force_refresh && let Some(current_ref) = current.as_ref() {
             // Fast path: we have a value that satisfies the requirements already.
-            if current.schema_version == source.schema_version()
-                && current.computed_at.elapsed() < ttl
+            if current_ref.schema_version == source.schema_version()
+                && current_ref.computed_at.elapsed() < ttl
             {
-                return Ok(Arc::clone(current));
+                return Ok(Arc::clone(current_ref));
             }
 
             // We need a refresh. Try lock to refresh. If already held, another refresh is happening, just return current stale data.
             return match self.inner.refresh.try_lock() {
-                Ok(guard) => self.refresh_locked(source, requested_at, guard).await,
-                Err(_) => Ok(Arc::clone(current)),
+                Ok(guard) => {
+                    // Drop current to avoid holding lock.
+                    drop(current);
+                    self.refresh_locked(source, requested_at, guard).await
+                },
+                Err(_) => Ok(Arc::clone(current_ref)),
             };
         }
+
+        // Drop current to avoid holding lock.
+        drop(current);
 
         // Cold start (nothing to serve) or a forced refresh: wait our turn, then refresh.
         let guard = self.inner.refresh.lock().await;
@@ -232,7 +239,7 @@ where
             {
                 format!(
                     "SELECT DISTINCT deployment FROM sys_vqueues \
-             WHERE entry_kind = 'invocation' AND stage != 'finished' \
+             WHERE entry_kind = 'invocation' AND stage IN ('inbox', 'running', 'suspended', 'paused') \
              AND deployment IN ({not_latest_deployments_in_clause})"
                 )
             } else {

--- a/crates/admin/src/cache.rs
+++ b/crates/admin/src/cache.rs
@@ -1,0 +1,494 @@
+// Copyright (c) 2023 - 2025 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use arc_swap::ArcSwapOption;
+use datafusion::arrow::array::{Array, LargeStringArray};
+use futures::StreamExt;
+use itertools::Itertools;
+use restate_admin_rest_model::deployments::DeploymentStatus;
+use restate_storage_query_datafusion::context::QueryContext;
+use restate_types::Version;
+use restate_types::config::Configuration;
+use restate_types::identifiers::DeploymentId;
+use restate_types::schema::registry::{MetadataService, SchemaRegistry};
+use tokio::sync::{Mutex, MutexGuard};
+use tokio::time::Instant;
+
+#[derive(Clone)]
+pub struct DeploymentStatusSnapshot {
+    cached: Arc<CachedDeploymentStatuses>,
+    pub age: Duration,
+}
+
+impl DeploymentStatusSnapshot {
+    pub fn statuses(&self) -> &HashMap<DeploymentId, DeploymentStatus> {
+        &self.cached.statuses
+    }
+}
+
+/// Status of a single deployment together with the age of the underlying cache entry.
+pub struct DeploymentStatusEntry {
+    pub status: Option<DeploymentStatus>,
+    pub age: Duration,
+}
+
+struct CachedDeploymentStatuses {
+    statuses: HashMap<DeploymentId, DeploymentStatus>,
+    computed_at: Instant,
+    schema_version: Version,
+}
+
+#[derive(Clone)]
+pub struct DeploymentStatusCache {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    /// The cached value, read-mostly.
+    value: ArcSwapOption<CachedDeploymentStatuses>,
+    /// Used to serialize refreshes.
+    refresh: Mutex<()>,
+}
+
+trait DeploymentStatusReader {
+    /// Get the current schema version.
+    fn schema_version(&self) -> Version;
+
+    /// Recomputes the status of every deployment. The expensive step (a query engine round-trip
+    /// in production).
+    async fn compute(&self) -> anyhow::Result<HashMap<DeploymentId, DeploymentStatus>>;
+}
+
+impl DeploymentStatusCache {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                value: ArcSwapOption::empty(),
+                refresh: Mutex::new(()),
+            }),
+        }
+    }
+
+    /// Returns all the deployment statuses
+    pub async fn get_all<Metadata, Discovery, Telemetry>(
+        &self,
+        schema_registry: &SchemaRegistry<Metadata, Discovery, Telemetry>,
+        query_context: &QueryContext,
+        force_refresh: bool,
+    ) -> anyhow::Result<DeploymentStatusSnapshot>
+    where
+        Metadata: MetadataService,
+    {
+        let source = QueryDeploymentStatusReader {
+            schema_registry,
+            query_context,
+        };
+        let cached = self.ensure_fresh(&source, force_refresh).await?;
+        let age = cached.computed_at.elapsed();
+        Ok(DeploymentStatusSnapshot { cached, age })
+    }
+
+    /// Returns the status of a single deployment without cloning the whole status map.
+    pub async fn get<Metadata, Discovery, Telemetry>(
+        &self,
+        schema_registry: &SchemaRegistry<Metadata, Discovery, Telemetry>,
+        query_context: &QueryContext,
+        deployment_id: DeploymentId,
+        force_refresh: bool,
+    ) -> anyhow::Result<DeploymentStatusEntry>
+    where
+        Metadata: MetadataService,
+    {
+        let source = QueryDeploymentStatusReader {
+            schema_registry,
+            query_context,
+        };
+        let cached = self.ensure_fresh(&source, force_refresh).await?;
+        Ok(DeploymentStatusEntry {
+            status: cached.statuses.get(&deployment_id).copied(),
+            age: cached.computed_at.elapsed(),
+        })
+    }
+
+    /// Returns a fresh cache entry, recomputing it if needed.
+    async fn ensure_fresh<S: DeploymentStatusReader>(
+        &self,
+        source: &S,
+        force_refresh: bool,
+    ) -> anyhow::Result<Arc<CachedDeploymentStatuses>> {
+        let requested_at = Instant::now();
+        let ttl: Duration = Configuration::pinned()
+            .admin
+            .deployment_status_cache_ttl
+            .into();
+        let current = self.inner.value.load();
+
+        if !force_refresh && let Some(current) = current.as_ref() {
+            // Fast path: we have a value that satisfies the requirements already.
+            if current.schema_version == source.schema_version()
+                && current.computed_at.elapsed() < ttl
+            {
+                return Ok(Arc::clone(current));
+            }
+
+            // We need a refresh. Try lock to refresh. If already held, another refresh is happening, just return current stale data.
+            return match self.inner.refresh.try_lock() {
+                Ok(guard) => self.refresh_locked(source, requested_at, guard).await,
+                Err(_) => Ok(Arc::clone(current)),
+            };
+        }
+
+        // Cold start (nothing to serve) or a forced refresh: wait our turn, then refresh.
+        let guard = self.inner.refresh.lock().await;
+        self.refresh_locked(source, requested_at, guard).await
+    }
+
+    /// Recomputes the cache entry while holding the refresh lock, stores it, and returns it.
+    async fn refresh_locked<S: DeploymentStatusReader>(
+        &self,
+        source: &S,
+        requested_at: Instant,
+        _guard: MutexGuard<'_, ()>,
+    ) -> anyhow::Result<Arc<CachedDeploymentStatuses>> {
+        // Another caller may have refreshed while we entered the lock, skip refreshing in that case.
+        if let Some(current) = self.inner.value.load().as_ref()
+            && current.computed_at >= requested_at
+            && current.schema_version == source.schema_version()
+        {
+            return Ok(Arc::clone(current));
+        }
+
+        // Snapshot the schema version we compute against.
+        // If it advances mid-compute, it's fine as worst case next read will refresh it.
+        let schema_version = source.schema_version();
+        let statuses = source.compute().await?;
+
+        // Store the new statuses
+        let refreshed = Arc::new(CachedDeploymentStatuses {
+            statuses,
+            computed_at: Instant::now(),
+            schema_version,
+        });
+        self.inner.value.store(Some(Arc::clone(&refreshed)));
+
+        Ok(refreshed)
+    }
+}
+
+/// Implementation of [`DeploymentStatusReader`] backed by the schema registry and the query engine.
+struct QueryDeploymentStatusReader<'a, Metadata, Discovery, Telemetry> {
+    schema_registry: &'a SchemaRegistry<Metadata, Discovery, Telemetry>,
+    query_context: &'a QueryContext,
+}
+
+impl<Metadata, Discovery, Telemetry> DeploymentStatusReader
+    for QueryDeploymentStatusReader<'_, Metadata, Discovery, Telemetry>
+where
+    Metadata: MetadataService,
+{
+    fn schema_version(&self) -> Version {
+        self.schema_registry.schema_version()
+    }
+
+    async fn compute(&self) -> anyhow::Result<HashMap<DeploymentId, DeploymentStatus>> {
+        let deployments = self.schema_registry.list_deployments();
+
+        // Figure out which deployments are not being used as "latest" by any service.
+        let latest_deployments: HashSet<_> = self
+            .schema_registry
+            .list_services()
+            .into_iter()
+            .map(|service| service.deployment_id)
+            .collect();
+        let not_latest_deployments: Vec<_> = deployments
+            .iter()
+            .map(|(deployment, _)| deployment.id)
+            .filter(|deployment_id| !latest_deployments.contains(deployment_id))
+            .collect();
+
+        // Of the non-latest deployments, find the ones that are pinned to any invocation.
+        let mut pinned_non_latest_deployments: HashSet<DeploymentId> = HashSet::new();
+        if !not_latest_deployments.is_empty() {
+            let not_latest_deployments_in_clause = not_latest_deployments
+                .iter()
+                .map(|id| format!("'{id}'"))
+                .join(", ");
+            let query = if Configuration::pinned()
+                .common
+                .experimental
+                .is_vqueues_enabled()
+            {
+                format!(
+                    "SELECT DISTINCT deployment FROM sys_vqueues \
+             WHERE entry_kind = 'invocation' AND stage != 'finished' \
+             AND deployment IN ({not_latest_deployments_in_clause})"
+                )
+            } else {
+                // TODO remove this once vqueues are enabled by default
+                format!(
+                    "SELECT DISTINCT pinned_deployment_id FROM sys_invocation_status \
+             WHERE status != 'completed' AND pinned_deployment_id IN ({not_latest_deployments_in_clause})"
+                )
+            };
+
+            // Execute the query
+            let mut query_result = self.query_context.execute(&query).await?;
+            while let Some(batch) = query_result.stream.next().await {
+                let batch = batch?;
+                let column = batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<LargeStringArray>()
+                    .context("deployment status query returned an unexpected column type")?;
+                for value in column.iter().flatten() {
+                    pinned_non_latest_deployments.insert(value.parse()?);
+                }
+            }
+        }
+
+        // Compute statuses
+        Ok(deployments
+            .into_iter()
+            .map(|(deployment, _)| {
+                let status = if latest_deployments.contains(&deployment.id)
+                    || pinned_non_latest_deployments.contains(&deployment.id)
+                {
+                    DeploymentStatus::Active
+                } else {
+                    DeploymentStatus::Drained
+                };
+                (deployment.id, status)
+            })
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Mutex as StdMutex;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    use restate_types::config::set_current_config;
+    use tokio::sync::Notify;
+
+    /// A controllable [`DeploymentStatusReader`]: counts recomputations and can gate them so a
+    /// refresh can be held in-flight while another caller races.
+    struct FakeSource {
+        version: StdMutex<Version>,
+        computes: AtomicUsize,
+        result: StdMutex<HashMap<DeploymentId, DeploymentStatus>>,
+        /// Signalled right after a *gated* compute starts, so a test knows the refresher now holds
+        /// the refresh lock.
+        entered: Notify,
+        /// A gated compute waits on this before returning.
+        gate: Notify,
+        gated: AtomicBool,
+    }
+
+    impl FakeSource {
+        fn new() -> Self {
+            Self {
+                version: StdMutex::new(Version::MIN),
+                computes: AtomicUsize::new(0),
+                result: StdMutex::new(HashMap::new()),
+                entered: Notify::new(),
+                gate: Notify::new(),
+                gated: AtomicBool::new(false),
+            }
+        }
+
+        fn computes(&self) -> usize {
+            self.computes.load(Ordering::SeqCst)
+        }
+
+        fn set_version(&self, version: Version) {
+            *self.version.lock().unwrap() = version;
+        }
+
+        fn set_gated(&self, gated: bool) {
+            self.gated.store(gated, Ordering::SeqCst);
+        }
+    }
+
+    impl DeploymentStatusReader for FakeSource {
+        fn schema_version(&self) -> Version {
+            *self.version.lock().unwrap()
+        }
+
+        async fn compute(&self) -> anyhow::Result<HashMap<DeploymentId, DeploymentStatus>> {
+            self.computes.fetch_add(1, Ordering::SeqCst);
+            if self.gated.load(Ordering::SeqCst) {
+                self.entered.notify_one();
+                self.gate.notified().await;
+            }
+            Ok(self.result.lock().unwrap().clone())
+        }
+    }
+
+    fn install_config() {
+        set_current_config(Configuration::default());
+    }
+
+    /// A fresh value is served from the fast path, and a clone shares the same underlying cache.
+    #[tokio::test]
+    async fn fast_path_and_clone_share_state() {
+        install_config();
+        let cache = DeploymentStatusCache::new();
+        let source = FakeSource::new();
+
+        let first = cache.ensure_fresh(&source, false).await.unwrap();
+        assert_eq!(source.computes(), 1);
+
+        // A clone shares the same inner cache: a fresh read hits the fast path, no recompute.
+        let again = cache.clone().ensure_fresh(&source, false).await.unwrap();
+        assert!(Arc::ptr_eq(&first, &again));
+        assert_eq!(source.computes(), 1);
+    }
+
+    /// A forced refresh recomputes even when the cached value is still fresh.
+    #[tokio::test]
+    async fn force_refresh_recomputes() {
+        install_config();
+        let cache = DeploymentStatusCache::new();
+        let source = FakeSource::new();
+
+        let first = cache.ensure_fresh(&source, false).await.unwrap();
+        let forced = cache.ensure_fresh(&source, true).await.unwrap();
+        assert_eq!(source.computes(), 2);
+        assert!(!Arc::ptr_eq(&first, &forced));
+    }
+
+    /// A schema-version bump makes the cached value stale even within the TTL.
+    #[tokio::test]
+    async fn schema_version_bump_recomputes() {
+        install_config();
+        let cache = DeploymentStatusCache::new();
+        let source = FakeSource::new();
+
+        cache.ensure_fresh(&source, false).await.unwrap();
+        source.set_version(Version::MIN.next());
+        let refreshed = cache.ensure_fresh(&source, false).await.unwrap();
+        assert_eq!(source.computes(), 2);
+        assert_eq!(refreshed.schema_version, Version::MIN.next());
+    }
+
+    /// Once the TTL elapses the next read recomputes.
+    #[tokio::test(start_paused = true)]
+    async fn ttl_expiry_recomputes() {
+        install_config();
+        let ttl: Duration = Configuration::pinned()
+            .admin
+            .deployment_status_cache_ttl
+            .into();
+        let cache = DeploymentStatusCache::new();
+        let source = FakeSource::new();
+
+        let first = cache.ensure_fresh(&source, false).await.unwrap();
+        // Within the TTL: fast path, no recompute.
+        let fresh = cache.ensure_fresh(&source, false).await.unwrap();
+        assert!(Arc::ptr_eq(&first, &fresh));
+        assert_eq!(source.computes(), 1);
+
+        // Past the TTL: recompute.
+        tokio::time::advance(ttl + Duration::from_secs(1)).await;
+        let stale = cache.ensure_fresh(&source, false).await.unwrap();
+        assert!(!Arc::ptr_eq(&first, &stale));
+        assert_eq!(source.computes(), 2);
+    }
+
+    /// While one refresh is in flight, a concurrent stale reader is served the old value instead of
+    /// launching a second refresh.
+    #[tokio::test]
+    async fn stale_serve_is_single_flight() {
+        install_config();
+        let cache = DeploymentStatusCache::new();
+        let source = Arc::new(FakeSource::new());
+
+        // Populate, then make the entry stale by bumping the schema version and arm the gate.
+        let stale = cache.ensure_fresh(&*source, false).await.unwrap();
+        source.set_version(Version::MIN.next());
+        source.set_gated(true);
+        assert_eq!(source.computes(), 1);
+
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                // Refresher A wins the lock and blocks inside compute.
+                let refresher = {
+                    let cache = cache.clone();
+                    let source = Arc::clone(&source);
+                    tokio::task::spawn_local(async move {
+                        cache.ensure_fresh(&*source, false).await.unwrap()
+                    })
+                };
+                // Wait until A holds the refresh lock and is inside compute. This is the second
+                // compute overall (the initial populate above was the first).
+                source.entered.notified().await;
+                assert_eq!(source.computes(), 2);
+
+                // B sees the in-flight refresh and serves the stale value immediately.
+                let served = cache.ensure_fresh(&*source, false).await.unwrap();
+                assert!(Arc::ptr_eq(&served, &stale));
+                assert_eq!(
+                    source.computes(),
+                    2,
+                    "B must serve stale, not trigger a compute"
+                );
+
+                // Release A; it publishes the fresh value.
+                source.gate.notify_one();
+                let refreshed = refresher.await.unwrap();
+                assert!(!Arc::ptr_eq(&refreshed, &stale));
+                assert_eq!(source.computes(), 2);
+            })
+            .await;
+    }
+
+    /// Concurrent callers against a cold cache trigger exactly one recompute and share its result.
+    #[tokio::test]
+    async fn cold_start_coalesces() {
+        install_config();
+        let cache = DeploymentStatusCache::new();
+        let source = Arc::new(FakeSource::new());
+        source.set_gated(true);
+
+        tokio::task::LocalSet::new()
+            .run_until(async {
+                // Three cold callers race; one wins the lock and blocks in compute, the rest queue.
+                let mut handles = Vec::new();
+                for _ in 0..3 {
+                    let cache = cache.clone();
+                    let source = Arc::clone(&source);
+                    handles.push(tokio::task::spawn_local(async move {
+                        cache.ensure_fresh(&*source, false).await.unwrap()
+                    }));
+                }
+                // Wait until the winner is inside compute.
+                source.entered.notified().await;
+                assert_eq!(source.computes(), 1);
+
+                // Release; the queued callers should coalesce onto the winner's result.
+                source.gate.notify_one();
+                let mut results = Vec::new();
+                for handle in handles {
+                    results.push(handle.await.unwrap());
+                }
+                assert_eq!(source.computes(), 1, "cold-start callers must coalesce");
+                assert!(results.iter().all(|r| Arc::ptr_eq(r, &results[0])));
+            })
+            .await;
+    }
+}

--- a/crates/admin/src/cache.rs
+++ b/crates/admin/src/cache.rs
@@ -158,8 +158,7 @@ impl DeploymentStatusCache {
                 Ok(guard) => {
                     // Drop current to avoid holding lock.
                     drop(current);
-                    self.refresh_locked(source, requested_at, false, guard)
-                        .await
+                    self.do_refresh_cache(source, requested_at, guard).await
                 }
                 Err(_) => Ok(Arc::clone(current_ref)),
             };
@@ -170,37 +169,33 @@ impl DeploymentStatusCache {
 
         // Cold start (nothing to serve) or a forced refresh: wait our turn, then refresh.
         let guard = self.inner.refresh.lock().await;
-        self.refresh_locked(source, requested_at, force_refresh, guard)
-            .await
+        self.do_refresh_cache(source, requested_at, guard).await
     }
 
     /// Recomputes the cache entry while holding the refresh lock, stores it, and returns it.
-    async fn refresh_locked<S: DeploymentStatusReader>(
+    async fn do_refresh_cache<S: DeploymentStatusReader>(
         &self,
         source: &S,
         requested_at: Instant,
-        force_refresh: bool,
         _guard: MutexGuard<'_, ()>,
     ) -> anyhow::Result<Arc<CachedDeploymentStatuses>> {
         // Another caller may have refreshed while we entered the lock, skip refreshing in that case.
-        if !force_refresh
-            && let Some(current) = self.inner.value.load().as_ref()
-            && current.computed_at >= requested_at
-            && current.schema_version >= source.schema_version()
+        if let Some(current_cache) = self.inner.value.load().as_ref()
+            && current_cache.computed_at >= requested_at
         {
-            return Ok(Arc::clone(current));
+            return Ok(Arc::clone(current_cache));
         }
 
-        // Snapshot the schema version we compute against.
+        // Snapshot the current schema version
         // If it advances mid-compute, it's fine as worst case next read will refresh it.
-        let schema_version = source.schema_version();
+        let current_schema_version = source.schema_version();
         let statuses = source.compute().await?;
 
         // Store the new statuses
         let refreshed = Arc::new(CachedDeploymentStatuses {
             statuses,
             computed_at: Instant::now(),
-            schema_version,
+            schema_version: current_schema_version,
         });
         self.inner.value.store(Some(Arc::clone(&refreshed)));
 
@@ -405,26 +400,6 @@ mod tests {
         let refreshed = cache.ensure_fresh(&source, false).await.unwrap();
         assert_eq!(source.computes(), 2);
         assert_eq!(refreshed.schema_version, Version::MIN.next());
-    }
-
-    /// A refresh computed against an older schema version must never clobber a newer cached entry,
-    /// even when forced.
-    #[tokio::test]
-    async fn refresh_never_regresses_schema_version() {
-        install_config();
-        let cache = DeploymentStatusCache::new();
-        let source = FakeSource::new();
-
-        // Cache an entry at a newer schema version.
-        source.set_version(Version::MIN.next());
-        let newer = cache.ensure_fresh(&source, true).await.unwrap();
-
-        // A forced refresh that sees an older schema version recomputes but keeps the newer entry.
-        source.set_version(Version::MIN);
-        let after = cache.ensure_fresh(&source, true).await.unwrap();
-        assert!(Arc::ptr_eq(&after, &newer));
-        assert_eq!(after.schema_version, Version::MIN.next());
-        assert_eq!(source.computes(), 2);
     }
 
     /// Once the TTL elapses the next read recomputes.

--- a/crates/admin/src/cache.rs
+++ b/crates/admin/src/cache.rs
@@ -29,19 +29,30 @@ use tokio::time::Instant;
 #[derive(Clone)]
 pub struct DeploymentStatusSnapshot {
     cached: Arc<CachedDeploymentStatuses>,
-    pub age: Duration,
 }
 
 impl DeploymentStatusSnapshot {
     pub fn statuses(&self) -> &HashMap<DeploymentId, DeploymentStatus> {
         &self.cached.statuses
     }
+
+    /// Age of the underlying cache entry.
+    pub fn age(&self) -> Duration {
+        self.cached.computed_at.elapsed()
+    }
 }
 
 /// Status of a single deployment together with the age of the underlying cache entry.
 pub struct DeploymentStatusEntry {
     pub status: Option<DeploymentStatus>,
-    pub age: Duration,
+    computed_at: Instant,
+}
+
+impl DeploymentStatusEntry {
+    /// Age of the underlying cache entry.
+    pub fn age(&self) -> Duration {
+        self.computed_at.elapsed()
+    }
 }
 
 struct CachedDeploymentStatuses {
@@ -96,8 +107,7 @@ impl DeploymentStatusCache {
             query_context,
         };
         let cached = self.ensure_fresh(&source, force_refresh).await?;
-        let age = cached.computed_at.elapsed();
-        Ok(DeploymentStatusSnapshot { cached, age })
+        Ok(DeploymentStatusSnapshot { cached })
     }
 
     /// Returns the status of a single deployment without cloning the whole status map.
@@ -118,7 +128,7 @@ impl DeploymentStatusCache {
         let cached = self.ensure_fresh(&source, force_refresh).await?;
         Ok(DeploymentStatusEntry {
             status: cached.statuses.get(&deployment_id).copied(),
-            age: cached.computed_at.elapsed(),
+            computed_at: cached.computed_at,
         })
     }
 

--- a/crates/admin/src/cache.rs
+++ b/crates/admin/src/cache.rs
@@ -147,7 +147,7 @@ impl DeploymentStatusCache {
 
         if !force_refresh && let Some(current_ref) = current.as_ref() {
             // Fast path: we have a value that satisfies the requirements already.
-            if current_ref.schema_version == source.schema_version()
+            if current_ref.schema_version >= source.schema_version()
                 && current_ref.computed_at.elapsed() < ttl
             {
                 return Ok(Arc::clone(current_ref));
@@ -156,7 +156,7 @@ impl DeploymentStatusCache {
             // We need a refresh. Try lock to refresh. If already held, another refresh is happening, just return current stale data.
             return match self.inner.refresh.try_lock() {
                 Ok(guard) => {
-                    // Drop current to avoid holding lock.
+                    // Drop current to avoid holding proxy returned by arcswap.
                     drop(current);
                     self.do_refresh_cache(source, requested_at, guard).await
                 }
@@ -164,7 +164,7 @@ impl DeploymentStatusCache {
             };
         }
 
-        // Drop current to avoid holding lock.
+        // Drop current to avoid holding proxy returned by arcswap.
         drop(current);
 
         // Cold start (nothing to serve) or a forced refresh: wait our turn, then refresh.
@@ -179,7 +179,7 @@ impl DeploymentStatusCache {
         requested_at: Instant,
         _guard: MutexGuard<'_, ()>,
     ) -> anyhow::Result<Arc<CachedDeploymentStatuses>> {
-        // Another caller may have refreshed while we entered the lock, skip refreshing in that case.
+        // Another caller may have refreshed while we waited for obtaining the lock, skip refreshing in that case.
         if let Some(current_cache) = self.inner.value.load().as_ref()
             && current_cache.computed_at >= requested_at
         {

--- a/crates/admin/src/cache.rs
+++ b/crates/admin/src/cache.rs
@@ -157,26 +157,38 @@ impl DeploymentStatusCache {
                 Ok(guard) => {
                     // Drop current to avoid holding proxy returned by arcswap.
                     drop(current);
-                    self.do_refresh_cache(source, guard).await
+                    self.do_refresh_cache(source, false, false, guard).await
                 }
                 Err(_) => Ok(Arc::clone(current_ref)),
             };
         }
 
         // Drop current to avoid holding proxy returned by arcswap.
+        let was_empty = current.is_none();
         drop(current);
 
         // Cold start (nothing to serve) or a forced refresh: wait our turn, then refresh.
         let guard = self.inner.refresh.lock().await;
-        self.do_refresh_cache(source, guard).await
+        self.do_refresh_cache(source, force_refresh, was_empty, guard)
+            .await
     }
 
     /// Recomputes the cache entry while holding the refresh lock, stores it, and returns it.
     async fn do_refresh_cache<S: DeploymentStatusReader>(
         &self,
         source: &S,
+        force_refresh: bool,
+        was_empty: bool,
         _guard: MutexGuard<'_, ()>,
     ) -> anyhow::Result<Arc<CachedDeploymentStatuses>> {
+        if !force_refresh
+            && was_empty
+            && let Some(current_cache) = self.inner.value.load().as_ref()
+        {
+            // In this case, it was a storm of refreshes on startup. Skip it.
+            return Ok(Arc::clone(current_cache));
+        }
+
         // Snapshot the current schema version
         // If it advances mid-compute, it's fine as worst case next read will refresh it.
         let current_schema_version = source.schema_version();

--- a/crates/admin/src/cache.rs
+++ b/crates/admin/src/cache.rs
@@ -331,7 +331,7 @@ mod tests {
         }
 
         fn computes(&self) -> usize {
-            self.computes.load(Ordering::SeqCst)
+            self.computes.load(Ordering::Relaxed)
         }
 
         fn set_version(&self, version: Version) {

--- a/crates/admin/src/cache.rs
+++ b/crates/admin/src/cache.rs
@@ -186,7 +186,7 @@ impl DeploymentStatusCache {
         if !force_refresh
             && let Some(current) = self.inner.value.load().as_ref()
             && current.computed_at >= requested_at
-            && current.schema_version == source.schema_version()
+            && current.schema_version >= source.schema_version()
         {
             return Ok(Arc::clone(current));
         }
@@ -405,6 +405,26 @@ mod tests {
         let refreshed = cache.ensure_fresh(&source, false).await.unwrap();
         assert_eq!(source.computes(), 2);
         assert_eq!(refreshed.schema_version, Version::MIN.next());
+    }
+
+    /// A refresh computed against an older schema version must never clobber a newer cached entry,
+    /// even when forced.
+    #[tokio::test]
+    async fn refresh_never_regresses_schema_version() {
+        install_config();
+        let cache = DeploymentStatusCache::new();
+        let source = FakeSource::new();
+
+        // Cache an entry at a newer schema version.
+        source.set_version(Version::MIN.next());
+        let newer = cache.ensure_fresh(&source, true).await.unwrap();
+
+        // A forced refresh that sees an older schema version recomputes but keeps the newer entry.
+        source.set_version(Version::MIN);
+        let after = cache.ensure_fresh(&source, true).await.unwrap();
+        assert!(Arc::ptr_eq(&after, &newer));
+        assert_eq!(after.schema_version, Version::MIN.next());
+        assert_eq!(source.computes(), 2);
     }
 
     /// Once the TTL elapses the next read recomputes.

--- a/crates/admin/src/cache.rs
+++ b/crates/admin/src/cache.rs
@@ -138,7 +138,6 @@ impl DeploymentStatusCache {
         source: &S,
         force_refresh: bool,
     ) -> anyhow::Result<Arc<CachedDeploymentStatuses>> {
-        let requested_at = Instant::now();
         let ttl: Duration = Configuration::pinned()
             .admin
             .deployment_status_cache_ttl
@@ -158,7 +157,7 @@ impl DeploymentStatusCache {
                 Ok(guard) => {
                     // Drop current to avoid holding proxy returned by arcswap.
                     drop(current);
-                    self.do_refresh_cache(source, requested_at, guard).await
+                    self.do_refresh_cache(source, guard).await
                 }
                 Err(_) => Ok(Arc::clone(current_ref)),
             };
@@ -169,23 +168,15 @@ impl DeploymentStatusCache {
 
         // Cold start (nothing to serve) or a forced refresh: wait our turn, then refresh.
         let guard = self.inner.refresh.lock().await;
-        self.do_refresh_cache(source, requested_at, guard).await
+        self.do_refresh_cache(source, guard).await
     }
 
     /// Recomputes the cache entry while holding the refresh lock, stores it, and returns it.
     async fn do_refresh_cache<S: DeploymentStatusReader>(
         &self,
         source: &S,
-        requested_at: Instant,
         _guard: MutexGuard<'_, ()>,
     ) -> anyhow::Result<Arc<CachedDeploymentStatuses>> {
-        // Another caller may have refreshed while we waited for obtaining the lock, skip refreshing in that case.
-        if let Some(current_cache) = self.inner.value.load().as_ref()
-            && current_cache.computed_at >= requested_at
-        {
-            return Ok(Arc::clone(current_cache));
-        }
-
         // Snapshot the current schema version
         // If it advances mid-compute, it's fine as worst case next read will refresh it.
         let current_schema_version = source.schema_version();
@@ -469,41 +460,6 @@ mod tests {
                 let refreshed = refresher.await.unwrap();
                 assert!(!Arc::ptr_eq(&refreshed, &stale));
                 assert_eq!(source.computes(), 2);
-            })
-            .await;
-    }
-
-    /// Concurrent callers against a cold cache trigger exactly one recompute and share its result.
-    #[tokio::test]
-    async fn cold_start_coalesces() {
-        install_config();
-        let cache = DeploymentStatusCache::new();
-        let source = Arc::new(FakeSource::new());
-        source.set_gated(true);
-
-        tokio::task::LocalSet::new()
-            .run_until(async {
-                // Three cold callers race; one wins the lock and blocks in compute, the rest queue.
-                let mut handles = Vec::new();
-                for _ in 0..3 {
-                    let cache = cache.clone();
-                    let source = Arc::clone(&source);
-                    handles.push(tokio::task::spawn_local(async move {
-                        cache.ensure_fresh(&*source, false).await.unwrap()
-                    }));
-                }
-                // Wait until the winner is inside compute.
-                source.entered.notified().await;
-                assert_eq!(source.computes(), 1);
-
-                // Release; the queued callers should coalesce onto the winner's result.
-                source.gate.notify_one();
-                let mut results = Vec::new();
-                for handle in handles {
-                    results.push(handle.await.unwrap());
-                }
-                assert_eq!(source.computes(), 1, "cold-start callers must coalesce");
-                assert!(results.iter().all(|r| Arc::ptr_eq(r, &results[0])));
             })
             .await;
     }

--- a/crates/admin/src/lib.rs
+++ b/crates/admin/src/lib.rs
@@ -8,6 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod cache;
 pub mod cluster_controller;
 mod error;
 #[cfg(feature = "metadata-api")]

--- a/crates/admin/src/rest_api/deployments.rs
+++ b/crates/admin/src/rest_api/deployments.rs
@@ -673,7 +673,6 @@ fn deployment_status_headers(age: std::time::Duration) -> HeaderMap {
         header::AGE,
         HeaderValue::from_str(&age.as_secs().to_string()).expect("age is a valid header value"),
     );
-    headers.insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
     headers
 }
 

--- a/crates/admin/src/rest_api/deployments.rs
+++ b/crates/admin/src/rest_api/deployments.rs
@@ -243,7 +243,7 @@ where
             .map_err(|err| MetaApiError::Internal(err.to_string()))?;
         let status = entry.status.unwrap_or(DeploymentStatus::Active);
         Ok((
-            deployment_status_headers(entry.age),
+            deployment_status_headers(entry.age()),
             Json(to_detailed_deployment_response(
                 deployment,
                 services,
@@ -306,7 +306,7 @@ where
 
     if let Some(snapshot) = snapshot {
         Ok((
-            deployment_status_headers(snapshot.age),
+            deployment_status_headers(snapshot.age()),
             Json(ListDeploymentsResponse { deployments }),
         )
             .into_response())

--- a/crates/admin/src/rest_api/deployments.rs
+++ b/crates/admin/src/rest_api/deployments.rs
@@ -12,8 +12,8 @@ use std::collections::HashMap;
 use std::time::SystemTime;
 
 use axum::extract::{Path, Query, State};
-use axum::http::{StatusCode, header};
-use axum::response::IntoResponse;
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
+use axum::response::{IntoResponse, Response};
 use axum::{Extension, Json};
 use http::{Method, Uri};
 use serde::Deserialize;
@@ -34,6 +34,25 @@ use restate_types::schema::service::ServiceMetadata;
 use super::error::*;
 use crate::rest_api::ErrorDescriptionResponse;
 use crate::state::AdminServiceState;
+
+#[derive(Debug, Default, Deserialize)]
+pub struct DeploymentStatusParams {
+    include: Option<DeploymentStatusInclude>,
+    #[serde(default)]
+    refresh: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum DeploymentStatusInclude {
+    Status,
+}
+
+impl DeploymentStatusParams {
+    fn include_status(&self) -> bool {
+        matches!(self.include, Some(DeploymentStatusInclude::Status))
+    }
+}
 
 /// Register deployment
 ///
@@ -198,6 +217,7 @@ where
     tag = "deployment",
     params(
         ("deployment" = String, Path, description = "Deployment identifier"),
+        ("include" = Option<String>, Query, description = "If set to `status`, includes the deployment's computed status (`active` or `drained`) in the response. This information is periodically refreshed and cached, so it might not be fully accurate."),
     ),
     responses(
         (status = 200, description = "Deployment details including services and configuration", body = DetailedDeploymentResponse),
@@ -207,7 +227,8 @@ where
 pub async fn get_deployment<Metadata, Discovery, Telemetry, Invocations, Transport>(
     State(state): State<AdminServiceState<Metadata, Discovery, Telemetry, Invocations, Transport>>,
     Path(deployment_id): Path<DeploymentId>,
-) -> Result<Json<DetailedDeploymentResponse>, MetaApiError>
+    Query(params): Query<DeploymentStatusParams>,
+) -> Result<Response, MetaApiError>
 where
     Metadata: MetadataService,
 {
@@ -215,8 +236,24 @@ where
         .schema_registry
         .get_deployment_and_services(deployment_id)
         .ok_or_else(|| MetaApiError::DeploymentNotFound(deployment_id))?;
-
-    Ok(to_detailed_deployment_response(deployment, services).into())
+    if params.include_status() {
+        let entry = state
+            .deployment_status(deployment_id, params.refresh)
+            .await
+            .map_err(|err| MetaApiError::Internal(err.to_string()))?;
+        let status = entry.status.unwrap_or(DeploymentStatus::Active);
+        Ok((
+            deployment_status_headers(entry.age),
+            Json(to_detailed_deployment_response(
+                deployment,
+                services,
+                Some(status),
+            )),
+        )
+            .into_response())
+    } else {
+        Ok(Json(to_detailed_deployment_response(deployment, services, None)).into_response())
+    }
 }
 
 /// List deployments
@@ -227,24 +264,55 @@ where
     path = "/deployments",
     operation_id = "list_deployments",
     tag = "deployment",
+    params(
+        ("include" = Option<String>, Query, description = "If set to `status`, includes each deployment's computed status (`active` or `drained`) in the response. This information is periodically refreshed and cached, so it might not be fully accurate."),
+    ),
     responses(
         (status = 200, description = "List of all registered deployments with their metadata", body = ListDeploymentsResponse)
     )
 )]
 pub async fn list_deployments<Metadata, Discovery, Telemetry, Invocations, Transport>(
     State(state): State<AdminServiceState<Metadata, Discovery, Telemetry, Invocations, Transport>>,
-) -> Json<ListDeploymentsResponse>
+    Query(params): Query<DeploymentStatusParams>,
+) -> Result<Response, MetaApiError>
 where
     Metadata: MetadataService,
 {
+    let snapshot = if params.include_status() {
+        Some(
+            state
+                .deployment_statuses(params.refresh)
+                .await
+                .map_err(|err| MetaApiError::Internal(err.to_string()))?,
+        )
+    } else {
+        None
+    };
     let deployments = state
         .schema_registry
         .list_deployments()
         .into_iter()
-        .map(|(deployment, services)| to_deployment_response(deployment, services))
+        .map(|(deployment, services)| {
+            let status = snapshot.as_ref().map(|snapshot| {
+                snapshot
+                    .statuses()
+                    .get(&deployment.id)
+                    .copied()
+                    .unwrap_or(DeploymentStatus::Active)
+            });
+            to_deployment_response(deployment, services, status)
+        })
         .collect();
 
-    ListDeploymentsResponse { deployments }.into()
+    if let Some(snapshot) = snapshot {
+        Ok((
+            deployment_status_headers(snapshot.age),
+            Json(ListDeploymentsResponse { deployments }),
+        )
+            .into_response())
+    } else {
+        Ok(Json(ListDeploymentsResponse { deployments }).into_response())
+    }
 }
 
 #[derive(Debug, Deserialize, utoipa::IntoParams)]
@@ -359,7 +427,7 @@ where
                     .get_deployment_and_services(deployment_id)
                     .ok_or_else(|| MetaApiError::DeploymentNotFound(deployment_id))?;
 
-                return Ok(to_detailed_deployment_response(deployment, services).into());
+                return Ok(to_detailed_deployment_response(deployment, services, None).into());
             }
 
             if let Some(uri) = &uri {
@@ -413,7 +481,7 @@ where
                     .get_deployment_and_services(deployment_id)
                     .ok_or_else(|| MetaApiError::DeploymentNotFound(deployment_id))?;
 
-                return Ok(to_detailed_deployment_response(deployment, services).into());
+                return Ok(to_detailed_deployment_response(deployment, services, None).into());
             }
 
             (
@@ -450,7 +518,9 @@ where
         .await
         .inspect_err(|e| warn_it!(e))?;
 
-    Ok(Json(to_detailed_deployment_response(deployment, services)))
+    Ok(Json(to_detailed_deployment_response(
+        deployment, services, None,
+    )))
 }
 
 fn to_register_response(
@@ -486,6 +556,7 @@ fn to_deployment_response(
         ..
     }: Deployment,
     services: Vec<(String, ServiceRevision)>,
+    status: Option<DeploymentStatus>,
 ) -> DeploymentResponse {
     match ty {
         DeploymentType::Http {
@@ -495,6 +566,7 @@ fn to_deployment_response(
             auth,
         } => DeploymentResponse::Http {
             id,
+            status,
             uri: address,
             protocol_type,
             http_version,
@@ -517,6 +589,7 @@ fn to_deployment_response(
             compression,
         } => DeploymentResponse::Lambda {
             id,
+            status,
             arn,
             assume_role_arn: assume_role_arn.map(Into::into),
             compression,
@@ -548,6 +621,7 @@ fn to_detailed_deployment_response(
         ..
     }: Deployment,
     services: Vec<ServiceMetadata>,
+    status: Option<DeploymentStatus>,
 ) -> DetailedDeploymentResponse {
     match ty {
         DeploymentType::Http {
@@ -557,6 +631,7 @@ fn to_detailed_deployment_response(
             auth,
         } => DetailedDeploymentResponse::Http {
             id,
+            status,
             uri: address,
             protocol_type,
             http_version,
@@ -576,6 +651,7 @@ fn to_detailed_deployment_response(
             compression,
         } => DetailedDeploymentResponse::Lambda {
             id,
+            status,
             arn,
             assume_role_arn: assume_role_arn.map(Into::into),
             compression,
@@ -589,6 +665,16 @@ fn to_detailed_deployment_response(
             info,
         },
     }
+}
+
+fn deployment_status_headers(age: std::time::Duration) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::AGE,
+        HeaderValue::from_str(&age.as_secs().to_string()).expect("age is a valid header value"),
+    );
+    headers.insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
+    headers
 }
 
 #[inline]

--- a/crates/admin/src/rest_api/query.rs
+++ b/crates/admin/src/rest_api/query.rs
@@ -50,8 +50,6 @@ struct QueryErrorBody {
 pub(crate) enum QueryError {
     #[error("Datafusion error: {0}")]
     Datafusion(#[from] datafusion::error::DataFusionError),
-    #[error("Query service not available")]
-    Unavailable,
     #[error("Rate limited")]
     RateLimited(#[from] gardal::RateLimited),
 }
@@ -79,7 +77,6 @@ impl IntoResponse for QueryError {
                 StatusCode::BAD_REQUEST
             }
             QueryError::Datafusion(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            QueryError::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
             QueryError::RateLimited(e) => {
                 headers.insert(
                     RETRY_AFTER_HEADER,
@@ -128,11 +125,7 @@ where
     Invocations: InvocationClient + Send + Sync + Clone + 'static,
     Transport: TransportConnect,
 {
-    let Some(query_context) = state.query_context.as_ref() else {
-        return Err(QueryError::Unavailable);
-    };
-
-    let query_result = query_context.execute(&payload.query).await?;
+    let query_result = state.query_context.execute(&payload.query).await?;
 
     let (result_stream, content_type) = match headers.get(http::header::ACCEPT) {
         Some(v) if v == HeaderValue::from_static("application/json") => (

--- a/crates/admin/src/service.rs
+++ b/crates/admin/src/service.rs
@@ -29,6 +29,7 @@ use restate_metadata_store::MetadataStoreClient;
 use restate_service_client::HttpClient;
 use restate_service_protocol_v4::discovery::ServiceDiscovery;
 use restate_service_protocol_v4::serdes::SerdesClient;
+use restate_storage_query_datafusion::context::QueryContext;
 use restate_types::config::AdminOptions;
 use restate_types::invocation::client::InvocationClient;
 use restate_types::live::LiveLoad;
@@ -51,7 +52,7 @@ pub struct AdminService<Metadata, Discovery, Telemetry, Invocations, Transport> 
     schema_registry: SchemaRegistry<Metadata, Discovery, Telemetry>,
     serdes_client: SerdesClient,
     invocation_client: Invocations,
-    query_context: Option<restate_storage_query_datafusion::context::QueryContext>,
+    query_context: QueryContext,
     metadata_client: MetadataStoreClient,
     rule_book_observer: Option<Arc<dyn RuleBookObserver>>,
 }
@@ -62,6 +63,7 @@ where
     Invocations: InvocationClient + Send + Sync + Clone + 'static,
     Transport: TransportConnect,
 {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         listeners: Listeners<AdminPort>,
         metadata_writer: MetadataWriter,
@@ -70,6 +72,7 @@ where
         serdes_client: SerdesClient,
         service_discovery: ServiceDiscovery,
         telemetry_http_client: Option<HttpClient>,
+        query_context: QueryContext,
     ) -> Self {
         let metadata_client = metadata_writer.raw_metadata_store_client().clone();
         Self {
@@ -82,19 +85,9 @@ where
             ),
             serdes_client,
             invocation_client,
-            query_context: None,
+            query_context,
             metadata_client,
             rule_book_observer: None,
-        }
-    }
-
-    pub fn with_query_context(
-        self,
-        query_context: restate_storage_query_datafusion::context::QueryContext,
-    ) -> Self {
-        Self {
-            query_context: Some(query_context),
-            ..self
         }
     }
 

--- a/crates/admin/src/state.rs
+++ b/crates/admin/src/state.rs
@@ -28,7 +28,7 @@ pub struct AdminServiceState<Metadata, Discovery, Telemetry, Invocations, Transp
     /// directly (e.g. the rule book) via `read_modify_write`.
     pub metadata_store_client: MetadataStoreClient,
     // Some value if the query endpoint is activated
-    pub query_context: Option<QueryContext>,
+    pub query_context: QueryContext,
     pub rule_book_observer: Option<Arc<dyn RuleBookObserver>>,
 }
 
@@ -43,7 +43,7 @@ where
         invocation_client: Invocations,
         ingestion_client: IngestionClient<Transport, Envelope>,
         metadata_store_client: MetadataStoreClient,
-        query_context: Option<QueryContext>,
+        query_context: QueryContext,
         rule_book_observer: Option<Arc<dyn RuleBookObserver>>,
     ) -> Self {
         Self {

--- a/crates/admin/src/state.rs
+++ b/crates/admin/src/state.rs
@@ -8,13 +8,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use crate::cache::{DeploymentStatusCache, DeploymentStatusEntry, DeploymentStatusSnapshot};
 use restate_core::network::TransportConnect;
 use restate_ingestion_client::IngestionClient;
 use restate_limiter::rule_book::RuleBookObserver;
 use restate_metadata_store::MetadataStoreClient;
 use restate_service_protocol_v4::serdes::SerdesClient;
 use restate_storage_query_datafusion::context::QueryContext;
-use restate_types::schema::registry::SchemaRegistry;
+use restate_types::identifiers::DeploymentId;
+use restate_types::schema::registry::{MetadataService, SchemaRegistry};
 use restate_wal_protocol::Envelope;
 use std::sync::Arc;
 
@@ -30,6 +32,7 @@ pub struct AdminServiceState<Metadata, Discovery, Telemetry, Invocations, Transp
     // Some value if the query endpoint is activated
     pub query_context: QueryContext,
     pub rule_book_observer: Option<Arc<dyn RuleBookObserver>>,
+    deployment_status_cache: DeploymentStatusCache,
 }
 
 impl<Metadata, Discovery, Telemetry, Invocations, Transport>
@@ -54,6 +57,37 @@ where
             metadata_store_client,
             query_context,
             rule_book_observer,
+            deployment_status_cache: DeploymentStatusCache::new(),
         }
+    }
+}
+
+impl<Metadata, Discovery, Telemetry, Invocations, Transport>
+    AdminServiceState<Metadata, Discovery, Telemetry, Invocations, Transport>
+where
+    Metadata: MetadataService,
+{
+    pub async fn deployment_statuses(
+        &self,
+        force_refresh: bool,
+    ) -> anyhow::Result<DeploymentStatusSnapshot> {
+        self.deployment_status_cache
+            .get_all(&self.schema_registry, &self.query_context, force_refresh)
+            .await
+    }
+
+    pub async fn deployment_status(
+        &self,
+        deployment_id: DeploymentId,
+        force_refresh: bool,
+    ) -> anyhow::Result<DeploymentStatusEntry> {
+        self.deployment_status_cache
+            .get(
+                &self.schema_registry,
+                &self.query_context,
+                deployment_id,
+                force_refresh,
+            )
+            .await
     }
 }

--- a/crates/node/src/roles/admin.rs
+++ b/crates/node/src/roles/admin.rs
@@ -152,8 +152,8 @@ impl<T: TransportConnect> AdminRole<T> {
             serdes_client,
             service_discovery,
             telemetry_http_client,
-        )
-        .with_query_context(query_context.clone());
+            query_context.clone(),
+        );
 
         if let Some(observer) = local_rule_book_observer {
             admin = admin.with_rule_book_observer(observer);

--- a/crates/types/src/config/admin.rs
+++ b/crates/types/src/config/admin.rs
@@ -138,7 +138,7 @@ impl Default for AdminOptions {
             disable_cluster_controller: false,
             disable_web_ui: false,
             storage_accounting_update_interval: None,
-            // TODO reconsider this default once vqueues are enabled by default
+            // TODO v1.8.0 reconsider this default once vqueues are enabled by default
             deployment_status_cache_ttl: NonZeroFriendlyDuration::from_secs_unchecked(60 * 60),
         }
     }

--- a/crates/types/src/config/admin.rs
+++ b/crates/types/src/config/admin.rs
@@ -78,7 +78,7 @@ pub struct AdminOptions {
 
     /// Maximum age of the cached deployment status used by the Admin API.
     ///
-    /// Since v1.8.0
+    /// Since v1.7.5
     pub deployment_status_cache_ttl: NonZeroFriendlyDuration,
 }
 

--- a/crates/types/src/config/admin.rs
+++ b/crates/types/src/config/admin.rs
@@ -75,6 +75,9 @@ pub struct AdminOptions {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "schemars", schemars(skip))]
     pub storage_accounting_update_interval: Option<NonZeroFriendlyDuration>,
+
+    /// Maximum age of the cached deployment status used by the Admin API.
+    pub deployment_status_cache_ttl: NonZeroFriendlyDuration,
 }
 
 impl AdminOptions {
@@ -133,6 +136,7 @@ impl Default for AdminOptions {
             disable_cluster_controller: false,
             disable_web_ui: false,
             storage_accounting_update_interval: None,
+            deployment_status_cache_ttl: NonZeroFriendlyDuration::from_secs_unchecked(60 * 60),
         }
     }
 }

--- a/crates/types/src/config/admin.rs
+++ b/crates/types/src/config/admin.rs
@@ -77,6 +77,8 @@ pub struct AdminOptions {
     pub storage_accounting_update_interval: Option<NonZeroFriendlyDuration>,
 
     /// Maximum age of the cached deployment status used by the Admin API.
+    ///
+    /// Since v1.8.0
     pub deployment_status_cache_ttl: NonZeroFriendlyDuration,
 }
 

--- a/crates/types/src/config/admin.rs
+++ b/crates/types/src/config/admin.rs
@@ -138,6 +138,7 @@ impl Default for AdminOptions {
             disable_cluster_controller: false,
             disable_web_ui: false,
             storage_accounting_update_interval: None,
+            // TODO reconsider this default once vqueues are enabled by default
             deployment_status_cache_ttl: NonZeroFriendlyDuration::from_secs_unchecked(60 * 60),
         }
     }

--- a/crates/types/src/schema/registry/mod.rs
+++ b/crates/types/src/schema/registry/mod.rs
@@ -36,6 +36,7 @@ use crate::schema::metadata::updater::{
 };
 use crate::schema::service::{HandlerMetadata, ServiceMetadata, ServiceMetadataResolver};
 use crate::schema::subscriptions::{ListSubscriptionFilter, Subscription, SubscriptionResolver};
+use crate::{Version, Versioned};
 
 use crate::schema::Redaction;
 pub use crate::schema::metadata::updater::{
@@ -713,6 +714,10 @@ impl<Metadata: MetadataService, Discovery, Telemetry>
 
     pub fn list_deployments(&self) -> Vec<(Deployment, Vec<(String, ServiceRevision)>)> {
         self.metadata_service.get().get_deployments()
+    }
+
+    pub fn schema_version(&self) -> Version {
+        self.metadata_service.get().version()
     }
 
     pub fn list_service_handlers(

--- a/release-notes/unreleased/1958-deployment-status-api.md
+++ b/release-notes/unreleased/1958-deployment-status-api.md
@@ -1,0 +1,32 @@
+# Release Notes for Issue #1958: Deployment status in the Admin API
+
+## New Feature
+
+### What Changed
+The Admin API can now report the computed status of a deployment, either `active` or `drained`.
+
+- `GET /deployments?include=status` includes the status of every registered deployment.
+- `GET /deployments/{deployment}?include=status` includes the status of a single deployment.
+
+The status is computed on demand and cached. Responses that carry a status include an `Age` header (in seconds) indicating how old the cached value is, together with `Cache-Control: no-store`. Adding `&refresh=true` forces a recomputation, bypassing the cached value.
+
+The cache is refreshed when it expires or when the schema registry changes. The maximum age of a cached status is controlled by the new `admin.deployment-status-cache-ttl` configuration option (default: `1h`).
+
+### Why This Matters
+Operators can now discover which deployments are still actively serving invocations (`active`) and which have been fully drained (`drained`), for example to decide when a deployment can be safely removed.
+
+### Impact on Users
+- New deployments and existing deployments: the API is opt-in via the `include=status` query parameter, so existing clients that do not request the status are unaffected.
+- Because the status is cached, it may lag behind the current state by up to `admin.deployment-status-cache-ttl`. Use `refresh=true` when an up-to-date value is required.
+
+### Migration Guidance
+No action required. To tune how long the status is cached, set:
+
+```toml
+[admin]
+deployment-status-cache-ttl = "1h"
+```
+
+### Related Issues
+- Issue #1958: Add an API to get the status of a deployment
+- PR #5169: `[admin]` `/deployments?include=status` API

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -26,6 +26,7 @@ use restate_ingestion_client::{IngestionClient, SessionOptions};
 use restate_service_client::{AssumeRoleCacheMode, ServiceClient};
 use restate_service_protocol_v4::discovery::ServiceDiscovery;
 use restate_service_protocol_v4::serdes::SerdesClient;
+use restate_storage_query_datafusion::context::{NoTables, QueryContext};
 use restate_storage_query_datafusion::table_docs;
 use restate_types::config::Configuration;
 use restate_types::identifiers::{InvocationId, PartitionProcessorRpcRequestId};
@@ -239,6 +240,7 @@ async fn generate_rest_api_doc() -> anyhow::Result<()> {
         SerdesClient::new(service_client.clone()),
         ServiceDiscovery::new(RetryPolicy::default(), service_client),
         None,
+        QueryContext::create(&Default::default(), NoTables).await?,
     );
 
     TaskCenter::spawn(


### PR DESCRIPTION
Fix #1958, introduces new API to get the status of a deployment. Status can either be `Active` or `Drained`, this status is fetched on request and gets cached up to some expiration time (configurable) or when the schema registry has an update.

Details in the individual commits.