### PR TITLE
[worker] respect retention policy for pre-flight invocations

### DIFF
--- a/crates/storage-api/src/invocation_status_table/mod.rs
+++ b/crates/storage-api/src/invocation_status_table/mod.rs
@@ -756,6 +756,49 @@ pub enum JournalRetentionPolicy {
 }
 
 impl CompletedInvocation {
+    pub fn from_pre_flight_invocation_metadata(
+        mut metadata: PreFlightInvocationMetadata,
+        journal_retention_policy: JournalRetentionPolicy,
+        response_result: ResponseResult,
+        timestamp: MillisSinceEpoch,
+    ) -> Self {
+        metadata
+            .timestamps
+            .record_completed_transition_time(timestamp);
+
+        let (journal_metadata, pinned_deployment) = match metadata.input {
+            PreFlightInvocationArgument::Input(_) => (JournalMetadata::empty(), None),
+            PreFlightInvocationArgument::Journal(PreFlightInvocationJournal {
+                journal_metadata,
+                pinned_deployment,
+            }) => (
+                if journal_retention_policy == JournalRetentionPolicy::Retain {
+                    journal_metadata
+                } else {
+                    JournalMetadata::empty()
+                },
+                pinned_deployment,
+            ),
+        };
+
+        Self {
+            invocation_target: metadata.invocation_target,
+            vqueue_id: metadata.vqueue_id,
+            limit_key: metadata.limit_key,
+            created_using_restate_version: metadata.created_using_restate_version,
+            source: metadata.source,
+            execution_time: metadata.execution_time,
+            idempotency_key: metadata.idempotency_key,
+            timestamps: metadata.timestamps,
+            response_result,
+            completion_retention_duration: metadata.completion_retention_duration,
+            journal_retention_duration: metadata.journal_retention_duration,
+            journal_metadata,
+            pinned_deployment,
+            random_seed: metadata.random_seed,
+        }
+    }
+
     pub fn from_in_flight_invocation_metadata(
         mut in_flight_invocation_metadata: InFlightInvocationMetadata,
         journal_retention_policy: JournalRetentionPolicy,

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -840,6 +840,11 @@ experimental! {
     ///
     /// Since v1.7.5
     vqueues_migration_skip_completed,
+
+    /// Apply completion and journal retention when terminating a preflight invocation.
+    ///
+    /// Since v1.7.8
+    preflight_invocation_termination_retention,
 }
 
 serde_with::with_prefix!(pub prefix_tokio_console "tokio_console_");

--- a/crates/types/src/partitions/features.rs
+++ b/crates/types/src/partitions/features.rs
@@ -17,7 +17,8 @@ use crate::storage::{
     encode,
 };
 use crate::{
-    RESTATE_VERSION_1_6_0, RESTATE_VERSION_1_7_0, RESTATE_VERSION_1_7_5, SemanticRestateVersion,
+    RESTATE_VERSION_1_6_0, RESTATE_VERSION_1_7_0, RESTATE_VERSION_1_7_5, RESTATE_VERSION_1_7_8,
+    SemanticRestateVersion,
 };
 
 /// A change to the set of state-machine features enabled on a partition.
@@ -64,6 +65,10 @@ pub enum PartitionFeatureChange {
     ///
     /// *Since v1.7.5*
     EnableVqueuesSkipCompleted = 4,
+    /// Apply completion and journal retention when terminating a preflight invocation.
+    ///
+    /// *Since v1.7.8*
+    EnablePreflightInvocationTerminationRetention = 5,
 }
 
 impl PartitionFeatureChange {
@@ -81,6 +86,7 @@ impl PartitionFeatureChange {
             Self::EnableVqueues => &RESTATE_VERSION_1_7_0,
             Self::EnableUniqueRandomSeeds => &RESTATE_VERSION_1_7_0,
             Self::EnableVqueuesSkipCompleted => &RESTATE_VERSION_1_7_5,
+            Self::EnablePreflightInvocationTerminationRetention => &RESTATE_VERSION_1_7_8,
         }
     }
 
@@ -101,6 +107,10 @@ impl PartitionFeatureChange {
             Self::EnableUniqueRandomSeeds => {
                 !std::mem::replace(&mut features.unique_random_seeds, true)
             }
+            Self::EnablePreflightInvocationTerminationRetention => !std::mem::replace(
+                &mut features.preflight_invocation_termination_retention,
+                true,
+            ),
         }
     }
 }
