### PR TITLE
Apply relaxed compaction limits on cfs

### DIFF
--- a/crates/partition-store/src/partition_db.rs
+++ b/crates/partition-store/src/partition_db.rs
@@ -577,6 +577,7 @@ impl DbConfigurator for RocksConfigurator<AllDataCf> {
         let storage_config = &Configuration::pinned().worker.storage;
         self.apply_db_opts_from_config(&mut db_options, &storage_config.rocksdb);
 
+        db_options.set_max_subcompactions(storage_config.rocksdb_max_sub_compactions());
         // Avoid pushing back on compaction delays, sacrifice storage and do not hinder
         // writes and flushes.
         db_options.set_soft_pending_compaction_bytes_limit(512 * 1024 * 1024 * 1024);
@@ -696,6 +697,13 @@ impl CfConfigurator for RocksConfigurator<AllDataCf> {
         cf_options.set_target_file_size_base(mem_config.target_file_size_base() as u64);
         cf_options.set_max_bytes_for_level_base(mem_config.max_bytes_for_level_base() as u64);
         cf_options.set_max_compaction_bytes(mem_config.max_compaction_bytes() as u64);
+
+        // Avoid pushing back on compaction delays, sacrifice storage and do not hinder
+        // writes and flushes.
+        cf_options.set_soft_pending_compaction_bytes_limit(512 * 1024 * 1024 * 1024);
+        // Do not push back on compaction delays, sacrifice storage and do not hinder
+        // writes and flushes.
+        cf_options.set_hard_pending_compaction_bytes_limit(2 * 1024 * 1024 * 1024 * 1024);
 
         cf_options
     }

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -882,6 +882,15 @@ pub struct StorageOptions {
     #[cfg_attr(feature = "schemars", schemars(skip))]
     rocksdb_max_background_compactions: Option<NonZeroU32>,
 
+    /// The maximum number of subcompactions to run in parallel.
+    ///
+    /// Setting this to 1 means no sub-compactions are allowed.
+    ///
+    /// Default is 1
+    ///
+    /// Since v1.7.5
+    rocksdb_max_sub_compactions: u32,
+
     /// # Clamps target size for sst files
     ///
     /// The target size for sst files. Restate uses this value to internally determine
@@ -929,6 +938,14 @@ impl StorageOptions {
             .unwrap_or(NonZeroU32::new(1).unwrap())
     }
 
+    pub fn rocksdb_max_sub_compactions(&self) -> u32 {
+        if self.rocksdb_max_sub_compactions == 0 {
+            1
+        } else {
+            self.rocksdb_max_sub_compactions
+        }
+    }
+
     pub fn rocksdb_memory_budget(&self) -> NonZeroByteCount {
         self.rocksdb_memory_budget
             .unwrap_or_else(|| {
@@ -971,6 +988,7 @@ impl Default for StorageOptions {
             rocksdb_disable_auto_memory_reclaimer: false,
             rocksdb_max_background_flushes: None,
             rocksdb_max_background_compactions: None,
+            rocksdb_max_sub_compactions: 1,
             rocksdb_max_file_size: NonZeroByteCount::new(
                 NonZeroUsize::new(64 * 1024 * 1024).unwrap(),
             ),
@@ -1206,5 +1224,17 @@ mod tests {
             new.request_identity_private_key_pem_file.as_deref(),
             Some(Path::new("/key.pem"))
         );
+    }
+    #[test]
+
+    fn sanitize_rocksdb_max_sub_compactions() {
+        let mut options = StorageOptions::default();
+        assert_eq!(options.rocksdb_max_sub_compactions(), 1);
+
+        options.rocksdb_max_sub_compactions = 0;
+        assert_eq!(options.rocksdb_max_sub_compactions(), 1);
+
+        options.rocksdb_max_sub_compactions = 4;
+        assert_eq!(options.rocksdb_max_sub_compactions(), 4);
     }
 }


### PR DESCRIPTION

The pending compaction limit needs to be configured on per-column-family basis, that was an oversight from previous PR. The other addition is adding configuration option for max_sub_compactions for partition store.
