### PR TITLE
[ingress] `/restate/invocation/:invocation_id/status` to retrieve invocation status

### DIFF
--- a/crates/ingress-http/src/handler/invocation.rs
+++ b/crates/ingress-http/src/handler/invocation.rs
@@ -29,21 +29,19 @@ use restate_types::schema::invocation_target::InvocationTargetResolver;
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "lowercase")]
-pub enum InvocationStatus {
-    /// not yet started, be run later (might be in inbox, or queued, or cron scheduled)
-    Scheduled,
-    /// invocation started (this might be either actually in flight now, or suspended)
-    Running,
-    Paused,
-    Killed,
-    Failed,
-    Succeeded,
+pub enum InvocationStage {
+    /// Means the invocation has been created but not yet started.
+    Created,
+    /// The invocation started and has not yet completed.
+    Started,
+    /// The invocation completed, with either success or failure.
+    Completed,
 }
 
 #[derive(Debug, Serialize)]
 pub struct InvocationStatusResponse {
-    status: InvocationStatus,
-    /// Filled if `status = 'failed'`
+    stage: InvocationStage,
+    /// Filled if `stage = 'completed'` and the invocation failed
     error: Option<InvocationError>,
 }
 
@@ -296,21 +294,20 @@ where
             }
         };
 
-        let status = match response.state {
+        let stage = match response.state {
             client::InvocationState::Scheduled | client::InvocationState::Inboxed => {
-                InvocationStatus::Scheduled
+                InvocationStage::Created
             }
-            client::InvocationState::Invoked | client::InvocationState::Suspended => {
-                InvocationStatus::Running
-            }
-            client::InvocationState::Paused => InvocationStatus::Paused,
-            client::InvocationState::Killed => InvocationStatus::Killed,
-            client::InvocationState::Failed => InvocationStatus::Failed,
-            client::InvocationState::Succeeded => InvocationStatus::Succeeded,
+            client::InvocationState::Invoked
+            | client::InvocationState::Suspended
+            | client::InvocationState::Paused => InvocationStage::Started,
+            client::InvocationState::Killed
+            | client::InvocationState::Failed
+            | client::InvocationState::Succeeded => InvocationStage::Completed,
         };
 
         let body = serde_json::to_vec(&InvocationStatusResponse {
-            status,
+            stage,
             error: response.error,
         })
         .unwrap();

--- a/crates/ingress-http/src/handler/invocation.rs
+++ b/crates/ingress-http/src/handler/invocation.rs
@@ -11,18 +11,39 @@
 use bytes::Bytes;
 use http::{Method, Request, Response};
 use http_body_util::{BodyExt, Full};
+use serde::Serialize;
 use tracing::warn;
-
-use restate_types::errors::GenericError;
-use restate_types::identifiers::IdempotencyId;
-use restate_types::invocation::InvocationQuery;
-use restate_types::invocation::client::{AttachInvocationResponse, GetInvocationOutputResponse};
-use restate_types::schema::invocation_target::InvocationTargetResolver;
 
 use super::HandlerError;
 use super::path_parsing::{InvocationRequestType, InvocationTargetType, TargetType};
 use super::{Handler, InvocationTargetRequest};
 use crate::RequestDispatcher;
+use crate::handler::responses::X_RESTATE_ID;
+use restate_types::errors::GenericError;
+use restate_types::identifiers::{IdempotencyId, InvocationId};
+use restate_types::invocation::client::{
+    AttachInvocationResponse, GetInvocationOutputResponse, GetInvocationStatusResponse,
+};
+use restate_types::invocation::{InvocationQuery, client};
+use restate_types::schema::invocation_target::InvocationTargetResolver;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum InvocationStatus {
+    /// not yet started, be run later (might be in inbox, or queued, or cron scheduled)
+    Scheduled,
+    /// invocation started (this might be either actually in flight now, or suspended)
+    Running,
+    Paused,
+    Killed,
+    Failed,
+    Succeeded,
+}
+
+#[derive(Debug, Serialize)]
+pub struct InvocationStatusResponse {
+    status: InvocationStatus,
+}
 
 impl<Schemas, Dispatcher> Handler<Schemas, Dispatcher>
 where
@@ -49,6 +70,13 @@ where
                 self.handle_invocation_get_output(
                     req,
                     Self::convert_to_invocation_query(invocation_target_type)?,
+                )
+                .await
+            }
+            InvocationRequestType::Status(invocation_target_type) => {
+                self.handle_invocation_get_status(
+                    req,
+                    Self::convert_to_invocation_query(invocation_target_type)?.to_invocation_id(),
                 )
                 .await
             }