@@ -151,6 +161,12 @@ pub struct PersistedFeatures {
     /// *Since v1.7.5*
     #[bilrost(tag(4))]
     pub vqueues_skip_completed: bool,
+
+    /// Apply completion and journal retention when terminating a preflight invocation.
+    ///
+    /// *Since v1.7.8*
+    #[bilrost(tag(5))]
+    pub preflight_invocation_termination_retention: bool,
 }
 
 impl PersistedFeatures {
@@ -164,6 +180,8 @@ impl PersistedFeatures {
             self.unique_random_seeds.then_some("unique_random_seeds"),
             self.vqueues_skip_completed
                 .then_some("vqueues_skip_completed"),
+            self.preflight_invocation_termination_retention
+                .then_some("preflight_invocation_termination_retention"),
         ]
         .into_iter()
         .flatten()

--- a/crates/types/src/restate_version.rs
+++ b/crates/types/src/restate_version.rs
@@ -238,6 +238,10 @@ pub static RESTATE_VERSION_1_7_0: LazyLock<SemanticRestateVersion> =
 pub static RESTATE_VERSION_1_7_5: LazyLock<SemanticRestateVersion> =
     LazyLock::new(|| SemanticRestateVersion::parse("1.7.5-dev").expect("valid semver version"));
 
+/// Why isn't this value simply v1.7.8? See description of [`RESTATE_VERSION_1_6_0`].
+pub static RESTATE_VERSION_1_7_8: LazyLock<SemanticRestateVersion> =
+    LazyLock::new(|| SemanticRestateVersion::parse("1.7.8-dev").expect("valid semver version"));
+
 /// Why isn't this value simply v1.8.0? See description of [`RESTATE_VERSION_1_6_0`].
 pub static RESTATE_VERSION_1_8_0: LazyLock<SemanticRestateVersion> =
     LazyLock::new(|| SemanticRestateVersion::parse("1.8.0-dev").expect("valid semver version"));

--- a/crates/worker-api/src/processor/features.rs
+++ b/crates/worker-api/src/processor/features.rs
@@ -41,6 +41,14 @@ pub trait PartitionFeatures {
     ///
     /// *Since v1.7.5*
     fn is_fully_migrated_to_vqueues(&self) -> bool;
+
+    /// Whether completion and journal retention should be respected when terminating an invocation
+    /// before it starts running.
+    ///
+    /// *Since v1.7.8*
+    fn is_preflight_invocation_termination_retention_enabled(&self) -> bool {
+        self.has_feature(PartitionFeatureChange::EnablePreflightInvocationTerminationRetention)
+    }
 }
 
 impl PartitionFeatures for PersistedFeatures {
@@ -51,6 +59,9 @@ impl PartitionFeatures for PersistedFeatures {
             PartitionFeatureChange::EnableVqueues => self.vqueues,
             PartitionFeatureChange::EnableUniqueRandomSeeds => self.unique_random_seeds,
             PartitionFeatureChange::EnableVqueuesSkipCompleted => self.vqueues_skip_completed,
+            PartitionFeatureChange::EnablePreflightInvocationTerminationRetention => {
+                self.preflight_invocation_termination_retention
+            }
         }
     }
 
@@ -72,6 +83,11 @@ impl PartitionFeatures for PersistedFeatures {
     #[inline]
     fn is_unique_random_seeds_enabled(&self) -> bool {
         self.unique_random_seeds
+    }
+
+    #[inline]
+    fn is_preflight_invocation_termination_retention_enabled(&self) -> bool {
+        self.preflight_invocation_termination_retention
     }
 }
 
@@ -97,6 +113,10 @@ impl<T: PartitionFeatures> PartitionFeatures for &T {
     fn is_unique_random_seeds_enabled(&self) -> bool {
         (**self).is_unique_random_seeds_enabled()
     }
+
+    fn is_preflight_invocation_termination_retention_enabled(&self) -> bool {
+        (**self).is_preflight_invocation_termination_retention_enabled()
+    }
 }
 
 impl<T: PartitionFeatures> PartitionFeatures for &mut T {
@@ -118,5 +138,9 @@ impl<T: PartitionFeatures> PartitionFeatures for &mut T {
 
     fn is_unique_random_seeds_enabled(&self) -> bool {
         (**self).is_unique_random_seeds_enabled()
+    }
+
+    fn is_preflight_invocation_termination_retention_enabled(&self) -> bool {
+        (**self).is_preflight_invocation_termination_retention_enabled()
     }
 }

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -591,6 +591,19 @@ where
                 feature_changes.push(PartitionFeatureChange::EnableUniqueRandomSeeds);
             }
 
+            if config
+                .common
+                .experimental
+                .is_preflight_invocation_termination_retention_enabled()
+                && !processor
+                    .fsm()
+                    .features()
+                    .is_preflight_invocation_termination_retention_enabled()
+            {
+                feature_changes
+                    .push(PartitionFeatureChange::EnablePreflightInvocationTerminationRetention);
+            }
+
             if !feature_changes.is_empty() {
                 // Smallest version that supports every listed feature, but never below
                 // the partition's current min_restate_version.
@@ -1251,6 +1264,7 @@ mod tests {
                 vqueues: true,
                 vqueues_skip_completed: true,
                 unique_random_seeds: true,
+                preflight_invocation_termination_retention: true,
             },
         );
         let (leader_query_tx, _leader_query_rx) = restate_worker_api::channel();

--- a/crates/worker/src/partition/processor/commands/version_barrier.rs
+++ b/crates/worker/src/partition/processor/commands/version_barrier.rs
@@ -186,6 +186,7 @@ impl<L: LeaderPromotion> ApplyPartitionCommand<VersionBarrierCommand>
                     // point. Pre-existing invocations without a stored random seed keep working via the
                     // `to_random_seed()` fallback in `invoker_storage_reader.rs`.
                     PartitionFeatureChange::EnableUniqueRandomSeeds => {}
+                    PartitionFeatureChange::EnablePreflightInvocationTerminationRetention => {}
                 }
             }
         }

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -1780,15 +1780,40 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
 
         let InboxedInvocation {
             inbox_sequence_number,
-            metadata:
-                PreFlightInvocationMetadata {
-                    response_sinks,
-                    invocation_target,
-                    input,
-                    vqueue_id,
-                    ..
-                },
+            mut metadata,
         } = inboxed_invocation;
