### PR TITLE
[LogServer] Partition log-server SSTs at log boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "rust-librocksdb-sys"
 version = "0.47.1+11.1.2"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=c9ce6e982362da2b2bb783c28056b2603aba50df#c9ce6e982362da2b2bb783c28056b2603aba50df"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=5df796cd539c15cec10f5c3c0d9dff1b4fbc6e42#5df796cd539c15cec10f5c3c0d9dff1b4fbc6e42"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -9605,8 +9605,8 @@ dependencies = [
 
 [[package]]
 name = "rust-rocksdb"
-version = "0.51.0"
-source = "git+https://github.com/restatedev/rust-rocksdb?rev=c9ce6e982362da2b2bb783c28056b2603aba50df#c9ce6e982362da2b2bb783c28056b2603aba50df"
+version = "0.51.1"
+source = "git+https://github.com/restatedev/rust-rocksdb?rev=5df796cd539c15cec10f5c3c0d9dff1b4fbc6e42#5df796cd539c15cec10f5c3c0d9dff1b4fbc6e42"
 dependencies = [
  "libc",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,10 +232,10 @@ reqwest = { version = "0.12", default-features = false, features = [
     "stream",
 ] }
 rlimit = { version = "0.11.0" }
-rocksdb = { version = "0.51.0", package = "rust-rocksdb", features = [
+rocksdb = { version = "0.51.1", package = "rust-rocksdb", features = [
     "multi-threaded-cf",
     "jemalloc",
-], git = "https://github.com/restatedev/rust-rocksdb", rev = "c9ce6e982362da2b2bb783c28056b2603aba50df" }
+], git = "https://github.com/restatedev/rust-rocksdb", rev = "5df796cd539c15cec10f5c3c0d9dff1b4fbc6e42" }
 rstest = "0.26.1"
 rustls = { version = "0.23.35", default-features = false, features = ["ring"] }
 rustyline = { version = "14.0.0" }

--- a/crates/log-server/src/rocksdb_logstore/builder.rs
+++ b/crates/log-server/src/rocksdb_logstore/builder.rs
@@ -22,9 +22,11 @@ use restate_rocksdb::{
 };
 use restate_types::config::{Configuration, LogServerOptions};
 use restate_types::health::HealthStatus;
+use restate_types::logs::LogId;
 use restate_types::protobuf::common::{DatabaseKind, LogServerStatus};
 use restate_util_bytecount::ByteCount;
 
+use super::keys::KeyPrefixKind;
 use super::writer::LogStoreWriterBuilder;
 use super::{DATA_CF, METADATA_CF};
 use super::{RocksDbLogStore, RocksDbLogStoreError};
@@ -465,6 +467,23 @@ fn cf_data_options(
                 .get() as u64,
         );
     }
