### PR TITLE
Make partition-store write-buffer configurable

### DIFF
--- a/crates/partition-store/src/memory.rs
+++ b/crates/partition-store/src/memory.rs
@@ -27,11 +27,7 @@ use crate::{PartitionDb, SharedState};
 const INITIAL_NUM_PARTITIONS: usize = 24;
 const DEBUG_MEMORY_REPORTING: bool = false;
 
-pub const MAX_WRITE_BUFFERS: u32 = 4;
 pub const NOMINAL_WRITE_BUFFERS: u32 = 4;
-// merge 2 memtables when flushing to L0
-pub const WRITE_BUFFERS_TO_MERGE: u32 = 2;
-pub const LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER: u32 = 2;
 /// Matches rocksdb default (target_file_size_base * 25)
 pub const COMPACTION_BYTES_MULTIPLIER: u32 = 25;
 /// Try to keep the table files above this size if partition write buffers are too small
@@ -42,6 +38,9 @@ pub const MIN_WRITE_BUFFER_SIZE: usize = 1024 * 1024;
 pub struct PartitionDbMemoryConfig {
     memory_budget: usize,
     max_file_size: usize,
+    max_write_buffer_number: u32,
+    write_buffers_to_merge: u32,
+    level_zero_file_num_compaction_trigger: u32,
 }
 
 impl PartitionDbMemoryConfig {
@@ -49,6 +48,10 @@ impl PartitionDbMemoryConfig {
         Self {
             memory_budget,
             max_file_size: MIN_FILE_SIZE.max(opts.rocksdb_max_file_size.as_usize()),
+            max_write_buffer_number: opts.rocksdb_max_write_buffer_number(),
+            write_buffers_to_merge: opts.rocksdb_write_buffers_to_merge(),
+            level_zero_file_num_compaction_trigger: opts
+                .rocksdb_level_zero_file_num_compaction_trigger(),
         }
     }
 
@@ -61,15 +64,15 @@ impl PartitionDbMemoryConfig {
     }
 
     pub const fn min_write_buffer_number_to_merge(&self) -> u32 {
-        WRITE_BUFFERS_TO_MERGE
+        self.write_buffers_to_merge
     }
 
     pub const fn max_write_buffer_number(&self) -> u32 {
-        MAX_WRITE_BUFFERS
+        self.max_write_buffer_number
     }
 
     pub const fn level_zero_file_num_compaction_trigger(&self) -> u32 {
-        LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER
+        self.level_zero_file_num_compaction_trigger
     }
 
     pub fn max_bytes_for_level_base(&self) -> usize {
@@ -261,6 +264,13 @@ async fn collect_memory_usage(
     })
 }
 
