### PR TITLE
[vqueues] Change vqueues skip completed to be a partition feature

### DIFF
--- a/crates/types/src/partitions/features.rs
+++ b/crates/types/src/partitions/features.rs
@@ -16,7 +16,9 @@ use crate::storage::{
     StorageCodecKind, StorageDecode, StorageDecodeError, StorageEncode, StorageEncodeError, decode,
     encode,
 };
-use crate::{RESTATE_VERSION_1_6_0, RESTATE_VERSION_1_7_0, SemanticRestateVersion};
+use crate::{
+    RESTATE_VERSION_1_6_0, RESTATE_VERSION_1_7_0, RESTATE_VERSION_1_7_5, SemanticRestateVersion,
+};
 
 /// A change to the set of state-machine features enabled on a partition.
 ///
@@ -49,7 +51,7 @@ pub enum PartitionFeatureChange {
     ///
     /// *Since v1.7.0*
     EnableJournalV2 = 1,
-    /// Enable vqueues for the partition.
+    /// Enable vqueues for the partition and migrate all invocations.
     ///
     /// *Since v1.7.0*
     EnableVqueues = 2,
@@ -58,6 +60,10 @@ pub enum PartitionFeatureChange {
     ///
     /// *Since v1.7.0*
     EnableUniqueRandomSeeds = 3,
+    /// Enable vqueues for the partition and skip migrating completed invocations.
+    ///
+    /// *Since v1.7.5*
+    EnableVqueuesSkipCompleted = 4,
 }
 
 impl PartitionFeatureChange {
@@ -74,6 +80,7 @@ impl PartitionFeatureChange {
             Self::EnableJournalV2 => &RESTATE_VERSION_1_6_0,
             Self::EnableVqueues => &RESTATE_VERSION_1_7_0,
             Self::EnableUniqueRandomSeeds => &RESTATE_VERSION_1_7_0,
+            Self::EnableVqueuesSkipCompleted => &RESTATE_VERSION_1_7_5,
         }
     }
 
@@ -82,7 +89,15 @@ impl PartitionFeatureChange {
     pub fn apply_to(self, features: &mut PersistedFeatures) -> bool {
         match self {
             Self::EnableJournalV2 => !std::mem::replace(&mut features.journal_v2, true),
-            Self::EnableVqueues => !std::mem::replace(&mut features.vqueues, true),
+            Self::EnableVqueues => {
+                // Setting vqueues to true is a superset of vqueues_skip_completed, so unsetting it
+                // to make it less confusing.
+                features.vqueues_skip_completed = false;
+                !std::mem::replace(&mut features.vqueues, true)
+            }
+            Self::EnableVqueuesSkipCompleted => {
+                !std::mem::replace(&mut features.vqueues_skip_completed, true)
+            }
             Self::EnableUniqueRandomSeeds => {
                 !std::mem::replace(&mut features.unique_random_seeds, true)
             }
@@ -130,6 +145,12 @@ pub struct PersistedFeatures {
     /// *Since v1.7.0*
     #[bilrost(tag(3))]
     pub unique_random_seeds: bool,
+
+    /// Virtual queues are enabled on this partition with only inflight-invocations migrated.
+    ///
+    /// *Since v1.7.5*
+    #[bilrost(tag(4))]
+    pub vqueues_skip_completed: bool,
 }
 
 impl PersistedFeatures {
@@ -141,6 +162,8 @@ impl PersistedFeatures {
             self.journal_v2.then_some("journal_v2"),
             self.vqueues.then_some("vqueues"),
             self.unique_random_seeds.then_some("unique_random_seeds"),
+            self.vqueues_skip_completed
+                .then_some("vqueues_skip_completed"),
         ]
         .into_iter()
         .flatten()
@@ -204,6 +227,22 @@ mod tests {
         PartitionFeatureChange::EnableUniqueRandomSeeds.apply_to(&mut features);
         assert!(features.vqueues);
         assert!(features.unique_random_seeds);
+    }
+
+    #[test]
+    fn set_vqueue_features() {
+        let mut features = PersistedFeatures::default();
+        assert!(!features.vqueues);
+        assert!(!features.vqueues_skip_completed);
+
+        PartitionFeatureChange::EnableVqueuesSkipCompleted.apply_to(&mut features);
+        assert!(!features.vqueues);
+        assert!(features.vqueues_skip_completed);
+
+        // Setting vqueues to true, unsets vqueues_skip_completed.
+        PartitionFeatureChange::EnableVqueues.apply_to(&mut features);
+        assert!(features.vqueues);
+        assert!(!features.vqueues_skip_completed);
     }
 
     #[test]

--- a/crates/types/src/restate_version.rs
+++ b/crates/types/src/restate_version.rs
@@ -234,6 +234,10 @@ pub static RESTATE_VERSION_1_6_0: LazyLock<SemanticRestateVersion> =
 pub static RESTATE_VERSION_1_7_0: LazyLock<SemanticRestateVersion> =
     LazyLock::new(|| SemanticRestateVersion::parse("1.7.0-dev").expect("valid semver version"));
 
+/// Why isn't this value simply v1.7.5? See description of [`RESTATE_VERSION_1_6_0`].
+pub static RESTATE_VERSION_1_7_5: LazyLock<SemanticRestateVersion> =
+    LazyLock::new(|| SemanticRestateVersion::parse("1.7.5-dev").expect("valid semver version"));
+
 /// Why isn't this value simply v1.8.0? See description of [`RESTATE_VERSION_1_6_0`].
 pub static RESTATE_VERSION_1_8_0: LazyLock<SemanticRestateVersion> =
     LazyLock::new(|| SemanticRestateVersion::parse("1.8.0-dev").expect("valid semver version"));

--- a/crates/vqueues/src/migrations.rs
+++ b/crates/vqueues/src/migrations.rs
@@ -59,13 +59,18 @@ fn increment_unchecked(bytes: &mut BytesMut) {
     unreachable!("failed to find a byte to increment");
 }
 
+pub enum MigrationResult {
+    SkippedCompleted,
+    FullyMigrated,
+}
+
 /// VQueues migration for a range of partition keys.
 pub async fn migrate_to_vqueues(
     ctx: &mut MigrationContext<'_>,
     cache: &mut VQueuesMetaCache,
     migration_record_created_at: UniqueTimestamp,
     skip_completed: bool,
-) -> Result<(), StorageError> {
+) -> Result<MigrationResult, StorageError> {
     // Design Notes:
     // We need to make the migration of a single invocation atomic. An invocation is either migrated
     // or not. To make this atomic, all mutations necessary to migrate a single invocation must be
@@ -90,7 +95,12 @@ pub async fn migrate_to_vqueues(
     // clean up old keyed service status table after we have migrated everything
     restate_partition_store::migrations::migrate_to_locks_table::delete_service_status_data(ctx)?;
     stats.report_finish();
-    Ok(())
+
+    Ok(if stats.num_skipped_completed > 0 {
+        MigrationResult::SkippedCompleted
+    } else {
+        MigrationResult::FullyMigrated
+    })
 }
 
 /// Migrate inboxes

--- a/crates/worker-api/src/processor/features.rs
+++ b/crates/worker-api/src/processor/features.rs
@@ -36,6 +36,11 @@ pub trait PartitionFeatures {
     ///
     /// *Since v1.7.0*
     fn is_unique_random_seeds_enabled(&self) -> bool;
+
+    /// Whether all invocations in this partition (completed and inflight) are fully migrated to vqueues.
+    ///
+    /// *Since v1.7.5*
+    fn is_fully_migrated_to_vqueues(&self) -> bool;
 }
 
 impl PartitionFeatures for PersistedFeatures {
@@ -45,6 +50,7 @@ impl PartitionFeatures for PersistedFeatures {
             PartitionFeatureChange::EnableJournalV2 => self.journal_v2,
             PartitionFeatureChange::EnableVqueues => self.vqueues,
             PartitionFeatureChange::EnableUniqueRandomSeeds => self.unique_random_seeds,
+            PartitionFeatureChange::EnableVqueuesSkipCompleted => self.vqueues_skip_completed,
         }
     }
 
@@ -55,6 +61,11 @@ impl PartitionFeatures for PersistedFeatures {
 
     #[inline]
     fn is_vqueues_enabled(&self) -> bool {
+        self.vqueues || self.vqueues_skip_completed
+    }
+
+    #[inline]
+    fn is_fully_migrated_to_vqueues(&self) -> bool {
         self.vqueues
     }
 
@@ -79,6 +90,10 @@ impl<T: PartitionFeatures> PartitionFeatures for &T {
         (**self).is_vqueues_enabled()
     }
 
+    fn is_fully_migrated_to_vqueues(&self) -> bool {
+        (**self).is_fully_migrated_to_vqueues()
+    }
+
     fn is_unique_random_seeds_enabled(&self) -> bool {
         (**self).is_unique_random_seeds_enabled()
     }
@@ -95,6 +110,10 @@ impl<T: PartitionFeatures> PartitionFeatures for &mut T {
 
     fn is_vqueues_enabled(&self) -> bool {
         (**self).is_vqueues_enabled()
+    }
+
+    fn is_fully_migrated_to_vqueues(&self) -> bool {
+        (**self).is_fully_migrated_to_vqueues()
     }
 
     fn is_unique_random_seeds_enabled(&self) -> bool {

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -546,10 +546,41 @@ where
             // flag on and the FSM hasn't already recorded the opt-in. The FSM update itself
             // happens via `OnVersionBarrierCommand` once this proposed barrier is applied; we do
             // not touch the local FSM mirror here.
-            if config.common.experimental.is_vqueues_enabled()
-                && !processor.fsm().features().is_vqueues_enabled()
-            {
-                feature_changes.push(PartitionFeatureChange::EnableVqueues);
+            if config.common.experimental.is_vqueues_enabled() {
+                // The vqueues flag is true, one of the following will happen:
+                //   1. We're already on vqueues, so nothing to do.
+                //   2. We're not yet on vqueues, so we'll migrate either fully or partially depending
+                //      on the vqueues_skip_completed flag.
+                //   3. We've previously partially migrated to vqueues, but now we want to fully migrate,
+                //      so we'll trigger a full migration.
+                match (
+                    config
+                        .common
+                        .experimental
+                        .is_vqueues_migration_skip_completed_enabled(),
+                    processor.fsm().features().is_vqueues_enabled(),
+                    processor.fsm().features().is_fully_migrated_to_vqueues(),
+                ) {
+                    (_, _, true) => {
+                        // Nothing to do here, we're fully migrated to vqueues.
+                    }
+
+                    (false, _, false) => {
+                        // skip_completed=False (full migration), and we're not yet fully migrated,
+                        // so we'll trigger a full migration.
+                        feature_changes.push(PartitionFeatureChange::EnableVqueues);
+                    }
+
+                    (true, true, false) => {
+                        // skip_completed=True (partial migration), and we're already partially migrated,
+                        // nothing to do here.
+                    }
+                    (true, false, false) => {
+                        // skip_completed=True (partial migration), and we're yet on vqueues, so we'll
+                        // trigger a partial migration.
+                        feature_changes.push(PartitionFeatureChange::EnableVqueuesSkipCompleted);
+                    }
+                }
             }
 
             // Persist a unique random seed on new invocations. Needs to be opted-in because
@@ -1210,6 +1241,7 @@ mod tests {
             PersistedFeatures {
                 journal_v2: true,
                 vqueues: true,
+                vqueues_skip_completed: true,
                 unique_random_seeds: true,
             },
         );

--- a/crates/worker/src/partition/processor/commands/version_barrier.rs
+++ b/crates/worker/src/partition/processor/commands/version_barrier.rs
@@ -10,11 +10,10 @@
 
 use std::assert_matches;
 
-use restate_clock::UniqueTimestamp;
-use restate_vqueues::context::HasVQueuesMut;
-use tracing::debug;
+use tracing::{debug, info};
 
 use restate_bifrost::DataRecord;
+use restate_clock::UniqueTimestamp;
 use restate_core::cancellation_token;
 use restate_partition_store::migrations::MigrationContext;
 use restate_partition_store::{PartitionDb, PartitionStoreTransaction};
@@ -22,6 +21,8 @@ use restate_storage_api::Transaction;
 use restate_types::SemanticRestateVersion;
 use restate_types::partitions::features::PartitionFeatureChange;
 use restate_types::protobuf::cluster::DetailedRunMode;
+use restate_vqueues::context::HasVQueuesMut;
+use restate_vqueues::migrations::MigrationResult;
 use restate_wal_protocol::control::VersionBarrierCommand;
 use restate_wal_protocol::v2::{CommandScope, Envelope};
 
@@ -142,7 +143,8 @@ impl<L: LeaderPromotion> ApplyPartitionCommand<VersionBarrierCommand>
                     // and scheduled-invocation timers via the `InvocationStatus::Scheduled`
                     // source-of-truth) must be migrated to vqueue form before vqueues is
                     // enabled.
-                    PartitionFeatureChange::EnableVqueues => {
+                    PartitionFeatureChange::EnableVqueues
+                    | PartitionFeatureChange::EnableVqueuesSkipCompleted => {
                         // if we are in "Leader" mode, then something is wrong!
                         assert_matches!(
                             self.leadership.current_mode(),
@@ -151,10 +153,8 @@ impl<L: LeaderPromotion> ApplyPartitionCommand<VersionBarrierCommand>
                                 | DetailedRunMode::Candidate
                         );
                         let config = self.node_ctx.config.live_load();
-                        let skip_completed = config
-                            .common
-                            .experimental
-                            .is_vqueues_migration_skip_completed_enabled();
+                        let skip_completed =
+                            matches!(change, PartitionFeatureChange::EnableVqueuesSkipCompleted);
                         let partition_db = &self.partition_db;
                         let mut ctx = MigrationContext::new(
                             config,
@@ -163,13 +163,23 @@ impl<L: LeaderPromotion> ApplyPartitionCommand<VersionBarrierCommand>
                             cancellation_token(),
                         );
 
-                        restate_vqueues::migrations::migrate_to_vqueues(
+                        let res = restate_vqueues::migrations::migrate_to_vqueues(
                             &mut ctx,
                             self.processor.vqueues_mut(),
                             UniqueTimestamp::from_unix_millis_unchecked(created_at.into()),
                             skip_completed,
                         )
                         .await?;
+
+                        if skip_completed && matches!(res, MigrationResult::FullyMigrated) {
+                            // Our initial intention was skipping completed invocation, but the full scan
+                            // found no completed invocations. We can safely consider it a full migration.
+                            info!(
+                                partition_id = %self.processor.partition_id(),
+                                "Auto promoting the vqueue migration into a full migration as no completed invocations were found",
+                            );
+                            PartitionFeatureChange::EnableVqueues.apply_to(&mut updated);
+                        }
                     }
                     PartitionFeatureChange::EnableJournalV2 => {}
                     // Flipping unique-random-seeds on only affects invocations created after the apply


### PR DESCRIPTION

Previously, the `vqueues_migration_skip_completed` was read as part of the version barrier and chanaged the behavior of the migration to ignore completed invocations without leaving any marker for this behavior. This makes it hard to differentiate on whether all invocations are migrated or not (specially when we enable vqueues by default in 1.8)

This PR changes the behavior when migration_skip_completed is set. Instead, the leader will propose a different a different feature change `EnableVqueuesSkipCompleted`, and leave a `vqueues_skip_completed` persisted feature when it's done. Later on, if skip_completed gets set to `false`, a new version barrier with `EnableVqueues` will be sent and complete the job.

Both the persisted features `vqueues` and `vqueues_skip_completed` should enable the vqueues machinery, as such `fsm().is_vqueues_enabled()` returns true if either of them is set. A new method `is_vqueues_fully_migrated()` makes the distinction between the two. Already migrated customers are all fully migrated and all will have `vqueues` persisted in the FSM.

As an optimization, if a skip_completed is set, and as part of the full scan we did, we didn't find any completed invocation, we automatically promote the migration to a full migration.

---
[//]: # (BEGIN SAPLING FOOTER)
* __->__ #5211
* #5210