### PR TITLE
[metadata] Add a configurable limit for the number of registered deployments

### DIFF
--- a/crates/types/src/config/admin.rs
+++ b/crates/types/src/config/admin.rs
@@ -58,6 +58,15 @@ pub struct AdminOptions {
     ///
     /// Concurrency limit for the Admin APIs. Default is unlimited.
     concurrent_api_requests_limit: Option<NonZeroUsize>,
+
+    /// # Number of deployments limit
+    ///
+    /// Maximum number of deployments that can be registered. Default is unlimited.
+    ///
+    /// Since v1.8.0
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    num_deployments_limit: Option<NonZeroUsize>,
+
     pub query_engine: QueryEngineOptions,
 
     /// # Controller heartbeats
@@ -105,6 +114,10 @@ impl AdminOptions {
         )
     }
 
+    pub fn num_deployments_limit(&self) -> Option<usize> {
+        self.num_deployments_limit.map(Into::into)
+    }
+
     pub fn is_cluster_controller_enabled(&self) -> bool {
         #[cfg(not(any(test, feature = "test-util")))]
         return true;
@@ -127,6 +140,7 @@ impl Default for AdminOptions {
             // max is limited by Tower's LoadShedLayer.
             deployment_routing_headers: vec![],
             concurrent_api_requests_limit: None,
+            num_deployments_limit: None,
             query_engine: Default::default(),
             heartbeat_interval: NonZeroFriendlyDuration::from_millis_unchecked(1500),
             #[cfg(any(test, feature = "test-util"))]

--- a/crates/types/src/schema/metadata/mod.rs
+++ b/crates/types/src/schema/metadata/mod.rs
@@ -94,6 +94,10 @@ impl Default for Schema {
 }
 
 impl Schema {
+    pub(in crate::schema) fn deployment_count(&self) -> usize {
+        self.deployments.len()
+    }
+
     pub fn is_legacy_v1(&self) -> bool {
         self.legacy_v1
     }

--- a/crates/types/src/schema/registry/mod.rs
+++ b/crates/types/src/schema/registry/mod.rs
@@ -22,12 +22,14 @@ use codederror::{BoxedCodedError, CodedError};
 use http::{StatusCode, Uri};
 use tracing::subscriber::NoSubscriber;
 
+use crate::config::Configuration;
 use crate::deployment;
 use crate::deployment::{
     DeploymentAddress, Headers, HttpDeploymentAddress, LambdaDeploymentAddress,
 };
 use crate::identifiers::{DeploymentId, LambdaARN, ServiceRevision, SubscriptionId};
 use crate::net::address::{AdvertisedAddress, HttpIngressPort};
+use crate::schema::Schema;
 use crate::schema::deployment::{Deployment, DeploymentResolver, DeploymentType};
 use crate::schema::kafka::{KafkaCluster, KafkaClusterName, KafkaClusterResolver};
 use crate::schema::metadata::updater;
@@ -76,7 +78,8 @@ impl SchemaRegistryError {
                 SchemaError::KafkaCluster(_) => StatusCode::BAD_REQUEST,
                 _ => StatusCode::BAD_REQUEST,
             },
-            SchemaRegistryErrorInner::UpdateDeployment { .. } => StatusCode::BAD_REQUEST,
+            SchemaRegistryErrorInner::UpdateDeployment { .. }
+            | SchemaRegistryErrorInner::DeploymentLimit { .. } => StatusCode::BAD_REQUEST,
             SchemaRegistryErrorInner::Discovery(_) | SchemaRegistryErrorInner::Internal(_) => {
                 StatusCode::INTERNAL_SERVER_ERROR
             }
@@ -106,6 +109,11 @@ enum SchemaRegistryErrorInner {
         actual_deployment_type: &'static str,
         expected_deployment_type: &'static str,
     },
+    #[error(
+        "registering this deployment would exceed the configured limit of {limit} ({current} deployments are currently registered). Delete unused deployments before registering a new one"
+    )]
+    #[code(unknown)]
+    DeploymentLimit { current: usize, limit: usize },
     #[error("{0}")]
     Discovery(
         #[source]
@@ -346,6 +354,8 @@ impl<Metadata: MetadataService, Discovery: DiscoveryClient, Telemetry: Telemetry
 
         let sdk_version = discovery_response.sdk_version.clone();
 
+        let num_deployments_limit = Configuration::pinned().admin.num_deployments_limit();
+
         let add_deployment_request = updater::AddDeploymentRequest {
             deployment_address,
             additional_headers,
@@ -366,6 +376,8 @@ impl<Metadata: MetadataService, Discovery: DiscoveryClient, Telemetry: Telemetry
                     )
                 })?;
 
+            validate_deployment_limit(deployment_result, &schemas, num_deployments_limit)?;
+
             let (deployment, services) = schemas
                 .get_deployment_and_services(&deployment_id)
                 .expect("deployment was just added");
