### PR TITLE
[RocksDB] Export max_successive_merges to worker storage options

### DIFF
--- a/crates/partition-store/src/partition_db.rs
+++ b/crates/partition-store/src/partition_db.rs
@@ -649,7 +649,7 @@ impl CfConfigurator for RocksConfigurator<AllDataCf> {
             KeyKind::full_merge,
             KeyKind::partial_merge,
         );
-        cf_options.set_max_successive_merges(5000);
+        cf_options.set_max_successive_merges(config.rocksdb_max_successive_merges as usize);
 
         cf_options.set_disable_auto_compactions(config.rocksdb.rocksdb_disable_auto_compactions());
         if let Some(compaction_period) = config.rocksdb.rocksdb_periodic_compaction_seconds() {

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -38,6 +38,9 @@ const MIN_ROCKSDB_MEMORY: NonZeroByteCount =
 
 const X_RESTATE_CLUSTER_NAME: http::HeaderName =
     http::HeaderName::from_static("x-restate-cluster-name");
+
+const DEFAULT_MAX_SUCCESSIVE_MERGES: u16 = 5000;
+
 /// # Worker options
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, derive_builder::Builder)]
@@ -944,6 +947,19 @@ pub struct StorageOptions {
     /// Since v1.7.7
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rocksdb_max_open_files: Option<NonZeroU32>,
+
+    /// # Max Successive Merge Operations
+    ///
+    /// When a merge operation is added to the memtable and the maximum number of
+    /// successive merges is reached, the value of the key will be calculated and
+    /// inserted into the memtable instead of the merge operation. This will
+    /// ensure that there are never more than max_successive_merges merge
+    /// operations in the memtable.
+    ///
+    /// Since v1.7.8
+    #[cfg_attr(feature = "schemars", schemars(skip))]
+    #[serde(default, skip_serializing_if = "is_default_max_successive_merges")]
+    pub rocksdb_max_successive_merges: u16,
 }
 
 impl StorageOptions {
@@ -1039,8 +1055,13 @@ impl Default for StorageOptions {
             ),
             rocksdb_l0_num_compaction_trigger: NonZeroU32::new(2).unwrap(),
             rocksdb_max_open_files: None,
+            rocksdb_max_successive_merges: DEFAULT_MAX_SUCCESSIVE_MERGES,
         }
     }
+}
+
+fn is_default_max_successive_merges(i: &u16) -> bool {
+    *i == DEFAULT_MAX_SUCCESSIVE_MERGES
 }
 
 /// # Snapshot options


### PR DESCRIPTION

Tuning this can be helpful in scenarios where a single vqueue is very hot. This configuration option is hidden
until the work on an efficient partial merge strategy is complete which will allow us to disable successive merges altogether
while maintaining reasonable read efficiency.
