### PR TITLE
Properly initialize vqueue entries with deployment

### DIFF
--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -448,6 +448,13 @@ impl PreFlightInvocationArgument {
             }) => &journal_metadata.span_context,
         }
     }
+
+    pub fn pinned_deployment(&self) -> Option<&PinnedDeployment> {
+        match self {
+            PreFlightInvocationArgument::Input(_) => None,
+            PreFlightInvocationArgument::Journal(journal) => journal.pinned_deployment.as_ref(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/storage-query-datafusion/src/invocation_status/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/row.rs
@@ -98,6 +98,7 @@ pub(crate) fn append_invocation_status_row<'a>(
     match invocation_status.inner.status() {
         Status::Scheduled => {
             row.status("scheduled");
+            fill_pinned_deployment(&mut row, invocation_status)?;
             if row.is_created_using_restate_version_defined() {
                 row.created_using_restate_version(
                     invocation_status.created_using_restate_version()?,
@@ -123,6 +124,7 @@ pub(crate) fn append_invocation_status_row<'a>(
         }
         Status::Inboxed => {
             row.status("inboxed");
+            fill_pinned_deployment(&mut row, invocation_status)?;
             if row.is_created_using_restate_version_defined() {
                 row.created_using_restate_version(
                     invocation_status.created_using_restate_version()?,
@@ -192,20 +194,7 @@ pub(crate) fn append_invocation_status_row<'a>(
         Status::Completed => {
             row.status("completed");
             fill_journal_metadata(&mut row, invocation_status)?;
-
-            if row.is_pinned_deployment_id_defined()
-                && let Some(deployment_id) = invocation_status.deployment_id()?
-            {
-                row.fmt_pinned_deployment_id(deployment_id);
-            }
-            if row.is_pinned_service_protocol_version_defined()
-                && let Some(service_protocol_version) =
-                    invocation_status.service_protocol_version()?
-            {
-                row.pinned_service_protocol_version(
-                    service_protocol_version.as_repr().unsigned_abs(),
-                );
-            }
+            fill_pinned_deployment(&mut row, invocation_status)?;
 
             if row.is_created_using_restate_version_defined() {
                 row.created_using_restate_version(
@@ -272,16 +261,7 @@ fn fill_in_flight_invocation_metadata(
         row.created_using_restate_version(status.created_using_restate_version()?);
     }
     // journal_metadata and stats are filled by other functions
-    if row.is_pinned_deployment_id_defined()
-        && let Some(deployment_id) = status.deployment_id()?
-    {
-        row.fmt_pinned_deployment_id(deployment_id);
-    }
-    if row.is_pinned_service_protocol_version_defined()
-        && let Some(service_protocol_version) = status.service_protocol_version()?
-    {
-        row.pinned_service_protocol_version(service_protocol_version.as_repr().unsigned_abs());
-    }
+    fill_pinned_deployment(row, status)?;
     if row.is_scheduled_start_at_defined()
         && let Some(execution_time) = status.inner.execution_time
     {
@@ -292,6 +272,24 @@ fn fill_in_flight_invocation_metadata(
     }
     if row.is_journal_retention_defined() {
         row.journal_retention(status.journal_retention_duration()?.as_millis() as i64);
+    }
+
+    Ok(())
+}
+
+fn fill_pinned_deployment(
+    row: &mut SysInvocationStatusRowBuilder,
+    status: &InvocationStatusV2Lazy,
+) -> Result<(), ConversionError> {
+    if row.is_pinned_deployment_id_defined()
+        && let Some(deployment_id) = status.deployment_id()?
+    {
+        row.fmt_pinned_deployment_id(deployment_id);
+    }
+    if row.is_pinned_service_protocol_version_defined()
+        && let Some(service_protocol_version) = status.service_protocol_version()?
+    {
+        row.pinned_service_protocol_version(service_protocol_version.as_repr().unsigned_abs());
     }
 
     Ok(())

--- a/crates/vqueues/src/migrations.rs
+++ b/crates/vqueues/src/migrations.rs
@@ -38,7 +38,7 @@ use restate_types::sharding::{PartitionId, WithPartitionKey};
 use restate_types::storage::StorageCodec;
 use restate_types::vqueues::EntryId;
 use restate_types::{LimitKey, LockName, ServiceName};
-use restate_util_string::ReString;
+use restate_util_string::{ReString, ToReString};
 use restate_util_time::DurationExt;
 
 use crate::{VQueue, VQueueEvent, VQueuesMetaCache};
@@ -173,6 +173,15 @@ async fn migrate_inboxes(
                     .try_as_inboxed()
                     .expect("inbox entry must be inboxed");
 
+                let entry_metadata = EntryMetadata {
+                    deployment: inboxed
+                        .metadata
+                        .input
+                        .pinned_deployment()
+                        .map(|pinned_deployment| pinned_deployment.deployment_id.to_restring()),
+                    ..Default::default()
+                };
+
                 vqueue.enqueue_new(
                     UniqueTimestamp::from_unix_millis_unchecked(
                         inboxed.metadata.timestamps.creation_time(),
@@ -184,7 +193,7 @@ async fn migrate_inboxes(
                     seq,
                     inboxed.metadata.execution_time,
                     EntryId::from(invocation_id),
-                    EntryMetadata::default(),
+                    entry_metadata,
                 );
                 // Now, let's update the invocation status to make it vqueue-powered
                 inboxed.metadata.vqueue_id = Some(qid.clone());
@@ -406,6 +415,15 @@ async fn migrate_scheduled_invocation(
     let entry_created_at =
         UniqueTimestamp::from_unix_millis_unchecked(scheduled.metadata.timestamps.creation_time());
 
+    let entry_metadata = EntryMetadata {
+        deployment: scheduled
+            .metadata
+            .input
+            .pinned_deployment()
+            .map(|pinned_deployment| pinned_deployment.deployment_id.to_restring()),
+        ..Default::default()
+    };
+
     // We use a special value (0) for invocations under the following assumptions:
     // - We don't allow two invocations with the same ID to co-exist
     // - Any new invocation with the same ID will be created with Lsn > 0 after migration.
@@ -415,7 +433,7 @@ async fn migrate_scheduled_invocation(
         seq,
         scheduled.metadata.execution_time,
         EntryId::from(invocation_id),
-        EntryMetadata::default(),
+        entry_metadata,
     );
 
     // Delete the timer entry, we don't need it anymore.

--- a/crates/worker/src/partition/state_machine/lifecycle/restart_as_new.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/restart_as_new.rs
@@ -332,6 +332,7 @@ mod tests {
     use restate_storage_api::invocation_status_table::{
         InFlightInvocationMetadata, InvocationStatusDiscriminants, ReadInvocationStatusTable,
     };
+    use restate_storage_api::vqueue_table::{EntryStatusHeader, ReadVQueueTable, Stage};
     use restate_types::identifiers::{
         DeploymentId, InvocationId, InvocationUuid, PartitionProcessorRpcRequestId,
         WithPartitionKey,
@@ -348,6 +349,8 @@ mod tests {
     use restate_types::partitions::{PartitionFeatureChange, PersistedFeatures};
     use restate_types::service_protocol::ServiceProtocolVersion;
     use restate_types::time::MillisSinceEpoch;
+    use restate_types::vqueues::EntryId;
+    use restate_util_string::ToReString;
     use restate_wal_protocol::timer::TimerKeyValue;
     use restate_wal_protocol::v2::{Command, commands};
     use std::time::Duration;
@@ -765,6 +768,98 @@ mod tests {
                 ],
             )
             .await;
+
+        test_env.shutdown().await;
+    }
+
+    #[restate_core::test]
+    async fn restart_propagates_pinned_deployment_to_vqueue_entry() {
+        let mut test_env = TestEnv::create_with_features(PersistedFeatures::from_iter([
+            PartitionFeatureChange::EnableJournalV2,
+        ]))
+        .await;
+
+        let invocation_target = InvocationTarget::mock_service();
+        let original_invocation_id = InvocationId::generate(&invocation_target, None);
+        let _ = test_env
+            .apply_multiple([
+                commands::InvokeCommand::test_envelope(ServiceInvocation {
+                    invocation_id: original_invocation_id,
+                    invocation_target: invocation_target.clone(),
+                    completion_retention_duration: Duration::from_secs(120),
+                    journal_retention_duration: Duration::from_secs(120),
+                    ..ServiceInvocation::mock()
+                }),
+                fixtures::pinned_deployment(original_invocation_id, ServiceProtocolVersion::V6),
+                fixtures::invoker_entry_effect(
+                    original_invocation_id,
+                    OutputCommand {
+                        result: OutputResult::Success(Default::default()),
+                        name: Default::default(),
+                    },
+                ),
+                fixtures::invoker_end_effect(original_invocation_id),
+            ])
+            .await;
+
+        test_env.set_enabled_features(PersistedFeatures::from_iter([
+            PartitionFeatureChange::EnableJournalV2,
+            PartitionFeatureChange::EnableVqueues,
+        ]));
+
+        let new_invocation_id = InvocationId::from_parts(
+            original_invocation_id.partition_key(),
+            InvocationUuid::generate(&invocation_target, None),
+        );
+        let new_deployment_id = DeploymentId::new();
+        let _ = test_env
+            .apply(commands::RestartAsNewInvocationCommand::test_envelope(
+                RestartAsNewInvocationRequest {
+                    invocation_id: original_invocation_id,
+                    new_invocation_id,
+                    copy_prefix_up_to_index_included: 0,
+                    patch_deployment_id: Some(new_deployment_id),
+                    response_sink: None,
+                },
+            ))
+            .await;
+
+        let InvocationStatus::Inboxed(inboxed) = test_env
+            .storage
+            .get_invocation_status(&new_invocation_id)
+            .await
+            .unwrap()
+        else {
+            panic!("restarted invocation must be inboxed");
+        };
+        let vqueue_id = inboxed
+            .metadata
+            .vqueue_id
+            .expect("restarted invocation must have a vqueue id");
+        assert_eq!(
+            inboxed
+                .metadata
+                .input
+                .pinned_deployment()
+                .map(|pinned| pinned.deployment_id),
+            Some(new_deployment_id)
+        );
+
+        let entry_id = EntryId::from(new_invocation_id);
+        let entry_status = {
+            let transaction = test_env.storage.transaction();
+            transaction
+                .get_vqueue_entry_status(new_invocation_id.partition_key(), &entry_id)
+                .await
+                .unwrap()
+                .expect("restarted invocation must have a vqueue entry")
+        };
+        assert_eq!(entry_status.vqueue_id(), &vqueue_id);
+        assert_eq!(entry_status.stage(), Stage::Inbox);
+        assert_eq!(
+            entry_status.metadata().deployment,
+            Some(new_deployment_id.to_restring())
+        );
 
         test_env.shutdown().await;
     }

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -115,7 +115,7 @@ use restate_types::state_mut::StateMutationVersion;
 use restate_types::storage::{StorageDecodeError, StoredRawEntry, StoredRawEntryHeader};
 use restate_types::time::MillisSinceEpoch;
 use restate_types::vqueues::{self, EntryId, VQueueId};
-use restate_util_string::ReString;
+use restate_util_string::{ReString, ToReString};
 use restate_vqueues::{VQueue, VQueueHandle};
 use restate_wal_protocol::timer::TimerKeyDisplay;
 use restate_wal_protocol::timer::TimerKeyValue;
@@ -931,6 +931,14 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
             .vqueue_id
             .as_ref()
             .expect("invariant violation: vqueue id must be set");
+        let entry_metadata = vqueue_table::EntryMetadata {
+            deployment: metadata
+                .input
+                .pinned_deployment()
+                .map(|pinned_deployment| pinned_deployment.deployment_id.to_restring()),
+            ..Default::default()
+        };
+
         VQueue::vqueue_from_invocation_target(
             record_unique_ts,
             qid,
@@ -946,7 +954,7 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
             self.record_lsn,
             metadata.execution_time,
             EntryId::from(invocation_id),
-            vqueue_table::EntryMetadata::default(),
+            entry_metadata,
         );
 
         // 1. Check if we need to schedule it


### PR DESCRIPTION
This commit ensures that we are properly initializing vqueue entries with deployment metadata if the input contains a configured deployment (e.g. how it is the case when restarting as new and pinning a deployment).

This fixes #5165.