### PR TITLE
[Restate UI] Update to v1.0.22

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9203,8 +9203,8 @@ dependencies = [
 
 [[package]]
 name = "restate-web-ui"
-version = "1.0.21"
-source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v1.0.21#d454961814d40daabd2e5dcda22def01ff845d48"
+version = "1.0.22"
+source = "git+https://github.com/restatedev/restate-web-ui-crate?tag=v1.0.22#9d0b1217420a71af7e89610628a10fc293f4fbed"
 dependencies = [
  "anyhow",
  "include_dir",

--- a/crates/admin/Cargo.toml
+++ b/crates/admin/Cargo.toml
@@ -39,7 +39,7 @@ restate-util-time = { workspace = true }
 restate-types = { workspace = true }
 restate-util-string = { workspace = true }
 restate-wal-protocol = { workspace = true }
-restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "1.0.21", tag = "v1.0.21" }
+restate-web-ui = { git = "https://github.com/restatedev/restate-web-ui-crate", optional = true, version = "1.0.22", tag = "v1.0.22" }
 
 ahash = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
[UI] Updating Restate UI to v1.0.22
published at https://github.com/restatedev/restate-web-ui/releases/download/v1.0.22/ui-v1.0.22.zip