### PR TITLE
[RocksDB] Fix incorrect reporting of memtable memory usage

### DIFF
--- a/crates/node/src/network_server/metrics.rs
+++ b/crates/node/src/network_server/metrics.rs
@@ -287,7 +287,7 @@ pub async fn render_metrics(State(state): State<NodeCtrlHandlerState>) -> String
 
             // Memory Usage Stats (Gauges)
             let memory_usage = manager
-                .get_memory_usage_stats(&[])
+                .get_db_memory_usage_stats(db)
                 .expect("get_memory_usage_stats");
 
             format_rocksdb_property_for_prometheus(

--- a/crates/rocksdb/src/db_manager.rs
+++ b/crates/rocksdb/src/db_manager.rs
@@ -231,6 +231,16 @@ impl RocksDbManager {
         Ok(builder.build()?)
     }
 
+    /// Returns aggregated memory usage for all databases if filter is empty
+    pub fn get_db_memory_usage_stats(
+        &self,
+        db: &Arc<RocksDb>,
+    ) -> Result<rocksdb::perf::MemoryUsage, RocksError> {
+        let mut builder = rocksdb::perf::MemoryUsageBuilder::new()?;
+        builder.add_db(db.inner().as_raw_db());
+        Ok(builder.build()?)
+    }
+
     pub fn get_all_dbs(&self) -> Vec<Arc<RocksDb>> {
         self.dbs.read().values().filter_map(Weak::upgrade).collect()
     }


### PR DESCRIPTION

The following metrics were aggregated across dbs incorrectly:
- `rocksdb_memory_approx_memtable_bytes`
- `rocksdb_memory_approx_memtable_unflushed_bytes`
- `rocksdb_memory_approx_memtable_readers`

The fix also removes an unnecessary re-load of all db memory usage metrics on each database (incorrectly nested and aggregated)

The memory usage now also does not include the cache size since we never reported it through the returned memory usage struct but we already report it through write buffer manager metrics.
