### PR TITLE
[Worker] Run orphaned jc cleanup before processing

### DIFF
--- a/crates/partition-store/src/tests/migrations_test/verify_and_run_migrations.rs
+++ b/crates/partition-store/src/tests/migrations_test/verify_and_run_migrations.rs
@@ -310,6 +310,12 @@ async fn flag_on_writes_post_migration_land_in_scoped() {
         store.storage_version(),
         StorageVersion::ScopedStateAndPromise
     );
+    assert!(
+        !store
+            .needs_jc_orphan_cleanup()
+            .await
+            .expect("fresh stores are marked cleanup-complete")
+    );
 
     let service_id = ServiceId::new(None, "svc", "k");
     {

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -845,6 +845,15 @@ experimental! {
     ///
     /// Since v1.7.8
     preflight_invocation_termination_retention,
+
+    /// # Enables one-time orphaned journal completion-id index cleanup
+    ///
+    /// When enabled, partition startup waits for the cleanup to complete before processing
+    /// records. Successful completion is persisted per partition; cancellation or failure leaves
+    /// the cleanup pending for the next startup.
+    ///
+    /// Since v1.7.9
+    jc_orphan_cleanup,
 }
 
 serde_with::with_prefix!(pub prefix_tokio_console "tokio_console_");

--- a/crates/worker/src/partition/jc_orphan_cleanup.rs
+++ b/crates/worker/src/partition/jc_orphan_cleanup.rs
@@ -1,0 +1,187 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::future::Future;
+use std::time::Instant;
+
+use anyhow::Context;
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+
+use restate_partition_store::{
+    OrphanCleanupResult, PartitionStore, cleanup_orphaned_completion_id_index_entries,
+};
+use restate_storage_api::StorageError;
+
+#[derive(Debug, thiserror::Error)]
+pub(super) enum Error {
+    #[error("orphaned jc cleanup was cancelled")]
+    Cancelled,
+    #[error(transparent)]
+    Storage(#[from] StorageError),
+}
+
+pub(super) async fn run(
+    storage: &mut PartitionStore,
+    cancel: CancellationToken,
+) -> Result<(), Error> {
+    run_with(storage, cancel, |mut storage, cancel| async move {
+        tokio::task::spawn_blocking(move || {
+            cleanup_orphaned_completion_id_index_entries(&mut storage, || cancel.is_cancelled())
+        })
+        .await
+        .context("orphaned jc cleanup blocking task failed")
+        .map_err(StorageError::Generic)?
+    })
+    .await
+}
+
+async fn run_with<F, Fut>(
+    storage: &mut PartitionStore,
+    cancel: CancellationToken,
+    cleanup: F,
+) -> Result<(), Error>
+where
+    F: FnOnce(PartitionStore, CancellationToken) -> Fut,
+    Fut: Future<Output = Result<OrphanCleanupResult, StorageError>>,
+{
+    if !storage.needs_jc_orphan_cleanup().await? {
+        return Ok(());
+    }
+
+    let partition_id = storage.partition_id();
+    info!(
+        %partition_id,
+        "Starting orphaned journal completion-id index cleanup"
+    );
+    let start = Instant::now();
+    let outcome = match cleanup(storage.clone(), cancel).await {
+        Ok(outcome) => outcome,
+        Err(err) => {
+            warn!(
+                %partition_id,
+                elapsed = ?start.elapsed(),
+                "Failed to clean up orphaned journal completion-id index entries: {err}"
+            );
+            return Err(err.into());
+        }
+    };
+
+    if outcome.cancelled {
+        info!(
+            %partition_id,
+            scanned_entries = outcome.scanned_entries,
+            scanned_invocations = outcome.scanned_invocations,
+            deleted_entries = outcome.deleted_entries,
+            affected_invocations = outcome.affected_invocations,
+            elapsed = ?start.elapsed(),
+            "Orphaned journal completion-id index cleanup cancelled; \
+             will retry on next opted-in startup"
+        );
+        return Err(Error::Cancelled);
+    }
+
+    if let Err(err) = storage.mark_jc_orphan_cleanup_done().await {
+        warn!(
+            %partition_id,
+            scanned_entries = outcome.scanned_entries,
+            scanned_invocations = outcome.scanned_invocations,
+            deleted_entries = outcome.deleted_entries,
+            affected_invocations = outcome.affected_invocations,
+            elapsed = ?start.elapsed(),
+            "Failed to mark orphaned journal completion-id index cleanup as complete: {err}"
+        );
+        return Err(err.into());
+    }
+
+    info!(
+        %partition_id,
+        scanned_entries = outcome.scanned_entries,
+        scanned_invocations = outcome.scanned_invocations,
+        deleted_entries = outcome.deleted_entries,
+        affected_invocations = outcome.affected_invocations,
+        elapsed = ?start.elapsed(),
+        "Completed orphaned journal completion-id index cleanup"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::assert_matches;
+
+    use restate_core::TaskCenter;
+    use restate_rocksdb::RocksDbManager;
+    use restate_storage_api::StorageError;
+    use restate_types::identifiers::{PartitionId, PartitionKey};
+    use restate_types::partitions::Partition;
+    use restate_types::sharding::KeyRange;
+
+    use super::*;
+
+    fn cleanup_result(cancelled: bool) -> OrphanCleanupResult {
+        OrphanCleanupResult {
+            scanned_entries: 4,
+            scanned_invocations: 2,
+            deleted_entries: 2,
+            affected_invocations: 1,
+            cancelled,
+        }
+    }
+
+    #[restate_core::test]
+    async fn cleanup_startup_policy_and_marker_lifecycle() {
+        let rocksdb_manager = RocksDbManager::init();
+        TaskCenter::current().set_on_shutdown(Box::pin(async {
+            rocksdb_manager.shutdown().await;
+        }));
+
+        let manager = restate_partition_store::PartitionStoreManager::create(true)
+            .await
+            .expect("manager creation succeeds");
+        let mut storage = manager
+            .open(
+                &Partition::new(PartitionId::MIN, KeyRange::new(0, PartitionKey::MAX - 1)),
+                None,
+            )
+            .await
+            .expect("partition store opens");
+        assert!(storage.needs_jc_orphan_cleanup().await.unwrap());
+
+        assert_matches!(
+            run_with(&mut storage, CancellationToken::new(), |_, _| async {
+                Ok(cleanup_result(true))
+            })
+            .await,
+            Err(Error::Cancelled)
+        );
+        assert!(storage.needs_jc_orphan_cleanup().await.unwrap());
+
+        let failed = run_with(&mut storage, CancellationToken::new(), |_, _| async {
+            Err(StorageError::OperationalError)
+        })
+        .await;
+        assert_matches!(failed, Err(Error::Storage(StorageError::OperationalError)));
+        assert!(storage.needs_jc_orphan_cleanup().await.unwrap());
+
+        run_with(&mut storage, CancellationToken::new(), |_, _| async {
+            Ok(cleanup_result(false))
+        })
+        .await
+        .expect("successful cleanup allows startup");
+        assert!(!storage.needs_jc_orphan_cleanup().await.unwrap());
+
+        run_with(&mut storage, CancellationToken::new(), |_, _| async {
+            panic!("completed cleanup must not run again")
+        })
+        .await
+        .expect("completed cleanup allows startup");
+    }
+}

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -18,6 +18,7 @@
 
 mod cleaner;
 pub mod invoker_storage_reader;
+mod jc_orphan_cleanup;
 mod leadership;
 pub mod node;
 mod processor;
@@ -401,6 +402,21 @@ where
                     "Shutting partition processor during data migration down because of error: {err}"
                 );
                 return Err(err.into());
+            }
+        }
+
+        let jc_orphan_cleanup_enabled = self
+            .node_ctx
+            .config
+            .live_load()
+            .common
+            .experimental
+            .is_jc_orphan_cleanup_enabled();
+        if jc_orphan_cleanup_enabled {
+            match jc_orphan_cleanup::run(&mut self.partition_store, cancel.clone()).await {
+                Ok(()) => {}
+                Err(jc_orphan_cleanup::Error::Cancelled) => return Ok(()),
+                Err(jc_orphan_cleanup::Error::Storage(err)) => return Err(err.into()),
             }
         }
 

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -8,13 +8,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::convert::Infallible;
 use std::sync::Arc;
 use std::time::Duration;
