### PR TITLE
[vqueues] Add CLI commands for managing vqueues

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -71,6 +71,9 @@ pub enum Command {
     /// Manage active invocations
     #[clap(subcommand)]
     Invocations(invocations::Invocations),
+    /// Manage virtual queues
+    #[clap(name = "vqueues", subcommand)]
+    VQueues(vqueues::VQueues),
     /// Manage concurrency-limit rules
     #[clap(subcommand)]
     Rules(rules::Rules),

--- a/cli/src/clients/admin_interface.rs
+++ b/cli/src/clients/admin_interface.rs
@@ -94,6 +94,16 @@ pub trait AdminClientInterface {
         id: &str,
     ) -> impl Future<Output = reqwest::Result<Envelope<()>>> + Send + 'static;
 
+    fn pause_vqueue(
+        &self,
+        id: &str,
+    ) -> impl Future<Output = reqwest::Result<Envelope<()>>> + Send + 'static;
+
+    fn resume_vqueue(
+        &self,
+        id: &str,
+    ) -> impl Future<Output = reqwest::Result<Envelope<()>>> + Send + 'static;
+
     fn patch_state(
         &self,
         service: &str,
@@ -294,6 +304,22 @@ impl AdminClientInterface for AdminClient {
     ) -> impl Future<Output = reqwest::Result<Envelope<()>>> + Send + 'static {
         let url = self.versioned_url(["invocations", id, "pause"]);
         self.run(reqwest::Method::PATCH, url)
+    }
+
+    fn pause_vqueue(
+        &self,
+        id: &str,
+    ) -> impl Future<Output = reqwest::Result<Envelope<()>>> + Send + 'static {
+        let url = self.versioned_url(["vqueues", id, "pause"]);
+        self.run(reqwest::Method::POST, url)
+    }
+
+    fn resume_vqueue(
+        &self,
+        id: &str,
+    ) -> impl Future<Output = reqwest::Result<Envelope<()>>> + Send + 'static {
+        let url = self.versioned_url(["vqueues", id, "resume"]);
+        self.run(reqwest::Method::POST, url)
     }
 
     fn patch_state(

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -23,4 +23,5 @@ pub mod services;
 pub mod sql;
 pub mod state;
 pub mod subscriptions;
+pub mod vqueues;
 pub mod whoami;

--- a/cli/src/commands/vqueues/describe.rs
+++ b/cli/src/commands/vqueues/describe.rs
@@ -1,0 +1,159 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::Result;
+use chrono::{DateTime, Local};
+use cling::prelude::*;
+use comfy_table::{Cell, Table};
+use serde::Deserialize;
+
+use restate_cli_util::ui::console::StyledTable;
+use restate_cli_util::ui::watcher::Watch;
+use restate_cli_util::{c_eprintln, c_println, c_title};
+use restate_types::vqueues::VQueueId;
+
+use crate::cli_env::CliEnv;
+use crate::clients::DataFusionHttpClient;
+use crate::ui::datetime::DateTimeExt;
+
+#[derive(Run, Parser, Collect, Clone)]
+#[cling(run = "run_describe")]
+#[clap(visible_alias = "get")]
+pub struct Describe {
+    /// Virtual queue ID
+    vqueue_id: VQueueId,
+
+    /// Limit the number of displayed entries
+    #[clap(long, default_value = "100")]
+    limit: usize,
+
+    #[clap(long, default_value = "false")]
+    newest_first: bool,
+
+    #[clap(flatten)]
+    watch: Watch,
+}
+
+#[derive(Debug, Deserialize)]
+struct VQueueEntryRow {
+    entry_id: String,
+    entry_kind: String,
+    stage: String,
+    status: String,
+    has_lock: bool,
+    created_at: DateTime<Local>,
+    num_attempts: u32,
+    deployment: Option<String>,
+}
+
+pub async fn run_describe(State(env): State<CliEnv>, opts: &Describe) -> Result<()> {
+    opts.watch.run(|| describe(&env, opts)).await
+}
+
+async fn describe(env: &CliEnv, opts: &Describe) -> Result<()> {
+    let client = DataFusionHttpClient::new(env).await?;
+    let queue = super::get_vqueue(&client, &opts.vqueue_id).await?;
+
+    let order_clause = if opts.newest_first {
+        "ORDER BY sequence_number DESC"
+    } else {
+        ""
+    };
+
+    let entries: Vec<VQueueEntryRow> = client
+        .run_json_query(format!(
+            "SELECT entry_id, entry_kind, stage, status, has_lock, created_at, num_attempts, \
+             deployment FROM sys_vqueues WHERE id = '{}' \
+            {order_clause} LIMIT {}",
+            opts.vqueue_id, opts.limit
+        ))
+        .await?;
+
+    let mut info = Table::new_styled();
+    info.add_kv_row("ID:", &queue.id);
+    info.add_kv_row("Service:", queue.service_name.as_deref().unwrap_or("-"));
+    info.add_kv_row("Scope:", queue.scope.as_deref().unwrap_or("-"));
+    info.add_kv_row("Limit key:", queue.limit_key.as_deref().unwrap_or("-"));
+    info.add_kv_row("Lock:", queue.lock_name.as_deref().unwrap_or("-"));
+    info.add_kv_row("Active:", queue.is_active);
+    info.add_kv_row("Paused:", queue.queue_is_paused);
+    info.add_kv_row("Created at:", queue.created_at.display());
+    info.add_kv_row(
+        "Last enqueued at:",
+        display_optional(queue.last_enqueued_at),
+    );
+    info.add_kv_row("Last started at:", display_optional(queue.last_start_at));
+    info.add_kv_row(
+        "Last attempted at:",
+        display_optional(queue.last_attempt_at),
+    );
+    info.add_kv_row("Last finished at:", display_optional(queue.last_finish_at));
+
+    c_title!("📜", "Virtual Queue Information");
+    c_println!("{info}");
+    c_println!();
+
+    let mut counts = Table::new_styled();
+    counts.set_styled_header(vec!["INBOX", "RUNNING", "SUSPENDED", "PAUSED", "FINISHED"]);
+    counts.add_row(vec![
+        Cell::new(queue.num_inbox),
+        Cell::new(queue.num_running),
+        Cell::new(queue.num_suspended),
+        Cell::new(queue.num_paused),
+        Cell::new(queue.num_finished),
+    ]);
+    c_title!("📊", "Entry Counts");
+    c_println!("{counts}");
+    c_println!();
+
+    c_title!("📥", "Entries");
+    if entries.is_empty() {
+        c_println!("No entries found.");
+    } else {
+        let mut entries_table = Table::new_styled();
+        entries_table.set_styled_header(vec![
+            "ENTRY ID",
+            "KIND",
+            "STAGE",
+            "STATUS",
+            "HAS LOCK",
+            "ATTEMPTS",
+            "CREATED-AT",
+            "DEPLOYMENT",
+        ]);
+        for entry in &entries {
+            entries_table.add_row(vec![
+                Cell::new(&entry.entry_id),
+                Cell::new(&entry.entry_kind),
+                Cell::new(&entry.stage),
+                Cell::new(&entry.status),
+                Cell::new(entry.has_lock),
+                Cell::new(entry.num_attempts),
+                Cell::new(entry.created_at.display()),
+                Cell::new(entry.deployment.as_deref().unwrap_or("-")),
+            ]);
+        }
+        c_println!("{entries_table}");
+    }
+
+    let total_entries = queue.num_inbox
+        + queue.num_running
+        + queue.num_suspended
+        + queue.num_paused
+        + queue.num_finished;
+    c_eprintln!("Showing {}/{} entries.", entries.len(), total_entries);
+    Ok(())
+}
+
+fn display_optional(value: Option<DateTime<Local>>) -> String {
+    value
+        .map(|value| value.display())
+        .unwrap_or_else(|| "-".to_owned())
+}

--- a/cli/src/commands/vqueues/list.rs
+++ b/cli/src/commands/vqueues/list.rs
@@ -1,0 +1,88 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::Result;
+use cling::prelude::*;
+use comfy_table::{Cell, Table};
+
+use restate_cli_util::c_println;
+use restate_cli_util::ui::console::StyledTable;
+use restate_cli_util::ui::watcher::Watch;
+
+use super::{VQUEUE_COLUMNS, VQueueRow};
+use crate::cli_env::CliEnv;
+use crate::clients::DataFusionHttpClient;
+
+#[derive(Run, Parser, Collect, Clone)]
+#[cling(run = "run_list")]
+#[clap(visible_alias = "ls")]
+pub struct List {
+    /// Limit the number of results
+    #[clap(long, default_value = "100")]
+    limit: usize,
+
+    #[clap(flatten)]
+    watch: Watch,
+}
+
+pub async fn run_list(State(env): State<CliEnv>, opts: &List) -> Result<()> {
+    opts.watch.run(|| list(&env, opts)).await
+}
+
+async fn list(env: &CliEnv, opts: &List) -> Result<()> {
+    let client = DataFusionHttpClient::new(env).await?;
+    let rows: Vec<VQueueRow> = client
+        .run_json_query(format!(
+            "SELECT {VQUEUE_COLUMNS} FROM sys_vqueue_meta LIMIT {}",
+            opts.limit
+        ))
+        .await?;
+
+    if rows.is_empty() {
+        c_println!("No virtual queues found.");
+        return Ok(());
+    }
+
+    let mut table = Table::new_styled();
+    table.set_styled_header(vec![
+        "ID",
+        "SERVICE",
+        "SCOPE",
+        "LIMIT-KEY",
+        "LOCK",
+        "QUEUE-PAUSED",
+        "INBOX",
+        "RUNNING",
+        "SUSPENDED",
+        "PAUSED ENTRIES",
+        "FINISHED",
+    ]);
+
+    for row in rows {
+        let service_name = row.service_name.as_deref().unwrap_or("-");
+        let scope = row.scope.as_deref().unwrap_or("-");
+        table.add_row(vec![
+            Cell::new(row.id),
+            Cell::new(service_name),
+            Cell::new(scope),
+            Cell::new(row.limit_key.as_deref().unwrap_or("-")),
+            Cell::new(row.lock_name.as_deref().unwrap_or("-")),
+            Cell::new(row.queue_is_paused),
+            Cell::new(row.num_inbox),
+            Cell::new(row.num_running),
+            Cell::new(row.num_suspended),
+            Cell::new(row.num_paused),
+            Cell::new(row.num_finished),
+        ]);
+    }
+
+    c_println!("{table}");
+    Ok(())
+}

--- a/cli/src/commands/vqueues/mod.rs
+++ b/cli/src/commands/vqueues/mod.rs
@@ -1,0 +1,73 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod describe;
+mod list;
+mod pause;
+mod resume;
+
+use chrono::{DateTime, Local};
+use cling::prelude::*;
+use restate_types::vqueues::VQueueId;
+use serde::Deserialize;
+
+use crate::clients::DataFusionHttpClient;
+
+const VQUEUE_COLUMNS: &str = "id, is_active, queue_is_paused, service_name, scope, limit_key, \
+    lock_name, created_at, last_enqueued_at, last_start_at, last_attempt_at, last_finish_at, \
+    num_inbox, num_running, num_suspended, num_paused, num_finished";
+
+#[derive(Run, Subcommand, Clone)]
+pub enum VQueues {
+    /// List virtual queues
+    List(list::List),
+    /// Print detailed information about a virtual queue
+    Describe(describe::Describe),
+    /// Pause a virtual queue
+    #[command(hide = true)]
+    Pause(pause::Pause),
+    /// Resume a virtual queue
+    #[command(hide = true)]
+    Resume(resume::Resume),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct VQueueRow {
+    id: String,
+    is_active: bool,
+    queue_is_paused: bool,
+    service_name: Option<String>,
+    scope: Option<String>,
+    limit_key: Option<String>,
+    lock_name: Option<String>,
+    created_at: DateTime<Local>,
+    last_enqueued_at: Option<DateTime<Local>>,
+    last_start_at: Option<DateTime<Local>>,
+    last_attempt_at: Option<DateTime<Local>>,
+    last_finish_at: Option<DateTime<Local>>,
+    num_inbox: u64,
+    num_running: u64,
+    num_suspended: u64,
+    num_paused: u64,
+    num_finished: u64,
+}
+
+async fn get_vqueue(
+    client: &DataFusionHttpClient,
+    vqueue_id: &VQueueId,
+) -> anyhow::Result<VQueueRow> {
+    let mut rows: Vec<VQueueRow> = client
+        .run_json_query(format!(
+            "SELECT {VQUEUE_COLUMNS} FROM sys_vqueue_meta WHERE id = '{vqueue_id}'"
+        ))
+        .await?;
+    rows.pop()
+        .ok_or_else(|| anyhow::anyhow!("Virtual queue {vqueue_id} not found!"))
+}

--- a/cli/src/commands/vqueues/pause.rs
+++ b/cli/src/commands/vqueues/pause.rs
@@ -1,0 +1,40 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::Result;
+use cling::prelude::*;
+
+use restate_cli_util::c_success;
+use restate_types::vqueues::VQueueId;
+
+use crate::cli_env::CliEnv;
+use crate::clients::{AdminClient, AdminClientInterface, DataFusionHttpClient};
+
+#[derive(Run, Parser, Collect, Clone)]
+#[cling(run = "run_pause")]
+pub struct Pause {
+    /// Virtual queue ID
+    vqueue_id: VQueueId,
+}
+
+pub async fn run_pause(State(env): State<CliEnv>, opts: &Pause) -> Result<()> {
+    // Validate that the vqueue exists
+    let client = DataFusionHttpClient::new(&env).await?;
+    super::get_vqueue(&client, &opts.vqueue_id).await?;
+
+    let client = AdminClient::new(&env).await?;
+    client
+        .pause_vqueue(&opts.vqueue_id.to_string())
+        .await?
+        .success_or_error()?;
+
+    c_success!("Paused virtual queue {}", opts.vqueue_id);
+    Ok(())
+}

--- a/cli/src/commands/vqueues/resume.rs
+++ b/cli/src/commands/vqueues/resume.rs
@@ -1,0 +1,40 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::Result;
+use cling::prelude::*;
+
+use restate_cli_util::c_success;
+use restate_types::vqueues::VQueueId;
+
+use crate::cli_env::CliEnv;
+use crate::clients::{AdminClient, AdminClientInterface, DataFusionHttpClient};
+
+#[derive(Run, Parser, Collect, Clone)]
+#[cling(run = "run_resume")]
+pub struct Resume {
+    /// Virtual queue ID
+    vqueue_id: VQueueId,
+}
+
+pub async fn run_resume(State(env): State<CliEnv>, opts: &Resume) -> Result<()> {
+    // Validate that the vqueue exists
+    let client = DataFusionHttpClient::new(&env).await?;
+    super::get_vqueue(&client, &opts.vqueue_id).await?;
+
+    let client = AdminClient::new(&env).await?;
+    client
+        .resume_vqueue(&opts.vqueue_id.to_string())
+        .await?
+        .success_or_error()?;
+
+    c_success!("Resumed virtual queue {}", opts.vqueue_id);
+    Ok(())
+}

--- a/release-notes/unreleased/vqueue-management.md
+++ b/release-notes/unreleased/vqueue-management.md
@@ -1,0 +1,16 @@
+# Manage virtual queues
+
+## New Feature
+
+Virtual queues can now be paused and resumed through the Admin API using
+`POST /vqueues/{vqueue_id}/pause` and `POST /vqueues/{vqueue_id}/resume`.
+
+The Restate CLI adds `restate vqueues` commands to:
+
+- List virtual queues and their entry counts with `restate vqueues list`.
+- Inspect a virtual queue and its entries with `restate vqueues describe <VQUEUE_ID>`.
+- Pause or resume processing with `restate vqueues pause <VQUEUE_ID>` and
+  `restate vqueues resume <VQUEUE_ID>`.
+
+Pause and resume requests are applied asynchronously. No configuration or migration changes are
+required.


### PR DESCRIPTION

Add new parent command `vqueues` for managing vqueues. This includes listing and inspecting a vqueue, but also the new pause and resume commands.

To see it in action:

```

~/repos/restate/restate ❯❯❯ cargo run -p restate-cli -- vqueues list --limit 5
 ID                                     SERVICE  SCOPE  LIMIT-KEY  LOCK            QUEUE-PAUSED  INBOX  RUNNING  SUSPENDED  PAUSED ENTRIES  FINISHED
 vq_13XA4logZZbc2GRr8Tg8hGX8OXHGpbTe4i  Counter  -      -          Counter/key-15  true          0      0        0          0               177
 vq_18tiDK27w8sG0C9DV6mUzZZSLnjK8Oq3Nf  Counter  -      -          Counter/key-9   false         0      0        0          0               147
 vq_1kXUWMSpIxnT7kixPvWRXMcX94bzJ1ZxUy  Counter  -      -          Counter/key-12  false         0      0        0          0               152
 vq_1eaBrJMNZecZ4pJgkRsNH1MKiTnhkIaDv7  Counter  -      -          Counter/key-7   false         0      0        0          0               124
 vq_193yfeTMdqSl2pKhIWz06LA3tPx6wFQRdQ  Counter  -      -          Counter/key-16  false         0      0        0          0               141

~/repos/restate/restate ❯❯❯ cargo run -p restate-cli -- vqueues resume vq_13XA4logZZbc2GRr8Tg8hGX8OXHGpbTe4i                                                           ✘ 130
✅ Resumed virtual queue vq_13XA4logZZbc2GRr8Tg8hGX8OXHGpbTe4i

~/repos/restate/restate ❯❯❯ cargo run -p restate-cli -- vqueues list --limit 5
 ID                                     SERVICE  SCOPE  LIMIT-KEY  LOCK            QUEUE-PAUSED  INBOX  RUNNING  SUSPENDED  PAUSED ENTRIES  FINISHED
 vq_13XA4logZZbc2GRr8Tg8hGX8OXHGpbTe4i  Counter  -      -          Counter/key-15  false         0      0        0          0               178
 vq_18tiDK27w8sG0C9DV6mUzZZSLnjK8Oq3Nf  Counter  -      -          Counter/key-9   false         0      0        0          0               152
 vq_1kXUWMSpIxnT7kixPvWRXMcX94bzJ1ZxUy  Counter  -      -          Counter/key-12  false         0      0        0          0               153
 vq_1eaBrJMNZecZ4pJgkRsNH1MKiTnhkIaDv7  Counter  -      -          Counter/key-7   false         0      0        0          0               126
 vq_193yfeTMdqSl2pKhIWz06LA3tPx6wFQRdQ  Counter  -      -          Counter/key-16  false         0      0        0          0               145

~/repos/restate/restate ❯❯❯ cargo run -p restate-cli -- vqueues describe vq_18tiDK27w8sG0C9DV6mUzZZSLnjK8Oq3Nf --limit 5
📜 Virtual Queue Information:
―――――――――――――――――――――――――――――
 ID:                 vq_18tiDK27w8sG0C9DV6mUzZZSLnjK8Oq3Nf
 Service:            Counter
 Scope:              -
 Limit key:          -
 Lock:               Counter/key-9
 Active:             false
 Paused:             false
 Created at:         Tue 18 Aug 2026 08:47:14 +01:00
 Last enqueued at:   Tue 18 Aug 2026 09:39:40 +01:00
 Last started at:    Tue 18 Aug 2026 09:39:40 +01:00
 Last attempted at:  Tue 18 Aug 2026 09:39:40 +01:00
 Last finished at:   Tue 18 Aug 2026 09:39:40 +01:00


📊 Entry Counts:
――――――――――――――――
 INBOX  RUNNING  SUSPENDED  PAUSED  FINISHED
 0      0        0          0       154


📥 Entries:
―――――――――――
 ENTRY ID                                KIND        STAGE     STATUS     LOCK   ATTEMPTS  CREATED-AT                       DEPLOYMENT
 inv_18tiDK27w8sG365aOoWZitxzBUqjjs2EY3  invocation  finished  succeeded  false  1         Tue 18 Aug 2026 08:47:14 +01:00  dp_17wBIJgtV7waesVGvixGceJ
 inv_18tiDK27w8sG2fq5XrJQF6EKYdPPDrpinY  invocation  finished  succeeded  false  1         Tue 18 Aug 2026 08:47:14 +01:00  dp_17wBIJgtV7waesVGvixGceJ
 inv_18tiDK27w8sG0YVPmARcCAfgvMlklwoMWy  invocation  finished  succeeded  false  1         Tue 18 Aug 2026 08:47:27 +01:00  dp_17wBIJgtV7waesVGvixGceJ
 inv_18tiDK27w8sG1yh4KEWNoN30kKcK84baYP  invocation  finished  succeeded  false  1         Tue 18 Aug 2026 08:47:43 +01:00  dp_17wBIJgtV7waesVGvixGceJ
 inv_18tiDK27w8sG3LzJk6XpQEXtorx1zQNV7r  invocation  finished  succeeded  false  1         Tue 18 Aug 2026 08:47:54 +01:00  dp_17wBIJgtV7waesVGvixGceJ
Showing 5/154 entries.


```

---
[//]: # (BEGIN SAPLING FOOTER)
* __->__ #5186
* #5185