@@ -109,6 +137,20 @@ where
         self.get_invocation_output_query(invocation_query).await
     }
 
+    pub(crate) async fn handle_invocation_get_status<B: http_body::Body>(
+        self,
+        req: Request<B>,
+        invocation_id: InvocationId,
+    ) -> Result<Response<Full<Bytes>>, HandlerError>
+    where
+        <B as http_body::Body>::Error: Into<GenericError>,
+    {
+        if req.method() != Method::GET {
+            return Err(HandlerError::MethodNotAllowed);
+        }
+        self.get_invocation_status(invocation_id).await
+    }
+
     pub(crate) async fn handle_attach_by_target<B: http_body::Body>(
         self,
         req: Request<B>,
@@ -129,6 +171,17 @@ where
     {
         let invocation_query = Self::parse_invocation_target_body(req).await?;
         self.get_invocation_output_query(invocation_query).await
+    }
+    pub(crate) async fn handle_status_by_target<B: http_body::Body>(
+        self,
+        req: Request<B>,
+    ) -> Result<Response<Full<Bytes>>, HandlerError>
+    where
+        <B as http_body::Body>::Error: Into<GenericError>,
+    {
+        let invocation_query = Self::parse_invocation_target_body(req).await?;
+        self.get_invocation_status(invocation_query.to_invocation_id())
+            .await
     }
 
     async fn parse_invocation_target_body<B: http_body::Body>(
@@ -220,5 +273,45 @@ where
                 )
                 .ok_or(HandlerError::NotFound)
         })
+    }
+
+    async fn get_invocation_status(
+        self,
+        invocation_id: InvocationId,
+    ) -> Result<Response<Full<Bytes>>, HandlerError> {
+        let response = match self.dispatcher.get_invocation_status(invocation_id).await {
+            Ok(GetInvocationStatusResponse::Status(out)) => out,
+            Ok(GetInvocationStatusResponse::NotFound) => {
+                return Err(HandlerError::InvocationNotFound);
+            }
+            Err(e) => {
+                warn!(
+                    restate.invocation.id = ?invocation_id,
+                    "Failed to read status: {}",
+                    e,
+                );
+                return Err(HandlerError::Unavailable);
+            }
+        };
+
+        let status = match response.state {
+            client::InvocationState::Scheduled | client::InvocationState::Inboxed => {
+                InvocationStatus::Scheduled
+            }
+            client::InvocationState::Invoked | client::InvocationState::Suspended => {
+                InvocationStatus::Running
+            }
+            client::InvocationState::Paused => InvocationStatus::Paused,
+            client::InvocationState::Killed => InvocationStatus::Killed,
+            client::InvocationState::Failed => InvocationStatus::Failed,
+            client::InvocationState::Succeeded => InvocationStatus::Succeeded,
+        };
+
+        let body = serde_json::to_vec(&InvocationStatusResponse { status }).unwrap();
+
+        Ok(Response::builder()
+            .header(X_RESTATE_ID, invocation_id.to_string())
+            .body(Full::new(body.into()))
+            .unwrap())
     }
 }

--- a/crates/ingress-http/src/handler/invocation.rs
+++ b/crates/ingress-http/src/handler/invocation.rs
@@ -19,7 +19,7 @@ use super::path_parsing::{InvocationRequestType, InvocationTargetType, TargetTyp
 use super::{Handler, InvocationTargetRequest};
 use crate::RequestDispatcher;
 use crate::handler::responses::X_RESTATE_ID;
-use restate_types::errors::GenericError;
+use restate_types::errors::{GenericError, InvocationError};
 use restate_types::identifiers::{IdempotencyId, InvocationId};
 use restate_types::invocation::client::{
     AttachInvocationResponse, GetInvocationOutputResponse, GetInvocationStatusResponse,
@@ -43,6 +43,8 @@ pub enum InvocationStatus {
 #[derive(Debug, Serialize)]
 pub struct InvocationStatusResponse {
     status: InvocationStatus,
+    /// Filled if `status = 'failed'`
+    error: Option<InvocationError>,
 }
 
 impl<Schemas, Dispatcher> Handler<Schemas, Dispatcher>
@@ -307,7 +309,11 @@ where
             client::InvocationState::Succeeded => InvocationStatus::Succeeded,
         };
 
-        let body = serde_json::to_vec(&InvocationStatusResponse { status }).unwrap();
+        let body = serde_json::to_vec(&InvocationStatusResponse {
+            status,
+            error: response.error,
+        })
+        .unwrap();
 
         Ok(Response::builder()
             .header(X_RESTATE_ID, invocation_id.to_string())

--- a/crates/ingress-http/src/handler/invocation.rs
+++ b/crates/ingress-http/src/handler/invocation.rs
@@ -290,7 +290,7 @@ where
                     "Failed to read status: {}",
                     e,
                 );
-                return Err(HandlerError::Unavailable);
+                return Err(HandlerError::GenericReadDispatcherError(e));
             }
         };
 

