### PR TITLE
[RocksDB] Make storage sizing and file options configurable

### DIFF
--- a/crates/log-server/src/rocksdb_logstore/builder.rs
+++ b/crates/log-server/src/rocksdb_logstore/builder.rs
@@ -32,6 +32,9 @@ use crate::logstore::LogStoreState;
 use crate::rocksdb_logstore::keys::KeyPrefix;
 use crate::rocksdb_logstore::metadata_merge::{metadata_full_merge, metadata_partial_merge};
 
+const BLOB_GC_AGE_CUTOFF: f64 = 0.25;
+const BLOB_GC_FORCE_THRESHOLD: f64 = 0.5;
+
 #[derive(Clone)]
 pub struct RocksDbLogStoreBuilder {
     rocksdb: Arc<RocksDb>,
@@ -163,6 +166,19 @@ impl restate_rocksdb::configuration::DbConfigurator for RocksDbConfigurator {
         db_options.set_wal_size_limit_mb(0);
         db_options.set_wal_ttl_seconds(0);
 
+        if let Some(max_open_files) = log_server_config.rocksdb_max_open_files {
+            db_options.set_max_open_files(max_open_files.get().min(i32::MAX as u32) as i32);
+        } else {
+            db_options.set_max_open_files(-1);
+        }
+
+        // Sets the available buffer for writing to SST files.
+        db_options.set_writable_file_max_buffer_size(
+            log_server_config
+                .rocksdb_writable_file_max_buffer_size
+                .as_u64(),
+        );
+
         restate_rocksdb::configuration::set_background_work_budget(
             &mut db_options,
             // dedicated flush thread for log-server
@@ -172,8 +188,7 @@ impl restate_rocksdb::configuration::DbConfigurator for RocksDbConfigurator {
 
         if !log_server_config.rocksdb_disable_wal() {
             // RocksDB does not support recycling wal log files if wal is disabled when writing
-            db_options
-                .set_recycle_log_file_num(log_server_config.max_write_buffer_number() as usize);
+            db_options.set_recycle_log_file_num(log_server_config.num_write_buffers() as usize);
         }
 
         // log-server specific customizations
@@ -209,7 +224,12 @@ impl restate_rocksdb::configuration::DbConfigurator for RocksDbConfigurator {
 
     fn note_config_update(&self, db: &restate_rocksdb::RocksAccess) {
         let config = &Configuration::pinned().log_server;
-        update_data_cf_budget(db, config);
+        if let Err(err) = update_data_cf_options(db, config) {
+            warn!(
+                "Failed to update data CF options for {}/{DATA_CF}: {err}",
+                db.name(),
+            );
+        }
         // Keep metadata CF write_buffer_size in sync so it never triggers a flush on
         // its own (atomic_flush means any CF triggering a flush drags all CFs along).
         update_metadata_cf_write_buffer_size(db, config.write_buffer_size());
@@ -240,15 +260,34 @@ impl restate_rocksdb::configuration::DbConfigurator for RocksDbConfigurator {
     }
 }
 
-/// Dynamically updates the data CF sizing options to match the new memory budget.
-fn update_data_cf_budget(db: &restate_rocksdb::RocksAccess, opts: &LogServerOptions) {
+/// Dynamically updates the mutable data CF options from configuration.
+fn update_data_cf_options(
+    db: &restate_rocksdb::RocksAccess,
+    opts: &LogServerOptions,
+) -> Result<(), restate_rocksdb::RocksError> {
     let max_bytes_for_level_base_str = opts.max_bytes_for_level_base().to_restring();
     let write_buffer_size_str = opts.write_buffer_size().to_restring();
-    let max_write_buffer_number_str = opts.max_write_buffer_number().to_restring();
+    let max_write_buffer_number_str = opts.num_write_buffers().to_restring();
     let target_file_size_base_str = opts.target_file_size_base().to_restring();
     let max_compaction_bytes = opts.max_compaction_bytes().to_restring();
+    let level_zero_file_num_compaction_trigger =
+        opts.level_zero_file_num_compaction_trigger().to_restring();
+    let blob_separation_enabled = opts.rocksdb_enable_blob_separation.to_restring();
+    let min_blob_size = opts.rocksdb_blob_min_size().as_u64().to_restring();
+    let blob_compression_type = if opts.rocksdb_disable_blob_compression {
+        "kNoCompression"
+    } else {
+        "kZSTD"
+    };
+    let blob_gc_age_cutoff = BLOB_GC_AGE_CUTOFF.to_restring();
+    let blob_gc_force_threshold = BLOB_GC_FORCE_THRESHOLD.to_restring();
+    let blob_compaction_readahead_size = opts
+        .rocksdb
+        .rocksdb_compaction_readahead_size()
+        .get()
+        .to_restring();
 
-    if let Err(err) = db.set_options_cf(
+    db.set_options_cf(
         DATA_CF,
         &[
             ("write_buffer_size", &write_buffer_size_str),
@@ -256,13 +295,25 @@ fn update_data_cf_budget(db: &restate_rocksdb::RocksAccess, opts: &LogServerOpti
             ("max_write_buffer_number", &max_write_buffer_number_str),
             ("max_bytes_for_level_base", &max_bytes_for_level_base_str),
             ("max_compaction_bytes", &max_compaction_bytes),
+            (
+                "level0_file_num_compaction_trigger",
+                &level_zero_file_num_compaction_trigger,
+            ),
+            ("enable_blob_files", &blob_separation_enabled),
+            ("min_blob_size", &min_blob_size),
+            ("blob_compression_type", blob_compression_type),
+            ("enable_blob_garbage_collection", &blob_separation_enabled),
+            ("blob_garbage_collection_age_cutoff", &blob_gc_age_cutoff),
+            (
+                "blob_garbage_collection_force_threshold",
+                &blob_gc_force_threshold,
+            ),
+            (
+                "blob_compaction_readahead_size",
+                &blob_compaction_readahead_size,
+            ),
         ],
-    ) {
-        warn!(
-            "Failed to update data CF memory budget for {}/{DATA_CF}: {err}",
-            db.name(),
-        );
-    }
+    )
 }
 
 /// Keeps the metadata CF write_buffer_size in sync with the data CF so that
@@ -352,7 +403,7 @@ fn cf_data_options(
     );
 
     opts.set_write_buffer_size(log_server_config.write_buffer_size());
-    opts.set_max_write_buffer_number(log_server_config.max_write_buffer_number() as i32);
+    opts.set_max_write_buffer_number(log_server_config.num_write_buffers() as i32);
     opts.set_target_file_size_base(log_server_config.target_file_size_base() as u64);
     opts.set_max_compaction_bytes(log_server_config.max_compaction_bytes() as u64);
     opts.set_max_bytes_for_level_base(log_server_config.max_bytes_for_level_base() as u64);
@@ -399,11 +450,11 @@ fn cf_data_options(
 
         // Blob GC: relocate live blobs during compaction to reclaim space after trimming.
         opts.set_enable_blob_gc(true);
-        opts.set_blob_gc_age_cutoff(0.25);
+        opts.set_blob_gc_age_cutoff(BLOB_GC_AGE_CUTOFF);
         // Trigger forced compactions when >=50% of data in eligible blob files is garbage.
         // Without this (default 1.0 = disabled), SSTs referencing trimmed blob data may
         // not be picked for compaction naturally, delaying disk space reclamation.
-        opts.set_blob_gc_force_threshold(0.5);
+        opts.set_blob_gc_force_threshold(BLOB_GC_FORCE_THRESHOLD);
         // Use the same readahead size for blob files as for SST files during compaction.
         // Blob GC reads blobs from old files during compaction; readahead improves
         // throughput, especially with direct I/O enabled.
@@ -427,7 +478,7 @@ fn cf_metadata_options(
     // triggers a flush (with atomic_flush, any CF triggering drags all CFs along).
     // Metadata writes are tiny (~20 bytes per op), so actual memory use is negligible.
     opts.set_write_buffer_size(log_server_config.write_buffer_size());
-    opts.set_max_write_buffer_number(log_server_config.max_write_buffer_number() as i32);
+    opts.set_max_write_buffer_number(log_server_config.num_write_buffers() as i32);
 
     // Do not slow down on l0 number of files writes even if it hurts read
     // amplification.
@@ -450,4 +501,36 @@ fn cf_metadata_options(
     // max_successive_merges at the default (0 = disabled) to avoid unnecessary memtable
     // lookups on the write path. Merge chains are naturally bounded by flush frequency.
     opts.set_merge_operator("MetadataMerge", metadata_full_merge, metadata_partial_merge);
+}
+
+#[cfg(test)]
+mod tests {
+    use test_log::test;
+
+    use restate_core::TaskCenter;
+    use restate_rocksdb::RocksDbManager;
+    use restate_types::config::{Configuration, set_current_config};
+
+    use super::*;
+
+    #[test(restate_core::test(start_paused = true))]
+    async fn dynamically_update_blob_and_l0_options() -> anyhow::Result<()> {
+        let config = Configuration::default();
+        set_current_config(config.clone());
+
+        RocksDbManager::init();
+        let builder = RocksDbLogStoreBuilder::create().await?;
+        let mut log_server_options = config.log_server;
+        log_server_options.rocksdb_enable_blob_separation = true;
+        log_server_options.rocksdb_l0_num_compaction_trigger = NonZeroU32::new(3).unwrap();
+        update_data_cf_options(builder.rocksdb.inner(), &log_server_options)?;
+
+        log_server_options.rocksdb_enable_blob_separation = false;
+        update_data_cf_options(builder.rocksdb.inner(), &log_server_options)?;
+
+        drop(builder);
+        TaskCenter::shutdown_node("test completed", 0).await;
+        RocksDbManager::get().shutdown().await;
+        Ok(())
+    }
 }

--- a/crates/partition-store/src/memory.rs
+++ b/crates/partition-store/src/memory.rs
@@ -27,20 +27,22 @@ use crate::{PartitionDb, SharedState};
 const INITIAL_NUM_PARTITIONS: usize = 24;
 const DEBUG_MEMORY_REPORTING: bool = false;
 
-pub const MAX_WRITE_BUFFERS: u32 = 4;
-pub const NOMINAL_WRITE_BUFFERS: u32 = 4;
-// merge 2 memtables when flushing to L0
-pub const WRITE_BUFFERS_TO_MERGE: u32 = 2;
-pub const LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER: u32 = 2;
+// RocksDB applies this floor when opening a column family. Apply it here too so
+// dynamic updates use the same effective value.
+const MIN_WRITE_BUFFER_SIZE: usize = 64 * 1024;
+// We need at least 3 write buffers so we can accept writes while a flush is in progress and 2 older
+// memtables are being merged into one.
+const MIN_WRITE_BUFFERS: u32 = 3;
+// Merge 2 memtables when flushing to L0.
+const WRITE_BUFFERS_TO_MERGE: u32 = 2;
 /// Matches rocksdb default (target_file_size_base * 25)
-pub const COMPACTION_BYTES_MULTIPLIER: u32 = 25;
+const COMPACTION_BYTES_MULTIPLIER: u32 = 25;
 /// Try to keep the table files above this size if partition write buffers are too small
-pub const MIN_FILE_SIZE: usize = 16 * 1024 * 1024;
-/// The absolute minimum write buffer size
-pub const MIN_WRITE_BUFFER_SIZE: usize = 1024 * 1024;
+const MIN_FILE_SIZE: usize = 8 * 1024 * 1024;
 
 pub struct PartitionDbMemoryConfig {
     memory_budget: usize,
+    l0_num_compaction_trigger: u32,
     max_file_size: usize,
 }
 
@@ -48,6 +50,10 @@ impl PartitionDbMemoryConfig {
     pub fn calculate(memory_budget: usize, opts: &StorageOptions) -> Self {
         Self {
             memory_budget,
+            l0_num_compaction_trigger: opts
+                .rocksdb_l0_num_compaction_trigger
+                .get()
+                .min(i32::MAX as u32),
             max_file_size: MIN_FILE_SIZE.max(opts.rocksdb_max_file_size.as_usize()),
         }
     }
@@ -57,35 +63,74 @@ impl PartitionDbMemoryConfig {
     }
 
     pub fn write_buffer_size(&self) -> usize {
-        MIN_WRITE_BUFFER_SIZE.max(self.memory_budget / NOMINAL_WRITE_BUFFERS as usize)
+        MIN_WRITE_BUFFER_SIZE.max(
+            self.memory_budget()
+                .div_ceil(self.num_write_buffers() as usize),
+        )
     }
 
-    pub const fn min_write_buffer_number_to_merge(&self) -> u32 {
+    pub fn min_write_buffer_number_to_merge(&self) -> u32 {
         WRITE_BUFFERS_TO_MERGE
     }
 
-    pub const fn max_write_buffer_number(&self) -> u32 {
-        MAX_WRITE_BUFFERS
+    pub fn num_write_buffers(&self) -> u32 {
+        // We need at least 3 write buffers so we can accept writes while a flush is in progress and 2 older
+        // memtables are being merged into one.
+        MIN_WRITE_BUFFERS.max(
+            self.memory_budget()
+                .div_ceil(self.max_file_size)
+                .min(i32::MAX as usize) as u32,
+        )
     }
 
     pub const fn level_zero_file_num_compaction_trigger(&self) -> u32 {
-        LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER
+        self.l0_num_compaction_trigger
     }
 
     pub fn max_bytes_for_level_base(&self) -> usize {
         self.write_buffer_size()
-            * self.min_write_buffer_number_to_merge() as usize
-            * self.level_zero_file_num_compaction_trigger() as usize
+            .saturating_mul(self.min_write_buffer_number_to_merge() as usize)
+            .saturating_mul(self.level_zero_file_num_compaction_trigger() as usize)
     }
 
     pub fn target_file_size_base(&self) -> usize {
-        // Set the target file within the range of acceptable values
-        self.write_buffer_size()
-            .clamp(MIN_FILE_SIZE, self.max_file_size)
+        self.write_buffer_size().max(self.max_file_size)
     }
 
     pub fn max_compaction_bytes(&self) -> usize {
-        self.target_file_size_base() * COMPACTION_BYTES_MULTIPLIER as usize
+        self.target_file_size_base()
+            .saturating_mul(COMPACTION_BYTES_MULTIPLIER as usize)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+
+    use super::*;
+
+    #[test]
+    fn sanitize_rocksdb_sizing_limits() {
+        let mut options = StorageOptions::default();
+        options.rocksdb_l0_num_compaction_trigger = NonZeroU32::MAX;
+
+        let config = PartitionDbMemoryConfig::calculate(1, &options);
+        assert_eq!(config.write_buffer_size(), MIN_WRITE_BUFFER_SIZE);
+        assert_eq!(
+            config.level_zero_file_num_compaction_trigger(),
+            i32::MAX as u32
+        );
+
+        options.rocksdb_l0_num_compaction_trigger = NonZeroU32::MIN;
+        let config = PartitionDbMemoryConfig::calculate(usize::MAX, &options);
+        assert_eq!(config.num_write_buffers(), i32::MAX as u32);
+
+        options.rocksdb_max_file_size =
+            restate_util_bytecount::NonZeroByteCount::new(std::num::NonZeroUsize::MAX);
+        options.rocksdb_l0_num_compaction_trigger = NonZeroU32::MAX;
+        let config = PartitionDbMemoryConfig::calculate(usize::MAX, &options);
+        assert_eq!(config.max_bytes_for_level_base(), usize::MAX);
+        assert_eq!(config.max_compaction_bytes(), usize::MAX);
     }
 }
 

--- a/crates/partition-store/src/partition_db.rs
+++ b/crates/partition-store/src/partition_db.rs
@@ -145,10 +145,12 @@ impl PartitionDb {
                 let max_bytes_for_level_base_str =
                     mem_config.max_bytes_for_level_base().to_restring();
                 let write_buffer_size_str = mem_config.write_buffer_size().to_restring();
-                let max_write_buffer_number_str =
-                    mem_config.max_write_buffer_number().to_restring();
+                let max_write_buffer_number_str = mem_config.num_write_buffers().to_restring();
                 let target_file_size_base_str = mem_config.target_file_size_base().to_restring();
                 let max_compaction_bytes = mem_config.max_compaction_bytes().to_restring();
+                let level_zero_file_num_compaction_trigger = mem_config
+                    .level_zero_file_num_compaction_trigger()
+                    .to_restring();
 
                 debug!(
                     "Updating memory budget for {}/{} to {}",
@@ -165,6 +167,10 @@ impl PartitionDb {
                         ("max_write_buffer_number", &max_write_buffer_number_str),
                         ("max_bytes_for_level_base", &max_bytes_for_level_base_str),
                         ("max_compaction_bytes", &max_compaction_bytes),
+                        (
+                            "level0_file_num_compaction_trigger",
+                            &level_zero_file_num_compaction_trigger,
+                        ),
                     ],
                 ) {
                     warn!(
@@ -585,6 +591,19 @@ impl DbConfigurator for RocksConfigurator<AllDataCf> {
         // writes and flushes.
         db_options.set_hard_pending_compaction_bytes_limit(2 * 1024 * 1024 * 1024 * 1024);
 
+        // Sets the available buffer for writing to SST files.
+        db_options.set_writable_file_max_buffer_size(
+            storage_config
+                .rocksdb_writable_file_max_buffer_size
+                .as_u64(),
+        );
+
+        if let Some(max_open_files) = storage_config.rocksdb_max_open_files {
+            db_options.set_max_open_files(max_open_files.get().min(i32::MAX as u32) as i32);
+        } else {
+            db_options.set_max_open_files(-1);
+        }
+
         if self.use_multi_db_layout {
             // In multi-db layout we don't want every database to grown the thread pool
             restate_rocksdb::configuration::set_background_work_budget(
@@ -690,7 +709,7 @@ impl CfConfigurator for RocksConfigurator<AllDataCf> {
         cf_options.set_min_write_buffer_number_to_merge(
             mem_config.min_write_buffer_number_to_merge() as i32,
         );
-        cf_options.set_max_write_buffer_number(mem_config.max_write_buffer_number() as i32);
+        cf_options.set_max_write_buffer_number(mem_config.num_write_buffers() as i32);
         cf_options.set_level_zero_file_num_compaction_trigger(
             mem_config.level_zero_file_num_compaction_trigger() as i32,
         );

--- a/crates/types/src/config/log_server.rs
+++ b/crates/types/src/config/log_server.rs
@@ -21,17 +21,13 @@ use super::{BackgroundWorkBudget, CommonOptions, RocksDbOptions};
 
 const MIN_ROCKSDB_MEMORY: NonZeroByteCount =
     NonZeroByteCount::new(NonZeroUsize::new(32 * 1024 * 1024).unwrap());
-// We'll use 50% extra memory in the worst case, but will reduce write stalls.
-const MAX_WRITE_BUFFERS: u32 = 12;
-const NOMINAL_WRITE_BUFFERS: u32 = 8;
+// We need at least 2 write buffers so we can accept writes while a flush is in progress.
+const MIN_WRITE_BUFFERS: u32 = 2;
 const WRITE_BUFFERS_TO_MERGE: u32 = 1;
-const LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER: u32 = 8;
 /// Matches rocksdb default (target_file_size_base * 25)
 const COMPACTION_BYTES_MULTIPLIER: u32 = 25;
 /// Try to keep the table files above this size if partition write buffers are too small
-const MIN_FILE_SIZE: usize = 16 * 1024 * 1024;
-/// The absolute minimum write buffer size
-const MIN_WRITE_BUFFER_SIZE: usize = 4 * 1024 * 1024;
+const MIN_FILE_SIZE: usize = 8 * 1024 * 1024;
 
 /// # Log server options
 ///
@@ -49,6 +45,9 @@ pub struct LogServerOptions {
     /// The memory budget for rocksdb memtables in bytes
     ///
     /// If this value is set, it overrides the ratio defined in `rocksdb-memory-ratio`.
+    ///
+    /// The memory budget is automatically sanitized to the minimum of 32 MiB if set to
+    /// a smaller value.
     #[serde(skip_serializing_if = "Option::is_none")]
     rocksdb_memory_budget: Option<NonZeroByteCount>,
 
@@ -90,7 +89,8 @@ pub struct LogServerOptions {
     /// awaiting garbage collection.
     ///
     /// This is safe to enable/disable at any time.
-    #[cfg_attr(feature = "schemars", schemars(skip))]
+    ///
+    /// Since v1.7.0
     pub rocksdb_enable_blob_separation: bool,
 
     /// Minimum value size for blob file separation
@@ -101,8 +101,11 @@ pub struct LogServerOptions {
     /// BlobIndex pointers) at the cost of an extra read indirection on cache misses.
     ///
     /// Only takes effect when `rocksdb-enable-blob-separation` is true.
+    ///
+    /// [default] is 512 KiB
+    ///
+    /// Since v1.7.0
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "schemars", schemars(skip))]
     rocksdb_blob_min_size: Option<NonZeroByteCount>,
 
     /// Disable compression for blob files
@@ -112,7 +115,8 @@ pub struct LogServerOptions {
     /// on writes and blob-GC reads.
     ///
     /// Only takes effect when `rocksdb-enable-blob-separation` is true.
-    #[cfg_attr(feature = "schemars", schemars(skip))]
+    ///
+    /// Since v1.7.0
     #[serde(skip_serializing_if = "std::ops::Not::not", default)]
     pub rocksdb_disable_blob_compression: bool,
 
@@ -121,8 +125,9 @@ pub struct LogServerOptions {
     /// Maximum number of concurrent compaction operations for this database.
     ///
     /// If unset, defaults are computed based on CPU count and active node roles.
+    ///
+    /// Since v1.7.0
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "schemars", schemars(skip))]
     rocksdb_max_background_compactions: Option<NonZeroU32>,
 
     /// # Write Batch (in bytes)
@@ -168,17 +173,50 @@ pub struct LogServerOptions {
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     rocksdb_disable_wal: bool,
 
-    /// # Clamps target size for sst files
+    /// # Target size for SST files
     ///
     /// The target size for sst files. Restate uses this value to internally determine
     /// the number of memtables to keep in memory and how much to merge before flushing.
     ///
-    /// The value is automatically sanitized to 16 MiB if set to a smaller value.
+    /// The value is automatically sanitized to 8 MiB if set to a smaller value.
+    /// When blob separation is enabled, non-L0 SST files instead target 8 MiB.
     ///
     /// [default] is 128 MiB
     ///
     /// Since v1.7.0
     pub rocksdb_max_file_size: NonZeroByteCount,
+
+    /// # Buffer size used for writing to SST files
+    ///
+    /// Sets the maximum buffer size that is used to write SST files to disk.
+    /// Larger values translate to larger IO operations which can be helpful
+    /// for slow or network-attached storage devices.
+    ///
+    /// [default] is 1 MiB
+    ///
+    /// Since v1.7.7
+    pub rocksdb_writable_file_max_buffer_size: NonZeroByteCount,
+
+    /// # Number of L0 files to trigger compaction
+    ///
+    /// Sets the number of files to trigger level-0 compaction.
+    ///
+    /// [default] is 8
+    ///
+    /// Since v1.7.7
+    pub rocksdb_l0_num_compaction_trigger: NonZeroU32,
+
+    /// # Max open files
+    ///
+    /// Sets the number of open files that can be used by the DB. You may need to
+    /// increase this if your database has a large working set. Unset means
+    /// files opened are always kept open.
+    ///
+    /// [default] is unset
+    ///
+    /// Since v1.7.7
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rocksdb_max_open_files: Option<NonZeroU32>,
 
     /// Disable RocksDB paranoid checks
     ///
@@ -249,13 +287,15 @@ impl LogServerOptions {
     }
 
     pub fn rocksdb_memory_budget(&self) -> NonZeroByteCount {
-        self.rocksdb_memory_budget.unwrap_or_else(|| {
-            warn!(
-                "LogServer's rocksdb_memory_budget is not set, defaulting to {}",
+        self.rocksdb_memory_budget
+            .unwrap_or_else(|| {
+                warn!(
+                    "LogServer's rocksdb_memory_budget is not set, defaulting to {}",
+                    MIN_ROCKSDB_MEMORY
+                );
                 MIN_ROCKSDB_MEMORY
-            );
-            MIN_ROCKSDB_MEMORY
-        })
+            })
+            .max(MIN_ROCKSDB_MEMORY)
     }
 
     /// Minimum value size for blob separation. Defaults to 512 KiB.
@@ -301,41 +341,67 @@ impl LogServerOptions {
     }
 
     pub fn write_buffer_size(&self) -> usize {
-        MIN_WRITE_BUFFER_SIZE
-            .max(self.rocksdb_memory_budget().as_usize() / NOMINAL_WRITE_BUFFERS as usize)
+        let all_memtables_memory = self.rocksdb_memory_budget().as_usize();
+        let write_buffers = self.num_write_buffers() as usize;
+        all_memtables_memory.div_ceil(write_buffers)
     }
 
     pub const fn min_write_buffer_number_to_merge(&self) -> u32 {
         WRITE_BUFFERS_TO_MERGE
     }
 
-    pub const fn max_write_buffer_number(&self) -> u32 {
-        MAX_WRITE_BUFFERS
+    pub fn num_write_buffers(&self) -> u32 {
+        let all_memtables_memory = self.rocksdb_memory_budget().as_usize();
+        // We want to have a minimum of 2 write buffers. If the sst file is too large,
+        // we will sanitize it (make it smaller) to still meet this requirement.
+        MIN_WRITE_BUFFERS.max(
+            all_memtables_memory
+                .div_ceil(self.max_file_size())
+                .min(i32::MAX as usize) as u32,
+        )
     }
 
-    pub const fn level_zero_file_num_compaction_trigger(&self) -> u32 {
-        LEVEL_ZERO_FILE_NUM_COMPACTION_TRIGGER
+    pub fn level_zero_file_num_compaction_trigger(&self) -> u32 {
+        self.rocksdb_l0_num_compaction_trigger
+            .get()
+            .min(i32::MAX as u32)
     }
 
     pub fn max_bytes_for_level_base(&self) -> usize {
-        self.write_buffer_size()
-            * self.min_write_buffer_number_to_merge() as usize
-            * self.level_zero_file_num_compaction_trigger() as usize
+        if self.rocksdb_enable_blob_separation {
+            // See performance tuning remarks https://github.com/facebook/rocksdb/wiki/BlobDB#performance-tuning
+            self.target_file_size_base().saturating_mul(10)
+        } else {
+            self.write_buffer_size()
+                .saturating_mul(self.min_write_buffer_number_to_merge() as usize)
+                .saturating_mul(self.level_zero_file_num_compaction_trigger() as usize)
+        }
     }
 
     pub fn target_file_size_base(&self) -> usize {
         // Set the target file within the range of acceptable values
-        self.write_buffer_size()
-            .clamp(MIN_FILE_SIZE, self.max_file_size())
+        if self.rocksdb_enable_blob_separation {
+            // Note: If blob-separation is enabled, the target file size in > L0 should
+            // be much smaller than L0 since most of of the data will be keys and value
+            // references. This makes compactions cheaper and more concurrent.
+            //
+            // todo(asoli): Consider making this configurable if needed.
+            MIN_FILE_SIZE
+        } else {
+            self.write_buffer_size().max(self.max_file_size())
+        }
     }
 
     pub fn max_compaction_bytes(&self) -> usize {
-        self.target_file_size_base() * COMPACTION_BYTES_MULTIPLIER as usize
+        self.target_file_size_base()
+            .saturating_mul(COMPACTION_BYTES_MULTIPLIER as usize)
     }
 
     pub fn max_wal_total_size(&self) -> usize {
         const SAFETY_MULTIPLIER: usize = 8;
-        self.write_buffer_size() * self.max_write_buffer_number() as usize * SAFETY_MULTIPLIER
+        self.write_buffer_size()
+            .saturating_mul(self.num_write_buffers() as usize)
+            .saturating_mul(SAFETY_MULTIPLIER)
     }
 
     pub fn max_file_size(&self) -> usize {
@@ -369,6 +435,38 @@ impl Default for LogServerOptions {
             rocksdb_max_file_size: NonZeroByteCount::new(
                 NonZeroUsize::new(128 * 1024 * 1024).unwrap(),
             ),
+            rocksdb_writable_file_max_buffer_size: NonZeroByteCount::new(
+                NonZeroUsize::new(1024 * 1024).unwrap(),
+            ),
+            rocksdb_l0_num_compaction_trigger: NonZeroU32::new(8).unwrap(),
+            rocksdb_max_open_files: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_rocksdb_sizing_limits() {
+        let mut options = LogServerOptions {
+            rocksdb_memory_budget: Some(NonZeroByteCount::new(NonZeroUsize::MIN)),
+            rocksdb_l0_num_compaction_trigger: NonZeroU32::MAX,
+            ..Default::default()
+        };
+
+        assert_eq!(options.rocksdb_memory_budget(), MIN_ROCKSDB_MEMORY);
+        assert_eq!(
+            options.level_zero_file_num_compaction_trigger(),
+            i32::MAX as u32
+        );
+
+        options.rocksdb_memory_budget = Some(NonZeroByteCount::new(NonZeroUsize::MAX));
+        assert_eq!(options.num_write_buffers(), i32::MAX as u32);
+
+        options.rocksdb_max_file_size = NonZeroByteCount::new(NonZeroUsize::MAX);
+        assert_eq!(options.max_compaction_bytes(), usize::MAX);
+        assert_eq!(options.max_wal_total_size(), usize::MAX);
     }
 }

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -901,17 +901,49 @@ pub struct StorageOptions {
     /// Since v1.7.5
     rocksdb_max_sub_compactions: u32,
 
-    /// # Clamps target size for sst files
+    /// # Target size for SST files
     ///
     /// The target size for sst files. Restate uses this value to internally determine
     /// the number of memtables to keep in memory and how much to merge before flushing.
     ///
-    /// The value is automatically sanitized to 16 MiB if set to a smaller value.
+    /// The value is automatically sanitized to 8 MiB if set to a smaller value.
     ///
     /// [default] is 64 MiB
     ///
     /// Since v1.7.0
     pub rocksdb_max_file_size: NonZeroByteCount,
+
+    /// # Buffer size used for writing to SST files
+    ///
+    /// Sets the maximum buffer size that is used to write SST files to disk.
+    /// Larger values translate to larger IO operations which can be helpful
+    /// for slow or network-attached storage devices.
+    ///
+    /// [default] is 1 MiB
+    ///
+    /// Since v1.7.7
+    pub rocksdb_writable_file_max_buffer_size: NonZeroByteCount,
+
+    /// # Number of L0 files to trigger compaction
+    ///
+    /// Sets the number of files to trigger level-0 compaction.
+    ///
+    /// [default] is 2
+    ///
+    /// Since v1.7.7
+    pub rocksdb_l0_num_compaction_trigger: NonZeroU32,
+
+    /// # Max open files
+    ///
+    /// Sets the number of open files that can be used by the DB. You may need to
+    /// increase this if your database has a large working set. Unset means
+    /// files opened are always kept open.
+    ///
+    /// [default] is unset
+    ///
+    /// Since v1.7.7
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rocksdb_max_open_files: Option<NonZeroU32>,
 }
 
 impl StorageOptions {
@@ -1002,6 +1034,11 @@ impl Default for StorageOptions {
             rocksdb_max_file_size: NonZeroByteCount::new(
                 NonZeroUsize::new(64 * 1024 * 1024).unwrap(),
             ),
+            rocksdb_writable_file_max_buffer_size: NonZeroByteCount::new(
+                NonZeroUsize::new(1024 * 1024).unwrap(),
+            ),
+            rocksdb_l0_num_compaction_trigger: NonZeroU32::new(2).unwrap(),
+            rocksdb_max_open_files: None,
         }
     }
 }

--- a/release-notes/unreleased/rocksdb-storage-tuning.md
+++ b/release-notes/unreleased/rocksdb-storage-tuning.md
@@ -1,0 +1,29 @@
+# Configurable RocksDB storage tuning
+
+## Behavioral Change / New Feature
+
+### What Changed
+
+Log-server and partition-store RocksDB configurations now support these options:
+
+- `rocksdb-writable-file-max-buffer-size`, which defaults to `1 MiB`.
+- `rocksdb-l0-num-compaction-trigger`, which defaults to `8` for `[log-server]` and `2` for `[worker.storage]`.
+- `rocksdb-max-open-files`, which is unset by default so opened files are kept open.
+
+Existing log-server BlobDB and background-compaction options are now included in the generated configuration schema.
+
+Restate now derives each database's memtable count and write-buffer size from its memory budget and configured target SST size. Once individual write buffers reach the target SST size, increasing the log-server memtable budget adds more memtables instead of continuing to grow each write buffer. The minimum target SST size is lowered from `16 MiB` to `8 MiB`, and explicit log-server memtable budgets below `32 MiB` are raised to that minimum. When log-server blob separation is enabled, non-L0 SST files target `8 MiB` and the base level targets `80 MiB`.
+
+### Why This Matters
+
+The new settings let operators tune RocksDB file I/O and compaction behavior for their storage devices and workloads. Using larger budgets for more memtables rather than larger write buffers bounds the size of individual buffers while still letting operators increase total memtable memory.
+
+### Impact on Users
+
+Existing configurations remain accepted, but deployments will adopt the new write-buffer, SST, compaction, and log-server WAL sizing behavior after upgrading. The configurable L0 trigger defaults preserve the previous hard-coded values.
+
+### Migration Guidance
+
+No configuration migration is required. Operators with workload-specific RocksDB tuning should review the new sizing behavior and benchmark their existing `rocksdb-memory-budget` and `rocksdb-max-file-size` settings.
+
+Changes to DB-level writable-file buffers, open-file limits, and partition-store L0 triggers take effect when the database is reopened. Log-server BlobDB and L0 options support live configuration updates.


### PR DESCRIPTION

Derive memtable counts and write-buffer sizes from each database's memory budget and target SST size, lower the minimum SST target to 8 MiB, and apply RocksDB-compatible bounds to derived options. The goal here is to allow total memtable memory to be set high while limiting the single write buffer size (~= L0 SST) to a reasonable value, by increasing the number of write buffers rather than growing the single write buffer size.

Add log-server and partition-store settings for writable-file buffers, L0 compaction triggers, and open-file limits.

Use BlobDB-specific level sizing for the log server, support live log-server BlobDB and L0 updates, expose the relevant configuration schema, and document the behavioral changes.

---
[//]: # (BEGIN SAPLING FOOTER)
* #5227
* __->__ #5226