### PR TITLE
[Hotfix] allow decoding lock names with empty service key

### DIFF
--- a/crates/partition-store/src/locks_table/mod.rs
+++ b/crates/partition-store/src/locks_table/mod.rs
@@ -117,7 +117,7 @@ impl KeyDecode for LockName {
         // they are valid utf-8 strings.
         let raw = unsafe { std::str::from_utf8_unchecked(string_data.chunk()) };
         // make the lock name a shared string (arc or inlined if small)
-        LockName::parse(raw).map_err(|e| StorageError::Generic(e.into()))
+        LockName::parse_unchecked(raw).map_err(|e| StorageError::Generic(e.into()))
     }
 }
 

--- a/crates/types/src/locking.rs
+++ b/crates/types/src/locking.rs
@@ -97,6 +97,26 @@ impl LockName {
         })
     }
 
+    /// Parses a `"service_name/key"` string into a [`LockName`].
+    ///
+    /// Both the service name must be non-empty. The key segment is allowed to be empty
+    /// to accommodate for previously allowed empty VO key names.
+    pub fn parse_unchecked(data: &str) -> Result<Self, ParseError> {
+        let mut it = data.match_indices('/');
+        let Some((key_offset, _)) = it.next() else {
+            return Err(ParseError::Malformed(data.into()));
+        };
+        let service_name = &data[..key_offset];
+        if service_name.is_empty() {
+            return Err(ParseError::EmptyServiceName(data.into()));
+        }
+        let key = &data[(key_offset + 1)..];
+        Ok(Self {
+            service_name: ServiceName::new(service_name),
+            key: ReString::new(key),
+        })
+    }
+
     /// Returns the key segment of this lock name.
     #[inline]
     pub const fn key(&self) -> &ReString {


### PR DESCRIPTION

In the very rare case where users use empty VO keys, with vqueues the decoding of the lock name would fail and cause disruption. This commit relaxes this constraint.


The long-term plan is to disallow empty service keys at ingestion time.
