### PR TITLE
Allow disabling the VQueue scheduler

### DIFF
--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -63,6 +63,15 @@ pub struct WorkerOptions {
 
     pub storage: StorageOptions,
 
+    /// # Disable scheduler
+    ///
+    /// Prevents this worker from scheduling VQueue entries.
+    ///
+    /// Since v1.7.5
+    #[cfg_attr(feature = "schemars", schemars(skip))]
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    pub disable_scheduler: bool,
+
     pub invoker: InvokerOptions,
 
     /// # Maximum command batch size (count) for partition processors
@@ -203,6 +212,7 @@ impl Default for WorkerOptions {
             num_timers_in_memory_limit: None,
             cleanup_interval: NonZeroFriendlyDuration::from_secs_unchecked(60 * 60),
             storage: StorageOptions::default(),
+            disable_scheduler: false,
             invoker: Default::default(),
             max_command_batch_size: NonZeroUsize::new(32).expect("Non zero number"),
             max_command_batch_bytes: NonZeroByteCount::new(NonZeroUsize::new(1024 * 1024).unwrap()),
@@ -1172,6 +1182,18 @@ mod tests {
     use std::path::Path;
 
     use super::*;
+
+    #[test]
+    fn scheduler_is_enabled_by_default_and_can_be_disabled() {
+        let options = WorkerOptions::default();
+        assert!(!options.disable_scheduler);
+
+        let mut value = serde_json::to_value(options).unwrap();
+        value["disable-scheduler"] = true.into();
+
+        let options: WorkerOptions = serde_json::from_value(value).unwrap();
+        assert!(options.disable_scheduler);
+    }
 
     #[test]
     fn apply_deprecated_precedence() {

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -702,19 +702,28 @@ where
                 })?
                 .into_guard();
 
-            let scheduler_service = SchedulerService::create(
-                ResourceManager::create(
+            let scheduler_service = if config.worker.disable_scheduler {
+                warn!(
+                    leader_epoch = %leader_epoch,
+                    "The VQueue scheduler is disabled on this partition processor. Unsetting \
+                     worker.disable-scheduler and re-acquiring leadership is required to enable it."
+                );
+                SchedulerService::new_disabled()
+            } else {
+                SchedulerService::create(
+                    ResourceManager::create(
+                        partition_store.partition_db().clone(),
+                        node_ctx.invoker_capacity.concurrency.clone(),
+                        node_ctx.invoker_capacity.invocation_token_bucket.clone(),
+                        node_ctx.invoker_capacity.memory_pool.clone(),
+                        node_ctx.invoker_capacity.initial_invocation_memory,
+                    )
+                    .await?,
                     partition_store.partition_db().clone(),
-                    node_ctx.invoker_capacity.concurrency.clone(),
-                    node_ctx.invoker_capacity.invocation_token_bucket.clone(),
-                    node_ctx.invoker_capacity.memory_pool.clone(),
-                    node_ctx.invoker_capacity.initial_invocation_memory,
+                    processor.vqueues_mut(),
                 )
-                .await?,
-                partition_store.partition_db().clone(),
-                processor.vqueues_mut(),
-            )
-            .await?;
+                .await?
+            };
 
             // Seed the scheduler's UserLimiter with whatever rules
             // have already been applied to this partition.
@@ -1053,39 +1062,38 @@ mod tests {
 
     use assert2::let_assert;
     use restate_bifrost::Bifrost;
+    use restate_core::network::Reciprocal;
     use restate_core::partitions::PartitionRouting;
     use restate_core::{TaskCenter, TestCoreEnv};
     use restate_ingestion_client::{IngestionClient, SessionOptions};
     use restate_partition_store::PartitionStoreManager;
     use restate_rocksdb::RocksDbManager;
     use restate_types::config::Configuration;
-    use restate_types::identifiers::{LeaderEpoch, PartitionId};
+    use restate_types::deployment::PinnedDeployment;
+    use restate_types::identifiers::{
+        DeploymentId, InvocationId, LeaderEpoch, PartitionId, PartitionProcessorRpcRequestId,
+    };
+    use restate_types::invocation::FencingToken;
     use restate_types::logs::{KeyFilter, Lsn, SequenceNumber};
     use restate_types::partitions::state::PartitionReplicaSetStates;
     use restate_types::partitions::{
         Partition, PartitionConfiguration, PartitionFeatureChange, PersistedFeatures,
     };
+    use restate_types::service_protocol::ServiceProtocolVersion;
     use restate_types::sharding::KeyRange;
     use restate_types::{GenerationalNodeId, Version};
     use restate_wal_protocol::Command;
     use restate_wal_protocol::Envelope;
+    use restate_wal_protocol::invocation::PauseInvocationCommand;
     use restate_worker_api::invoker::capacity::InvokerCapacity;
+    use restate_worker_api::invoker::{Effect, EffectKind, FencedEffect};
 
     use crate::partition::leadership::{LeadershipState, State};
     use crate::partition::processor::ProcessorRawContext;
+    use crate::partition::types::InvokerEffect;
     use crate::partition::{LeadershipInfo, NodeContext};
     use crate::partition_processor_manager::PartitionLeaderHandlesRegistry;
     use crate::rule_book_cache::RuleBookCacheHandle;
-
-    use restate_core::network::Reciprocal;
-    use restate_types::deployment::PinnedDeployment;
-    use restate_types::identifiers::{DeploymentId, InvocationId, PartitionProcessorRpcRequestId};
-    use restate_types::invocation::FencingToken;
-    use restate_types::service_protocol::ServiceProtocolVersion;
-    use restate_wal_protocol::invocation::PauseInvocationCommand;
-    use restate_worker_api::invoker::{Effect, EffectKind, FencedEffect};
-
-    use crate::partition::types::InvokerEffect;
 
     const PARTITION_ID: PartitionId = PartitionId::MIN;
     const NODE_ID: GenerationalNodeId = GenerationalNodeId::new(0, 0);
@@ -1285,7 +1293,6 @@ mod tests {
         let State::Leader(leader_state) = &mut state.state else {
             panic!("expected to be leader");
         };
-
         let invocation_id = InvocationId::mock_random();
         // Four distinguishable effects so we can assert exactly which were appended.
         let dep_attempt1 = DeploymentId::from_parts(1, 1);

--- a/deny.toml
+++ b/deny.toml
@@ -100,9 +100,6 @@ skip = [
     { name = "windows_i686_msvc" },
     { name = "windows_aarch64_msvc" },
 
-    # Clash between tonic clap dependency (outdated) and hyper-rustls and prost-reflect
-    { name = "base64" },
-
     # The following is an internal dependency needed by librocksdb-sys
     { name = "syn" },
 

--- a/release-notes/unreleased/5193-disable-scheduler.md
+++ b/release-notes/unreleased/5193-disable-scheduler.md
@@ -1,0 +1,37 @@
+# Release Notes for Issue #5193: Disable the VQueue Scheduler
+
+## New Feature
+
+### What Changed
+
+Workers can now be started without running their VQueue scheduler:
+
+```toml
+[worker]
+disable-scheduler = true
+```
+
+The worker continues processing partitions and can perform partition migrations, but it does not
+produce new VQueue run or yield decisions. Decisions committed before the disabled worker became
+leader can still be applied during replay. Other VQueue invocations and state mutations remain in
+their current inbox or running stages until scheduling is re-enabled. Legacy invocations on
+partitions that have not migrated to VQueues are unaffected.
+
+### Impact on Users
+
+The option defaults to `false`, preserving existing behavior. Configure it consistently on every worker that can lead
+a partition.
+
+The option only affects workers on which it is configured. Stop or isolate incoming traffic before
+restarting every worker with scheduling disabled. Scheduler and user-limit introspection return no
+rows for partitions led by those workers while the scheduler is disabled.
+
+### Migration Guidance
+
+After validating a migration, set `disable-scheduler = false` and restart the workers to resume
+VQueue scheduling. The scheduler then recovers persisted running entries before processing queued
+work.
+
+### Related Issues
+
+- [#5193](https://github.com/restatedev/restate/issues/5193)


### PR DESCRIPTION
Partition migrations sometimes need workers to continue processing partition logs without starting queued VQueue work.

Add worker.disable-scheduler, disables the vqueue scheduler when leadership of a partition is acquired. Disabled leaders use the inert scheduler implementation, emit no new run or yield decisions, and suppress stale VQueue dispatch actions from decisions committed before promotion. Legacy non-VQueue execution remains unaffected, and scheduling resumes after the option is cleared and leadership is reacquired.

This fixes #5193.