### PR TITLE
Use mainstream h2 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,7 +893,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.4.16",
+ "h2",
  "http 1.5.0",
  "hyper",
  "hyper-rustls",
@@ -4035,27 +4035,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http 1.5.0",
- "indexmap 2.14.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.17"
-source = "git+https://github.com/muhamadazmy/h2?branch=configurable-data-frame-budget#4b2e989a503bdb78e15da15a47613c4d194d6c24"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4364,7 +4346,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.16",
+ "h2",
  "http 1.5.0",
  "http-body 1.1.0",
  "httparse",
@@ -7422,7 +7404,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.16",
+ "h2",
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
@@ -8733,7 +8715,7 @@ dependencies = [
  "futures",
  "google-cloud-auth",
  "googletest",
- "h2 0.4.17",
+ "h2",
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
@@ -10662,7 +10644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -11099,7 +11081,7 @@ dependencies = [
  "base64",
  "bytes",
  "flate2",
- "h2 0.4.16",
+ "h2",
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",

--- a/crates/service-client/Cargo.toml
+++ b/crates/service-client/Cargo.toml
@@ -32,8 +32,7 @@ dashmap = { workspace = true }
 derive_builder = { workspace = true }
 futures = { workspace = true }
 google-cloud-auth = { workspace = true }
-# TODO: Update to latest h2 version once https://github.com/hyperium/h2/pull/942 is merged
-h2 = { git = "https://github.com/muhamadazmy/h2", branch = "configurable-data-frame-budget"}
+h2 = { version = "0.4.18" }
 http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -126,8 +126,4 @@ allow-git = ["https://github.com/apache/arrow-rs.git"]
 
 [sources.allow-org]
 # 1 or more github.com organizations to allow git sources for
-github = [
-    "restatedev",
-    # TODO: remove after https://github.com/hyperium/h2/pull/942 is merged and released
-    "muhamadazmy",
-]
+github = ["restatedev"]


### PR DESCRIPTION
Switch back to use mainstream h2 crate
after it has been released

Follow up to #5209