+
+    match (
+        log_server_config.rocksdb_partition_sst_by_loglet,
+        log_server_config.rocksdb_partition_sst_by_log,
+    ) {
+        (true, _) => {
+            // loglet always wins
+            opts.set_sst_partitioner_fixed_prefix(KeyPrefix::size());
+        }
+        (_, true) => {
+            // Keep all loglets for the same log together.
+            opts.set_sst_partitioner_fixed_prefix(size_of::<KeyPrefixKind>() + size_of::<LogId>())
+        }
+        _ => {
+            // Do not partition SST files
+        }
+    }
 }
 
 fn cf_metadata_options(
@@ -509,9 +528,101 @@ mod tests {
 
     use restate_core::TaskCenter;
     use restate_rocksdb::RocksDbManager;
-    use restate_types::config::{Configuration, set_current_config};
+    use restate_types::config::{Configuration, node_dir, set_current_config};
+    use restate_types::logs::metadata::SegmentIndex;
+    use restate_types::logs::{LogletId, LogletOffset};
 
     use super::*;
+    use crate::rocksdb_logstore::keys::DataRecordKey;
+
+    #[test]
+    fn partition_compacted_ssts_by_log_and_loglet() -> anyhow::Result<()> {
+        let loglets = [
+            LogletId::new(LogId::new(1), SegmentIndex::OLDEST),
+            LogletId::new(LogId::new(1), SegmentIndex::OLDEST.next()),
+            LogletId::new(LogId::new(2), SegmentIndex::OLDEST),
+            LogletId::new(LogId::new(2), SegmentIndex::OLDEST.next()),
+        ];
+
+        for (name, partition_by_loglet, expected_partitions) in
+            [("by-log", false, 2), ("by-loglet", true, loglets.len())]
+        {
+            let mut config = LogServerOptions::default();
+            config.rocksdb_partition_sst_by_loglet = partition_by_loglet;
+            if !partition_by_loglet {
+                assert!(
+                    config.rocksdb_partition_sst_by_log,
+                    "log partitioning is enabled by default"
+                );
+            }
+
+            let block_options =
+                restate_rocksdb::configuration::create_default_block_options(&config.rocksdb, None);
+            let mut options = restate_rocksdb::configuration::create_default_cf_options(None);
+            cf_data_options(&mut options, &block_options, &config);
+            options.create_if_missing(true);
+            // Only the manual compaction below should determine the resulting file layout.
+            options.set_disable_auto_compactions(true);
+
+            let db =
+                rocksdb::DB::open(&options, node_dir().join(format!("sst-partitioner-{name}")))?;
+
+            // Overlapping flushes force compaction to rewrite the input files, which runs the
+            // SST partitioner instead of trivially moving a file to another level.
+            for round in 0..2u8 {
+                for loglet_id in loglets {
+                    for offset in 1..=4 {
+                        let key = DataRecordKey::new(loglet_id, LogletOffset::new(offset))
+                            .to_binary_array();
+                        db.put(key, [round])?;
+                    }
+                }
+                db.flush()?;
+            }
+            db.compact_range(None::<&[u8]>, None::<&[u8]>);
+
+            let files = db.live_files()?;
+            assert!(
+                files.len() >= expected_partitions,
+                "expected at least {expected_partitions} partitioned SSTs, got {}",
+                files.len()
+            );
+
+            let mut sst_spans_loglets = false;
+            for file in files {
+                let start = DataRecordKey::from_slice(
+                    file.start_key.as_deref().expect("SST has a smallest key"),
+                );
+                let end = DataRecordKey::from_slice(
+                    file.end_key.as_deref().expect("SST has a largest key"),
+                );
+
+                if partition_by_loglet {
+                    assert_eq!(
+                        start.loglet_id(),
+                        end.loglet_id(),
+                        "SST spans multiple loglets: {file:?}"
+                    );
+                } else {
+                    assert_eq!(
+                        start.loglet_id().log_id(),
+                        end.loglet_id().log_id(),
+                        "SST spans multiple logs: {file:?}"
+                    );
+                    sst_spans_loglets |= start.loglet_id() != end.loglet_id();
+                }
+            }
+
+            if !partition_by_loglet {
+                assert!(
+                    sst_spans_loglets,
+                    "log partitioning unexpectedly split every SST by loglet"
+                );
+            }
+        }
+
+        Ok(())
+    }
 
     #[test(restate_core::test(start_paused = true))]
     async fn dynamically_update_blob_and_l0_options() -> anyhow::Result<()> {

--- a/crates/types/src/config/log_server.rs
+++ b/crates/types/src/config/log_server.rs
@@ -225,6 +225,28 @@ pub struct LogServerOptions {
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub rocksdb_disable_paranoid_checks: bool,
 
+    /// # Partition SST files by log ID
+    ///
+    /// Splits SST files by the log ID.
+    ///
+    /// [default] is true
+    ///
+    /// Since v1.7.7
+    pub rocksdb_partition_sst_by_log: bool,
+
+    /// # Partition SST files by loglet ID
+    ///
+    /// Splits SST files by the loglet ID. Enabling this option may reduce the cost of compaction
+    /// and trimming but may increase the number of SST files. If the number of SST files became a
+    /// concern, consider setting `rocksdb-max-open-files` to a reasonable value.
+    ///
+    /// This overrides `rocksdb-partition-sst-by-log` if both are enabled.
+    ///
+    /// [default] is false
+    ///
+    /// Since v1.7.7
+    pub rocksdb_partition_sst_by_loglet: bool,
+
     /// Starts in read-only mode
     ///
     /// This is useful for testing, debugging, and development.
@@ -440,6 +462,8 @@ impl Default for LogServerOptions {
             ),
             rocksdb_l0_num_compaction_trigger: NonZeroU32::new(8).unwrap(),
             rocksdb_max_open_files: None,
+            rocksdb_partition_sst_by_log: true,
+            rocksdb_partition_sst_by_loglet: false,
         }
     }
 }

--- a/release-notes/unreleased/rocksdb-storage-tuning.md
+++ b/release-notes/unreleased/rocksdb-storage-tuning.md
@@ -9,6 +9,8 @@ Log-server and partition-store RocksDB configurations now support these options:
 - `rocksdb-writable-file-max-buffer-size`, which defaults to `1 MiB`.
 - `rocksdb-l0-num-compaction-trigger`, which defaults to `8` for `[log-server]` and `2` for `[worker.storage]`.
 - `rocksdb-max-open-files`, which is unset by default so opened files are kept open.
+- `rocksdb-partition-sst-by-log`, which defaults to `true` and prevents compacted log-server SST files from spanning logs.
+- `rocksdb-partition-sst-by-loglet`, which defaults to `false` and, when enabled, partitions compacted SST files by loglet instead of log.
 
 Existing log-server BlobDB and background-compaction options are now included in the generated configuration schema.
 
@@ -16,14 +18,23 @@ Restate now derives each database's memtable count and write-buffer size from it
 
 ### Why This Matters
 
-The new settings let operators tune RocksDB file I/O and compaction behavior for their storage devices and workloads. Using larger budgets for more memtables rather than larger write buffers bounds the size of individual buffers while still letting operators increase total memtable memory.
+The new settings let operators tune RocksDB file I/O and compaction behavior for their storage devices and workloads. Using larger budgets for more memtables rather than larger write buffers bounds the size of individual buffers while still letting operators increase total memtable memory. Keeping SST boundaries aligned with logs or loglets reduces compaction overlap when their data progresses independently.
 
 ### Impact on Users
 
-Existing configurations remain accepted, but deployments will adopt the new write-buffer, SST, compaction, and log-server WAL sizing behavior after upgrading. The configurable L0 trigger defaults preserve the previous hard-coded values.
+Existing configurations remain accepted, but deployments will adopt the new write-buffer, SST, compaction, and log-server WAL sizing behavior after upgrading. The configurable L0 trigger defaults preserve the previous hard-coded values. Log-server compaction output is partitioned by log by default; existing SST files are rewritten with these boundaries through normal compaction.
 
 ### Migration Guidance
 
 No configuration migration is required. Operators with workload-specific RocksDB tuning should review the new sizing behavior and benchmark their existing `rocksdb-memory-budget` and `rocksdb-max-file-size` settings.
 
 Changes to DB-level writable-file buffers, open-file limits, and partition-store L0 triggers take effect when the database is reopened. Log-server BlobDB and L0 options support live configuration updates.
+
+To retain SST file boundaries based only on the configured target file size, disable log partitioning:
+
+```toml
+[log-server]
+rocksdb-partition-sst-by-log = false
+```
+
+SST partitioning options take effect when the log-server database is reopened.


### PR DESCRIPTION

Use the fixed-prefix SST partitioner to align compaction output with log boundaries by default. Add opt-in loglet boundaries, which take precedence, for workloads that benefit from finer-grained compaction and trimming.

Bump rust-rocksdb to expose the partitioner binding and add a behavioral test that validates actual SST key ranges. Document the new configuration and upgrade behavior.

---
[//]: # (BEGIN SAPLING FOOTER)
* __->__ #5227
* #5226