### PR TITLE
Allow disabling invocation execution on workers

### DIFF
--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -381,6 +381,14 @@ pub struct InvokerOptions {
     /// Number of concurrent invocations that can be processed by the invoker.
     concurrent_invocations_limit: Option<NonZeroUsize>,
 
+    /// # Disable invocation execution
+    ///
+    /// Prevents this worker from starting or resuming service invocations. This option is
+    /// evaluated when the worker starts and requires a restart to take effect.
+    ///
+    /// Since v1.7.5
+    pub disable_invocation_execution: bool,
+
     /// # Eager state size limit (since v1.7.0)
     ///
     /// Maximum total size (in bytes) of state entries to send eagerly in the StartMessage.
@@ -615,6 +623,7 @@ impl Default for InvokerOptions {
             message_size_limit: None,
             tmp_dir: None,
             concurrent_invocations_limit: Some(NonZeroUsize::new(1000).expect("is non zero")),
+            disable_invocation_execution: false,
             eager_state_size_limit: None,
             disable_eager_state: false,
             invocation_throttling: None,
@@ -1154,6 +1163,19 @@ mod tests {
     use std::path::Path;
 
     use super::*;
+
+    #[test]
+    fn invocation_execution_is_enabled_by_default_and_can_be_disabled() {
+        let options = InvokerOptions::default();
+        assert!(!options.disable_invocation_execution);
+
+        let mut value = serde_json::to_value(options).unwrap();
+        assert_eq!(value["disable-invocation-execution"], false);
+        value["disable-invocation-execution"] = true.into();
+
+        let options: InvokerOptions = serde_json::from_value(value).unwrap();
+        assert!(options.disable_invocation_execution);
+    }
 
     #[test]
     fn apply_deprecated_precedence() {

--- a/crates/vqueues/src/scheduler/drr.rs
+++ b/crates/vqueues/src/scheduler/drr.rs
@@ -480,6 +480,7 @@ mod tests {
     use restate_types::vqueues::VQueueId;
     use restate_types::vqueues::{EntryId, EntryKind};
     use restate_worker_api::BlockedResource;
+    use restate_worker_api::invoker::capacity::InvocationExecutionMode;
 
     use crate::cache::VQueuesMetaCache;
     use crate::{GlobalTokenBucket, SchedulingStatus, VQueue, VQueueEvent};
@@ -686,6 +687,7 @@ mod tests {
     ) -> ResourceManager {
         ResourceManager::create(
             db.clone(),
+            InvocationExecutionMode::Enabled,
             concurrency,
             global_throttling,
             MemoryPool::unlimited(),
@@ -700,6 +702,22 @@ mod tests {
         concurrency: Concurrency,
     ) -> ResourceManager {
         create_resource_manager_with_throttling(db, concurrency, None).await
+    }
+
+    async fn create_resource_manager_with_invocation_execution(
+        db: &PartitionDb,
+        invocation_execution_mode: InvocationExecutionMode,
+    ) -> ResourceManager {
+        ResourceManager::create(
+            db.clone(),
+            invocation_execution_mode,
+            Concurrency::new_unlimited(),
+            None,
+            MemoryPool::unlimited(),
+            NonZeroByteCount::new(NonZeroUsize::MIN),
+        )
+        .await
+        .expect("resource manager creation should succeed")
     }
 
     async fn create_scheduler(
@@ -731,6 +749,49 @@ mod tests {
             db.clone(),
             cache.view(),
         )
+    }
+
+    #[restate_core::test]
+    async fn disabled_invocation_execution_yields_running_without_running_inbox() {
+        let mut rocksdb = storage_test_environment().await;
+        let mut cache = VQueuesMetaCache::new_empty(TEST_VQUEUES_CAPACITY);
+        let qid = test_qid(20_001);
+
+        let mut txn = rocksdb.transaction();
+        let running = enqueue_entry(&mut txn, &mut cache, &qid, 1, 0, None).await;
+        move_to_running(&mut txn, &mut cache, &qid, &running, None).await;
+        enqueue_entry(&mut txn, &mut cache, &qid, 2, 0, None).await;
+        txn.commit().await.expect("commit should succeed");
+        drop(txn);
+
+        let db = rocksdb.partition_db();
+        let mut scheduler = DRRScheduler::new(
+            NonZeroU16::new(100).unwrap(),
+            NonZeroU16::new(100).unwrap(),
+            create_resource_manager_with_invocation_execution(
+                db,
+                InvocationExecutionMode::Disabled,
+            )
+            .await,
+            db.clone(),
+            cache.view(),
+        );
+
+        let Poll::Ready(Ok(decision)) = poll_scheduler(Pin::new(&mut scheduler), cache.view())
+        else {
+            panic!("expected recovery decision");
+        };
+        assert_eq!(decision.num_yield(), 1);
+        assert_eq!(decision.num_run(), 0);
+
+        let handle = cache.view().handle_for(&qid).unwrap();
+        let status = scheduler.get_status(cache.view(), handle);
+        assert_eq!(
+            status.status,
+            SchedulingStatus::BlockedOn(BlockedResource::InvocationsDisabled)
+        );
+        assert_eq!(status.waiting_inbox, 1);
+        assert_eq!(status.remaining_running, 0);
     }
 
     fn poll_scheduler(

--- a/crates/vqueues/src/scheduler/resource_manager.rs
+++ b/crates/vqueues/src/scheduler/resource_manager.rs
@@ -35,6 +35,7 @@ use restate_types::identifiers::PartitionKey;
 use restate_types::vqueues::EntryKind;
 use restate_types::{LockName, Scope};
 use restate_util_string::ReString;
+use restate_worker_api::invoker::capacity::InvocationExecutionMode;
 use restate_worker_api::resources::{ResourceManagerUpdate, UserPermitKind};
 use restate_worker_api::{ResourceKind, UserLimitCounterEntry};
 
@@ -52,6 +53,7 @@ use crate::GlobalTokenBucket;
 type Waiters = VecDeque<VQueueHandle>;
 
 pub struct ResourceManager {
+    invocation_execution_mode: InvocationExecutionMode,
     // Resources
     locks: Locks,
     /// Limiter for invoker global capacity
@@ -73,6 +75,7 @@ pub(super) enum AcquireOutcome {
 impl ResourceManager {
     pub async fn create<S: LoadLocks + Send + Sync + 'static>(
         storage: S,
+        invocation_execution_mode: InvocationExecutionMode,
         concurrency_limiter: Concurrency,
         global_throttling: Option<GlobalTokenBucket>,
         memory_pool: MemoryPool,
@@ -83,6 +86,7 @@ impl ResourceManager {
         let (_tx, rx) = mpsc::unbounded_channel();
 
         Ok(Self {
+            invocation_execution_mode,
             invoker_concurrency: InvokerConcurrencyLimiter::new(concurrency_limiter),
             invoker_throttling: InvokerThrottlingLimiter::new(global_throttling),
             invoker_memory: InvokerMemoryLimiter::new(memory_pool, initial_invocation_memory),
@@ -111,6 +115,7 @@ impl ResourceManager {
             ResourceKind::InvokerConcurrency => {
                 self.invoker_concurrency.remove_from_waiters(handle);
             }
+            ResourceKind::InvocationsDisabled => {}
             ResourceKind::InvokerThrottling { .. } => {
                 self.invoker_throttling.remove_from_waiters(handle);
             }
@@ -186,6 +191,12 @@ impl ResourceManager {
         _metadata: &EntryMetadata,
         current_permit: &mut PermitBuilder,
     ) -> AcquireOutcome {
+        if matches!(key.kind(), EntryKind::Invocation)
+            && self.invocation_execution_mode == InvocationExecutionMode::Disabled
+        {
+            return AcquireOutcome::BlockedOn(ResourceKind::InvocationsDisabled);
+        }
+
         if !current_permit.has_user_permit() {
             // we need to acquire user permit first
 

--- a/crates/vqueues/src/scheduler/vqueue_state.rs
+++ b/crates/vqueues/src/scheduler/vqueue_state.rs
@@ -85,9 +85,9 @@ impl DetailedEligibility {
 /// via `Stats::set_wait`, and the elapsed time is the wait time attributed to
 /// that bucket.
 ///
-/// `WaitBucket::for_resource` maps every `BlockedOn(ResourceKind)` outcome to a
-/// bucket. The match is exhaustive, so adding a new `ResourceKind` is a compile
-/// error until a bucket is assigned.
+/// `WaitBucket::for_resource` maps measured `BlockedOn(ResourceKind)` outcomes to
+/// a bucket. The match is exhaustive, so adding a new `ResourceKind` is a compile
+/// error until its accounting behavior is explicitly chosen.
 ///
 /// The throttling buckets (`ThrottlingRules`, `InvokerThrottling`) are entered
 /// through normal `BlockedOn(ResourceKind)` outcomes.
@@ -118,18 +118,23 @@ impl WaitBucket {
     }
 
     /// Categorize a `BlockedOn(ResourceKind)` outcome into the wait bucket that
-    /// will accumulate the time spent blocked on it.
+    /// will accumulate the time spent blocked on it. Returning [`None`] means that
+    /// the wait time won't be added to a wait bucket.
     ///
     /// The match is exhaustive on purpose: any new `ResourceKind` variant must
     /// choose a bucket here, so accounting can never silently drop on the floor.
-    fn for_resource(r: &ResourceKind) -> Self {
+    fn for_resource(r: &ResourceKind) -> Option<Self> {
         match r {
-            ResourceKind::Lock { .. } => WaitBucket::Lock,
-            ResourceKind::LimitKeyConcurrency { .. } => WaitBucket::ConcurrencyRules,
-            ResourceKind::InvokerConcurrency => WaitBucket::InvokerConcurrency,
-            ResourceKind::InvokerMemory => WaitBucket::InvokerMemory,
-            ResourceKind::InvokerThrottling { .. } => WaitBucket::InvokerThrottling,
-            ResourceKind::DeploymentConcurrency => WaitBucket::DeploymentConcurrency,
+            ResourceKind::Lock { .. } => Some(WaitBucket::Lock),
+            ResourceKind::LimitKeyConcurrency { .. } => Some(WaitBucket::ConcurrencyRules),
+            ResourceKind::InvokerConcurrency => Some(WaitBucket::InvokerConcurrency),
+            // Administrative disablement is rare and already exposed as the queue's current
+            // blocked resource. Do not misattribute it to concurrency or grow WaitStats, which is
+            // persisted for every invocation and vqueue, solely to measure maintenance downtime.
+            ResourceKind::InvocationsDisabled => None,
+            ResourceKind::InvokerMemory => Some(WaitBucket::InvokerMemory),
+            ResourceKind::InvokerThrottling { .. } => Some(WaitBucket::InvokerThrottling),
+            ResourceKind::DeploymentConcurrency => Some(WaitBucket::DeploymentConcurrency),
         }
     }
 }
@@ -308,7 +313,7 @@ impl<S: VQueueStore> VQueueState<S> {
                 // One call handles the full state transition: closes any previously
                 // open segment (for a different resource) and opens the new one.
                 self.head_stats
-                    .set_wait(Some(WaitBucket::for_resource(&resource)));
+                    .set_wait(WaitBucket::for_resource(&resource));
                 Ok(Pop::Blocked(resource))
             }
         }

--- a/crates/worker-api/src/invoker/capacity.rs
+++ b/crates/worker-api/src/invoker/capacity.rs
@@ -16,8 +16,15 @@ use restate_types::config::{DEFAULT_PER_INVOCATION_INITIAL_MEMORY, ThrottlingOpt
 
 pub type TokenBucket<C = gardal::TokioClock> = gardal::SharedTokenBucket<C>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvocationExecutionMode {
+    Enabled,
+    Disabled,
+}
+
 #[derive(Clone)]
 pub struct InvokerCapacity {
+    pub invocation_execution_mode: InvocationExecutionMode,
     pub concurrency: Concurrency,
     pub invocation_token_bucket: Option<TokenBucket>,
     pub action_token_bucket: Option<TokenBucket>,
@@ -29,6 +36,7 @@ pub struct InvokerCapacity {
 impl InvokerCapacity {
     pub const fn new_unlimited() -> Self {
         Self {
+            invocation_execution_mode: InvocationExecutionMode::Enabled,
             concurrency: Concurrency::new_unlimited(),
             invocation_token_bucket: None,
             action_token_bucket: None,
@@ -38,6 +46,7 @@ impl InvokerCapacity {
     }
 
     pub fn new(
+        invocation_execution_mode: InvocationExecutionMode,
         concurrency: Option<NonZeroUsize>,
         invocation_throttling: Option<&ThrottlingOptions>,
         action_throttling: Option<&ThrottlingOptions>,
@@ -45,6 +54,7 @@ impl InvokerCapacity {
         initial_invocation_memory: NonZeroByteCount,
     ) -> Self {
         Self {
+            invocation_execution_mode,
             concurrency: Concurrency::new(concurrency),
             invocation_token_bucket: invocation_throttling.map(|opts| {
                 TokenBucket::new(gardal::Limit::from(opts.clone()), gardal::TokioClock)

--- a/crates/worker-api/src/scheduler_status.rs
+++ b/crates/worker-api/src/scheduler_status.rs
@@ -90,6 +90,8 @@ pub enum ResourceKind {
     },
     /// Waiting to acquire invoker concurrency capacity
     InvokerConcurrency,
+    /// Invocation execution is administratively disabled on this worker.
+    InvocationsDisabled,
     /// Waiting to acquire invoker throttling tokens.
     InvokerThrottling {
         /// Best-effort estimate for when this queue can retry token acquisition.
@@ -129,6 +131,7 @@ impl ResourceKind {
                 lock_name: lock_name.clone(),
             },
             ResourceKind::InvokerConcurrency => BlockedResource::InvokerConcurrency,
+            ResourceKind::InvocationsDisabled => BlockedResource::InvocationsDisabled,
             ResourceKind::InvokerThrottling { estimated_retry_at } => {
                 BlockedResource::InvokerThrottling {
                     estimated_retry_at: *estimated_retry_at,
@@ -178,6 +181,8 @@ pub enum BlockedResource {
     },
     /// Waiting on global invoker concurrency capacity.
     InvokerConcurrency,
+    /// Invocation execution is administratively disabled on this worker.
+    InvocationsDisabled,
     /// Waiting on node-level invoker throttling tokens.
     InvokerThrottling {
         /// Best-effort estimate for when this queue can retry token acquisition.
@@ -206,6 +211,7 @@ impl std::fmt::Display for BlockedResource {
                 None => write!(f, "Lock(name={lock_name})"),
             },
             BlockedResource::InvokerConcurrency => f.write_str("InvokerConcurrency"),
+            BlockedResource::InvocationsDisabled => f.write_str("InvocationsDisabled"),
             BlockedResource::InvokerThrottling { estimated_retry_at } => match estimated_retry_at {
                 Some(retry_at) => write!(f, "InvokerThrottling(retry_at_ts={})", retry_at.as_u64()),
                 None => f.write_str("InvokerThrottling"),

--- a/crates/worker/src/partition/leadership/leader_state.rs
+++ b/crates/worker/src/partition/leadership/leader_state.rs
@@ -56,6 +56,7 @@ use restate_wal_protocol::control::{UpdatePartitionDurabilityCommand, UpsertSche
 use restate_wal_protocol::timer::TimerKeyValue;
 use restate_wal_protocol::v1::UpsertRuleBookCommandWrapper;
 use restate_worker_api::invoker::InvokerHandle;
+use restate_worker_api::invoker::capacity::InvocationExecutionMode;
 use restate_worker_api::resources::ReservedResources;
 use restate_worker_api::{SchedulerStatusEntry, UserLimitCounterEntry};
 
@@ -93,6 +94,7 @@ pub struct LeaderState {
     shuffle_task_handle: Option<TaskHandle<anyhow::Result<()>>>,
     pub timer_service: Pin<Box<TimerService>>,
     scheduler: SchedulerService<PartitionDb>,
+    invocation_execution_mode: InvocationExecutionMode,
     invoker_handle: InvokerChannelServiceHandle,
     invoker_task_handle: Option<TaskHandle<()>>,
     self_proposer: SelfProposer,
@@ -132,6 +134,7 @@ impl LeaderState {
         shuffle_hint_tx: HintSender,
         timer_service: TimerService,
         scheduler: SchedulerService<PartitionDb>,
+        invocation_execution_mode: InvocationExecutionMode,
         invoker_handle: InvokerChannelServiceHandle,
         invoker_task_handle: TaskHandle<()>,
         self_proposer: SelfProposer,
@@ -160,6 +163,7 @@ impl LeaderState {
             rule_book_stream: WatchStream::new(rule_book_rx),
             timer_service: Box::pin(timer_service),
             scheduler,
+            invocation_execution_mode,
             invoker_handle,
             invoker_task_handle: Some(invoker_task_handle),
             self_proposer,
@@ -867,6 +871,13 @@ impl LeaderState {
                 invocation_id,
                 invocation_target,
             } => {
+                if self.invocation_execution_mode == InvocationExecutionMode::Disabled {
+                    debug!(
+                        restate.invocation.id = %invocation_id,
+                        "Suppressing invocation dispatch because invocation execution is disabled"
+                    );
+                    return Ok(());
+                }
                 let fencing_token = self.fencing_tokens.mint(invocation_id);
                 self.invoker_handle
                     .invoke(invocation_id, fencing_token, invocation_target)
@@ -1031,6 +1042,13 @@ impl LeaderState {
                 invocation_target,
                 idempotency_key,
             } => {
+                if self.invocation_execution_mode == InvocationExecutionMode::Disabled {
+                    debug!(
+                        entry_key = ?key,
+                        "Suppressing VQueue invocation dispatch because invocation execution is disabled"
+                    );
+                    return Ok(());
+                }
                 let metas = processor.vqueues();
                 let slot = metas.get(vq_handle).expect("vqueue meta must be in cache");
                 // state mutations should not create Invoke actions. At least for now.

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -71,6 +71,7 @@ use restate_wal_protocol::control::{
 use restate_wal_protocol::timer::TimerKeyValue;
 use restate_wal_protocol::{Command, Envelope};
 use restate_worker_api::invoker::InvokerHandle;
+use restate_worker_api::invoker::capacity::InvocationExecutionMode;
 use restate_worker_api::{
     LeaderQueryCommand, LeaderQueryRequest, LeaderQueryResponse, LeaderQuerySender,
 };
@@ -674,6 +675,7 @@ where
             let scheduler_service = SchedulerService::create(
                 ResourceManager::create(
                     partition_store.partition_db().clone(),
+                    node_ctx.invoker_capacity.invocation_execution_mode,
                     node_ctx.invoker_capacity.concurrency.clone(),
                     node_ctx.invoker_capacity.invocation_token_bucket.clone(),
                     node_ctx.invoker_capacity.memory_pool.clone(),
@@ -692,7 +694,10 @@ where
                 scheduler_service.on_rules_updated(initial_diff);
             }
 
-            let fencing_tokens = if processor.fsm().features().is_vqueues_enabled() {
+            let fencing_tokens = if processor.fsm().features().is_vqueues_enabled()
+                || node_ctx.invoker_capacity.invocation_execution_mode
+                    == InvocationExecutionMode::Disabled
+            {
                 // VQueues migration is atomic. Either all invocations have a vqueue id, or none of them do.
                 // As such, if the partition has the feature enabled, it means that we no longer have any "Invoked"
                 // invocation without a vqueue id. So the `resume_invoked_invocations` scan below would have skipped all
@@ -786,6 +791,7 @@ where
                 shuffle_hint_tx,
                 timer_service,
                 scheduler_service,
+                node_ctx.invoker_capacity.invocation_execution_mode,
                 invoker_handle,
                 invoker_task_guard.into_handle(),
                 self_proposer,
@@ -1022,39 +1028,44 @@ mod tests {
 
     use assert2::let_assert;
     use restate_bifrost::Bifrost;
+    use restate_clock::RoughTimestamp;
+    use restate_clock::time::MillisSinceEpoch;
+    use restate_core::network::Reciprocal;
     use restate_core::partitions::PartitionRouting;
     use restate_core::{TaskCenter, TestCoreEnv};
     use restate_ingestion_client::{IngestionClient, SessionOptions};
     use restate_partition_store::PartitionStoreManager;
     use restate_rocksdb::RocksDbManager;
+    use restate_storage_api::vqueue_table::EntryKey;
     use restate_types::config::Configuration;
-    use restate_types::identifiers::{LeaderEpoch, PartitionId};
+    use restate_types::deployment::PinnedDeployment;
+    use restate_types::identifiers::{
+        DeploymentId, InvocationId, LeaderEpoch, PartitionId, PartitionProcessorRpcRequestId,
+    };
+    use restate_types::invocation::{FencingToken, InvocationTarget};
     use restate_types::logs::{KeyFilter, Lsn, SequenceNumber};
     use restate_types::partitions::state::PartitionReplicaSetStates;
     use restate_types::partitions::{
         Partition, PartitionConfiguration, PartitionFeatureChange, PersistedFeatures,
     };
+    use restate_types::service_protocol::ServiceProtocolVersion;
     use restate_types::sharding::KeyRange;
+    use restate_types::vqueues::{EntryId, EntryKind};
     use restate_types::{GenerationalNodeId, Version};
+    use restate_vqueues::VQueueHandle;
     use restate_wal_protocol::Command;
     use restate_wal_protocol::Envelope;
-    use restate_worker_api::invoker::capacity::InvokerCapacity;
+    use restate_wal_protocol::invocation::PauseInvocationCommand;
+    use restate_worker_api::invoker::capacity::{InvocationExecutionMode, InvokerCapacity};
+    use restate_worker_api::invoker::{Effect, EffectKind, FencedEffect};
 
     use crate::partition::leadership::{LeadershipState, State};
     use crate::partition::processor::ProcessorRawContext;
+    use crate::partition::state_machine::Action;
+    use crate::partition::types::InvokerEffect;
     use crate::partition::{LeadershipInfo, NodeContext};
     use crate::partition_processor_manager::PartitionLeaderHandlesRegistry;
     use crate::rule_book_cache::RuleBookCacheHandle;
-
-    use restate_core::network::Reciprocal;
-    use restate_types::deployment::PinnedDeployment;
-    use restate_types::identifiers::{DeploymentId, InvocationId, PartitionProcessorRpcRequestId};
-    use restate_types::invocation::FencingToken;
-    use restate_types::service_protocol::ServiceProtocolVersion;
-    use restate_wal_protocol::invocation::PauseInvocationCommand;
-    use restate_worker_api::invoker::{Effect, EffectKind, FencedEffect};
-
-    use crate::partition::types::InvokerEffect;
 
     const PARTITION_ID: PartitionId = PartitionId::MIN;
     const NODE_ID: GenerationalNodeId = GenerationalNodeId::new(0, 0);
@@ -1194,13 +1205,15 @@ mod tests {
             NonZeroUsize::new(10 * 1024 * 1024).unwrap(),
             SessionOptions::default(),
         );
+        let mut invoker_capacity = InvokerCapacity::new_unlimited();
+        invoker_capacity.invocation_execution_mode = InvocationExecutionMode::Disabled;
         let mut node_ctx = NodeContext::new(
             NODE_ID,
             Configuration::live(),
             replica_set_states,
             RuleBookCacheHandle::detached(),
             bifrost.clone(),
-            InvokerCapacity::new_unlimited(),
+            invoker_capacity,
             PartitionLeaderHandlesRegistry::default(),
         );
 
@@ -1253,6 +1266,37 @@ mod tests {
         let State::Leader(leader_state) = &mut state.state else {
             panic!("expected to be leader");
         };
+
+        let suppressed_target = InvocationTarget::service("test.Service", "handler");
+        let suppressed_invocation_id = InvocationId::mock_generate(&suppressed_target);
+        leader_state.handle_actions(
+            &mut ctx,
+            [
+                Action::Invoke {
+                    invocation_id: suppressed_invocation_id,
+                    invocation_target: suppressed_target.clone(),
+                },
+                Action::VQInvoke {
+                    vq_handle: VQueueHandle::default(),
+                    key: EntryKey::new(
+                        false,
+                        RoughTimestamp::from_unix_millis_clamped(MillisSinceEpoch::new(0)),
+                        0,
+                        EntryId::new(EntryKind::Invocation, [0; EntryId::REMAINDER_LEN]),
+                    ),
+                    invocation_target: suppressed_target,
+                    idempotency_key: None,
+                },
+            ]
+            .into_iter(),
+        )?;
+        let first_token = leader_state
+            .fencing_tokens_mut()
+            .mint(suppressed_invocation_id);
+        assert_eq!(first_token, 0, "suppressed dispatch must not mint a token");
+        leader_state
+            .fencing_tokens_mut()
+            .clear(&suppressed_invocation_id);
 
         let invocation_id = InvocationId::mock_random();
         // Four distinguishable effects so we can assert exactly which were appended.

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -82,7 +82,7 @@ use restate_types::protobuf::common::WorkerStatus;
 use restate_util_string::format_restring;
 use restate_util_time::DurationExt;
 use restate_wal_protocol::Envelope;
-use restate_worker_api::invoker::capacity::InvokerCapacity;
+use restate_worker_api::invoker::capacity::{InvocationExecutionMode, InvokerCapacity};
 use restate_worker_api::{ProcessorsManagerCommand, ProcessorsManagerHandle};
 
 use crate::metric_definitions::{
@@ -221,6 +221,17 @@ where
         ingestion_client: IngestionClient<T, Envelope>,
     ) -> Self {
         let config = updateable_config.pinned();
+        let invocation_execution_mode = if config.worker.invoker.disable_invocation_execution {
+            InvocationExecutionMode::Disabled
+        } else {
+            InvocationExecutionMode::Enabled
+        };
+        if invocation_execution_mode == InvocationExecutionMode::Disabled {
+            warn!(
+                "Invocation execution is disabled on this worker. A restart with \
+                 worker.invoker.disable-invocation-execution=false is required to enable it."
+            );
+        }
         let ppm_svc_rx = router_builder.register_service(BackPressureMode::Lossy);
 
         // NOTE: this is a shared pool for RPC requests from ingress and ingestion
@@ -241,6 +252,7 @@ where
         });
 
         let invoker_capacity = InvokerCapacity::new(
+            invocation_execution_mode,
             config.worker.invoker.concurrent_invocations_limit(),
             config.worker.invoker.invocation_throttling.as_ref(),
             config.worker.invoker.action_throttling.as_ref(),

--- a/release-notes/unreleased/5193-disable-invocation-execution.md
+++ b/release-notes/unreleased/5193-disable-invocation-execution.md
@@ -1,0 +1,34 @@
+# Release Notes for Issue #5193: Disable Invocation Execution
+
+## New Feature
+
+### What Changed
+
+Workers can now be started without executing service invocations:
+
+```toml
+[worker.invoker]
+disable-invocation-execution = true
+```
+
+The worker continues processing partitions and can perform partition migrations, but it does not
+start or resume service invocation attempts. VQueue state mutations remain enabled, subject to
+their existing queue ordering with service invocations.
+
+### Impact on Users
+
+The option defaults to `false`, preserving existing behavior. It is evaluated when the worker
+starts, so changing it requires a restart. Configure it consistently on every worker that can lead
+a partition.
+
+The option only affects workers on which it is configured. Stop or isolate incoming traffic before
+restarting every worker with invocation execution disabled.
+
+### Migration Guidance
+
+After validating a migration, set `disable-invocation-execution = false` and restart the workers to
+resume invocation execution.
+
+### Related Issues
+
+- [#5193](https://github.com/restatedev/restate/issues/5193)


### PR DESCRIPTION
In order to support not doing any side effects during vqueue migration, this PR allows to disable invocation execution. The goal was to create a minimal impact change to address the problem at hand.

Add the startup-only `worker.invoker.disable-invocation-execution` option. Disabled workers keep processing partitions, block invocation heads with an explicit scheduler status, skip legacy invocation recovery, and defensively suppress dispatch. State mutations remain enabled subject to existing VQueue ordering. Re-enabling execution requires a worker restart.

This fixes #5193.