@@ -376,11 +388,16 @@ impl<Metadata: MetadataService, Discovery: DiscoveryClient, Telemetry: Telemetry
             let ((new_deployment_result, new_deployment_id), schemas) = self
                 .metadata_service
                 .update(|schema| {
-                    SchemaUpdater::update_and_return(schema, |updater| {
-                        updater
-                            .add_deployment(add_deployment_request.clone())
-                            .map_err(Into::into)
-                    })
+                    let ((deployment_result, deployment_id), schema) =
+                        SchemaUpdater::update_and_return(schema, |updater| {
+                            updater
+                                .add_deployment(add_deployment_request.clone())
+                                .map_err(SchemaRegistryError::from)
+                        })?;
+
+                    validate_deployment_limit(deployment_result, &schema, num_deployments_limit)?;
+
+                    Ok(((deployment_result, deployment_id), schema))
                 })
                 .await?;
 
@@ -398,6 +415,32 @@ impl<Metadata: MetadataService, Discovery: DiscoveryClient, Telemetry: Telemetry
 
         Ok((register_deployment_result, deployment, services))
     }
+}
+
+fn validate_deployment_limit(
+    result: AddDeploymentResult,
+    schema: &Schema,
+    limit: Option<usize>,
+) -> Result<(), SchemaRegistryError> {
+    if result != AddDeploymentResult::Created {
+        return Ok(());
+    }
+    let Some(limit) = limit else {
+        return Ok(());
+    };
+
+    // the deployment has already been tentatively added, so the pre-registration
+    // count is one less than what the schema reports
+    let count = schema.deployment_count();
+    if count > limit {
+        return Err(SchemaRegistryErrorInner::DeploymentLimit {
+            current: count - 1,
+            limit,
+        }
+        .into());
+    }
+
+    Ok(())
 }
 impl<Metadata: MetadataService, Discovery: DiscoveryClient, Telemetry>
     SchemaRegistry<Metadata, Discovery, Telemetry>

--- a/crates/types/src/schema/registry/tests.rs
+++ b/crates/types/src/schema/registry/tests.rs
@@ -8,12 +8,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use super::*;
+use std::assert_matches;
 
+use test_log::test;
+
+use restate_test_util::assert_eq;
+
+use super::*;
 use crate::endpoint_manifest;
 use crate::schema::registry::mocks::mock_arc_schema;
-use restate_test_util::assert_eq;
-use test_log::test;
 
 const GREETER_SERVICE_NAME: &str = "greeter.Greeter";
 const GREET_HANDLER_NAME: &str = "greet";
@@ -161,6 +164,51 @@ pub async fn register_deployment_lambda() {
     schema_metadata
         .get()
         .assert_service_revision(GREETER_SERVICE_NAME, 3);
+}
+
+#[test]
+fn validate_deployment_count_limit() {
+    let request = |uri| updater::AddDeploymentRequest {
+        deployment_address: DeploymentAddress::mock_uri(uri),
+        additional_headers: Default::default(),
+        metadata: Default::default(),
+        discovery_response: DiscoveryResponse::mock(vec![greeter_service()]),
+        allow_breaking_changes: AllowBreakingChanges::No,
+        overwrite: Overwrite::No,
+    };
+    let (_, schema) = SchemaUpdater::update_and_return(Schema::default(), |updater| {
+        updater.add_deployment(request("http://localhost:9080"))?;
+        updater.add_deployment(request("http://localhost:9081"))
+    })
+    .unwrap();
+
+    // This mimics the validation that runs after the 2nd deployment creation (which with the limit being 1, should fail).
+    // That's why it says "current: 1".
+    assert_matches!(
+        validate_deployment_limit(AddDeploymentResult::Created, &schema, Some(1)),
+        Err(SchemaRegistryError(
+            SchemaRegistryErrorInner::DeploymentLimit {
+                current: 1,
+                limit: 1
+            }
+        ))
+    );
+    assert_matches!(
+        validate_deployment_limit(AddDeploymentResult::Created, &schema, Some(2)),
+        Ok(())
+    );
+    assert_matches!(
+        validate_deployment_limit(AddDeploymentResult::Created, &schema, None),
+        Ok(())
+    );
+    assert_matches!(
+        validate_deployment_limit(AddDeploymentResult::Overwritten, &schema, Some(1)),
+        Ok(())
+    );
+    assert_matches!(
+        validate_deployment_limit(AddDeploymentResult::Unchanged, &schema, Some(1)),
+        Ok(())
+    );
 }
 
 #[cfg(test)]

--- a/release-notes/unreleased/5184-limit-deployments.md
+++ b/release-notes/unreleased/5184-limit-deployments.md
@@ -1,0 +1,18 @@
+# Limit the number of registered deployments
+
+## New Feature
+
+Operators can now limit the number of deployments in the schema registry with
+`admin.num-deployments-limit`:
+
+```toml
+[admin]
+num-deployments-limit = 100
+```
+
+The limit is unset by default, preserving the existing unlimited behavior. Once the configured
+limit is reached, Restate rejects registrations that would create another deployment. Re-registering
+or overwriting an existing deployment remains allowed, as does deleting deployments to get back
+under the limit.
+
+Related issue: [#5184](https://github.com/restatedev/restate/issues/5184).


### PR DESCRIPTION

Fixes #5184

Adds a new configurable limit for the number of deployments allowed (`admin.num-deployments-limit`) which defaults to unlimited. If set, creations that would take us above the limits are rejected. Overwrites and removals would still go through though to allow users to go back under the limit.