--- a/crates/ingress-http/src/handler/mod.rs
+++ b/crates/ingress-http/src/handler/mod.rs
@@ -63,10 +63,14 @@ enum RequestType {
     Attach(InvocationId),
     /// `GET /restate/output/{invocation_id}`
     Output(InvocationId),
+    /// `GET /restate/status/{invocation_id}`
+    Status(InvocationId),
     /// `POST /restate/attach` with a body resolving to an invocation target
     AttachByTarget,
     /// `POST /restate/output` with a body resolving to an invocation target
     OutputByTarget,
+    /// `POST /restate/status` with a body resolving to an invocation target
+    StatusByTarget,
     /// `POST /restate/lookup`
     Lookup,
 }
@@ -140,8 +144,12 @@ where
                     )
                     .await
                 }
+                RequestType::Status(invocation_id) => {
+                    this.handle_invocation_get_status(req, invocation_id).await
+                }
                 RequestType::AttachByTarget => this.handle_attach_by_target(req).await,
                 RequestType::OutputByTarget => this.handle_output_by_target(req).await,
+                RequestType::StatusByTarget => this.handle_status_by_target(req).await,
                 RequestType::Lookup => this.handle_lookup(req).await,
             }
         }

--- a/crates/ingress-http/src/handler/path_parsing.rs
+++ b/crates/ingress-http/src/handler/path_parsing.rs
@@ -21,6 +21,8 @@ pub(crate) enum WorkflowRequestType {
     Attach(ReString, ReString),
     /// (name, key)
     GetOutput(ReString, ReString),
+    /// (name, key)
+    Status(ReString, ReString),
 }
 
 impl WorkflowRequestType {
@@ -41,6 +43,7 @@ impl WorkflowRequestType {
         match path_parts.next().ok_or(HandlerError::BadWorkflowPath)? {
             "output" => Ok(WorkflowRequestType::GetOutput(workflow_name, workflow_key)),
             "attach" => Ok(WorkflowRequestType::Attach(workflow_name, workflow_key)),
+            "status" => Ok(WorkflowRequestType::Status(workflow_name, workflow_key)),
             _ => Err(HandlerError::NotFound),
         }
     }
@@ -59,6 +62,7 @@ pub(crate) enum InvocationTargetType {
 pub(crate) enum InvocationRequestType {
     Attach(InvocationTargetType),
     GetOutput(InvocationTargetType),
+    Status(InvocationTargetType),
 }
 
 impl InvocationRequestType {
@@ -119,6 +123,7 @@ impl InvocationRequestType {
         // Output or attach
         match last_chunk {
             "output" => Ok(InvocationRequestType::GetOutput(invocation_target)),
+            "status" => Ok(InvocationRequestType::Status(invocation_target)),
             "attach" => Ok(InvocationRequestType::Attach(invocation_target)),
             _ => Err(HandlerError::NotFound),
         }
@@ -238,8 +243,8 @@ impl ServiceRequestType {
 ///   - `send/{service}/{handler}` or `send/{service}/{key}/{handler}`
 ///   - `scope/{scopeKey}/call/{service}/{handler}`
 ///   - `scope/{scopeKey}/send/{service}/{key}/{handler}`
-///   - `attach/{invocation_id}` or `output/{invocation_id}`
-///   - `attach` or `output` (POST with body describing the target)
+///   - `attach/{invocation_id}` or `output/{invocation_id}` or `status/{invocation_id}`
+///   - `attach` or `output` or `status` (POST with body describing the target)
 ///   - `lookup`
 fn parse_restate_api_verb<'a, Schemas>(
     verb: &str,
@@ -259,11 +264,13 @@ where
             let inner_verb = path_parts.next().ok_or(HandlerError::BadRestateApiPath)?;
             parse_call_or_send(inner_verb, Some(scope_key), path_parts, schemas)
         }
-        "attach" | "output" => match path_parts.next() {
+        "attach" | "output" | "status" => match path_parts.next() {
             None => Ok(if verb == "attach" {
                 RequestType::AttachByTarget
-            } else {
+            } else if verb == "output" {
                 RequestType::OutputByTarget
+            } else {
+                RequestType::StatusByTarget
             }),
             Some(id_str) => {
                 if path_parts.next().is_some() {
@@ -274,8 +281,10 @@ where
                     .map_err(|e| HandlerError::BadInvocationId(id_str.to_owned(), e))?;
                 Ok(if verb == "attach" {
                     RequestType::Attach(invocation_id)
-                } else {
+                } else if verb == "output" {
                     RequestType::Output(invocation_id)
+                } else {
+                    RequestType::Status(invocation_id)
                 })
             }
         },

--- a/crates/ingress-http/src/handler/workflow.rs
+++ b/crates/ingress-http/src/handler/workflow.rs
@@ -49,6 +49,14 @@ where
                 )
                 .await
             }
+            WorkflowRequestType::Status(name, key) => {
+                self.handle_invocation_get_status(
+                    req,
+                    InvocationQuery::Workflow(ServiceId::new(None, name.as_str(), key.as_str()))
+                        .to_invocation_id(),
+                )
+                .await
+            }
         }
     }
 

--- a/crates/ingress-http/src/lib.rs
+++ b/crates/ingress-http/src/lib.rs
@@ -24,8 +24,8 @@ use bytes::Bytes;
 
 use restate_types::identifiers::InvocationId;
 use restate_types::invocation::client::{
-    AttachInvocationResponse, GetInvocationOutputResponse, InvocationOutput,
-    SubmittedInvocationNotification,
+    AttachInvocationResponse, GetInvocationOutputResponse, GetInvocationStatusResponse,
+    InvocationOutput, SubmittedInvocationNotification,
 };
 use restate_types::invocation::{InvocationQuery, InvocationRequest, InvocationResponse};
 use restate_types::journal_v2::Signal;
@@ -90,6 +90,12 @@ pub trait RequestDispatcher {
         &self,
         invocation_query: InvocationQuery,
     ) -> impl Future<Output = Result<GetInvocationOutputResponse, RequestDispatcherError>> + Send;
+
+    /// Get invocation status, without blocking when it's still running.
+    fn get_invocation_status(
+        &self,
+        invocation_id: InvocationId,
+    ) -> impl Future<Output = Result<GetInvocationStatusResponse, RequestDispatcherError>> + Send;
 
     /// Send invocation response (for awakeables).
     /// **NOTE:** This works only for targeting invocations using Journal Table V1/Service Protocol <= V3.
@@ -321,6 +327,14 @@ mod mocks {
         ) -> impl Future<Output = Result<GetInvocationOutputResponse, RequestDispatcherError>> + Send
         {
             MockRequestDispatcher::get_invocation_output(self, invocation_query)
+        }
+
+        fn get_invocation_status(
+            &self,
+            invocation_id: InvocationId,
+        ) -> impl Future<Output = Result<GetInvocationStatusResponse, RequestDispatcherError>> + Send
+        {
+            MockRequestDispatcher::get_invocation_status(self, invocation_id)
         }
 
         fn send_invocation_response(

--- a/crates/ingress-http/src/rpc_request_dispatcher.rs
+++ b/crates/ingress-http/src/rpc_request_dispatcher.rs
@@ -12,8 +12,8 @@ use super::{RequestDispatcher, RequestDispatcherError};
 
 use restate_types::identifiers::{InvocationId, PartitionProcessorRpcRequestId, WithInvocationId};
 use restate_types::invocation::client::{
-    AttachInvocationResponse, GetInvocationOutputResponse, InvocationClient, InvocationClientError,
-    InvocationOutput, SubmittedInvocationNotification,
+    AttachInvocationResponse, GetInvocationOutputResponse, GetInvocationStatusResponse,
+    InvocationClient, InvocationClientError, InvocationOutput, SubmittedInvocationNotification,
 };
 use restate_types::invocation::{InvocationQuery, InvocationRequest, InvocationResponse};
 use restate_types::journal_v2::Signal;
@@ -136,6 +136,19 @@ where
                 .get_invocation_output(request_id, invocation_query.clone())
         })
         .instrument(debug_span!("get invocation output", %request_id, invocation_id = %invocation_query.to_invocation_id()))
+        .await
+    }
+
+    async fn get_invocation_status(
+        &self,
+        invocation_id: InvocationId,
+    ) -> Result<GetInvocationStatusResponse, RequestDispatcherError> {
+        let request_id = PartitionProcessorRpcRequestId::default();
+        self.execute_rpc(true, || {
+            self.invocation_client
+                .get_invocation_status(request_id, invocation_id)
+        })
+        .instrument(debug_span!("get invocation status", %request_id, %invocation_id))
         .await
     }
 

