### PR TITLE
Retain output journal entry

### DIFF
--- a/crates/partition-store/src/journal_table_v2/mod.rs
+++ b/crates/partition-store/src/journal_table_v2/mod.rs
@@ -258,16 +258,16 @@ fn get_journal<'a, S: StorageAccess>(
     Ok(JournalEntryIter::new(iter, journal_length))
 }
 
-fn delete_journal<S: StorageAccess>(
+fn delete_journals<S: StorageAccess>(
     storage: &mut S,
     invocation_id: &InvocationId,
-    journal_length: EntryIndex,
+    journals: impl Iterator<Item = EntryIndex>,
 ) -> Result<()> {
     let _x = RocksDbReadPerfGuard::new("delete-journal");
 
     let mut key = write_journal_entry_key(invocation_id, 0);
     let k = &mut key;
-    for journal_index in 0..journal_length {
+    for journal_index in journals {
         k.journal_index = journal_index;
         storage.delete_key(k)?;
     }
@@ -805,14 +805,13 @@ impl WriteJournalTable for PartitionStoreTransaction<'_> {
         put_journal_entry(self, invocation_id, index, entry, related_completion_ids)
     }
 
-    fn delete_journal(
+    fn delete_journals(
         &mut self,
         invocation_id: &InvocationId,
-        journal_length: EntryIndex,
+        journals: impl Iterator<Item = EntryIndex>,
     ) -> Result<()> {
         self.assert_partition_key(invocation_id)?;
-        let _x = RocksDbReadPerfGuard::new("delete-journal");
-        delete_journal(self, invocation_id, journal_length)
+        delete_journals(self, invocation_id, journals)
     }
 }
 

--- a/crates/partition-store/src/journal_table_v2/mod.rs
+++ b/crates/partition-store/src/journal_table_v2/mod.rs
@@ -258,7 +258,7 @@ fn get_journal<'a, S: StorageAccess>(
     Ok(JournalEntryIter::new(iter, journal_length))
 }
 
-fn delete_journals<S: StorageAccess>(
+fn delete_journal<S: StorageAccess>(
     storage: &mut S,
     invocation_id: &InvocationId,
     journals: impl Iterator<Item = EntryIndex>,
@@ -805,13 +805,13 @@ impl WriteJournalTable for PartitionStoreTransaction<'_> {
         put_journal_entry(self, invocation_id, index, entry, related_completion_ids)
     }
 
-    fn delete_journals(
+    fn delete_journal(
         &mut self,
         invocation_id: &InvocationId,
         journals: impl Iterator<Item = EntryIndex>,
     ) -> Result<()> {
         self.assert_partition_key(invocation_id)?;
-        delete_journals(self, invocation_id, journals)
+        delete_journal(self, invocation_id, journals)
     }
 }
 

--- a/crates/partition-store/src/tests/journal_table_v2_test/mod.rs
+++ b/crates/partition-store/src/tests/journal_table_v2_test/mod.rs
@@ -199,7 +199,7 @@ async fn sleep_point_lookups<T: ReadJournalTable>(txn: &mut T) {
 }
 
 fn delete_journal<T: WriteJournalTable>(txn: &mut T, length: usize) {
-    txn.delete_journal(&MOCK_INVOCATION_ID_1, length as u32)
+    txn.delete_journals(&MOCK_INVOCATION_ID_1, 0..length as u32)
         .unwrap();
 }
 

--- a/crates/partition-store/src/tests/journal_table_v2_test/mod.rs
+++ b/crates/partition-store/src/tests/journal_table_v2_test/mod.rs
@@ -199,7 +199,7 @@ async fn sleep_point_lookups<T: ReadJournalTable>(txn: &mut T) {
 }
 
 fn delete_journal<T: WriteJournalTable>(txn: &mut T, length: usize) {
-    txn.delete_journals(&MOCK_INVOCATION_ID_1, 0..length as u32)
+    txn.delete_journal(&MOCK_INVOCATION_ID_1, 0..length as u32)
         .unwrap();
 }
 

--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -771,7 +771,7 @@ impl ResponseResultRef {
     /// Returns Some(index) only if the response result is a reference
     /// to an output journal. If embedded returns None
     pub fn referenced_journal_index(&self) -> Option<EntryIndex> {
-        if let Self::Reference(ResponseReference { entry_index, .. }) = self {
+        if let Self::Completed(CompletionReference { entry_index, .. }) = self {
             Some(*entry_index)
         } else {
             None

--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -771,10 +771,10 @@ impl ResponseResultRef {
     /// Returns Some(index) only if the response result is a reference
     /// to an output journal. If embedded returns None
     pub fn referenced_journal_index(&self) -> Option<EntryIndex> {
-        if let Self::Completed(CompletionReference { entry_index, .. }) = self {
-            Some(*entry_index)
-        } else {
-            None
+        match self {
+            Self::Completed(CompletionReference { entry_index, .. }) => Some(*entry_index),
+            Self::Killed(entry_index) => Some(*entry_index),
+            Self::Success(_) | Self::Failure(_) => None,
         }
     }
 }

--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -767,6 +767,16 @@ impl ResponseResultRef {
             Self::Completed(completion) => completion.status.clone().into(),
         }
     }
+
+    /// Returns Some(index) only if the response result is a reference
+    /// to an output journal. If embedded returns None
+    pub fn referenced_journal_index(&self) -> Option<EntryIndex> {
+        if let Self::Reference(ResponseReference { entry_index, .. }) = self {
+            Some(*entry_index)
+        } else {
+            None
+        }
+    }
 }
 
 impl From<ResponseResult> for ResponseResultRef {

--- a/crates/storage-api/src/journal_table_v2/mod.rs
+++ b/crates/storage-api/src/journal_table_v2/mod.rs
@@ -120,7 +120,7 @@ pub trait WriteJournalTable {
     ) -> Result<()>;
 
     /// When length is available, it is suggested to provide it as it makes the delete more efficient.
-    fn delete_journals(
+    fn delete_journal(
         &mut self,
         invocation_id: &InvocationId,
         journals: impl Iterator<Item = EntryIndex>,

--- a/crates/storage-api/src/journal_table_v2/mod.rs
+++ b/crates/storage-api/src/journal_table_v2/mod.rs
@@ -120,7 +120,11 @@ pub trait WriteJournalTable {
     ) -> Result<()>;
 
     /// When length is available, it is suggested to provide it as it makes the delete more efficient.
-    fn delete_journal(&mut self, invocation_id: &InvocationId, length: EntryIndex) -> Result<()>;
+    fn delete_journals(
+        &mut self,
+        invocation_id: &InvocationId,
+        journals: impl Iterator<Item = EntryIndex>,
+    ) -> Result<()>;
 }
 
 #[derive(Debug, Clone)]

--- a/crates/worker/src/partition/state_machine/lifecycle/end_invocation.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/end_invocation.rs
@@ -384,6 +384,7 @@ where
             }
         };
 
+        let retain_output = None;
         // If there are any response sinks, or we need to store back the completed status,
         //  we need to find the latest output entry
         if !invocation_metadata.response_sinks.is_empty() || !completion_retention.is_zero() {
@@ -517,6 +518,13 @@ where
 
             // Store the completed status, if needed
             if !completion_retention.is_zero() {
+                retain_output =
+                    if let ResponseResultRef::Completed(completion) = &response_result_ref {
+                        Some(completion.entry_index)
+                    } else {
+                        None
+                    };
+
                 let completed_invocation = CompletedInvocation::from_in_flight_invocation_metadata(
                     invocation_metadata,
                     if journal_retention.is_zero() {
@@ -545,9 +553,15 @@ where
         }
 
         if journal_retention.is_zero() {
+            // drop the journals, and only retain
+            // the output journal if completion retention
+            // is not zero.
+            let retain_output = retain_output.filter(|_| !completion_retention.is_zero());
+
             ctx.do_drop_journal(
                 &invocation_id,
                 journal_length,
+                (0..journal_length).filter(|idx| retain_output.is_none_or(|retain| retain != *idx)),
                 pinned_service_protocol_version,
             )
             .await?;

--- a/crates/worker/src/partition/state_machine/lifecycle/end_invocation.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/end_invocation.rs
@@ -384,7 +384,7 @@ where
             }
         };
 
-        let retain_output = None;
+        let mut retain_journal_index = None;
         // If there are any response sinks, or we need to store back the completed status,
         //  we need to find the latest output entry
         if !invocation_metadata.response_sinks.is_empty() || !completion_retention.is_zero() {
@@ -518,12 +518,7 @@ where
 
             // Store the completed status, if needed
             if !completion_retention.is_zero() {
-                retain_output =
-                    if let ResponseResultRef::Completed(completion) = &response_result_ref {
-                        Some(completion.entry_index)
-                    } else {
-                        None
-                    };
+                retain_journal_index = response_result_ref.referenced_journal_index();
 
                 let completed_invocation = CompletedInvocation::from_in_flight_invocation_metadata(
                     invocation_metadata,
@@ -553,15 +548,11 @@ where
         }
 
         if journal_retention.is_zero() {
-            // drop the journals, and only retain
-            // the output journal if completion retention
-            // is not zero.
-            let retain_output = retain_output.filter(|_| !completion_retention.is_zero());
-
             ctx.do_drop_journal(
                 &invocation_id,
                 journal_length,
-                (0..journal_length).filter(|idx| retain_output.is_none_or(|retain| retain != *idx)),
+                (0..journal_length)
+                    .filter(|idx| retain_journal_index.is_none_or(|retain| retain != *idx)),
                 pinned_service_protocol_version,
             )
             .await?;

--- a/crates/worker/src/partition/state_machine/lifecycle/purge.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/purge.rs
@@ -66,6 +66,7 @@ where
                 invocation_target,
                 journal_metadata,
                 pinned_deployment,
+                response_result,
                 ..
             }) => {
                 // delete the vqueue entry information.
@@ -119,6 +120,17 @@ where
                     ctx.do_drop_journal(
                         invocation_id,
                         journal_metadata.length,
+                        0..journal_metadata.length,
+                        pinned_service_protocol_version,
+                    )
+                    .await?;
+                } else if let Some(output_idx) = response_result.referenced_journal_index() {
+                    // delete only the output journal index
+                    // since it's the only one remaining
+                    ctx.do_drop_journal(
+                        invocation_id,
+                        0,
+                        output_idx..=output_idx,
                         pinned_service_protocol_version,
                     )
                     .await?;

--- a/crates/worker/src/partition/state_machine/lifecycle/purge.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/purge.rs
@@ -161,6 +161,7 @@ mod tests {
 
     use bytes::Bytes;
     use googletest::prelude::{all, assert_that, none, ok, pat};
+    use rstest::rstest;
 
     use restate_storage_api::invocation_status_table::{
         InvocationStatusDiscriminants, ReadInvocationStatusTable,
@@ -177,32 +178,14 @@ mod tests {
         invoker_end_effect, invoker_entry_effect, pinned_deployment,
     };
     use crate::partition::state_machine::tests::matchers::storage::{
-        has_commands, has_journal_length, is_variant,
+        has_commands, has_journal_length, has_result_reference, is_variant,
     };
 
+    #[rstest]
     #[restate_core::test]
-    async fn purge_completed_invocation_with_journal_and_embedded_result() {
-        run_purge_completed_invocation(false, false).await;
-    }
-
-    #[restate_core::test]
-    async fn purge_completed_invocation_with_journal_and_referenced_result() {
-        run_purge_completed_invocation(true, false).await;
-    }
-
-    #[restate_core::test]
-    async fn purge_completed_invocation_after_journal_purge_with_embedded_result() {
-        run_purge_completed_invocation(false, true).await;
-    }
-
-    #[restate_core::test]
-    async fn purge_completed_invocation_after_journal_purge_with_referenced_result() {
-        run_purge_completed_invocation(true, true).await;
-    }
-
     async fn run_purge_completed_invocation(
-        write_result_reference: bool,
-        purge_journal_first: bool,
+        #[values(false, true)] write_result_reference: bool,
+        #[values(false, true)] purge_journal_first: bool,
     ) {
         let mut test_env = TestEnv::create_with_features(PersistedFeatures {
             write_result_reference,
@@ -242,7 +225,8 @@ mod tests {
             ok(all!(
                 is_variant(InvocationStatusDiscriminants::Completed),
                 has_commands(2),
-                has_journal_length(2)
+                has_journal_length(2),
+                has_result_reference(write_result_reference.then_some(1))
             ))
         );
         test_env
@@ -251,19 +235,6 @@ mod tests {
                 [CommandType::Input.into(), CommandType::Output.into()],
             )
             .await;
-
-        let InvocationStatus::Completed(completed) = test_env
-            .storage()
-            .get_invocation_status(&invocation_id)
-            .await
-            .unwrap()
-        else {
-            panic!("invocation must be completed");
-        };
-        assert_eq!(
-            completed.response_result.referenced_journal_index(),
-            write_result_reference.then_some(1)
-        );
 
         if purge_journal_first {
             test_env

--- a/crates/worker/src/partition/state_machine/lifecycle/purge.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/purge.rs
@@ -152,3 +152,182 @@ where
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    use bytes::Bytes;
+    use googletest::prelude::{all, assert_that, none, ok, pat};
+
+    use restate_storage_api::invocation_status_table::{
+        InvocationStatusDiscriminants, ReadInvocationStatusTable,
+    };
+    use restate_storage_api::journal_table_v2::ReadJournalTable;
+    use restate_types::invocation::{InvocationTarget, PurgeInvocationRequest, ServiceInvocation};
+    use restate_types::journal_v2::{CommandType, OutputCommand, OutputResult};
+    use restate_types::partitions::PersistedFeatures;
+    use restate_types::service_protocol::ServiceProtocolVersion;
+    use restate_wal_protocol::v2::{Command, commands};
+
+    use crate::partition::state_machine::tests::TestEnv;
+    use crate::partition::state_machine::tests::fixtures::{
+        invoker_end_effect, invoker_entry_effect, pinned_deployment,
+    };
+    use crate::partition::state_machine::tests::matchers::storage::{
+        has_commands, has_journal_length, is_variant,
+    };
+
+    #[restate_core::test]
+    async fn purge_completed_invocation_with_journal_and_embedded_result() {
+        run_purge_completed_invocation(false, false).await;
+    }
+
+    #[restate_core::test]
+    async fn purge_completed_invocation_with_journal_and_referenced_result() {
+        run_purge_completed_invocation(true, false).await;
+    }
+
+    #[restate_core::test]
+    async fn purge_completed_invocation_after_journal_purge_with_embedded_result() {
+        run_purge_completed_invocation(false, true).await;
+    }
+
+    #[restate_core::test]
+    async fn purge_completed_invocation_after_journal_purge_with_referenced_result() {
+        run_purge_completed_invocation(true, true).await;
+    }
+
+    async fn run_purge_completed_invocation(
+        write_result_reference: bool,
+        purge_journal_first: bool,
+    ) {
+        let mut test_env = TestEnv::create_with_features(PersistedFeatures {
+            write_result_reference,
+            ..PersistedFeatures::default()
+        })
+        .await;
+
+        let invocation_target = InvocationTarget::mock_virtual_object();
+        let invocation_id = InvocationId::mock_generate(&invocation_target);
+
+        test_env
+            .apply_multiple([
+                commands::InvokeCommand::test_envelope(ServiceInvocation {
+                    invocation_id,
+                    invocation_target,
+                    completion_retention_duration: Duration::from_secs(60),
+                    journal_retention_duration: Duration::from_secs(60),
+                    ..ServiceInvocation::mock()
+                }),
+                pinned_deployment(invocation_id, ServiceProtocolVersion::V5),
+                invoker_entry_effect(
+                    invocation_id,
+                    OutputCommand {
+                        result: OutputResult::Success(Bytes::from_static(b"result")),
+                        name: Default::default(),
+                    },
+                ),
+                invoker_end_effect(invocation_id),
+            ])
+            .await;
+
+        assert_that!(
+            test_env
+                .storage()
+                .get_invocation_status(&invocation_id)
+                .await,
+            ok(all!(
+                is_variant(InvocationStatusDiscriminants::Completed),
+                has_commands(2),
+                has_journal_length(2)
+            ))
+        );
+        test_env
+            .verify_journal_components(
+                invocation_id,
+                [CommandType::Input.into(), CommandType::Output.into()],
+            )
+            .await;
+
+        let InvocationStatus::Completed(completed) = test_env
+            .storage()
+            .get_invocation_status(&invocation_id)
+            .await
+            .unwrap()
+        else {
+            panic!("invocation must be completed");
+        };
+        assert_eq!(
+            completed.response_result.referenced_journal_index(),
+            write_result_reference.then_some(1)
+        );
+
+        if purge_journal_first {
+            test_env
+                .apply(commands::PurgeJournalCommand::test_envelope(
+                    PurgeInvocationRequest {
+                        invocation_id,
+                        response_sink: None,
+                    },
+                ))
+                .await;
+
+            assert_that!(
+                test_env
+                    .storage()
+                    .get_invocation_status(&invocation_id)
+                    .await,
+                ok(all!(
+                    is_variant(InvocationStatusDiscriminants::Completed),
+                    has_commands(0),
+                    has_journal_length(0)
+                ))
+            );
+            assert_that!(
+                test_env.storage().get_journal_entry(invocation_id, 0).await,
+                ok(none())
+            );
+            assert_eq!(
+                test_env
+                    .storage()
+                    .get_journal_entry(invocation_id, 1)
+                    .await
+                    .unwrap()
+                    .is_some(),
+                write_result_reference
+            );
+        }
+
+        test_env
+            .apply(commands::PurgeInvocationCommand::test_envelope(
+                PurgeInvocationRequest {
+                    invocation_id,
+                    response_sink: None,
+                },
+            ))
+            .await;
+
+        assert_that!(
+            test_env
+                .storage()
+                .get_invocation_status(&invocation_id)
+                .await
+                .unwrap(),
+            pat!(InvocationStatus::Free)
+        );
+        for entry_index in 0..2 {
+            assert_that!(
+                test_env
+                    .storage()
+                    .get_journal_entry(invocation_id, entry_index)
+                    .await,
+                ok(none())
+            );
+        }
+
+        test_env.shutdown().await;
+    }
+}

--- a/crates/worker/src/partition/state_machine/lifecycle/purge_journal.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/purge_journal.rs
@@ -94,19 +94,14 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
 
-    use crate::partition::state_machine::Action;
-    use crate::partition::state_machine::tests::TestEnv;
-    use crate::partition::state_machine::tests::fixtures::{
-        invoker_end_effect, invoker_entry_effect, pinned_deployment,
-    };
-    use crate::partition::state_machine::tests::matchers::storage::{
-        has_commands, has_journal_length, is_variant,
-    };
     use bytes::Bytes;
     use bytestring::ByteString;
-    use googletest::prelude::{all, assert_that, contains, eq, none, ok, pat, some};
+    use googletest::prelude::{all, assert_that, contains, eq, none, not, ok, pat, some};
+
     use restate_storage_api::invocation_status_table::{
         InvocationStatusDiscriminants, ReadInvocationStatusTable,
     };
@@ -117,13 +112,36 @@ mod tests {
         InvocationTarget, PurgeInvocationRequest, ServiceInvocation, ServiceInvocationResponseSink,
     };
     use restate_types::journal_v2::{CommandType, OutputCommand, OutputResult};
+    use restate_types::partitions::PersistedFeatures;
     use restate_types::service_protocol::ServiceProtocolVersion;
     use restate_wal_protocol::v2::{Command, commands};
-    use std::time::Duration;
+
+    use crate::partition::state_machine::Action;
+    use crate::partition::state_machine::tests::TestEnv;
+    use crate::partition::state_machine::tests::fixtures::{
+        invoker_end_effect, invoker_entry_effect, pinned_deployment,
+    };
+    use crate::partition::state_machine::tests::matchers::storage::{
+        has_commands, has_journal_length, is_variant,
+    };
 
     #[restate_core::test]
     async fn purge_journal_then_invocation() {
-        let mut test_env = TestEnv::create().await;
+        run_purge_journal_then_invocation(PersistedFeatures::default()).await;
+    }
+
+    #[restate_core::test]
+    async fn purge_journal_then_invocation_with_result_reference() {
+        run_purge_journal_then_invocation(PersistedFeatures {
+            write_result_reference: true,
+            ..PersistedFeatures::default()
+        })
+        .await;
+    }
+
+    async fn run_purge_journal_then_invocation(features: PersistedFeatures) {
+        let write_result_reference = features.write_result_reference;
+        let mut test_env = TestEnv::create_with_features(features).await;
 
         let idempotency_key = ByteString::from_static("my-idempotency-key");
         let completion_retention = Duration::from_secs(60) * 60 * 24;
@@ -182,6 +200,21 @@ mod tests {
                 has_journal_length(2)
             ))
         );
+        let InvocationStatus::Completed(completed) = test_env
+            .storage()
+            .get_invocation_status(&invocation_id)
+            .await
+            .unwrap()
+        else {
+            panic!("invocation must be completed");
+        };
+
+        assert_eq!(completed.journal_metadata.length, 2);
+
+        assert_eq!(
+            completed.response_result.referenced_journal_index(),
+            write_result_reference.then_some(1)
+        );
 
         // We also retain the journal here
         test_env
@@ -201,6 +234,21 @@ mod tests {
             ))
             .await;
 
+        // The output remains available if the completed status references it.
+        assert_that!(
+            test_env.storage().get_journal_entry(invocation_id, 0).await,
+            ok(none())
+        );
+        assert_eq!(
+            test_env
+                .storage()
+                .get_journal_entry(invocation_id, 1)
+                .await
+                .unwrap()
+                .is_some(),
+            write_result_reference
+        );
+
         // At this point we should still be able to de-duplicate the invocation
         let request_id = PartitionProcessorRpcRequestId::default();
         let actions = test_env
@@ -212,18 +260,21 @@ mod tests {
                 ..ServiceInvocation::mock()
             }))
             .await;
-
-        // Note: We can no longer match on the response result
-        // after the journals has been purged. This is because
-        // we don't embed the result any longer in the completion
-        // message and instead keep a reference. Once the journal
-        // is gone, we should get ErrorCode "GONE".
         assert_that!(
             actions,
-            contains(pat!(Action::IngressResponse {
-                request_id: eq(request_id),
-                invocation_id: some(eq(invocation_id)),
-            }))
+            all!(
+                contains(pat!(Action::IngressResponse {
+                    request_id: eq(request_id),
+                    invocation_id: some(eq(invocation_id)),
+                    response: eq(InvocationOutputResponse::Success(
+                        invocation_target.clone(),
+                        response_bytes.clone()
+                    ))
+                })),
+                not(contains(pat!(Action::Invoke {
+                    invocation_id: eq(invocation_id),
+                })))
+            )
         );
 
         // And InvocationStatus still contains completed, but without commands and length
@@ -258,10 +309,15 @@ mod tests {
                 .unwrap(),
             pat!(InvocationStatus::Free)
         );
-        assert_that!(
-            test_env.storage().get_journal_entry(invocation_id, 0).await,
-            ok(none())
-        );
+        for entry_index in 0..2 {
+            assert_that!(
+                test_env
+                    .storage()
+                    .get_journal_entry(invocation_id, entry_index)
+                    .await,
+                ok(none())
+            );
+        }
 
         test_env.shutdown().await;
     }

--- a/crates/worker/src/partition/state_machine/lifecycle/purge_journal.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/purge_journal.rs
@@ -101,6 +101,7 @@ mod tests {
     use bytes::Bytes;
     use bytestring::ByteString;
     use googletest::prelude::{all, assert_that, contains, eq, none, not, ok, pat, some};
+    use rstest::rstest;
 
     use restate_storage_api::invocation_status_table::{
         InvocationStatusDiscriminants, ReadInvocationStatusTable,
@@ -111,7 +112,9 @@ mod tests {
     use restate_types::invocation::{
         InvocationTarget, PurgeInvocationRequest, ServiceInvocation, ServiceInvocationResponseSink,
     };
-    use restate_types::journal_v2::{CommandType, OutputCommand, OutputResult};
+    use restate_types::journal_v2::{
+        ClearAllStateCommand, CommandType, OutputCommand, OutputResult,
+    };
     use restate_types::partitions::PersistedFeatures;
     use restate_types::service_protocol::ServiceProtocolVersion;
     use restate_wal_protocol::v2::{Command, commands};
@@ -122,24 +125,18 @@ mod tests {
         invoker_end_effect, invoker_entry_effect, pinned_deployment,
     };
     use crate::partition::state_machine::tests::matchers::storage::{
-        has_commands, has_journal_length, is_variant,
+        has_commands, has_journal_length, has_result_reference, is_variant,
     };
 
+    #[rstest]
+    #[case::embedded_results(PersistedFeatures::default(), false)]
+    #[case::with_result_reference(PersistedFeatures{write_result_reference: true, ..Default::default()}, false)]
+    #[case::with_result_reference_and_extra_journals(PersistedFeatures{write_result_reference: true, ..Default::default()}, true)]
     #[restate_core::test]
-    async fn purge_journal_then_invocation() {
-        run_purge_journal_then_invocation(PersistedFeatures::default()).await;
-    }
-
-    #[restate_core::test]
-    async fn purge_journal_then_invocation_with_result_reference() {
-        run_purge_journal_then_invocation(PersistedFeatures {
-            write_result_reference: true,
-            ..PersistedFeatures::default()
-        })
-        .await;
-    }
-
-    async fn run_purge_journal_then_invocation(features: PersistedFeatures) {
+    async fn run_purge_journal_then_invocation(
+        #[case] features: PersistedFeatures,
+        #[case] append_after_output: bool,
+    ) {
         let write_result_reference = features.write_result_reference;
         let mut test_env = TestEnv::create_with_features(features).await;
 
@@ -152,7 +149,7 @@ mod tests {
         let response_bytes = Bytes::from_static(b"123");
 
         // Create and complete a fresh invocation
-        let actions = test_env
+        test_env
             .apply_multiple([
                 commands::InvokeCommand::test_envelope(ServiceInvocation {
                     invocation_id,
@@ -171,9 +168,21 @@ mod tests {
                         name: Default::default(),
                     },
                 ),
-                invoker_end_effect(invocation_id),
             ])
             .await;
+
+        if append_after_output {
+            test_env
+                .apply(invoker_entry_effect(
+                    invocation_id,
+                    ClearAllStateCommand {
+                        name: Default::default(),
+                    },
+                ))
+                .await;
+        }
+
+        let actions = test_env.apply(invoker_end_effect(invocation_id)).await;
 
         // Assert response
         assert_that!(
@@ -188,6 +197,7 @@ mod tests {
             }))
         );
 
+        let expected_journal_length = if append_after_output { 3 } else { 2 };
         // InvocationStatus contains completed
         assert_that!(
             test_env
@@ -196,32 +206,20 @@ mod tests {
                 .await,
             ok(all!(
                 is_variant(InvocationStatusDiscriminants::Completed),
-                has_commands(2),
-                has_journal_length(2)
+                has_commands(expected_journal_length),
+                has_journal_length(expected_journal_length),
+                has_result_reference(write_result_reference.then_some(1))
             ))
-        );
-        let InvocationStatus::Completed(completed) = test_env
-            .storage()
-            .get_invocation_status(&invocation_id)
-            .await
-            .unwrap()
-        else {
-            panic!("invocation must be completed");
-        };
-
-        assert_eq!(completed.journal_metadata.length, 2);
-
-        assert_eq!(
-            completed.response_result.referenced_journal_index(),
-            write_result_reference.then_some(1)
         );
 
         // We also retain the journal here
+        let mut journal_types = vec![CommandType::Input, CommandType::Output];
+        if append_after_output {
+            journal_types.push(CommandType::ClearAllState);
+        }
+
         test_env
-            .verify_journal_components(
-                invocation_id,
-                [CommandType::Input.into(), CommandType::Output.into()],
-            )
+            .verify_journal_components(invocation_id, journal_types.into_iter().map(Into::into))
             .await;
 
         // Now let's purge the journal
@@ -309,7 +307,7 @@ mod tests {
                 .unwrap(),
             pat!(InvocationStatus::Free)
         );
-        for entry_index in 0..2 {
+        for entry_index in 0..expected_journal_length {
             assert_that!(
                 test_env
                     .storage()

--- a/crates/worker/src/partition/state_machine/lifecycle/purge_journal.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/purge_journal.rs
@@ -7,9 +7,8 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
+use tracing::trace;
 
-use crate::partition::processor::ProcessorContext;
-use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
 use restate_storage_api::invocation_status_table::{
     InvocationStatus, ReadInvocationStatusTable, WriteInvocationStatusTable,
 };
@@ -19,7 +18,9 @@ use restate_storage_api::journal_table_v2::WriteJournalTable;
 use restate_types::identifiers::InvocationId;
 use restate_types::invocation::InvocationMutationResponseSink;
 use restate_types::invocation::client::PurgeInvocationResponse;
-use tracing::trace;
+
+use crate::partition::processor::ProcessorContext;
+use crate::partition::state_machine::{CommandHandler, Error, StateMachineApplyContext};
 
 pub struct OnPurgeJournalCommand<'a> {
     pub invocation_id: &'a InvocationId,
@@ -48,11 +49,15 @@ where
                     .as_ref()
                     .map(|pd| pd.service_protocol_version);
 
+                let retained_output_index = completed.response_result.referenced_journal_index();
                 // If journal is not empty, clean it up
                 if completed.journal_metadata.length != 0 {
                     ctx.do_drop_journal(
                         invocation_id,
                         completed.journal_metadata.length,
+                        (0..completed.journal_metadata.length).filter(|idx| {
+                            retained_output_index.is_none_or(|retain| retain != *idx)
+                        }),
                         pinned_service_protocol_version,
                     )
                     .await?;

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -4803,7 +4803,7 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
                 .map_err(Error::Storage)?;
         };
         if pinned_protocol_version.is_none_or(|sp| sp >= ServiceProtocolVersion::V4) {
-            journal_table_v2::WriteJournalTable::delete_journals(
+            journal_table_v2::WriteJournalTable::delete_journal(
                 self.storage,
                 invocation_id,
                 journals,

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -1919,6 +1919,7 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
             self.do_drop_journal(
                 &invocation_id,
                 journal_length,
+                0..journal_length,
                 pinned_service_protocol_version,
             )
             .await?;
@@ -2065,6 +2066,7 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
             self.do_drop_journal(
                 &invocation_id,
                 journal_length,
+                0..journal_length,
                 pinned_service_protocol_version,
             )
             .await?;
@@ -4772,10 +4774,19 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
             .map_err(Error::Storage)
     }
 
+    /// Drop all invocations indexes specified
+    /// by the journals iterator.
+    ///
+    /// Note: journal_length is **ONLY** used by
+    /// journal_table v1 (Protocol version < V4)
+    /// in that case, no retention is possible.
     async fn do_drop_journal(
         &mut self,
         invocation_id: &InvocationId,
+        // journal length is only for backward compatibility
+        // with journal table v1
         journal_length: EntryIndex,
+        journals: impl Iterator<Item = EntryIndex>,
         pinned_protocol_version: Option<ServiceProtocolVersion>,
     ) -> Result<(), Error>
     where
@@ -4792,10 +4803,10 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
                 .map_err(Error::Storage)?;
         };
         if pinned_protocol_version.is_none_or(|sp| sp >= ServiceProtocolVersion::V4) {
-            journal_table_v2::WriteJournalTable::delete_journal(
+            journal_table_v2::WriteJournalTable::delete_journals(
                 self.storage,
                 invocation_id,
-                journal_length,
+                journals,
             )
             .map_err(Error::Storage)?
         };

--- a/crates/worker/src/partition/state_machine/tests/invocation_end.rs
+++ b/crates/worker/src/partition/state_machine/tests/invocation_end.rs
@@ -24,6 +24,8 @@ use restate_types::partitions::PersistedFeatures;
 use restate_types::service_protocol::ServiceProtocolVersion;
 use restate_wal_protocol::v2::{Command, commands};
 
+use crate::partition::state_machine::tests::matchers::storage::has_result_reference;
+
 use super::TestEnv;
 use super::fixtures::{invoker_end_effect, invoker_entry_effect, pinned_deployment};
 use super::matchers::storage::{has_commands, has_journal_length, is_variant};
@@ -43,7 +45,7 @@ async fn zero_completion_retention_drops_invocation_and_journal_with_result_refe
             .unwrap(),
         pat!(InvocationStatus::Free)
     );
-    assert_journal_entries(&mut test_env, invocation_id, &[false, false]).await;
+    assert_journal_entries_exists(&mut test_env, invocation_id, &[false, false]).await;
 
     test_env.shutdown().await;
 }
@@ -54,18 +56,19 @@ async fn zero_journal_retention_keeps_referenced_output() {
         end_invocation(true, Duration::from_secs(60), Duration::ZERO, false).await;
 
     assert_completed_with_reference(&mut test_env, invocation_id, Some(1)).await;
-    assert_journal_entries(&mut test_env, invocation_id, &[false, true]).await;
+    assert_journal_entries_exists(&mut test_env, invocation_id, &[false, true]).await;
 
     test_env.shutdown().await;
 }
 
+// todo(azmy): Remove once write_result_reference becomes a default feature.
 #[restate_core::test]
 async fn zero_journal_retention_drops_all_journals_with_result_reference_disabled() {
     let (mut test_env, invocation_id) =
         end_invocation(false, Duration::from_secs(60), Duration::ZERO, false).await;
 
     assert_completed_with_reference(&mut test_env, invocation_id, None).await;
-    assert_journal_entries(&mut test_env, invocation_id, &[false, false]).await;
+    assert_journal_entries_exists(&mut test_env, invocation_id, &[false, false]).await;
 
     test_env.shutdown().await;
 }
@@ -76,7 +79,7 @@ async fn referenced_output_does_not_need_to_be_last_journal_entry() {
         end_invocation(true, Duration::from_secs(60), Duration::ZERO, true).await;
 
     assert_completed_with_reference(&mut test_env, invocation_id, Some(1)).await;
-    assert_journal_entries(&mut test_env, invocation_id, &[false, true, false]).await;
+    assert_journal_entries_exists(&mut test_env, invocation_id, &[false, true, false]).await;
     assert_that!(
         test_env
             .read_journal_entry::<OutputCommand>(invocation_id, 1)
@@ -170,20 +173,13 @@ async fn assert_completed_with_reference(
         all!(
             is_variant(InvocationStatusDiscriminants::Completed),
             has_commands(0),
-            has_journal_length(0)
+            has_journal_length(0),
+            has_result_reference(expected_output_index)
         )
-    );
-
-    let InvocationStatus::Completed(completed) = status else {
-        panic!("invocation must be completed");
-    };
-    assert_eq!(
-        completed.response_result.referenced_journal_index(),
-        expected_output_index
     );
 }
 
-async fn assert_journal_entries(
+async fn assert_journal_entries_exists(
     test_env: &mut TestEnv,
     invocation_id: InvocationId,
     expected_entries: &[bool],

--- a/crates/worker/src/partition/state_machine/tests/invocation_end.rs
+++ b/crates/worker/src/partition/state_machine/tests/invocation_end.rs
@@ -1,0 +1,210 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::Duration;
+
+use bytes::Bytes;
+use googletest::prelude::{all, assert_that, eq, none, ok, pat};
+
+use restate_storage_api::invocation_status_table::{
+    InvocationStatus, InvocationStatusDiscriminants, ReadInvocationStatusTable,
+};
+use restate_storage_api::journal_table_v2::ReadJournalTable;
+use restate_types::identifiers::InvocationId;
+use restate_types::invocation::{InvocationTarget, ServiceInvocation};
+use restate_types::journal_v2::{ClearAllStateCommand, CommandType, OutputCommand, OutputResult};
+use restate_types::partitions::PersistedFeatures;
+use restate_types::service_protocol::ServiceProtocolVersion;
+use restate_wal_protocol::v2::{Command, commands};
+
+use super::TestEnv;
+use super::fixtures::{invoker_end_effect, invoker_entry_effect, pinned_deployment};
+use super::matchers::storage::{has_commands, has_journal_length, is_variant};
+
+const RESULT: Bytes = Bytes::from_static(b"result");
+
+#[restate_core::test]
+async fn zero_completion_retention_drops_invocation_and_journal_with_result_reference_enabled() {
+    let (mut test_env, invocation_id) =
+        end_invocation(true, Duration::ZERO, Duration::ZERO, false).await;
+
+    assert_that!(
+        test_env
+            .storage()
+            .get_invocation_status(&invocation_id)
+            .await
+            .unwrap(),
+        pat!(InvocationStatus::Free)
+    );
+    assert_journal_entries(&mut test_env, invocation_id, &[false, false]).await;
+
+    test_env.shutdown().await;
+}
+
+#[restate_core::test]
+async fn zero_journal_retention_keeps_referenced_output() {
+    let (mut test_env, invocation_id) =
+        end_invocation(true, Duration::from_secs(60), Duration::ZERO, false).await;
+
+    assert_completed_with_reference(&mut test_env, invocation_id, Some(1)).await;
+    assert_journal_entries(&mut test_env, invocation_id, &[false, true]).await;
+
+    test_env.shutdown().await;
+}
+
+#[restate_core::test]
+async fn zero_journal_retention_drops_all_journals_with_result_reference_disabled() {
+    let (mut test_env, invocation_id) =
+        end_invocation(false, Duration::from_secs(60), Duration::ZERO, false).await;
+
+    assert_completed_with_reference(&mut test_env, invocation_id, None).await;
+    assert_journal_entries(&mut test_env, invocation_id, &[false, false]).await;
+
+    test_env.shutdown().await;
+}
+
+#[restate_core::test]
+async fn referenced_output_does_not_need_to_be_last_journal_entry() {
+    let (mut test_env, invocation_id) =
+        end_invocation(true, Duration::from_secs(60), Duration::ZERO, true).await;
+
+    assert_completed_with_reference(&mut test_env, invocation_id, Some(1)).await;
+    assert_journal_entries(&mut test_env, invocation_id, &[false, true, false]).await;
+    assert_that!(
+        test_env
+            .read_journal_entry::<OutputCommand>(invocation_id, 1)
+            .await,
+        pat!(OutputCommand {
+            result: eq(OutputResult::Success(RESULT)),
+        })
+    );
+
+    test_env.shutdown().await;
+}
+
+async fn end_invocation(
+    write_result_reference: bool,
+    completion_retention_duration: Duration,
+    journal_retention_duration: Duration,
+    append_after_output: bool,
+) -> (TestEnv, InvocationId) {
+    let mut test_env = TestEnv::create_with_features(PersistedFeatures {
+        write_result_reference,
+        ..PersistedFeatures::default()
+    })
+    .await;
+
+    let invocation_target = InvocationTarget::mock_virtual_object();
+    let invocation_id = InvocationId::mock_generate(&invocation_target);
+    test_env
+        .apply_multiple([
+            commands::InvokeCommand::test_envelope(ServiceInvocation {
+                invocation_id,
+                invocation_target,
+                completion_retention_duration,
+                journal_retention_duration,
+                ..ServiceInvocation::mock()
+            }),
+            pinned_deployment(invocation_id, ServiceProtocolVersion::V5),
+            invoker_entry_effect(
+                invocation_id,
+                OutputCommand {
+                    result: OutputResult::Success(RESULT),
+                    name: Default::default(),
+                },
+            ),
+        ])
+        .await;
+
+    if append_after_output {
+        test_env
+            .apply(invoker_entry_effect(
+                invocation_id,
+                ClearAllStateCommand {
+                    name: Default::default(),
+                },
+            ))
+            .await;
+        test_env
+            .verify_journal_components(
+                invocation_id,
+                [
+                    CommandType::Input.into(),
+                    CommandType::Output.into(),
+                    CommandType::ClearAllState.into(),
+                ],
+            )
+            .await;
+    } else {
+        test_env
+            .verify_journal_components(
+                invocation_id,
+                [CommandType::Input.into(), CommandType::Output.into()],
+            )
+            .await;
+    }
+
+    test_env.apply(invoker_end_effect(invocation_id)).await;
+    (test_env, invocation_id)
+}
+
+async fn assert_completed_with_reference(
+    test_env: &mut TestEnv,
+    invocation_id: InvocationId,
+    expected_output_index: Option<u32>,
+) {
+    let status = test_env
+        .storage()
+        .get_invocation_status(&invocation_id)
+        .await
+        .unwrap();
+    assert_that!(
+        status,
+        all!(
+            is_variant(InvocationStatusDiscriminants::Completed),
+            has_commands(0),
+            has_journal_length(0)
+        )
+    );
+
+    let InvocationStatus::Completed(completed) = status else {
+        panic!("invocation must be completed");
+    };
+    assert_eq!(
+        completed.response_result.referenced_journal_index(),
+        expected_output_index
+    );
+}
+
+async fn assert_journal_entries(
+    test_env: &mut TestEnv,
+    invocation_id: InvocationId,
+    expected_entries: &[bool],
+) {
+    for (entry_index, expected) in expected_entries.iter().cloned().enumerate() {
+        assert_eq!(
+            test_env
+                .storage()
+                .get_journal_entry(invocation_id, entry_index as u32)
+                .await
+                .unwrap()
+                .is_some(),
+            expected,
+            "unexpected journal presence at index {entry_index}"
+        );
+    }
+    assert_that!(
+        test_env
+            .storage()
+            .get_journal_entry(invocation_id, expected_entries.len() as u32)
+            .await,
+        ok(none())
+    );
+}

--- a/crates/worker/src/partition/state_machine/tests/matchers.rs
+++ b/crates/worker/src/partition/state_machine/tests/matchers.rs
@@ -28,6 +28,16 @@ pub mod storage {
     use restate_types::invocation::InvocationTarget;
     use restate_types::journal::Entry;
 
+    pub fn has_result_reference(
+        reference: Option<EntryIndex>,
+    ) -> impl Matcher<ActualT = InvocationStatus> {
+        predicate(move |is: &InvocationStatus| {
+            let InvocationStatus::Completed(completed) = is else {
+                return false;
+            };
+            completed.response_result.referenced_journal_index() == reference
+        })
+    }
     pub fn has_journal_length(
         journal_length: EntryIndex,
     ) -> impl Matcher<ActualT = InvocationStatus> {

--- a/crates/worker/src/partition/state_machine/tests/matchers.rs
+++ b/crates/worker/src/partition/state_machine/tests/matchers.rs
@@ -37,6 +37,7 @@ pub mod storage {
             };
             completed.response_result.referenced_journal_index() == reference
         })
+        .with_description("has result reference", "has NO result reference")
     }
     pub fn has_journal_length(
         journal_length: EntryIndex,

--- a/crates/worker/src/partition/state_machine/tests/mod.rs
+++ b/crates/worker/src/partition/state_machine/tests/mod.rs
@@ -15,6 +15,7 @@ use super::*;
 mod delayed_send;
 pub mod fixtures;
 mod idempotency;
+mod invocation_end;
 mod kill_cancel;
 pub mod matchers;
 mod workflow;


### PR DESCRIPTION
- Prepare the WriteJournalTable trait with required
functions and params
- Use the new interface to delete and retain output
entry

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>