-use std::time::Instant;
 
 use tokio::sync::watch;
-use tracing::{debug, info, instrument, warn};
+use tracing::{info, instrument, warn};
 
 use restate_core::network::{ShardSender, TransportConnect};
 use restate_core::{RuntimeTaskHandle, TaskCenter, TaskKind, cancellation_token};
@@ -147,82 +145,6 @@ where
                         return Err(ProcessorError::from(seal));
                     }
 
-                    // One-time background cleanup of orphaned jc index entries left behind
-                    // by a bug in delete_journal that used the wrong scan prefix.
-                    // Runs on a blocking thread so it doesn't starve the tokio runtime.
-                    // The child task is bound to the partition processor's lifecycle and
-                    // will be cancelled if the processor shuts down (e.g. due to trim gap).
-                    let cleanup_task = if partition_store.needs_jc_orphan_cleanup().await? {
-                        let mut cleanup_store = partition_store.clone();
-                        let cleanup_partition_id = partition_store.partition_id();
-                        let cleanup_task = TaskCenter::spawn_unmanaged_child(
-                            TaskKind::Background,
-                            "jc-orphan-cleanup",
-                            async move {
-                                // Observe this task's own cancellation token so the
-                                // cancel_task() below reliably stops the blocking scan.
-                                let cancel = cancellation_token();
-                                let result = tokio::task::spawn_blocking(move || {
-                                    let start = Instant::now();
-                                    let result = restate_partition_store::cleanup_orphaned_completion_id_index_entries(
-                                        &mut cleanup_store,
-                                        || cancel.is_cancelled(),
-                                    );
-                                    (result, cleanup_store, start.elapsed())
-                                }).await.expect("cleanup blocking task must not panic");
-
-                                let (result, mut cleanup_store, elapsed) = result;
-                                match result {
-                                    Ok(outcome) => {
-                                        if outcome.cancelled {
-                                            info!(
-                                                partition_id = %cleanup_partition_id,
-                                                deleted_entries = outcome.deleted_entries,
-                                                affected_invocations = outcome.affected_invocations,
-                                                ?elapsed,
-                                                "Orphaned jc index cleanup cancelled, \
-                                                 will retry on next startup"
-                                            );
-                                        } else if outcome.deleted_entries > 0 {
-                                            info!(
-                                                partition_id = %cleanup_partition_id,
-                                                deleted_entries = outcome.deleted_entries,
-                                                affected_invocations = outcome.affected_invocations,
-                                                ?elapsed,
-                                                "Cleaned up orphaned journal completion-id index entries"
-                                            );
-                                        } else {
-                                            debug!(
-                                                partition_id = %cleanup_partition_id,
-                                                ?elapsed,
-                                                "No orphaned journal completion-id index entries found"
-                                            );
-                                        }
-                                        if !outcome.cancelled && let Err(err) = cleanup_store.mark_jc_orphan_cleanup_done().await
-                                            {
-                                                warn!(
-                                                    partition_id = %cleanup_partition_id,
-                                                    "Failed to mark jc orphan cleanup as done, \
-                                                     will retry on next startup: {err}"
-                                                );
-                                            }
-                                    }
-                                    Err(err) => {
-                                        warn!(
-                                            partition_id = %cleanup_partition_id,
-                                            ?elapsed,
-                                            "Failed to clean up orphaned journal completion-id \
-                                             index entries, will retry on next startup: {err}"
-                                        );
-                                    }
-                                }
-                                Ok::<_, Infallible>(())
-                            },
-                        )?;
-                        Some(cleanup_task)
-                    } else {
-                        None
-                    };
                     let db = partition_store.into_inner();
 
                     let run_result = async move {
@@ -231,17 +153,6 @@ where
                         pp.run().await
                     }
                     .await;
