### PR TITLE
Fix failure detector startup timing baseline

### DIFF
--- a/crates/node/src/failure_detector.rs
+++ b/crates/node/src/failure_detector.rs
@@ -163,8 +163,9 @@ impl<T: NetworkSender> FailureDetector<T> {
             self.broadcast_bring_up(node_status, &mut fd_state);
         }
         info!("Failure Detector Started");
-        // Explicit reset because the interval could have been created long time ago, and we don't
-        // want to erroneously report that a stall was detected.
+        // Explicit reset because the interval and FD state could have been created long ago, and
+        // we don't want to treat startup time as missed gossip activity.
+        fd_state.reset_gossip_timing();
         self.gossip_interval.reset_immediately();
 
         // Start receiving gossip messages

--- a/crates/node/src/failure_detector/fd_state.rs
+++ b/crates/node/src/failure_detector/fd_state.rs
@@ -204,6 +204,13 @@ impl FdState {
         self.num_gossip_received >= (opts.gossip_fd_stability_threshold.get() as usize)
     }
 
+    /// Resets elapsed-time tracking when gossip processing becomes active.
+    pub(super) fn reset_gossip_timing(&mut self) {
+        let now = Instant::now();
+        self.last_gossip_received_at = now;
+        self.last_gossip_tick = now;
+    }
+
     /// returns true if there has been at least a gossip interval since the last one.
     pub fn gossip_tick(&mut self, opts: &GossipOptions) -> bool {
         let now = Instant::now();
@@ -693,5 +700,70 @@ impl FdState {
     fn my_node_mut(&mut self) -> &mut Node {
         self.node_mut(&self.my_node_id.as_plain())
             .expect("my node must be in FD")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use restate_types::cluster_state::ClusterState;
+    use restate_types::net::address::AdvertisedAddress;
+    use restate_types::nodes_config::{NodeConfig, NodesConfiguration, Role};
+    use restate_types::{GenerationalNodeId, RestateVersion};
+
+    use super::*;
+
+    const A: GenerationalNodeId = GenerationalNodeId::new(1, 1);
+    const B: GenerationalNodeId = GenerationalNodeId::new(2, 1);
+
+    #[tokio::test(start_paused = true)]
+    async fn resetting_gossip_timing_excludes_startup_time() {
+        let opts = GossipOptions::default();
+        let cluster_state = ClusterState::default();
+        let mut state = FdState::new(
+            A,
+            &nodes_config(),
+            PartitionReplicaSetStates::default(),
+            cluster_state.updater(),
+        );
+        state.num_gossip_received = opts.gossip_fd_stability_threshold.get() as usize;
+        for node in state.node_states.values_mut() {
+            node.gossip_age = 0;
+            node.state = NodeState::Alive;
+        }
+
+        tokio::time::advance(
+            *opts.gossip_tick_interval * (opts.gossip_loneliness_threshold.get() + 1),
+        )
+        .await;
+        assert!(state.is_lonely(&opts));
+
+        state.reset_gossip_timing();
+
+        assert!(!state.is_lonely(&opts));
+        assert!(!state.gossip_tick(&opts));
+        state.detect_peer_failures(&opts);
+        assert_eq!(state.node_states[&B.as_plain()].gossip_age, 0);
+        assert_eq!(state.node_states[&B.as_plain()].state, NodeState::Alive);
+
+        tokio::time::advance(*opts.gossip_tick_interval).await;
+        assert!(state.gossip_tick(&opts));
+        assert_eq!(state.node_states[&B.as_plain()].gossip_age, 1);
+        assert!(!state.is_lonely(&opts));
+    }
+
+    fn nodes_config() -> NodesConfiguration {
+        let mut nodes_config = NodesConfiguration::new_for_testing();
+        for node_id in [A, B] {
+            nodes_config.upsert_node(
+                NodeConfig::builder()
+                    .name(format!("node-{node_id}"))
+                    .current_generation(node_id)
+                    .address(AdvertisedAddress::default())
+                    .roles(Role::Admin | Role::Worker)
+                    .binary_version(RestateVersion::current())
+                    .build(),
+            );
+        }
+        nodes_config
     }
 }

--- a/release-notes/unreleased/5156-reset-failure-detector-startup-timing.md
+++ b/release-notes/unreleased/5156-reset-failure-detector-startup-timing.md
@@ -1,0 +1,11 @@
+# Failure detector startup timing
+
+## Bug Fix
+
+The failure detector now resets its gossip timing when the node becomes ready. Time spent starting
+node roles is no longer counted as missed gossip intervals or as time without received gossip,
+preventing a starting node from incorrectly considering healthy peers dead or itself isolated.
+
+No configuration or migration changes are required.
+
+Related issue: [#5156](https://github.com/restatedev/restate/issues/5156).


### PR DESCRIPTION
Reset the failure detector's last gossip tick and receive timestamps when the node finishes starting, alongside the Tokio interval. This prevents time spent starting node roles from bulk-aging healthy peers or making the node immediately report itself as lonely.

Add a paused-time regression test covering both clocks and document the reliability fix.

Related to #5156.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>