### PR TITLE
[partition store] Avoid double clone on journal entry writes

### DIFF
--- a/crates/partition-store/src/journal_table_v2/mod.rs
+++ b/crates/partition-store/src/journal_table_v2/mod.rs
@@ -167,9 +167,9 @@ fn put_journal_entry<S: StorageAccess>(
         }
     }
 
-    storage.put_kv_proto(
+    storage.put_kv_proto_owned(
         write_journal_entry_key(invocation_id, journal_index),
-        &StoredEntry(journal_entry.clone()),
+        StoredEntry(journal_entry.clone()),
     )
 }
 

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -1140,6 +1140,18 @@ pub(crate) trait StorageAccess {
     }
 
     #[inline]
+    fn put_kv_proto_owned<K: EncodeTableKey, V: PartitionStoreProtobufValue + 'static>(
+        &mut self,
+        key: K,
+        value: V,
+    ) -> Result<()> {
+        self.put_kv_storage_codec(
+            key,
+            &ProtobufStorageWrapper::<V::ProtobufType>(value.into()),
+        )
+    }
+
+    #[inline]
     fn put_kv_storage_codec<K: EncodeTableKey, V: StorageEncode + 'static>(
         &mut self,
         key: K,


### PR DESCRIPTION

It seems like we're doing an unncessary double clone on every journal write. This PR introduces a new `put_kv_proto_owned` that takes an owned value and avoides the extra clone.