-
-                    // Cancel and join the one-time jc-orphan-cleanup task before this
-                    // runtime task returns. The partition store manager only drops or
-                    // re-imports this partition's column family on a *subsequent* open(),
-                    // which cannot run until this runtime task has fully completed (see
-                    // PartitionProcessorManager::await_runtime_task_result). Joining here
-                    // guarantees the cleanup can never write through a stale column-family
-                    // handle and poison the shared RocksDB instance (see #4838).
-                    if let Some(cleanup_task) = cleanup_task {
-                        let _ = cleanup_task.cancel_and_wait().await;
-                    }
 
                     info!(
                         partition_id = %partition.partition_id,

--- a/release-notes/unreleased/5238-opt-in-orphaned-jc-cleanup.md
+++ b/release-notes/unreleased/5238-opt-in-orphaned-jc-cleanup.md
@@ -1,0 +1,39 @@
+# Release Notes for Issue #5238: Opt In to Orphaned Journal Index Cleanup
+
+## Behavioral Change
+
+### What Changed
+
+The one-time cleanup of orphaned journal completion-id index entries no longer runs
+automatically in the background. It is now disabled by default and can be enabled with:
+
+```toml
+experimental_enable_jc_orphan_cleanup = true
+```
+
+When enabled, each partition with a pending cleanup completes the scan before it starts
+processing records. Fresh partition stores and stores that have already completed the cleanup
+skip the scan.
+
+### Why This Matters
+
+Running cleanup before partition processing prevents it from racing with creation of a new journal
+that reuses an invocation ID.
+
+### Impact on Users
+
+Opted-in partition startup can take longer while the cleanup scans the journal completion-id index.
+The unavailability of partitions depends on the number of journal entries and how many orphaned journal
+completion id index entries are present. An `INFO` event reports when the scan starts and when it 
+completes, including elapsed duration and scan/deletion counters. Cleanup failure prevents that partition 
+from starting.
+
+### Migration Guidance
+
+Set `experimental_enable_jc_orphan_cleanup = true` to run the cleanup. Successful completion is
+persisted per partition. Cancellation or failure leaves the cleanup pending and it is retried on the
+next opted-in startup.
+
+### Related Issues
+
+- Issue #5238


### PR DESCRIPTION
Gate the one-time cleanup behind an experimental opt-in and await it during partition startup after migrations. Cancellation stops the partition processor normally, while cleanup and marker failures prevent processing from starting. Failing on failures is intentional to prevent the cleanup from running on every partition processor start.

The cleanup must not run concurrently with partition processing: a new journal can reuse an invocation ID while the scan is in progress, causing the cleanup to mistake newly-created completion-id index entries for orphans and delete them. Running it synchronously establishes the required ordering before Bifrost records are processed.

Since the cleanup is a synchronous step before starting the partition processor, it is currently made opt-in until we have established that this scan can run by default when migrating from 1.6 to 1.7.8. The effect will be a full scan of the journal completion index table before the partition processor can run.

This fixes #5238.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>