### PR TITLE
[PartitionStore] Pending compaction bytes parity with log-server

### DIFF
--- a/crates/partition-store/src/partition_db.rs
+++ b/crates/partition-store/src/partition_db.rs
@@ -577,6 +577,13 @@ impl DbConfigurator for RocksConfigurator<AllDataCf> {
         let storage_config = &Configuration::pinned().worker.storage;
         self.apply_db_opts_from_config(&mut db_options, &storage_config.rocksdb);
 
+        // Avoid pushing back on compaction delays, sacrifice storage and do not hinder
+        // writes and flushes.
+        db_options.set_soft_pending_compaction_bytes_limit(512 * 1024 * 1024 * 1024);
+        // Do not push back on compaction delays, sacrifice storage and do not hinder
+        // writes and flushes.
+        db_options.set_hard_pending_compaction_bytes_limit(2 * 1024 * 1024 * 1024 * 1024);
+
         if self.use_multi_db_layout {
             // In multi-db layout we don't want every database to grown the thread pool
             restate_rocksdb::configuration::set_background_work_budget(


### PR DESCRIPTION

This delays write stalls for much longer at the cost of more disk space and poorer read performance. The higher value suits more the larger use-cases with bigger partitions.