+        let response_sinks = std::mem::take(&mut metadata.response_sinks);
+        let invocation_target = metadata.invocation_target.clone();
+        let vqueue_id = metadata.vqueue_id.as_ref();
+        let (completion_retention, journal_retention) = if self
+            .processor
+            .fsm()
+            .features()
+            .is_preflight_invocation_termination_retention_enabled()
+        {
+            (
+                metadata.completion_retention_duration,
+                metadata.journal_retention_duration,
+            )
+        } else {
+            (Duration::ZERO, Duration::ZERO)
+        };
+        let span_context = metadata.span_context().clone();
+        let journal_to_drop = if journal_retention.is_zero()
+            && let PreFlightInvocationArgument::Journal(PreFlightInvocationJournal {
+                journal_metadata,
+                pinned_deployment,
+            }) = &metadata.input
+        {
+            Some((
+                journal_metadata.length,
+                pinned_deployment
+                    .as_ref()
+                    .map(|pd| pd.service_protocol_version),
+            ))
+        } else {
+            None
+        };
 
         // Reply back to callers with error, and publish end trace
         self.send_response_to_sinks(
@@ -1816,17 +1841,22 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
                 };
 
                 VQueue::get(
-                    &vqueue_id,
+                    vqueue_id,
                     self.storage,
                     self.processor.vqueues_mut(),
                     self.is_leader.then_some(self.action_collector),
                 )
                 .await?
                 .expect("terminate expects vqueue to exist")