--- a/crates/types/src/invocation/client.rs
+++ b/crates/types/src/invocation/client.rs
@@ -103,6 +103,7 @@ pub enum InvocationState {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct InvocationStatus {
     pub state: InvocationState,
+    pub error: Option<InvocationError>,
 }
 
 // the most used variant is the largest one, so we are muting clippy intentionally.

--- a/crates/types/src/invocation/client.rs
+++ b/crates/types/src/invocation/client.rs
@@ -88,6 +88,30 @@ pub enum GetInvocationOutputResponse {
     Ready(InvocationOutput),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum InvocationState {
+    Scheduled,
+    Inboxed,
+    Invoked,
+    Suspended,
+    Paused,
+    Killed,
+    Failed,
+    Succeeded,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct InvocationStatus {
+    pub state: InvocationState,
+}
+
+// the most used variant is the largest one, so we are muting clippy intentionally.
+#[derive(Debug, Clone)]
+pub enum GetInvocationStatusResponse {
+    NotFound,
+    Status(InvocationStatus),
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CancelInvocationResponse {
     /// The cancellation was processed immediately (e.g. for inboxed/scheduled invocations)
@@ -211,6 +235,13 @@ pub trait InvocationClient {
         request_id: PartitionProcessorRpcRequestId,
         invocation_query: InvocationQuery,
     ) -> impl Future<Output = Result<GetInvocationOutputResponse, InvocationClientError>> + Send;
+
+    /// Get invocation status, when present.
+    fn get_invocation_status(
+        &self,
+        request_id: PartitionProcessorRpcRequestId,
+        invocation_id: InvocationId,
+    ) -> impl Future<Output = Result<GetInvocationStatusResponse, InvocationClientError>> + Send;
 
     /// **DEPRECATED** Append [`InvocationResponse`] to an existing invocation journal. Only ServiceProtocol <= 3
     fn append_invocation_response(

--- a/crates/types/src/net/partition_processor.rs
+++ b/crates/types/src/net/partition_processor.rs
@@ -18,9 +18,9 @@ use crate::identifiers::{
     PartitionProcessorRpcRequestId, WithPartitionKey,
 };
 use crate::invocation::client::{
-    CancelInvocationResponse, InvocationOutput, KillInvocationResponse, PatchDeploymentId,
-    PauseInvocationResponse, PurgeInvocationResponse, RestartAsNewInvocationResponse,
-    ResumeInvocationResponse, SubmittedInvocationNotification,
+    CancelInvocationResponse, InvocationOutput, InvocationStatus, KillInvocationResponse,
+    PatchDeploymentId, PauseInvocationResponse, PurgeInvocationResponse,
+    RestartAsNewInvocationResponse, ResumeInvocationResponse, SubmittedInvocationNotification,
 };
 use crate::invocation::{InvocationQuery, InvocationRequest, InvocationResponse};
 use crate::journal_v2::Signal;
@@ -117,6 +117,9 @@ pub enum GetInvocationOutputResponseMode {
 pub enum PartitionProcessorRpcRequestInner {
     AppendInvocation(Arc<InvocationRequest>, AppendInvocationReplyOn),
     GetInvocationOutput(InvocationQuery, GetInvocationOutputResponseMode),
+    GetInvocationStatus {
+        invocation_id: InvocationId,
+    },
     AppendInvocationResponse(InvocationResponse),
     AppendSignal(InvocationId, Signal),
     CancelInvocation {
@@ -172,6 +175,9 @@ impl WithPartitionKey for PartitionProcessorRpcRequestInner {
                 invocation_id.partition_key()
             }
             PartitionProcessorRpcRequestInner::PauseInvocation { invocation_id } => {
+                invocation_id.partition_key()
+            }
+            PartitionProcessorRpcRequestInner::GetInvocationStatus { invocation_id } => {
                 invocation_id.partition_key()
             }
         }
@@ -535,6 +541,7 @@ pub enum PartitionProcessorRpcResponse {
     NotSupported,
     Submitted(SubmittedInvocationNotification),
     Output(InvocationOutput),
+    Status(InvocationStatus),
     CancelInvocation(CancelInvocationRpcResponse),
     KillInvocation(KillInvocationRpcResponse),
     PurgeInvocation(PurgeInvocationRpcResponse),

--- a/crates/worker-api/src/partition_processor_rpc_client.rs
+++ b/crates/worker-api/src/partition_processor_rpc_client.rs
@@ -26,8 +26,8 @@ use restate_types::identifiers::{
 };
 use restate_types::invocation::client::{
     AttachInvocationResponse, CancelInvocationResponse, GetInvocationOutputResponse,
-    InvocationClient, InvocationClientError, InvocationOutput, KillInvocationResponse,
-    PatchDeploymentId, PauseInvocationResponse, PurgeInvocationResponse,
+    GetInvocationStatusResponse, InvocationClient, InvocationClientError, InvocationOutput,
+    KillInvocationResponse, PatchDeploymentId, PauseInvocationResponse, PurgeInvocationResponse,
     RestartAsNewInvocationResponse, ResumeInvocationResponse, SubmittedInvocationNotification,
 };
 use restate_types::invocation::{InvocationQuery, InvocationRequest, InvocationResponse};
@@ -427,6 +427,7 @@ where
             }
         })
     }
+
     async fn get_invocation_output(
         &self,
         request_id: PartitionProcessorRpcRequestId,
@@ -458,6 +459,34 @@ where
             }
         })
     }
+
+    async fn get_invocation_status(
+        &self,
+        request_id: PartitionProcessorRpcRequestId,
+        invocation_id: InvocationId,
+    ) -> Result<GetInvocationStatusResponse, InvocationClientError> {
+        let response = self
+            .resolve_partition_id_and_send(
+                request_id,
+                PartitionProcessorRpcRequestInner::GetInvocationStatus {
+                    invocation_id,
+                },
+            )
+            .await?;
+
+        Ok(match response {
+            PartitionProcessorRpcResponse::NotFound => GetInvocationStatusResponse::NotFound,
+            PartitionProcessorRpcResponse::Status(output) => {
+                GetInvocationStatusResponse::Status(output)
+            }
+            _ => {
+                panic!(
+                    "Expecting either PartitionProcessorRpcResponse::Status or PartitionProcessorRpcResponse::NotFound"
+                )
+            }
+        })
+    }
+
     async fn append_invocation_response(
         &self,
         request_id: PartitionProcessorRpcRequestId,

--- a/crates/worker-api/src/partition_processor_rpc_client.rs
+++ b/crates/worker-api/src/partition_processor_rpc_client.rs
@@ -468,9 +468,7 @@ where
         let response = self
             .resolve_partition_id_and_send(
                 request_id,
-                PartitionProcessorRpcRequestInner::GetInvocationStatus {
-                    invocation_id,
-                },
+                PartitionProcessorRpcRequestInner::GetInvocationStatus { invocation_id },
             )
             .await?;
 

--- a/crates/worker/src/partition/rpc/get_invocation_status.rs
+++ b/crates/worker/src/partition/rpc/get_invocation_status.rs
@@ -40,26 +40,31 @@ where
                     InvocationStatus::Scheduled(_) => {
                         PartitionProcessorRpcResponse::Status(client::InvocationStatus {
                             state: client::InvocationState::Scheduled,
+                            error: None,
                         })
                     }
                     InvocationStatus::Inboxed(_) => {
                         PartitionProcessorRpcResponse::Status(client::InvocationStatus {
                             state: client::InvocationState::Inboxed,
+                            error: None,
                         })
                     }
                     InvocationStatus::Invoked(_) => {
                         PartitionProcessorRpcResponse::Status(client::InvocationStatus {
                             state: client::InvocationState::Invoked,
+                            error: None,
                         })
                     }
                     InvocationStatus::Suspended { .. } => {
                         PartitionProcessorRpcResponse::Status(client::InvocationStatus {
                             state: client::InvocationState::Suspended,
+                            error: None,
                         })
                     }
                     InvocationStatus::Paused(_) => {
                         PartitionProcessorRpcResponse::Status(client::InvocationStatus {
                             state: client::InvocationState::Paused,
+                            error: None,
                         })
                     }
                     InvocationStatus::Completed(CompletedInvocation {
@@ -67,12 +72,14 @@ where
                         ..
                     }) => PartitionProcessorRpcResponse::Status(client::InvocationStatus {
                         state: client::InvocationState::Succeeded,
+                        error: None,
                     }),
                     InvocationStatus::Completed(CompletedInvocation {
-                        response_result: ResponseResult::Failure(_),
+                        response_result: ResponseResult::Failure(error),
                         ..
                     }) => PartitionProcessorRpcResponse::Status(client::InvocationStatus {
                         state: client::InvocationState::Failed,
+                        error: Some(error),
                     }),
                     InvocationStatus::Free => PartitionProcessorRpcResponse::NotFound,
                 })

--- a/crates/worker/src/partition/rpc/get_invocation_status.rs
+++ b/crates/worker/src/partition/rpc/get_invocation_status.rs
@@ -1,0 +1,82 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use super::*;
+use restate_storage_api::invocation_status_table::{
+    CompletedInvocation, InvocationStatus, ReadInvocationStatusTable,
+};
+use restate_types::invocation::{ResponseResult, client};
+use restate_types::net::partition_processor::{
+    PartitionProcessorRpcError, PartitionProcessorRpcResponse,
+};
+
+pub(super) struct Request {
+    pub(super) invocation_id: InvocationId,
+}
+
+impl<'a, TSchemas, Storage> RpcHandler<Request> for RpcContext<'a, TSchemas, Storage>
+where
+    Storage: ReadInvocationStatusTable,
+{
+    async fn handle(self, Request { invocation_id }: Request) -> Decision {
+        if !self.is_leader {
+            return Decision::Reply(Err(PartitionProcessorRpcError::NotLeader(
+                self.partition_id,
+            )));
+        }
+
+        Decision::Reply(
+            self.storage
+                .get_invocation_status(&invocation_id)
+                .await
+                .map(|invocation_status| match invocation_status {
+                    InvocationStatus::Scheduled(_) => {
+                        PartitionProcessorRpcResponse::Status(client::InvocationStatus {
+                            state: client::InvocationState::Scheduled,
+                        })
+                    }
+                    InvocationStatus::Inboxed(_) => {
+                        PartitionProcessorRpcResponse::Status(client::InvocationStatus {
+                            state: client::InvocationState::Inboxed,
+                        })
+                    }
+                    InvocationStatus::Invoked(_) => {
+                        PartitionProcessorRpcResponse::Status(client::InvocationStatus {
+                            state: client::InvocationState::Invoked,
+                        })
+                    }
+                    InvocationStatus::Suspended { .. } => {
+                        PartitionProcessorRpcResponse::Status(client::InvocationStatus {
+                            state: client::InvocationState::Suspended,
+                        })
+                    }
+                    InvocationStatus::Paused(_) => {
+                        PartitionProcessorRpcResponse::Status(client::InvocationStatus {
+                            state: client::InvocationState::Paused,
+                        })
+                    }
+                    InvocationStatus::Completed(CompletedInvocation {
+                        response_result: ResponseResult::Success(_),
+                        ..
+                    }) => PartitionProcessorRpcResponse::Status(client::InvocationStatus {
+                        state: client::InvocationState::Succeeded,
+                    }),
+                    InvocationStatus::Completed(CompletedInvocation {
+                        response_result: ResponseResult::Failure(_),
+                        ..
+                    }) => PartitionProcessorRpcResponse::Status(client::InvocationStatus {
+                        state: client::InvocationState::Failed,
+                    }),
+                    InvocationStatus::Free => PartitionProcessorRpcResponse::NotFound,
+                })
+                .map_err(|err| PartitionProcessorRpcError::Internal(err.to_string())),
+        )
+    }
+}

--- a/crates/worker/src/partition/rpc/mod.rs
+++ b/crates/worker/src/partition/rpc/mod.rs
@@ -13,6 +13,7 @@ mod append_invocation_response;
 mod append_signal;
 mod cancel_invocation;
 mod get_invocation_output;
+mod get_invocation_status;
 mod kill_invocation;
 mod pause_invocation;
 mod purge_invocation;
@@ -145,6 +146,10 @@ where
                     response_mode,
                 })
                 .await
