### PR TITLE
Back out "Remove experimental vqueues_migration_skip_completed feature"

### DIFF
--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -825,6 +825,21 @@ experimental! {
     ///
     /// Since v1.7.0
     kafka_scope,
+
+    /// # Skip completed invocations during the vqueues migration
+    ///
+    /// When enabled, the vqueues migration does not migrate completed
+    /// invocations into their vqueue's `Finished` stage. Completed invocations
+    /// keep their existing status and are still cleaned up by their
+    /// `CleanInvocationStatus` timer, but they will not appear in vqueue
+    /// introspection. This can significantly speed up the migration on stores
+    /// with a large completion-retention backlog. Requires `vqueues` to also be
+    /// enabled.
+    ///
+    /// By default, all invocations (including completed ones) are migrated.
+    ///
+    /// Since v1.7.5
+    vqueues_migration_skip_completed,
 }
 
 serde_with::with_prefix!(pub prefix_tokio_console "tokio_console_");

--- a/crates/vqueues/src/migrations.rs
+++ b/crates/vqueues/src/migrations.rs
@@ -64,6 +64,7 @@ pub async fn migrate_to_vqueues(
     ctx: &mut MigrationContext<'_>,
     cache: &mut VQueuesMetaCache,
     migration_record_created_at: UniqueTimestamp,
+    skip_completed: bool,
 ) -> Result<(), StorageError> {
     // Design Notes:
     // We need to make the migration of a single invocation atomic. An invocation is either migrated
@@ -77,7 +78,14 @@ pub async fn migrate_to_vqueues(
     let mut stats = MigrationStats::new(partition_id);
     info!(partition_id = %partition_id, "Starting migration to vqueues");
     migrate_inboxes(&mut stats, migration_record_created_at, cache, ctx).await?;
-    migrate_invocations(&mut stats, migration_record_created_at, cache, ctx).await?;
+    migrate_invocations(
+        &mut stats,
+        migration_record_created_at,
+        cache,
+        ctx,
+        skip_completed,
+    )
+    .await?;
 
     // clean up old keyed service status table after we have migrated everything
     restate_partition_store::migrations::migrate_to_locks_table::delete_service_status_data(ctx)?;
@@ -244,6 +252,7 @@ async fn migrate_invocations(
     migration_record_created_at: UniqueTimestamp,
     cache: &mut VQueuesMetaCache,
     ctx: &mut MigrationContext<'_>,
+    skip_completed: bool,
 ) -> Result<(), StorageError> {
     let mut readopts = rocksdb::ReadOptions::default();
     readopts.set_total_order_seek(true);
@@ -278,7 +287,9 @@ async fn migrate_invocations(
         // Allow tokio to cancel this task if the processor is being cancelled.
         tokio::task::consume_budget().await;
         let (key, value) = iterator.item().unwrap();
-        let Some((invocation_id, status)) = read_invocation_status(key, value)? else {
+        let Some((invocation_id, status)) =
+            read_invocation_status(key, value, skip_completed, stats)?
+        else {
             iterator.next();
             continue;
         };
@@ -621,6 +632,8 @@ fn invocation_id_from_key_bytes<B: bytes::Buf>(
 fn read_invocation_status(
     mut k: &[u8],
     v: &[u8],
+    skip_completed: bool,
+    stats: &mut MigrationStats,
 ) -> Result<Option<(InvocationId, InvocationStatus)>, StorageError> {
     let invocation_id = invocation_id_from_key_bytes(&mut k)?;
 
@@ -635,6 +648,16 @@ fn read_invocation_status(
             InvocationStatusDiscriminants::Inboxed
         )
     {
+        Ok(None)
+    } else if skip_completed
+        && matches!(
+            invocation_status.status,
+            InvocationStatusDiscriminants::Completed
+        )
+    {
+        // The `InvocationLite` discriminant is enough to know we can skip this entry, so we avoid
+        // the cost of fully decoding the (potentially large) completed invocation value.
+        stats.inc_skipped_completed();
         Ok(None)
     } else {
         Ok(Some((invocation_id, decode_value(v)?)))
@@ -665,6 +688,7 @@ struct MigrationStats {
     num_suspended: usize,
     num_paused: usize,
     num_completed: usize,
+    num_skipped_completed: usize,
 }
 
 impl MigrationStats {
@@ -682,6 +706,7 @@ impl MigrationStats {
             num_suspended: 0,
             num_paused: 0,
             num_completed: 0,
+            num_skipped_completed: 0,
         }
     }
 
@@ -695,7 +720,7 @@ impl MigrationStats {
         if self.total.is_multiple_of(100) && self.last_report.elapsed() >= Duration::from_secs(5) {
             info!(
                 partition_id = %self.partition_id,
-                "[VQueues Migration Progress] total={} inbox={} invoked={} scheduled={} paused={} suspended={} completed={} elapsed={}",
+                "[VQueues Migration Progress] total={} inbox={} invoked={} scheduled={} paused={} suspended={} completed={} skipped_completed={} elapsed={}",
                 self.total,
                 self.num_inboxed,
                 self.num_invoked,
@@ -703,6 +728,7 @@ impl MigrationStats {
                 self.num_paused,
                 self.num_suspended,
                 self.num_completed,
+                self.num_skipped_completed,
                 self.start_time.elapsed().friendly()
             );
             self.last_report = Instant::now();
@@ -712,7 +738,7 @@ impl MigrationStats {
     fn report_finish(&self) {
         info!(
             partition_id = %self.partition_id,
-            "[VQueues Migration Completed] total={} inbox={} invoked={} scheduled={} paused={} suspended={} completed={} elapsed={}",
+            "[VQueues Migration Completed] total={} inbox={} invoked={} scheduled={} paused={} suspended={} completed={} skipped_completed={} elapsed={}",
             self.total,
             self.num_inboxed,
             self.num_invoked,
@@ -720,6 +746,7 @@ impl MigrationStats {
             self.num_paused,
             self.num_suspended,
             self.num_completed,
+            self.num_skipped_completed,
             self.start_time.elapsed().friendly()
         );
     }
@@ -750,6 +777,12 @@ impl MigrationStats {
 
     fn inc_completed(&mut self) {
         self.num_completed += 1;
+        self.total += 1;
+        self.maybe_report();
+    }
+
+    fn inc_skipped_completed(&mut self) {
+        self.num_skipped_completed += 1;
         self.total += 1;
         self.maybe_report();
     }

--- a/crates/worker/src/partition/processor/commands/version_barrier.rs
+++ b/crates/worker/src/partition/processor/commands/version_barrier.rs
@@ -151,6 +151,10 @@ impl<L: LeaderPromotion> ApplyPartitionCommand<VersionBarrierCommand>
                                 | DetailedRunMode::Candidate
                         );
                         let config = self.node_ctx.config.live_load();
+                        let skip_completed = config
+                            .common
+                            .experimental
+                            .is_vqueues_migration_skip_completed_enabled();
                         let partition_db = &self.partition_db;
                         let mut ctx = MigrationContext::new(
                             config,
@@ -163,6 +167,7 @@ impl<L: LeaderPromotion> ApplyPartitionCommand<VersionBarrierCommand>
                             &mut ctx,
                             self.processor.vqueues_mut(),
                             UniqueTimestamp::from_unix_millis_unchecked(created_at.into()),
+                            skip_completed,
                         )
                         .await?;
                     }


### PR DESCRIPTION

Original commit changeset: 5d5e215b579d

This is a backout of https://github.com/restatedev/restate/pull/5138 no change to the logic.

---
[//]: # (BEGIN SAPLING FOOTER)
* #5211
* __->__ #5210