### PR TITLE
Disable tokio task dumping

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -20,6 +20,9 @@ test-util = [
   "restate-types/test-util",
   "tokio/test-util"
 ]
+# Tokio task dumping. Not enabled by any of our binaries because dumping re-polls in-flight futures
+# which can panic (and abort the process) on current_thread runtimes.
+# See https://github.com/restatedev/restate/issues/5235
 taskdump = []
 
 [dependencies]
@@ -93,6 +96,8 @@ tracing-subscriber = { workspace = true }
 tracing-test = { workspace = true }
 
 [target.'cfg(all(target_os = "linux", any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")))'.dependencies]
+# tokio/taskdump hard-errors on unsupported targets, hence it cannot be pulled in by our `taskdump`
+# feature directly
 tokio = { workspace = true, features = ["taskdump"] }
 
 [lints]

--- a/crates/core/src/task_center.rs
+++ b/crates/core/src/task_center.rs
@@ -806,9 +806,16 @@ impl TaskCenterInner {
         any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
     )))]
     async fn dump_tasks(self: &Arc<Self>, _: impl std::io::Write) {
-        warn!("Cannot dump tokio tasks; taskdump feature was not enabled at compile time")
+        warn!(
+            "Cannot dump tokio tasks; the taskdump feature was not enabled at compile time. \
+            It is disabled by default because dumping re-polls in-flight futures which can abort \
+            the process, see https://github.com/restatedev/restate/issues/5235"
+        )
     }
 
+    // TODO(#5235): re-polling live futures is not side-effect free. It can wake tasks from within
+    //  poll which panics on current_thread runtimes (RefCell already borrowed) and can escalate
+    //  into a process abort. Don't enable the taskdump feature until this is fixed.
     #[cfg(all(
         feature = "taskdump",
         target_os = "linux",

--- a/release-notes/unreleased/5235-disable-tokio-task-dump.md
+++ b/release-notes/unreleased/5235-disable-tokio-task-dump.md
@@ -1,0 +1,27 @@
+# Release Notes for Issue #5235: Disable tokio task dumping (SIGUSR2)
+
+## Behavioral Change
+
+### What Changed
+Sending `SIGUSR2` to `restate-server` no longer dumps tokio task backtraces to stderr. Instead, the
+server logs a warning explaining that task dumping is not available. The `taskdump` feature is no
+longer enabled in the shipped binaries.
+
+### Why This Matters
+Tokio's task dump collects backtraces by re-polling live task futures. Re-polling is not
+side-effect free: a future that wakes a task from within `poll` can re-enter the scheduler it is
+currently being polled by. On Restate's `current_thread` runtimes this can panic and crash the
+process.
+
+### Impact on Users
+- `SIGUSR2` is now a no-op apart from a warning in the log. `SIGUSR1` (configuration dump) and
+  `SIGHUP` (RocksDB flush + compaction) are unaffected.
+- Nodes can no longer be aborted by sending `SIGUSR2`.
+- No configuration change is required, and no other functionality is affected.
+
+### Migration Guidance
+None required. If you previously relied on `SIGUSR2` to investigate stuck tasks, use the metrics,
+tracing, and log output instead, or reach out to us so we can help with the specific investigation.
+
+### Related Issues
+- Issue #5235: SIGUSR2 task dump can abort a server on `current_thread` runtimes

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -32,7 +32,6 @@ memory-loglet = ["restate-node/memory-loglet"]
 no-trace-logging = ["tracing/max_level_trace", "tracing/release_max_level_debug"]
 metadata-api = ["restate-admin/metadata-api"]
 kafka-oidc = ["restate-node/kafka-oidc"]
-taskdump = ["restate-core/taskdump"]
 
 [dependencies]
 restate-workspace-hack = { workspace = true }
@@ -93,9 +92,6 @@ url = { workspace = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { workspace = true }
-
-[target.'cfg(all(target_os = "linux", any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")))'.dependencies]
-restate-core = { workspace = true, features = ["taskdump"] }
 
 [build-dependencies]
 vergen = { workspace = true, default-features = false, features = [


### PR DESCRIPTION
Tokio's task dump collects backtraces by re-polling live task futures, which is not side-effect free. A future that wakes a task from within poll re-enters the scheduler it is currently polled by. On current_thread runtimes this panics with "RefCell already borrowed" and a follow-up panic while unwinding escalated it into a process abort.

Stop enabling the taskdump feature for restate-server so SIGUSR2 degrades to a warning instead of being able to terminate the node. The implementation is kept behind the feature so it can be re-enabled once re-polling is made safe.

Fixes #5235