+            }
+            PartitionProcessorRpcRequestInner::GetInvocationStatus { invocation_id } => {
+                self.handle(get_invocation_status::Request { invocation_id })
+                    .await
             }
             PartitionProcessorRpcRequestInner::AppendInvocationResponse(invocation_response) => {
                 self.handle(append_invocation_response::Request {

--- a/release-notes/unreleased/5178-ingress-invocation-status.md
+++ b/release-notes/unreleased/5178-ingress-invocation-status.md
@@ -1,0 +1,55 @@
+# Release Notes for PR #5178: Retrieve invocation status from the HTTP ingress
+
+## New Feature
+
+### What Changed
+
+The HTTP ingress now exposes a **non-blocking** endpoint to retrieve the current status of an
+invocation. Unlike `attach`/`output`, which block until the invocation completes, `status` returns
+immediately with the invocation's current lifecycle stage.
+
+New routes:
+
+- `GET /restate/invocation/{invocation_id}/status`
+- `GET /restate/invocation/{service}/{handler}/{idempotency_id}/status` (and the keyed variant
+  `.../{service}/{key}/{handler}/{idempotency_id}/status`) to look up by idempotency id
+- `GET /restate/workflow/{name}/{key}/status`
+- `GET /restate/status/{invocation_id}` and `POST /restate/status` with a body describing the target
+
+The response is a JSON body with a coarse-grained lifecycle `stage` and, when the invocation has
+completed with a failure, the terminal `error`:
+
+```json
+{
+  "stage": "created",
+  "error": null
+}
+```
+
+- `stage`: one of `created` (accepted but not yet started — scheduled or inboxed), `started`
+  (running — invoked, suspended or paused), or `completed` (finished — succeeded, failed or killed).
+- `error`: populated only when `stage` is `completed` and the invocation failed; `null` otherwise.
+
+The response also carries the `x-restate-id` header with the resolved invocation id. Unknown
+invocations return `404 Not Found`.
+
+### Why This Matters
+
+Until now, clients could only observe an invocation by attaching to it or fetching its output, both
+of which block until the invocation terminates. There was no way to cheaply poll whether an
+invocation had started or already completed without waiting for its result. The new `status`
+endpoint fills that gap, enabling lightweight progress polling and dashboards.
+
+The `stage` values are intentionally coarse-grained to mirror the invocation lifecycle documented at
+https://docs.restate.dev/services/invocation/managing-invocations#lifecycle, keeping the public
+contract stable even if the internal states evolve.
+
+### Impact on Users
+
+- **Existing deployments**: purely additive. Existing routes and behavior are unchanged.
+- **New deployments**: the new `status` routes are available out of the box.
+- **Migration considerations**: none required.
+
+### Related Issues
+
+- PR #5178: `/restate/invocation/:invocation_id/status` to retrieve invocation status

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -31,8 +31,8 @@ use restate_types::config::Configuration;
 use restate_types::identifiers::{InvocationId, PartitionProcessorRpcRequestId};
 use restate_types::invocation::client::{
     AttachInvocationResponse, CancelInvocationResponse, GetInvocationOutputResponse,
-    InvocationClient, InvocationClientError, InvocationOutput, KillInvocationResponse,
-    PatchDeploymentId, PauseInvocationResponse, PurgeInvocationResponse,
+    GetInvocationStatusResponse, InvocationClient, InvocationClientError, InvocationOutput,
+    KillInvocationResponse, PatchDeploymentId, PauseInvocationResponse, PurgeInvocationResponse,
     RestartAsNewInvocationResponse, ResumeInvocationResponse, SubmittedInvocationNotification,
 };
 use restate_types::invocation::{
@@ -128,6 +128,15 @@ impl InvocationClient for Mock {
         _: PartitionProcessorRpcRequestId,
         _: InvocationQuery,
     ) -> impl Future<Output = Result<GetInvocationOutputResponse, InvocationClientError>> + Send
+    {
+        pending()
+    }
+
+    fn get_invocation_status(
+        &self,
+        _: PartitionProcessorRpcRequestId,
+        _: InvocationId,
+    ) -> impl Future<Output = Result<GetInvocationStatusResponse, InvocationClientError>> + Send
     {
         pending()
     }


### PR DESCRIPTION
New endpoint in ingress `GET /restate/invocation/:invocation_id/status`, response type:

```
#[derive(Debug, Serialize)]
#[serde(rename_all = "lowercase")]
pub enum InvocationStage {
    /// Means the invocation has been created but not yet started.
    Created,
    /// The invocation started and has not yet completed.
    Started,
    /// The invocation completed, with either success or failure.
    Completed,
}

#[derive(Debug, Serialize)]
pub struct InvocationStatusResponse {
    stage: InvocationStage,
    /// Filled if `stage = 'completed'` and the invocation failed
    error: Option<InvocationError>,
}
```