-                .end(record_unique_ts, &entry_status, new_status, Duration::ZERO);
+                .end(
+                    record_unique_ts,
+                    &entry_status,
+                    new_status,
+                    completion_retention,
+                );
             }
         } else {
-            // Delete inbox entry and invocation status.
+            // Delete the inbox entry.
             self.do_delete_inbox_entry(
                 invocation_target
                     .as_keyed_service_id()
@@ -1835,21 +1865,27 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
             )
             .await?;
         }
-        self.do_free_invocation(&invocation_id)?;
 
-        // If there's a journal, delete journal
-        if let PreFlightInvocationArgument::Journal(PreFlightInvocationJournal {
-            journal_metadata,
-            pinned_deployment,
-        }) = &input
-        {
-            let pinned_service_protocol_version = pinned_deployment
-                .as_ref()
-                .map(|pd| pd.service_protocol_version);
+        if completion_retention.is_zero() {
+            self.do_free_invocation(&invocation_id)?;
+        } else {
+            let completed_invocation = CompletedInvocation::from_pre_flight_invocation_metadata(
+                metadata,
+                if journal_retention.is_zero() {
+                    JournalRetentionPolicy::Drop
+                } else {
+                    JournalRetentionPolicy::Retain
+                },
+                ResponseResult::Failure(error.clone()),
+                self.record_created_at,
+            );
+            self.do_store_completed_invocation(invocation_id, completed_invocation)?;
+        }
 
+        if let Some((journal_length, pinned_service_protocol_version)) = journal_to_drop {
             self.do_drop_journal(
                 &invocation_id,
-                journal_metadata.length,
+                journal_length,
                 pinned_service_protocol_version,
             )
             .await?;
@@ -1858,7 +1894,7 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
         self.emit_invocation_end_span(
             &invocation_id,
             &invocation_target,
-            input.span_context(),
+            &span_context,
             Err(&error),
         );
 
@@ -1888,17 +1924,40 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
             TerminationFlavor::Cancel => CANCELED_INVOCATION_ERROR,
         };
 
-        let ScheduledInvocation {
-            metadata:
-                PreFlightInvocationMetadata {
-                    response_sinks,
-                    input,
-                    invocation_target,
-                    execution_time,
-                    vqueue_id,
-                    ..
-                },
-        } = scheduled_invocation;
+        let ScheduledInvocation { mut metadata } = scheduled_invocation;
+        let response_sinks = std::mem::take(&mut metadata.response_sinks);
+        let invocation_target = metadata.invocation_target.clone();
+        let execution_time = metadata.execution_time;
+        let vqueue_id = metadata.vqueue_id.as_ref();
+        let (completion_retention, journal_retention) = if self
+            .processor
+            .fsm()
+            .features()
+            .is_preflight_invocation_termination_retention_enabled()
+        {
+            (
+                metadata.completion_retention_duration,
+                metadata.journal_retention_duration,
+            )
+        } else {
+            (Duration::ZERO, Duration::ZERO)
+        };
+        let span_context = metadata.span_context().clone();
+        let journal_to_drop = if journal_retention.is_zero()
+            && let PreFlightInvocationArgument::Journal(PreFlightInvocationJournal {
+                journal_metadata,
+                pinned_deployment,
+            }) = &metadata.input
+        {
+            Some((
+                journal_metadata.length,
+                pinned_deployment
+                    .as_ref()
+                    .map(|pd| pd.service_protocol_version),
+            ))
+        } else {
+            None
+        };
 
         // Reply back to callers with error, and publish end trace
         self.send_response_to_sinks(
@@ -1926,14 +1985,19 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
                 };
 
                 VQueue::get(
-                    &vqueue_id,
+                    vqueue_id,
                     self.storage,
                     self.processor.vqueues_mut(),
                     self.is_leader.then_some(self.action_collector),
                 )
                 .await?
                 .expect("terminate expects vqueue to exist")
-                .end(record_unique_ts, &entry_status, new_status, Duration::ZERO);
+                .end(
+                    record_unique_ts,
+                    &entry_status,
+                    new_status,
+                    completion_retention,
+                );
             }
         } else {
             // Delete timer
@@ -1948,22 +2012,26 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
             }
         }
 
