### PR TITLE
Fix keyed invocation filters in CLI

### DIFF
--- a/cli/src/commands/invocations/mod.rs
+++ b/cli/src/commands/invocations/mod.rs
@@ -50,15 +50,36 @@ fn create_query_filter(query: &str) -> String {
     if let Ok(id) = q.parse::<InvocationId>() {
         format!("id = '{id}'")
     } else {
-        match q.find('/').unwrap_or_default() {
+        match q.matches('/').count() {
             0 => format!("target LIKE '{q}/%'"),
             // If there's one slash, let's add the wildcard depending on the service type,
             // so we discriminate correctly with serviceName/handlerName with workflowName/workflowKey
             1 => format!(
-                "(target = '{q}' AND target_service_ty = 'service') OR (target LIKE '{q}/%' AND target_service_ty != 'service'))"
+                "((target = '{q}' AND target_service_ty = 'service') OR (target LIKE '{q}/%' AND target_service_ty != 'service'))"
             ),
             // Can only be exact match here
             _ => format!("target LIKE '{q}'"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::create_query_filter;
+
+    #[test]
+    fn creates_target_query_filters() {
+        assert_eq!(
+            create_query_filter("MyService"),
+            "target LIKE 'MyService/%'"
+        );
+        assert_eq!(
+            create_query_filter("Chat/session456"),
+            "((target = 'Chat/session456' AND target_service_ty = 'service') OR (target LIKE 'Chat/session456/%' AND target_service_ty != 'service'))"
+        );
+        assert_eq!(
+            create_query_filter("Chat/session456/send"),
+            "target LIKE 'Chat/session456/send'"
+        );
     }
 }

--- a/release-notes/unreleased/3752-fix-keyed-invocation-filter.md
+++ b/release-notes/unreleased/3752-fix-keyed-invocation-filter.md
@@ -1,0 +1,12 @@
+# Correct keyed invocation filters in the CLI
+
+## Bug Fix
+
+Batch invocation commands now correctly interpret two-component targets such as
+`MyObject/myKey`. The CLI matches all handlers for the keyed service while still treating
+`MyService/myHandler` as an exact service invocation target.
+
+This fixes keyed target selection for `cancel`, `kill`, `pause`, `resume`, `purge`, and
+`restart-as-new`. No configuration or migration changes are required.
+
+Related issue: [#3752](https://github.com/restatedev/restate/issues/3752)


### PR DESCRIPTION
## Summary

- classify invocation target queries by their number of `/` separators instead of the byte position of the first separator
- preserve the ambiguous two-component behavior: exact-match regular service handlers and prefix-match keyed services
- group the two-component `OR` expression before command-specific status predicates are appended
- add regression coverage for service, keyed, and exact three-component targets, plus a release note

Fixes #3752

## Testing

- `cargo fmt --all -- --check`
- `cargo check`
- `cargo clippy --all-features --all-targets --workspace -- -D warnings`
- `cargo nextest run --all-features -p restate-cli` (12 passed)

A local `cargo nextest run --all-features` also passed all relevant tests, with four unrelated server/integration tests timing out while waiting for local nodes to start:

- `restate-server::cluster replicated_loglet`
- `restate-server::fabric_tls fabric_tls_modes`
- `restate-server::trim_gap_handling fast_forward_over_trim_gap`
- `restatectl::bin/restatectl tests::restatectl_smoke_test`

A serial rerun of `restate-server::cluster replicated_loglet` had the same startup timeout and no assertion failure. The changed `restate-cli` package suite passes in full.
