### PR TITLE
[RocksDB] Propagate raw iterator errors

### DIFF
--- a/crates/log-server/src/rocksdb_logstore/store.rs
+++ b/crates/log-server/src/rocksdb_logstore/store.rs
@@ -281,6 +281,7 @@ impl LogStore for RocksDbLogStore {
                         );
                         decoded_key.offset().next()
                     } else {
+                        iterator.status().map_err(RocksDbLogStoreError::from)?;
                         trace!(
                             %loglet_id,
                             "No data records for loglet {}", loglet_id

--- a/crates/metadata-server/src/raft/storage/rocksdb.rs
+++ b/crates/metadata-server/src/raft/storage/rocksdb.rs
@@ -88,7 +88,7 @@ pub struct RocksDbStorage {
 impl RocksDbStorage {
     pub async fn create() -> Result<Self, BuildError> {
         let rocksdb = build_rocksdb().await?;
-        let (first_index, last_index) = Self::find_indices(rocksdb.inner().as_raw_db());
+        let (first_index, last_index) = Self::find_indices(rocksdb.inner().as_raw_db())?;
 
         Ok(Self {
             rocksdb,
@@ -388,7 +388,7 @@ impl RocksDbStorage {
     // Utils
     // ------------------------------
 
-    fn find_indices(db: &DB) -> (u64, u64) {
+    fn find_indices(db: &DB) -> Result<(u64, u64), BuildError> {
         block_in_place(|| {
             let data_cf = db.cf_handle(DATA_CF).expect("DATA_CF exists");
             let metadata_cf = db.cf_handle(METADATA_CF).expect("METADATA_CF exists");
@@ -407,13 +407,15 @@ impl RocksDbStorage {
                 let first_index = LogEntryKey::from_slice(key_bytes).index();
 
                 iterator.seek_to_last();
+                iterator.status().map_err(RocksError::from)?;
 
                 assert!(iterator.valid(), "iterator should be valid");
                 let key_bytes = iterator.key().expect("key should be present");
                 let last_index = LogEntryKey::from_slice(key_bytes).index();
 
-                (first_index, last_index)
+                Ok((first_index, last_index))
             } else {
+                iterator.status().map_err(RocksError::from)?;
                 let snapshot_bytes = db
                     .get_pinned_cf(&metadata_cf, SNAPSHOT_KEY)
                     .expect("snapshot key should be readable");
@@ -423,10 +425,10 @@ impl RocksDbStorage {
                     let last_index = snapshot.get_metadata().get_index();
                     let first_index = snapshot.get_metadata().get_index() + 1;
 
-                    (first_index, last_index)
+                    Ok((first_index, last_index))
                 } else {
                     // the first valid raft index starts at 1, so 0 means there are no replicated raft entries
-                    (FIRST_RAFT_INDEX, 0)
+                    Ok((FIRST_RAFT_INDEX, 0))
                 }
             }
         })

--- a/crates/partition-store/src/journal_table_v2/mod.rs
+++ b/crates/partition-store/src/journal_table_v2/mod.rs
@@ -280,7 +280,8 @@ fn delete_journal<S: StorageAccess>(
     let notification_id_index = OwnedIterator::new(storage.iterator_from(TableScan::Prefix(
         notification_id_to_notification_index.clone(),
     ))?)
-    .map(|(mut key, _)| {
+    .map(|item| {
+        let (mut key, _) = item?;
         let journal_key = JournalNotificationIdToNotificationIndexKey::deserialize_from(&mut key)?;
         let (_, _, notification_id) = journal_key.split();
         Ok(notification_id)
@@ -303,7 +304,8 @@ fn delete_journal<S: StorageAccess>(
     let completion_id_index = OwnedIterator::new(
         storage.iterator_from(TableScan::Prefix(completion_id_to_command_index.clone()))?,
     )
-    .map(|(mut key, _)| {
+    .map(|item| {
+        let (mut key, _) = item?;
         let journal_key = JournalCompletionIdToCommandIndexKey::deserialize_from(&mut key)?;
         let (_, _, completion_id) = journal_key.split();
         Ok(completion_id)
@@ -456,7 +458,8 @@ fn get_notifications_index<S: StorageAccess>(
         .invocation_uuid(invocation_id.invocation_uuid());
     let iter = storage.iterator_from(TableScan::Prefix(key))?;
     OwnedIterator::new(iter)
-        .map(|(mut key, mut value)| {
+        .map(|item| {
+            let (mut key, mut value) = item?;
             let journal_key =
                 JournalNotificationIdToNotificationIndexKey::deserialize_from(&mut key)?;
             let index = NotificationEntryIndex::decode(&mut value)

--- a/crates/partition-store/src/owned_iter.rs
+++ b/crates/partition-store/src/owned_iter.rs
@@ -11,9 +11,12 @@
 use bytes::{BufMut, Bytes, BytesMut};
 use rocksdb::{DBAccess, DBRawIteratorWithThreadMode};
 
+use restate_storage_api::{Result, StorageError};
+
 pub struct OwnedIterator<'a, DB: DBAccess> {
     iter: DBRawIteratorWithThreadMode<'a, DB>,
     arena: BytesMut,
+    done: bool,
 }
 
 impl<'a, DB: DBAccess> OwnedIterator<'a, DB> {
@@ -21,25 +24,34 @@ impl<'a, DB: DBAccess> OwnedIterator<'a, DB> {
         Self {
             iter,
             arena: BytesMut::new(),
+            done: false,
         }
     }
 }
 
 impl<DB: DBAccess> Iterator for OwnedIterator<'_, DB> {
-    type Item = (Bytes, Bytes);
+    type Item = Result<(Bytes, Bytes)>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some((k, v)) = self.iter.item() {
+        if self.done {
+            None
+        } else if let Some((k, v)) = self.iter.item() {
             self.arena.reserve(k.len() + v.len());
             self.arena.put_slice(k);
             let key = self.arena.split().freeze();
             self.arena.put_slice(v);
             let value = self.arena.split().freeze();
             self.iter.next();
-            Some((key, value))
+            Some(Ok((key, value)))
         } else {
-            None
+            self.done = true;
+            self.iter
+                .status()
+                .err()
+                .map(|err| Err(StorageError::Generic(err.into())))
         }
     }
 }
+
+impl<DB: DBAccess> std::iter::FusedIterator for OwnedIterator<'_, DB> {}

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -1249,7 +1249,13 @@ pub(crate) trait StorageAccess {
         F: FnOnce(Option<(&[u8], &[u8])>) -> Result<R>,
     {
         let iterator = self.iterator_from(scan)?;
-        f(iterator.item())
+        let item = iterator.item();
+        if item.is_none() {
+            iterator
+                .status()
+                .map_err(|err| StorageError::Generic(err.into()))?;
+        }
+        f(item)
     }
 
     #[inline]

--- a/tools/restate-doctor/src/commands/log_server/metadata.rs
+++ b/tools/restate-doctor/src/commands/log_server/metadata.rs
@@ -259,6 +259,7 @@ fn find_local_tail(
         return Ok(decoded_key.offset().next());
     }
 
+    iter.status()?;
     Ok(LogletOffset::OLDEST)
 }
 


### PR DESCRIPTION
Raw RocksDB iterators report both clean exhaustion and failures as an invalid iterator, with the distinction available through status(). Check and propagate that status instead of treating failures as empty or partial results.

Make OwnedIterator fallible and fused, update journal index consumers. Apply the same status handling to first-item scans, Raft index discovery, and log-server and doctor local-tail recovery.

Closes #5248.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>