-        // Free invocation
-        self.do_free_invocation(&invocation_id)?;
+        if completion_retention.is_zero() {
+            self.do_free_invocation(&invocation_id)?;
+        } else {
+            let completed_invocation = CompletedInvocation::from_pre_flight_invocation_metadata(
+                metadata,
+                if journal_retention.is_zero() {
+                    JournalRetentionPolicy::Drop
+                } else {
+                    JournalRetentionPolicy::Retain
+                },
+                ResponseResult::Failure(error.clone()),
+                self.record_created_at,
+            );
+            self.do_store_completed_invocation(invocation_id, completed_invocation)?;
+        }
 
-        // If there's a journal, delete journal
-        if let PreFlightInvocationArgument::Journal(PreFlightInvocationJournal {
-            journal_metadata,
-            pinned_deployment,
-        }) = &input
-        {
-            let pinned_service_protocol_version = pinned_deployment
-                .as_ref()
-                .map(|pd| pd.service_protocol_version);
-
+        if let Some((journal_length, pinned_service_protocol_version)) = journal_to_drop {
             self.do_drop_journal(
                 &invocation_id,
-                journal_metadata.length,
+                journal_length,
                 pinned_service_protocol_version,
             )
             .await?;
@@ -1972,7 +2040,7 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
         self.emit_invocation_end_span(
             &invocation_id,
             &invocation_target,
-            input.span_context(),
+            &span_context,
             Err(&error),
         );
 

--- a/release-notes/unreleased/5104-preflight-invocation-termination-retention.md
+++ b/release-notes/unreleased/5104-preflight-invocation-termination-retention.md
@@ -1,0 +1,56 @@
+# Release Notes: Retention is respected when terminating an invocation before it starts
+
+## Behavioral Change
+
+### What Changed
+
+Killing or cancelling an invocation that has not started running yet — one that is
+still queued (waiting for its Virtual Object / Workflow key or for a concurrency
+slot) or scheduled for a later time (a delayed call) — now honours the invocation's
+completion retention and journal retention, exactly like terminating an already
+running invocation does.
+
+Previously, terminating such an invocation freed its invocation status immediately
+and dropped its journal, regardless of the retention configured for the service or
+handler. The terminal result was therefore not observable afterwards.
+
+The change is gated behind an opt-in experimental flag and, once enabled, you can't go back to any version below 1.8:
+
+```toml
+[common]
+experimental-enable-preflight-invocation-termination-retention = true
+```
+
+This flag will be enabled by default in 1.9 such that this behavior becomes the default.
+
+### Why This Matters
+
+Whether a terminal result was retained used to depend on *when* the invocation was
+terminated rather than on the retention you configured. An invocation killed one
+moment before it was dequeued behaved differently from the same invocation killed
+one moment after. Retention semantics are now uniform across an invocation's
+lifetime.
+
+### Impact on Users
+
+With the flag enabled:
+
+- **Idempotent invocations**: re-submitting the same idempotency key within the
+  completion-retention window now returns the retained `KILLED` / `CANCELED`
+  failure for those queued/delayed invocations, instead of starting a fresh invocation.
+- **Workflow submissions**: cancelling a queued or delayed workflow submission now
+  keeps that workflow key occupied for the completion-retention window (24h by
+  default). Re-submitting the same workflow key during that window fails with
+  `409 Conflict` / "the workflow method was already invoked" instead of starting
+  the workflow.
+- **Introspection**: terminated pre-flight invocations now show up as completed
+  invocations (with their journal, when journal retention is non-zero) instead of
+  disappearing. They are reclaimed when their retention expires.
+
+Without the flag, or before the partition's feature barrier has been applied,
+behaviour is unchanged.
+
+### Migration Guidance
+
+No action is required — the flag is off by default. However, we're planning to make
+it the default in 1.9. Once the flag is enabled, you can't go back to any version below 1.8.


### PR DESCRIPTION

Killing inboxed or scheduled invocations used to immediately delete the invocation irrespective of its completion and journal durations (both in vqueue and pre-vqueue world). This can be confusing to users as after canceling such invocations, they'll see them disappear from the UI without retaining their status.

This PR introduces a new experimental flag and a partition feature that once enabled, starts respecting completion and journal retention for those invocations.


*Test Plan*:

Before:

```

~/repos/restate/restate-cluster ❯❯❯ curl -X POST "localhost:8080/Counter/mbassem/add/send?delay=1h" --json 1                                                     ✘ 130 main ✱ ◼
{"invocationId":"inv_1bNhetDrexeA3AFcX2hgN6bxQr6rhpdO3J","executionTime":"2026-08-25T14:02:59.763000000Z","status":"Accepted"}%                                                 ~/repos/restate/restate-cluster ❯❯❯ restate inv get inv_1bNhetDrexeA3AFcX2hgN6bxQr6rhpdO3J | head                                                                      main ✱ ◼

~/repos/restate/restate-cluster ❯❯❯ restate inv kill inv_1bNhetDrexeA3AFcX2hgN6bxQr6rhpdO3J                                                                            main ✱ ◼
 ID                                      TARGET
 inv_1bNhetDrexeA3AFcX2hgN6bxQr6rhpdO3J  Counter/mbassem/add

✔ Are you sure you want to kill these invocations? · yes

✅ Killed 1 invocations
~/repos/restate/restate-cluster ❯❯❯ restate inv get inv_1bNhetDrexeA3AFcX2hgN6bxQr6rhpdO3J                                                                             main ✱ ◼
Error: Invocation inv_1bNhetDrexeA3AFcX2hgN6bxQr6rhpdO3J not found!

```

After:

```
❯❯❯ curl -X POST "localhost:8080/Counter/mbassem/add/send?delay=1h" --json 1                                                     ✘ 130 main ✱ ◼
{"invocationId":"inv_1bNhetDrexeA0gwrqDp8Sdxn7hJgfJLJ0c","executionTime":"2026-08-25T14:21:22.618000000Z","status":"Accepted"}

❯❯❯ restate inv kill inv_1bNhetDrexeA0gwrqDp8Sdxn7hJgfJLJ0c                                                                            main ✱ ◼
 ID                                      TARGET
 inv_1bNhetDrexeA0gwrqDp8Sdxn7hJgfJLJ0c  Counter/mbassem/add

✔ Are you sure you want to kill these invocations? · yes

✅ Killed 1 invocations
~/repos/restate/restate-cluster ❯❯❯ restate inv get inv_1bNhetDrexeA0gwrqDp8Sdxn7hJgfJLJ0c                                                                             main ✱ ◼

📜 Invocation Information:
――――――――――――――――――――――――――
 Created at:       2026-08-25 14:21:22.618 +01:00 (14 seconds ago)
 Target:           Counter/mbassem/add
 Status:           completed with failure
 Idempotency key:  01M0WHA9NTPVDQGQDSA9QVR9YZ
 Error:            [409] killed
 Modified at:      2026-08-25 14:21:28.449 +01:00


🚂 Invocation Progress:
―――――――――――――――――――――――
[Ingress]
 └──(this)─> Counter/mbassem/add
     ▸
     ├──── #0 [2026-08-25 14:21:22.618 +01:00] Command: Input
     └────>> completed
```

NOTE: I'm currently assuming this to be a 1.8 flag, but main is still on 1.7.7. I'll update depending on when this gets reviewed and whether we'll have a 1.7.8