+/// Memtable size at which a partition is flushed to reclaim memory. Scales with the queue depth
+/// so a `max_write_buffer_number` above nominal isn't reclaimed before rocksdb throttles it.
+fn reclaim_threshold(per_partition_budget: usize, max_write_buffer_number: u32) -> usize {
+    let buffers = max_write_buffer_number.max(NOMINAL_WRITE_BUFFERS * 3 / 2);
+    per_partition_budget.saturating_mul(buffers as usize) / NOMINAL_WRITE_BUFFERS as usize
+}
+
 async fn rebalance_memory(
     memory_budget: &MemoryBudget,
     psm_state: &SharedState,
@@ -316,14 +326,19 @@ async fn rebalance_memory(
     // refresh the partition_budget since previous step may have changed it
     let current_per_partition_budget = memory_budget.current_per_partition_budget();
 
+    let reclaim_above = reclaim_threshold(
+        current_per_partition_budget,
+        Configuration::pinned()
+            .worker
+            .storage
+            .rocksdb_max_write_buffer_number(),
+    );
+
     let mut reclaim_candidates: Vec<_> = Vec::with_capacity(collected.partitions.len());
     // did we exceed the total memory budget?
     for (usage, partition_db) in collected.partitions.values() {
-        // is this an offending partition? only if it exceeds its budget by 50%
-        if !usage.is_flush_pending
-            && usage.total_bytes
-                > (current_per_partition_budget + current_per_partition_budget.div_ceil(2))
-        {
+        // is this an offending partition?
+        if !usage.is_flush_pending && usage.total_bytes > reclaim_above {
             reclaim_candidates.push((usage, partition_db));
         }
         if !usage.is_open() {
@@ -470,5 +485,33 @@ impl std::fmt::Display for MemoryUsage {
             ByteCount::from(self.total_bytes),
             self.is_flush_pending
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BUDGET: usize = 200 * 1024 * 1024;
+
+    #[test]
+    fn reclaim_threshold_scales_with_queue_depth() {
+        assert_eq!(reclaim_threshold(BUDGET, 1), BUDGET * 3 / 2);
+        assert_eq!(reclaim_threshold(BUDGET, 4), BUDGET * 3 / 2);
+        assert_eq!(reclaim_threshold(BUDGET, 6), BUDGET * 3 / 2);
+        assert_eq!(reclaim_threshold(BUDGET, 8), BUDGET * 2);
+    }
+
+    #[test]
+    fn memory_config_derives_geometry_from_storage_options() {
+        let config = PartitionDbMemoryConfig::calculate(BUDGET, &StorageOptions::default());
+
+        assert_eq!(config.max_write_buffer_number(), 4);
+        assert_eq!(config.min_write_buffer_number_to_merge(), 2);
+        assert_eq!(config.level_zero_file_num_compaction_trigger(), 2);
+        assert_eq!(
+            config.write_buffer_size(),
+            BUDGET / NOMINAL_WRITE_BUFFERS as usize
+        );
     }
 }

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -36,6 +36,8 @@ use crate::retries::RetryPolicy;
 const MIN_ROCKSDB_MEMORY: NonZeroByteCount =
     NonZeroByteCount::new(NonZeroUsize::new(32 * 1024 * 1024).unwrap());
 
+const MIN_WRITE_BUFFER_NUMBER: u32 = 4;
+
 const X_RESTATE_CLUSTER_NAME: http::HeaderName =
     http::HeaderName::from_static("x-restate-cluster-name");
 /// # Worker options
@@ -893,6 +895,60 @@ pub struct StorageOptions {
     ///
     /// Since v1.7.0
     pub rocksdb_max_file_size: NonZeroByteCount,
+
+    /// # Max write buffer number
+    ///
+    /// The maximum number of memtables a partition keeps in memory. Rocksdb throttles writes to
+    /// the partition-store database once `max - 1` memtables are waiting for a flush, and stops
+    /// them at `max`.
+    ///
+    /// A partition's budget is sliced into four nominal memtables, so raising this lets a
+    /// bursting partition borrow past its budget instead of stalling. It does not change how
+    /// often memtables are sealed, so it costs peak memory rather than compaction work.
+    ///
+    /// The value is automatically sanitized to 4 if set to a smaller value.
+    ///
+    /// Requires a restart to take effect.
+    ///
+    /// [default] is 4
+    ///
+    /// Since v1.8.0
+    rocksdb_max_write_buffer_number: NonZeroU32,
+
+    /// # Write buffers to merge before flushing
+    ///
+    /// How many memtables must be waiting before a flush is triggered (rocksdb's
+    /// `min_write_buffer_number_to_merge`). Merging more per flush collapses overwrites in memory
+    /// and produces fewer, larger L0 files, but delays the flush: at the default of 2, one
+    /// memtable of headroom separates the flush starting from writes being throttled.
+    ///
+    /// Set to 1 to flush as soon as a memtable is sealed, at the cost of more L0 files and more
+    /// compaction. It also shrinks L1, see `rocksdb-level-zero-file-num-compaction-trigger`.
+    ///
+    /// The value is automatically sanitized to `max-write-buffer-number - 2` if set higher.
+    ///
+    /// Requires a restart to take effect.
+    ///
+    /// [default] is 2
+    ///
+    /// Since v1.8.0
+    rocksdb_write_buffers_to_merge: NonZeroU32,
+
+    /// # Level-0 file count compaction trigger
+    ///
+    /// The number of L0 files that triggers an L0 -> L1 compaction. Together with
+    /// `rocksdb-write-buffers-to-merge` this sets how many bytes L0 holds before compacting,
+    /// which is also used as the L1 target size.
+    ///
+    /// Partition stores never throttle writes on L0 file count, so raising this trades read
+    /// amplification for less compaction work.
+    ///
+    /// Requires a restart to take effect.
+    ///
+    /// [default] is 2
+    ///
+    /// Since v1.8.0
+    rocksdb_level_zero_file_num_compaction_trigger: NonZeroU32,
 }
 
 impl StorageOptions {
@@ -927,6 +983,25 @@ impl StorageOptions {
     pub fn rocksdb_max_background_compactions(&self) -> NonZeroU32 {
         self.rocksdb_max_background_compactions
             .unwrap_or(NonZeroU32::new(1).unwrap())
+    }
+
+    pub fn rocksdb_max_write_buffer_number(&self) -> u32 {
+        self.rocksdb_max_write_buffer_number
+            .get()
+            .max(MIN_WRITE_BUFFER_NUMBER)
+    }
+
+    /// Clamped to keep the delayed-write tier reachable: it needs `unflushed >= max - 1` and
+    /// `unflushed - 1 >= merge`, so anything above `max - 2` only ever hits the hard stop.
+    pub fn rocksdb_write_buffers_to_merge(&self) -> u32 {
+        self.rocksdb_write_buffers_to_merge
+            .get()
+            .min(self.rocksdb_max_write_buffer_number().saturating_sub(2))
+            .max(1)
+    }
+
+    pub fn rocksdb_level_zero_file_num_compaction_trigger(&self) -> u32 {
+        self.rocksdb_level_zero_file_num_compaction_trigger.get()
     }
 
     pub fn rocksdb_memory_budget(&self) -> NonZeroByteCount {
@@ -974,6 +1049,9 @@ impl Default for StorageOptions {
             rocksdb_max_file_size: NonZeroByteCount::new(
                 NonZeroUsize::new(64 * 1024 * 1024).unwrap(),
             ),
+            rocksdb_max_write_buffer_number: NonZeroU32::new(4).unwrap(),
+            rocksdb_write_buffers_to_merge: NonZeroU32::new(2).unwrap(),
+            rocksdb_level_zero_file_num_compaction_trigger: NonZeroU32::new(2).unwrap(),
         }
     }
 }
@@ -1154,6 +1232,27 @@ mod tests {
     use std::path::Path;
 
     use super::*;
+
+    #[test]
+    fn write_buffer_geometry_is_sanitized() {
+        let mut opts = StorageOptions::default();
+        assert_eq!(opts.rocksdb_max_write_buffer_number(), 4);
+        assert_eq!(opts.rocksdb_write_buffers_to_merge(), 2);
+        assert_eq!(opts.rocksdb_level_zero_file_num_compaction_trigger(), 2);
+
+        opts.rocksdb_max_write_buffer_number = NonZeroU32::new(2).unwrap();
+        assert_eq!(opts.rocksdb_max_write_buffer_number(), 4);
+
+        opts.rocksdb_max_write_buffer_number = NonZeroU32::new(4).unwrap();
+        opts.rocksdb_write_buffers_to_merge = NonZeroU32::new(3).unwrap();
+        assert_eq!(opts.rocksdb_write_buffers_to_merge(), 2);
+
+        opts.rocksdb_max_write_buffer_number = NonZeroU32::new(8).unwrap();
+        assert_eq!(opts.rocksdb_write_buffers_to_merge(), 3);
+
+        opts.rocksdb_write_buffers_to_merge = NonZeroU32::new(1).unwrap();
+        assert_eq!(opts.rocksdb_write_buffers_to_merge(), 1);
+    }
 
     #[test]
     fn apply_deprecated_precedence() {


### PR DESCRIPTION
In general, we have seen that the partition stores never stalls on L0 file count. Rather, the write stalls comes memtable counts and the exhaustion. With the prior hardcoded depth of 4 and min_write_buffer_number_to_merge of 2, the flush start after two memtables are waiting, leaving only a single memtable of room. In the case of a hot partition, this can cause all the partitions to throttle.

This exposes three tunables to adjust the write characteristics:
1. rocksdb-max-write-buffer-number: allows the write buffer to be tuned.
2. rocksdb-write-buffers-to-merge: How many memtables must be waiting before flush happens. Setting to 1 increases the L0 file count and compaction. This is the default for the log-server.
3. rocksdb-level-zero-file-num-compaction-trigger: default of 2. The partition-store never throttles writes on L0 file count. Raising this trade read amplication for less compaction work.

These tunables allow for fine-tuning compaction and write_stalls on large memory clusters. On one cluster, we observed less than 1/3 of the IOPs and disk bandwidth, while having write stalls and compaction rising. Having the ability to tune these numbers can help offload the memory pressure to disk.