### PR TITLE
[RocksDB] do not constraint bottom-most compactions to a single thread

### DIFF
--- a/crates/log-server/src/rocksdb_logstore/builder.rs
+++ b/crates/log-server/src/rocksdb_logstore/builder.rs
@@ -97,7 +97,6 @@ impl RocksDbConfigurator {
             let mut env = rocksdb::Env::new()?;
             env.set_high_priority_background_threads(1);
             env.set_low_priority_background_threads(1);
-            env.set_bottom_priority_background_threads(1);
             env
         };
         Ok(Self { env })

--- a/crates/rocksdb/src/db_manager.rs
+++ b/crates/rocksdb/src/db_manager.rs
@@ -86,7 +86,6 @@ impl RocksDbManager {
         let mut env = rocksdb::Env::new().expect("rocksdb env is created");
         env.set_high_priority_background_threads(2);
         env.set_low_priority_background_threads(1);
-        env.set_bottom_priority_background_threads(1);
 
         // Setup the global write rate limiter
         let rate_limiter = RateLimiter::new(


### PR DESCRIPTION

Space reclamation mainly happens at bottom most levels (where the lower level has non-overlapping range). The environment is setup with 1 thread in `BOTTOM` priority and rocksdb will not auto expand this particular pool (unlike LOW). The original intent of my choice was to limit the heavy bottom most compactions from eating the background compaction budget and that has worked well but comes at the cost of not reclaiming space fast enough.

This change makes the bottom most compactions to be scheduled on the `LOW` pool, sharing the concurrency budget with other background compactions.

The change is applied to both partition store and log server
