### PR TITLE
[VQueues] Prepare removal of max_successive_merges with partial merges

### DIFF
--- a/crates/partition-store/benches/vqueue_meta_merge.rs
+++ b/crates/partition-store/benches/vqueue_meta_merge.rs
@@ -134,6 +134,9 @@ fn vqueue_meta_merge_benchmark(c: &mut Criterion) {
     let existing_value = initial_vqueue_meta();
     let operands = update_operands();
     let operand_slices = operands.iter().map(Vec::as_slice).collect::<Vec<_>>();
+    let aggregated =
+        vqueue_meta_merge::partial_merge_slices(key.as_slice(), operand_slices.iter().copied())
+            .expect("vqueue metadata partial merge succeeds");
 
     let mut group = c.benchmark_group("vqueue_meta_merge");
     group.throughput(Throughput::Elements(MERGE_OPERANDS as u64));
@@ -146,6 +149,26 @@ fn vqueue_meta_merge_benchmark(c: &mut Criterion) {
                 operands,
             )
             .expect("vqueue metadata merge succeeds");
+            black_box(merged);
+        });
+    });
+    group.bench_function("partial_merge_10000_operands", |bencher| {
+        bencher.iter(|| {
+            let operands = black_box(operand_slices.as_slice()).iter().copied();
+            let merged =
+                vqueue_meta_merge::partial_merge_slices(black_box(key.as_slice()), operands)
+                    .expect("vqueue metadata partial merge succeeds");
+            black_box(merged);
+        });
+    });
+    group.bench_function("full_merge_1_aggregated_operand", |bencher| {
+        bencher.iter(|| {
+            let merged = vqueue_meta_merge::full_merge_slices(
+                black_box(key.as_slice()),
+                Some(black_box(existing_value.as_slice())),
+                [black_box(aggregated.as_slice())],
+            )
+            .expect("aggregated vqueue metadata merge succeeds");
             black_box(merged);
         });
     });

--- a/crates/partition-store/src/keys.rs
+++ b/crates/partition-store/src/keys.rs
@@ -238,8 +238,24 @@ impl KeyKind {
         _unused: Option<&[u8]>,
         _operands: &MergeOperands,
     ) -> Option<Vec<u8>> {
-        // Currently, we have no partial merge operator for any key. Change this
-        // if/when this is needed.
+        // TODO: Enable once the minimum forward-compatible version is v1.7.8, when all supported
+        // versions can decode the persisted VQueueMeta update-batch operand.
+        // let mut kind_buf = _key;
+        // let kind = match KeyKind::deserialize(&mut kind_buf) {
+        //     Ok(kind) => kind,
+        //     Err(e) => {
+        //         error!("Cannot apply partial merge operator; {e}");
+        //         return None;
+        //     }
+        // };
+        // trace!(?kind, "partial merge");
+        //
+        // match kind {
+        //     KeyKind::VQueueMeta => {
+        //         vqueue_meta_merge::partial_merge(_key, _unused, _operands)
+        //     }
+        //     _ => None,
+        // }
         None
     }
 }

--- a/crates/partition-store/src/vqueue_table/metadata.rs
+++ b/crates/partition-store/src/vqueue_table/metadata.rs
@@ -80,16 +80,28 @@ impl From<ActiveKey> for MetaKey {
 
 // Rocksdb merge operator for the vqueue keys
 pub mod vqueue_meta_merge {
-    use bilrost::{Message, OwnedMessage};
+    use bilrost::{DistinguishedOwnedMessage, Message, OwnedMessage};
     use rocksdb::MergeOperands;
     use tracing::error;
 
-    use restate_storage_api::vqueue_table;
-    use restate_storage_api::vqueue_table::metadata::VQueueMeta;
+    use restate_memory::ByteCount;
+    use restate_storage_api::vqueue_table::metadata::{Update, UpdateBatch, VQueueMeta};
 
     use crate::keys::DecodeTableKey;
 
     use super::MetaKey;
+
+    // A zero byte cannot start a non-empty Bilrost message because top-level field tags start at 1.
+    const UPDATE_BATCH_MAGIC: &[u8] = b"\0VQM";
+    const UPDATE_BATCH_PREFIX: &[u8] = b"\0VQM\x01";
+    const MAX_UPDATE_BATCH_BYTES: usize = 4 * 1024 * 1024;
+
+    #[derive(Debug)]
+    enum BatchDecodeError {
+        UnsupportedVersion(Option<u8>),
+        TooLarge(usize),
+        Decode(bilrost::DecodeError),
+    }
 
     pub fn full_merge(
         key: &[u8],
@@ -125,21 +137,405 @@ pub mod vqueue_meta_merge {
             }
         };
 
-        let mut update = <vqueue_table::metadata::Update as bilrost::encoding::RawMessage>::empty();
+        let mut update = <Update as bilrost::encoding::RawMessage>::empty();
         for op in operands {
-            if let Err(err) = update.replace_from_slice(op) {
-                let key = MetaKey::deserialize_from(&mut key);
-                error!(
-                    ?err,
-                    ?key,
-                    "[full merge] Failed to decode vqueue meta update ({} bytes)",
-                    op.len(),
-                );
-                return None;
+            match decode_batch(op) {
+                Ok(Some(batch)) => {
+                    if !batch.try_apply(&mut vqueue_meta) {
+                        let key = MetaKey::deserialize_from(&mut key);
+                        error!(
+                            ?key,
+                            "[full merge] Vqueue meta update batch overflowed a stage counter"
+                        );
+                        return None;
+                    }
+                }
+                Ok(None) => {
+                    if let Err(err) = update.replace_from_slice(op) {
+                        let key = MetaKey::deserialize_from(&mut key);
+                        error!(
+                            ?err,
+                            ?key,
+                            "[full merge] Failed to decode vqueue meta update ({} bytes)",
+                            op.len(),
+                        );
+                        return None;
+                    }
+                    vqueue_meta.apply_update(&update);
+                }
+                Err(err) => {
+                    let key = MetaKey::deserialize_from(&mut key);
+                    match err {
+                        BatchDecodeError::UnsupportedVersion(version) => error!(
+                            ?version,
+                            ?key,
+                            "[full merge] Unsupported vqueue meta update batch version"
+                        ),
+                        BatchDecodeError::TooLarge(size) => error!(
+                            ?key,
+                            size = %ByteCount::from(size),
+                            limit = %ByteCount::from(MAX_UPDATE_BATCH_BYTES),
+                            "[full merge] Vqueue meta update batch exceeds the size limit"
+                        ),
+                        BatchDecodeError::Decode(err) => error!(
+                            ?err,
+                            ?key,
+                            "[full merge] Failed to decode vqueue meta update batch ({} bytes)",
+                            op.len(),
+                        ),
+                    }
+                    return None;
+                }
             }
-            vqueue_meta.apply_update(&update);
         }
 
         Some(vqueue_meta.encode_contiguous().into_vec())
+    }
+
+    pub fn partial_merge(
+        key: &[u8],
+        _unused: Option<&[u8]>,
+        operands: &MergeOperands,
+    ) -> Option<Vec<u8>> {
+        partial_merge_slices(key, operands)
+    }
+
+    pub fn partial_merge_slices<'a>(
+        mut key: &[u8],
+        operands: impl IntoIterator<Item = &'a [u8]>,
+    ) -> Option<Vec<u8>> {
+        let mut merged = UpdateBatch::default();
+        let mut update = <Update as bilrost::encoding::RawMessage>::empty();
+        let mut input_bytes = 0_usize;
+
+        for op in operands {
+            input_bytes = input_bytes.checked_add(op.len())?;
+            if input_bytes > MAX_UPDATE_BATCH_BYTES {
+                return None;
+            }
+
+            match decode_batch(op) {
+                Ok(Some(batch)) => {
+                    if !merged.try_append(batch) {
+                        let key = MetaKey::deserialize_from(&mut key);
+                        error!(
+                            ?key,
+                            "[partial merge] Vqueue meta update batch overflowed a stage counter"
+                        );
+                        return None;
+                    }
+                }
+                Ok(None) => {
+                    if let Err(err) = update.replace_from_slice(op) {
+                        let key = MetaKey::deserialize_from(&mut key);
+                        error!(
+                            ?err,
+                            ?key,
+                            "[partial merge] Failed to decode vqueue meta update ({} bytes)",
+                            op.len(),
+                        );
+                        return None;
+                    }
+                    if !merged.try_push(&update) {
+                        let key = MetaKey::deserialize_from(&mut key);
+                        error!(
+                            ?key,
+                            "[partial merge] Vqueue meta update batch overflowed a stage counter"
+                        );
+                        return None;
+                    }
+                }
+                Err(err) => {
+                    let key = MetaKey::deserialize_from(&mut key);
+                    match err {
+                        BatchDecodeError::UnsupportedVersion(version) => error!(
+                            ?version,
+                            ?key,
+                            "[partial merge] Unsupported vqueue meta update batch version"
+                        ),
+                        BatchDecodeError::TooLarge(size) => error!(
+                            ?key,
+                            size = %ByteCount::from(size),
+                            limit = %ByteCount::from(MAX_UPDATE_BATCH_BYTES),
+                            "[partial merge] Vqueue meta update batch exceeds the size limit"
+                        ),
+                        BatchDecodeError::Decode(err) => error!(
+                            ?err,
+                            ?key,
+                            "[partial merge] Failed to decode vqueue meta update batch ({} bytes)",
+                            op.len(),
+                        ),
+                    }
+                    return None;
+                }
+            }
+        }
+
+        if merged.encoded_len() + UPDATE_BATCH_PREFIX.len() > MAX_UPDATE_BATCH_BYTES {
+            return None;
+        }
+        let encoded = merged.encode_contiguous().into_vec();
+        let mut operand = Vec::with_capacity(UPDATE_BATCH_PREFIX.len() + encoded.len());
+        operand.extend_from_slice(UPDATE_BATCH_PREFIX);
+        operand.extend_from_slice(&encoded);
+        Some(operand)
+    }
+
+    fn decode_batch(operand: &[u8]) -> Result<Option<UpdateBatch>, BatchDecodeError> {
+        if let Some(payload) = operand.strip_prefix(UPDATE_BATCH_PREFIX) {
+            if operand.len() > MAX_UPDATE_BATCH_BYTES {
+                return Err(BatchDecodeError::TooLarge(operand.len()));
+            }
+            return UpdateBatch::decode_canonical(payload)
+                .map(Some)
+                .map_err(BatchDecodeError::Decode);
+        }
+        if let Some(versioned) = operand.strip_prefix(UPDATE_BATCH_MAGIC) {
+            return Err(BatchDecodeError::UnsupportedVersion(
+                versioned.first().copied(),
+            ));
+        }
+        Ok(None)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use bilrost::Message;
+
+        use restate_clock::UniqueTimestamp;
+        use restate_clock::time::MillisSinceEpoch;
+        use restate_limiter::LimitKey;
+        use restate_storage_api::vqueue_table::Stage;
+        use restate_storage_api::vqueue_table::metadata::{
+            Action, MoveMetrics, Update, VQueueLink, VQueueMeta,
+        };
+        use restate_storage_api::vqueue_table::stats::WaitStats;
+        use restate_types::vqueues::VQueueId;
+
+        use crate::keys::KeyKind;
+
+        use super::*;
+
+        const BASE_TS_MS: u64 = 1_744_000_000_000;
+
+        fn ts(offset_ms: u64) -> UniqueTimestamp {
+            UniqueTimestamp::from_unix_millis_unchecked(MillisSinceEpoch::new(
+                BASE_TS_MS + offset_ms,
+            ))
+        }
+
+        fn metrics(
+            last_transition_ms: u64,
+            first_runnable_ms: u64,
+            has_started: bool,
+            wait_stats: Option<WaitStats>,
+        ) -> MoveMetrics {
+            MoveMetrics {
+                last_transition_at: ts(last_transition_ms),
+                has_started,
+                first_runnable_at: ts(first_runnable_ms).to_unix_millis(),
+                scheduler_wait_stats: wait_stats,
+            }
+        }
+
+        fn raw_operands() -> Vec<Vec<u8>> {
+            [
+                Update::new(
+                    ts(1),
+                    Action::Move {
+                        prev_stage: None,
+                        next_stage: Stage::Inbox,
+                        metrics: metrics(1, 1, false, None),
+                    },
+                ),
+                Update::new(
+                    ts(2),
+                    Action::Move {
+                        prev_stage: Some(Stage::Inbox),
+                        next_stage: Stage::Running,
+                        metrics: metrics(
+                            1,
+                            1,
+                            false,
+                            Some(WaitStats {
+                                blocked_on_concurrency_rules_ms: 100,
+                                ..WaitStats::default()
+                            }),
+                        ),
+                    },
+                ),
+                Update::new(
+                    ts(3),
+                    Action::Move {
+                        prev_stage: Some(Stage::Running),
+                        next_stage: Stage::Suspended,
+                        metrics: metrics(2, 1, true, None),
+                    },
+                ),
+                Update::new(
+                    ts(4),
+                    Action::Move {
+                        prev_stage: Some(Stage::Suspended),
+                        next_stage: Stage::Inbox,
+                        metrics: metrics(3, 1, true, None),
+                    },
+                ),
+                Update::new(
+                    ts(5),
+                    Action::Move {
+                        prev_stage: Some(Stage::Inbox),
+                        next_stage: Stage::Running,
+                        metrics: metrics(
+                            4,
+                            1,
+                            true,
+                            Some(WaitStats {
+                                blocked_on_invoker_throttling_ms: 200,
+                                ..WaitStats::default()
+                            }),
+                        ),
+                    },
+                ),
+                Update::new(
+                    ts(6),
+                    Action::Move {
+                        prev_stage: Some(Stage::Running),
+                        next_stage: Stage::Finished,
+                        metrics: metrics(5, 1, true, None),
+                    },
+                ),
+                Update::new(
+                    ts(7),
+                    Action::RemoveEntry {
+                        stage: Stage::Finished,
+                    },
+                ),
+                Update::new(ts(8), Action::PauseVQueue {}),
+                Update::new(ts(9), Action::ResumeVQueue {}),
+            ]
+            .into_iter()
+            .map(|update| update.encode_contiguous().into_vec())
+            .collect()
+        }
+
+        #[test]
+        fn partial_merge_matches_raw_updates_and_composes_batches() {
+            let key = MetaKey::from(&VQueueId::custom(1, "partial-merge-test")).to_bytes();
+            let existing = VQueueMeta::new(ts(0), None, LimitKey::None, VQueueLink::None)
+                .encode_contiguous()
+                .into_vec();
+            let operands = raw_operands();
+            let operand_slices = operands.iter().map(Vec::as_slice).collect::<Vec<_>>();
+            let expected = full_merge_slices(&key, Some(&existing), operand_slices.iter().copied())
+                .expect("raw updates should merge");
+
+            let first = partial_merge_slices(&key, operand_slices[..4].iter().copied())
+                .expect("first update group should partially merge");
+            let second = partial_merge_slices(&key, operand_slices[4..].iter().copied())
+                .expect("second update group should partially merge");
+            assert!(first.starts_with(UPDATE_BATCH_PREFIX));
+            assert!(second.starts_with(UPDATE_BATCH_PREFIX));
+
+            let combined = partial_merge_slices(&key, [first.as_slice(), second.as_slice()])
+                .expect("update batches should compose");
+            let actual = full_merge_slices(&key, Some(&existing), [combined.as_slice()])
+                .expect("composed update batch should fully merge");
+            assert_eq!(actual, expected);
+
+            let mixed = partial_merge_slices(
+                &key,
+                std::iter::once(first.as_slice()).chain(operand_slices[4..].iter().copied()),
+            )
+            .expect("legacy updates and an update batch should partially merge");
+            let actual = full_merge_slices(&key, Some(&existing), [mixed.as_slice()])
+                .expect("mixed update batch should fully merge");
+            assert_eq!(actual, expected);
+        }
+
+        #[test]
+        fn unknown_update_batch_version_is_rejected() {
+            let key = MetaKey::from(&VQueueId::custom(1, "partial-merge-version-test")).to_bytes();
+            let operand = b"\0VQM\x02";
+
+            assert!(partial_merge_slices(&key, [operand.as_slice()]).is_none());
+            let existing = VQueueMeta::new(ts(0), None, LimitKey::None, VQueueLink::None)
+                .encode_contiguous()
+                .into_vec();
+            assert!(full_merge_slices(&key, Some(&existing), [operand.as_slice()]).is_none());
+        }
+
+        #[test]
+        fn update_batch_with_unknown_fields_is_rejected() {
+            let key = MetaKey::from(&VQueueId::custom(1, "partial-merge-fields-test")).to_bytes();
+            // Canonical Bilrost encoding for unknown varint field 17 with value 1.
+            let operand = b"\0VQM\x01\x44\x01";
+
+            assert!(partial_merge_slices(&key, [operand.as_slice()]).is_none());
+            let existing = VQueueMeta::new(ts(0), None, LimitKey::None, VQueueLink::None)
+                .encode_contiguous()
+                .into_vec();
+            assert!(full_merge_slices(&key, Some(&existing), [operand.as_slice()]).is_none());
+        }
+
+        #[test]
+        fn oversized_update_batch_is_rejected_before_decoding() {
+            let key = MetaKey::from(&VQueueId::custom(1, "partial-merge-size-test")).to_bytes();
+            let mut operand = vec![0; MAX_UPDATE_BATCH_BYTES + 1];
+            operand[..UPDATE_BATCH_PREFIX.len()].copy_from_slice(UPDATE_BATCH_PREFIX);
+
+            assert!(partial_merge_slices(&key, [operand.as_slice()]).is_none());
+            let existing = VQueueMeta::new(ts(0), None, LimitKey::None, VQueueLink::None)
+                .encode_contiguous()
+                .into_vec();
+            assert!(full_merge_slices(&key, Some(&existing), [operand.as_slice()]).is_none());
+        }
+
+        #[test]
+        fn rocksdb_flush_and_compaction_preserve_partially_merged_updates() {
+            let directory = tempfile::tempdir().expect("temporary directory should be created");
+            let mut options = rocksdb::Options::default();
+            options.create_if_missing(true);
+            options.set_merge_operator(
+                "VQueueMetaPartialMergeTest",
+                KeyKind::full_merge,
+                partial_merge,
+            );
+
+            let key = MetaKey::from(&VQueueId::custom(1, "rocksdb-partial-merge-test")).to_bytes();
+            let existing = VQueueMeta::new(ts(0), None, LimitKey::None, VQueueLink::None)
+                .encode_contiguous()
+                .into_vec();
+            let operands = raw_operands();
+            let expected =
+                full_merge_slices(&key, Some(&existing), operands.iter().map(Vec::as_slice))
+                    .expect("raw updates should merge");
+
+            {
+                let db = rocksdb::DB::open(&options, directory.path())
+                    .expect("rocksdb should be opened");
+                db.put(key, &existing)
+                    .expect("base value should be written");
+                db.flush().expect("base value should be flushed");
+                for operand in &operands {
+                    db.merge(key, operand)
+                        .expect("merge operand should be written");
+                }
+                db.flush().expect("merge operands should be flushed");
+            }
+
+            let db =
+                rocksdb::DB::open(&options, directory.path()).expect("rocksdb should be reopened");
+            assert_eq!(
+                db.get(key).expect("merged value should be read").as_deref(),
+                Some(expected.as_slice())
+            );
+            db.compact_range::<&[u8], &[u8]>(None, None);
+            assert_eq!(
+                db.get(key)
+                    .expect("compacted merged value should be read")
+                    .as_deref(),
+                Some(expected.as_slice())
+            );
+        }
     }
 }

--- a/crates/storage-api/src/vqueue_table/metadata.rs
+++ b/crates/storage-api/src/vqueue_table/metadata.rs
@@ -138,16 +138,6 @@ impl VQueueStatistics {
         }
     }
 
-    fn record_stage_exit(&mut self, stage: Stage, stage_dwell_ms: u64) {
-        match stage {
-            Stage::Unknown | Stage::Finished => {}
-            Stage::Inbox => self.update_avg_inbox_duration(stage_dwell_ms),
-            Stage::Running => self.update_avg_run_duration(stage_dwell_ms),
-            Stage::Suspended => self.update_avg_suspension_duration(stage_dwell_ms),
-            Stage::Paused => { /* tracking avg paused time is pointless */ }
-        }
-    }
-
     pub const fn created_at(&self) -> UniqueTimestamp {
         self.created_at
     }
@@ -383,6 +373,17 @@ impl VQueueMeta {
         }
     }
 
+    fn increment_stage(&mut self, stage: Stage) {
+        match stage {
+            Stage::Inbox => self.stats.num_inbox += 1,
+            Stage::Suspended => self.stats.num_suspended += 1,
+            Stage::Paused => self.stats.num_paused += 1,
+            Stage::Running => self.stats.num_running += 1,
+            Stage::Finished => self.stats.num_finished += 1,
+            Stage::Unknown => unreachable!(),
+        }
+    }
+
     /// A vqueue is considered active when it's of interest to the scheduler.
     ///
     /// The scheduler cares about vqueues that have entries that are already running or that are waiting
@@ -419,75 +420,342 @@ impl VQueueMeta {
     }
 
     pub fn apply_update(&mut self, update: &Update) {
-        let now = update.ts;
-        let now_ms = now.to_unix_millis();
-        // Note to future authors: This match needs to continue to work even when
-        // processing old/deprecated/removed actions. Therefore, removed actions should
-        // not be removed from the enum to avoid falling into the Unknown case.
-        match update.action {
-            Action::Unknown => {
-                panic!("Unrecognized vqueue action: {update:?}")
+        visit_update(update, |effect| match effect {
+            UpdateEffect::QueuePaused(paused) => self.queue_is_paused = paused,
+            UpdateEffect::DecrementStage(stage) => self.decrement_stage(stage),
+            UpdateEffect::IncrementStage(stage) => self.increment_stage(stage),
+            UpdateEffect::LastEnqueuedAt(ts) => self.stats.last_enqueued_at = Some(ts),
+            UpdateEffect::LastStartAt(ts) => self.stats.last_start_at = Some(ts),
+            UpdateEffect::LastAttemptAt(ts) => self.stats.last_attempt_at = Some(ts),
+            UpdateEffect::LastFinishAt(ts) => self.stats.last_finish_at = Some(ts),
+            UpdateEffect::QueueDuration(sample) => self.stats.update_avg_queue_duration(sample),
+            UpdateEffect::InboxDuration(sample) => self.stats.update_avg_inbox_duration(sample),
+            UpdateEffect::RunDuration(sample) => self.stats.update_avg_run_duration(sample),
+            UpdateEffect::SuspensionDuration(sample) => {
+                self.stats.update_avg_suspension_duration(sample)
             }
-            Action::PauseVQueue {} => {
-                self.queue_is_paused = true;
+            UpdateEffect::EndToEndDuration(sample) => {
+                self.stats.update_avg_end_to_end_duration(sample)
             }
-            Action::ResumeVQueue {} => {
-                self.queue_is_paused = false;
-            }
-            Action::RemoveEntry { stage } => {
-                self.decrement_stage(stage);
-            }
-            Action::Move {
-                prev_stage,
-                next_stage,
-                ref metrics,
-            } => {
-                if let Some(previous_stage) = prev_stage {
-                    let stage_dwell_ms = now.saturating_sub_ms(metrics.last_transition_at);
-                    self.stats.record_stage_exit(previous_stage, stage_dwell_ms);
-                    self.decrement_stage(previous_stage);
+            UpdateEffect::WaitStats(sample) => self.stats.avg_wait_stats.ema_apply(sample),
+        });
+    }
+}
+
+#[derive(Clone, Copy)]
+enum UpdateEffect {
+    QueuePaused(bool),
+    DecrementStage(Stage),
+    IncrementStage(Stage),
+    LastEnqueuedAt(UniqueTimestamp),
+    LastStartAt(UniqueTimestamp),
+    LastAttemptAt(UniqueTimestamp),
+    LastFinishAt(UniqueTimestamp),
+    QueueDuration(u64),
+    InboxDuration(u64),
+    RunDuration(u64),
+    SuspensionDuration(u64),
+    EndToEndDuration(u64),
+    WaitStats(WaitStats),
+}
+
+fn visit_update(update: &Update, mut visitor: impl FnMut(UpdateEffect)) {
+    let now = update.ts;
+    let now_ms = now.to_unix_millis();
+
+    // Note to future authors: This match needs to continue to work even when
+    // processing old/deprecated/removed actions. Therefore, removed actions should
+    // not be removed from the enum to avoid falling into the Unknown case.
+    match update.action {
+        Action::Unknown => panic!("Unrecognized vqueue action: {update:?}"),
+        Action::PauseVQueue {} => visitor(UpdateEffect::QueuePaused(true)),
+        Action::ResumeVQueue {} => visitor(UpdateEffect::QueuePaused(false)),
+        Action::RemoveEntry { stage } => visitor(UpdateEffect::DecrementStage(stage)),
+        Action::Move {
+            prev_stage,
+            next_stage,
+            ref metrics,
+        } => {
+            if let Some(previous_stage) = prev_stage {
+                let stage_dwell_ms = now.saturating_sub_ms(metrics.last_transition_at);
+                match previous_stage {
+                    Stage::Inbox => visitor(UpdateEffect::InboxDuration(stage_dwell_ms)),
+                    Stage::Running => visitor(UpdateEffect::RunDuration(stage_dwell_ms)),
+                    Stage::Suspended => visitor(UpdateEffect::SuspensionDuration(stage_dwell_ms)),
+                    Stage::Unknown | Stage::Paused | Stage::Finished => {}
                 }
+                visitor(UpdateEffect::DecrementStage(previous_stage));
+            }
 
-                match next_stage {
-                    Stage::Unknown => unreachable!(),
-                    Stage::Inbox => {
-                        self.stats.num_inbox += 1;
-                        if prev_stage.is_none() {
-                            self.stats.last_enqueued_at = Some(now);
-                        }
-                    }
-                    Stage::Running => {
-                        self.stats.num_running += 1;
-                        self.stats.last_attempt_at = Some(now);
-                        if let Some(wait_stats) = metrics.scheduler_wait_stats {
-                            self.stats.avg_wait_stats.ema_apply(wait_stats);
-                        }
+            if matches!(next_stage, Stage::Unknown) {
+                unreachable!();
+            }
+            visitor(UpdateEffect::IncrementStage(next_stage));
 
-                        if !metrics.has_started {
-                            let first_wait_ms = now_ms.saturating_sub_ms(metrics.first_runnable_at);
-                            self.stats.update_avg_queue_duration(first_wait_ms);
+            match next_stage {
+                Stage::Unknown => unreachable!(),
+                Stage::Inbox if prev_stage.is_none() => {
+                    visitor(UpdateEffect::LastEnqueuedAt(now));
+                }
+                Stage::Running => {
+                    visitor(UpdateEffect::LastAttemptAt(now));
+                    if let Some(wait_stats) = metrics.scheduler_wait_stats {
+                        visitor(UpdateEffect::WaitStats(wait_stats));
+                    }
 
-                            self.stats.last_start_at = Some(now);
-                        }
-                    }
-                    Stage::Paused => {
-                        self.stats.num_paused += 1;
-                    }
-                    Stage::Suspended => {
-                        self.stats.num_suspended += 1;
-                    }
-                    Stage::Finished => {
-                        self.stats.num_finished += 1;
-                        self.stats.last_finish_at = Some(now);
-                        if matches!(prev_stage, Some(Stage::Running)) {
-                            // Only track entries finishing normally.
-                            let end_to_end_ms = now_ms.saturating_sub_ms(metrics.first_runnable_at);
-                            self.stats.update_avg_end_to_end_duration(end_to_end_ms);
-                        }
+                    if !metrics.has_started {
+                        visitor(UpdateEffect::QueueDuration(
+                            now_ms.saturating_sub_ms(metrics.first_runnable_at),
+                        ));
+                        visitor(UpdateEffect::LastStartAt(now));
                     }
                 }
+                Stage::Finished => {
+                    visitor(UpdateEffect::LastFinishAt(now));
+                    if matches!(prev_stage, Some(Stage::Running)) {
+                        visitor(UpdateEffect::EndToEndDuration(
+                            now_ms.saturating_sub_ms(metrics.first_runnable_at),
+                        ));
+                    }
+                }
+                Stage::Inbox | Stage::Paused | Stage::Suspended => {}
             }
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, bilrost::Message)]
+#[bilrost(distinguished)]
+struct CounterUpdate {
+    #[bilrost(tag(1))]
+    subtract: u64,
+    #[bilrost(tag(2))]
+    add: u64,
+}
+
+impl CounterUpdate {
+    fn try_decrement(&mut self) -> bool {
+        if self.add > 0 {
+            self.add -= 1;
+            true
+        } else if let Some(subtract) = self.subtract.checked_add(1) {
+            self.subtract = subtract;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn try_increment(&mut self) -> bool {
+        if let Some(add) = self.add.checked_add(1) {
+            self.add = add;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn try_compose(self, next: Self) -> Option<Self> {
+        let cancelled = self.add.min(next.subtract);
+        Some(Self {
+            subtract: self.subtract.checked_add(next.subtract - cancelled)?,
+            add: next.add.checked_add(self.add - cancelled)?,
+        })
+    }
+
+    fn try_apply(self, value: u64) -> Option<u64> {
+        value.saturating_sub(self.subtract).checked_add(self.add)
+    }
+}
+
+/// A compact, composable sequence of [`Update`]s used as a RocksDB merge operand.
+#[derive(Debug, Clone, Default, PartialEq, Eq, bilrost::Message)]
+#[bilrost(distinguished)]
+pub struct UpdateBatch {
+    #[bilrost(tag(1))]
+    queue_is_paused: Option<bool>,
+    #[bilrost(tag(2))]
+    inbox_count: CounterUpdate,
+    #[bilrost(tag(3))]
+    suspended_count: CounterUpdate,
+    #[bilrost(tag(4))]
+    paused_count: CounterUpdate,
+    #[bilrost(tag(5))]
+    running_count: CounterUpdate,
+    #[bilrost(tag(6))]
+    finished_count: CounterUpdate,
+    #[bilrost(tag(7), encoding(fixed))]
+    last_enqueued_at: Option<UniqueTimestamp>,
+    #[bilrost(tag(8), encoding(fixed))]
+    last_start_at: Option<UniqueTimestamp>,
+    #[bilrost(tag(9), encoding(fixed))]
+    last_attempt_at: Option<UniqueTimestamp>,
+    #[bilrost(tag(10), encoding(fixed))]
+    last_finish_at: Option<UniqueTimestamp>,
+    #[bilrost(tag(11))]
+    queue_duration_samples: Vec<u64>,
+    #[bilrost(tag(12))]
+    inbox_duration_samples: Vec<u64>,
+    #[bilrost(tag(13))]
+    run_duration_samples: Vec<u64>,
+    #[bilrost(tag(14))]
+    suspension_duration_samples: Vec<u64>,
+    #[bilrost(tag(15))]
+    end_to_end_duration_samples: Vec<u64>,
+    #[bilrost(tag(16))]
+    wait_stats_samples: Vec<WaitStats>,
+}
+
+impl UpdateBatch {
+    /// Appends an update, returning false if its counter effect cannot be represented.
+    pub fn try_push(&mut self, update: &Update) -> bool {
+        let mut success = true;
+        visit_update(update, |effect| {
+            if success {
+                success = self.try_apply_effect(effect);
+            }
+        });
+        success
+    }
+
+    /// Appends another batch, returning false if the composed counters overflow.
+    pub fn try_append(&mut self, mut next: Self) -> bool {
+        let Some(inbox_count) = self.inbox_count.try_compose(next.inbox_count) else {
+            return false;
+        };
+        let Some(suspended_count) = self.suspended_count.try_compose(next.suspended_count) else {
+            return false;
+        };
+        let Some(paused_count) = self.paused_count.try_compose(next.paused_count) else {
+            return false;
+        };
+        let Some(running_count) = self.running_count.try_compose(next.running_count) else {
+            return false;
+        };
+        let Some(finished_count) = self.finished_count.try_compose(next.finished_count) else {
+            return false;
+        };
+
+        self.inbox_count = inbox_count;
+        self.suspended_count = suspended_count;
+        self.paused_count = paused_count;
+        self.running_count = running_count;
+        self.finished_count = finished_count;
+        self.queue_is_paused = next.queue_is_paused.or(self.queue_is_paused);
+        self.last_enqueued_at = next.last_enqueued_at.or(self.last_enqueued_at);
+        self.last_start_at = next.last_start_at.or(self.last_start_at);
+        self.last_attempt_at = next.last_attempt_at.or(self.last_attempt_at);
+        self.last_finish_at = next.last_finish_at.or(self.last_finish_at);
+        self.queue_duration_samples
+            .append(&mut next.queue_duration_samples);
+        self.inbox_duration_samples
+            .append(&mut next.inbox_duration_samples);
+        self.run_duration_samples
+            .append(&mut next.run_duration_samples);
+        self.suspension_duration_samples
+            .append(&mut next.suspension_duration_samples);
+        self.end_to_end_duration_samples
+            .append(&mut next.end_to_end_duration_samples);
+        self.wait_stats_samples.append(&mut next.wait_stats_samples);
+        true
+    }
+
+    /// Applies this batch to vqueue metadata.
+    pub fn try_apply(&self, meta: &mut VQueueMeta) -> bool {
+        let Some(num_inbox) = self.inbox_count.try_apply(meta.stats.num_inbox) else {
+            return false;
+        };
+        let Some(num_suspended) = self.suspended_count.try_apply(meta.stats.num_suspended) else {
+            return false;
+        };
+        let Some(num_paused) = self.paused_count.try_apply(meta.stats.num_paused) else {
+            return false;
+        };
+        let Some(num_running) = self.running_count.try_apply(meta.stats.num_running) else {
+            return false;
+        };
+        let Some(num_finished) = self.finished_count.try_apply(meta.stats.num_finished) else {
+            return false;
+        };
+
+        meta.stats.num_inbox = num_inbox;
+        meta.stats.num_suspended = num_suspended;
+        meta.stats.num_paused = num_paused;
+        meta.stats.num_running = num_running;
+        meta.stats.num_finished = num_finished;
+        if let Some(queue_is_paused) = self.queue_is_paused {
+            meta.queue_is_paused = queue_is_paused;
+        }
+        if let Some(last_enqueued_at) = self.last_enqueued_at {
+            meta.stats.last_enqueued_at = Some(last_enqueued_at);
+        }
+        if let Some(last_start_at) = self.last_start_at {
+            meta.stats.last_start_at = Some(last_start_at);
+        }
+        if let Some(last_attempt_at) = self.last_attempt_at {
+            meta.stats.last_attempt_at = Some(last_attempt_at);
+        }
+        if let Some(last_finish_at) = self.last_finish_at {
+            meta.stats.last_finish_at = Some(last_finish_at);
+        }
+        for &sample in &self.queue_duration_samples {
+            meta.stats.update_avg_queue_duration(sample);
+        }
+        for &sample in &self.inbox_duration_samples {
+            meta.stats.update_avg_inbox_duration(sample);
+        }
+        for &sample in &self.run_duration_samples {
+            meta.stats.update_avg_run_duration(sample);
+        }
+        for &sample in &self.suspension_duration_samples {
+            meta.stats.update_avg_suspension_duration(sample);
+        }
+        for &sample in &self.end_to_end_duration_samples {
+            meta.stats.update_avg_end_to_end_duration(sample);
+        }
+        for &sample in &self.wait_stats_samples {
+            meta.stats.avg_wait_stats.ema_apply(sample);
+        }
+        true
+    }
+
+    fn try_apply_effect(&mut self, effect: UpdateEffect) -> bool {
+        match effect {
+            UpdateEffect::QueuePaused(paused) => self.queue_is_paused = Some(paused),
+            UpdateEffect::DecrementStage(stage) => {
+                return match stage {
+                    Stage::Inbox => self.inbox_count.try_decrement(),
+                    Stage::Running => self.running_count.try_decrement(),
+                    Stage::Suspended => self.suspended_count.try_decrement(),
+                    Stage::Paused => self.paused_count.try_decrement(),
+                    Stage::Finished => self.finished_count.try_decrement(),
+                    Stage::Unknown => true,
+                };
+            }
+            UpdateEffect::IncrementStage(stage) => {
+                return match stage {
+                    Stage::Inbox => self.inbox_count.try_increment(),
+                    Stage::Running => self.running_count.try_increment(),
+                    Stage::Suspended => self.suspended_count.try_increment(),
+                    Stage::Paused => self.paused_count.try_increment(),
+                    Stage::Finished => self.finished_count.try_increment(),
+                    Stage::Unknown => unreachable!(),
+                };
+            }
+            UpdateEffect::LastEnqueuedAt(ts) => self.last_enqueued_at = Some(ts),
+            UpdateEffect::LastStartAt(ts) => self.last_start_at = Some(ts),
+            UpdateEffect::LastAttemptAt(ts) => self.last_attempt_at = Some(ts),
+            UpdateEffect::LastFinishAt(ts) => self.last_finish_at = Some(ts),
+            UpdateEffect::QueueDuration(sample) => self.queue_duration_samples.push(sample),
+            UpdateEffect::InboxDuration(sample) => self.inbox_duration_samples.push(sample),
+            UpdateEffect::RunDuration(sample) => self.run_duration_samples.push(sample),
+            UpdateEffect::SuspensionDuration(sample) => {
+                self.suspension_duration_samples.push(sample)
+            }
+            UpdateEffect::EndToEndDuration(sample) => self.end_to_end_duration_samples.push(sample),
+            UpdateEffect::WaitStats(sample) => self.wait_stats_samples.push(sample),
+        }
+        true
     }
 }
 
@@ -552,6 +820,8 @@ impl Update {
 
 #[cfg(test)]
 mod tests {
+    use bilrost::Message;
+
     use restate_util_string::RestateString;
 
     use super::*;
@@ -590,6 +860,185 @@ mod tests {
             }),
             ..metrics(last_transition_at_ms, first_runnable_at_ms, has_started)
         }
+    }
+
+    #[test]
+    fn counter_update_preserves_saturating_operation_order() {
+        for operations in 0_u16..=u8::MAX.into() {
+            let mut update = CounterUpdate::default();
+            for index in 0..8 {
+                let success = if operations & (1 << index) == 0 {
+                    update.try_decrement()
+                } else {
+                    update.try_increment()
+                };
+                assert!(success);
+            }
+
+            for initial in 0_u64..=8 {
+                let mut expected = initial;
+                for index in 0..8 {
+                    if operations & (1 << index) == 0 {
+                        expected = expected.saturating_sub(1);
+                    } else {
+                        expected += 1;
+                    }
+                }
+                assert_eq!(update.try_apply(initial), Some(expected));
+            }
+
+            for split in 0..=8 {
+                let mut first = CounterUpdate::default();
+                let mut second = CounterUpdate::default();
+                for index in 0..8 {
+                    let update = if index < split {
+                        &mut first
+                    } else {
+                        &mut second
+                    };
+                    let success = if operations & (1 << index) == 0 {
+                        update.try_decrement()
+                    } else {
+                        update.try_increment()
+                    };
+                    assert!(success);
+                }
+                let composed = first
+                    .try_compose(second)
+                    .expect("short counter updates should compose");
+                for initial in 0_u64..=8 {
+                    assert_eq!(composed.try_apply(initial), update.try_apply(initial));
+                }
+            }
+        }
+
+        let mut same_stage_move = CounterUpdate::default();
+        assert!(same_stage_move.try_decrement());
+        assert!(same_stage_move.try_increment());
+        assert_eq!(same_stage_move.try_apply(0), Some(1));
+        assert_eq!(same_stage_move.try_apply(1), Some(1));
+    }
+
+    #[test]
+    fn update_batch_matches_sequential_updates_and_composition() {
+        let created_at = ts(BASE_TS_MS);
+        let mut initial = VQueueMeta::new(created_at, None, LimitKey::None, VQueueLink::None);
+        initial.queue_is_paused = true;
+        initial.stats.avg_queue_duration_ms = 500;
+        initial.stats.avg_inbox_duration_ms = 600;
+        initial.stats.avg_run_duration_ms = 700;
+        initial.stats.avg_suspension_duration_ms = 800;
+        initial.stats.avg_end_to_end_duration_ms = 900;
+        initial.stats.avg_wait_stats = WaitStats {
+            blocked_on_concurrency_rules_ms: 1_000,
+            blocked_on_invoker_throttling_ms: 500,
+            ..WaitStats::default()
+        };
+
+        let updates = [
+            Update::new(
+                ts(BASE_TS_MS + 1_000),
+                Action::Move {
+                    prev_stage: Some(Stage::Inbox),
+                    next_stage: Stage::Inbox,
+                    metrics: metrics(BASE_TS_MS, BASE_TS_MS, true),
+                },
+            ),
+            Update::new(
+                ts(BASE_TS_MS + 2_000),
+                Action::Move {
+                    prev_stage: None,
+                    next_stage: Stage::Inbox,
+                    metrics: metrics(BASE_TS_MS + 2_000, BASE_TS_MS + 2_000, false),
+                },
+            ),
+            Update::new(
+                ts(BASE_TS_MS + 3_000),
+                Action::Move {
+                    prev_stage: Some(Stage::Inbox),
+                    next_stage: Stage::Running,
+                    metrics: metrics_with_wait(
+                        BASE_TS_MS + 2_000,
+                        BASE_TS_MS + 2_000,
+                        false,
+                        2_000,
+                        200,
+                    ),
+                },
+            ),
+            Update::new(
+                ts(BASE_TS_MS + 4_000),
+                Action::Move {
+                    prev_stage: Some(Stage::Running),
+                    next_stage: Stage::Suspended,
+                    metrics: metrics(BASE_TS_MS + 3_000, BASE_TS_MS + 2_000, true),
+                },
+            ),
+            Update::new(
+                ts(BASE_TS_MS + 5_000),
+                Action::Move {
+                    prev_stage: Some(Stage::Suspended),
+                    next_stage: Stage::Inbox,
+                    metrics: metrics(BASE_TS_MS + 4_000, BASE_TS_MS + 2_000, true),
+                },
+            ),
+            Update::new(
+                ts(BASE_TS_MS + 6_000),
+                Action::Move {
+                    prev_stage: Some(Stage::Inbox),
+                    next_stage: Stage::Running,
+                    metrics: metrics_with_wait(
+                        BASE_TS_MS + 5_000,
+                        BASE_TS_MS + 2_000,
+                        true,
+                        0,
+                        1_000,
+                    ),
+                },
+            ),
+            Update::new(
+                ts(BASE_TS_MS + 7_000),
+                Action::Move {
+                    prev_stage: Some(Stage::Running),
+                    next_stage: Stage::Finished,
+                    metrics: metrics(BASE_TS_MS + 6_000, BASE_TS_MS + 2_000, true),
+                },
+            ),
+            Update::new(
+                ts(BASE_TS_MS + 8_000),
+                Action::RemoveEntry {
+                    stage: Stage::Finished,
+                },
+            ),
+            Update::new(ts(BASE_TS_MS + 9_000), Action::PauseVQueue {}),
+            Update::new(ts(BASE_TS_MS + 10_000), Action::ResumeVQueue {}),
+        ];
+
+        let mut expected = initial.clone();
+        for update in &updates {
+            expected.apply_update(update);
+        }
+
+        let mut batch = UpdateBatch::default();
+        for update in &updates {
+            assert!(batch.try_push(update));
+        }
+        let mut actual = initial.clone();
+        assert!(batch.try_apply(&mut actual));
+        assert_eq!(actual.encode_to_bytes(), expected.encode_to_bytes());
+
+        let mut first = UpdateBatch::default();
+        for update in &updates[..4] {
+            assert!(first.try_push(update));
+        }
+        let mut second = UpdateBatch::default();
+        for update in &updates[4..] {
+            assert!(second.try_push(update));
+        }
+        assert!(first.try_append(second));
+        let mut composed = initial;
+        assert!(first.try_apply(&mut composed));
+        assert_eq!(composed.encode_to_bytes(), expected.encode_to_bytes());
     }
 
     #[test]
@@ -848,7 +1297,7 @@ mod tests {
 
     #[test]
     fn vqueue_meta_borrowed_decode_is_correct() {
-        use bilrost::{BorrowedMessage, Message};
+        use bilrost::BorrowedMessage;
 
         let owned = VQueueMeta {
             queue_is_paused: true,

--- a/crates/storage-api/src/vqueue_table/stats.rs
+++ b/crates/storage-api/src/vqueue_table/stats.rs
@@ -18,7 +18,8 @@ use restate_clock::{RoughTimestamp, UniqueTimestamp};
 ///
 /// Encoding is fixed which mimics the simplicity and efficiency of a Vec<(StatKey, Value)>
 /// on the wire.
-#[derive(Debug, Clone, Copy, Default, bilrost::Message)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, bilrost::Message)]
+#[bilrost(distinguished)]
 pub struct WaitStats {
     /// Total milliseconds the item spent waiting on global invoker capacity
     #[bilrost(tag(1), encoding(fixed))]


### PR DESCRIPTION

Add efficient exact partial merging for VQueueMeta operands so RocksDB can compact long update chains without forcing full merges. This prepares partition storage to remove max_successive_merges after the decoder-first compatibility window.

Keep production partial-merge dispatch disabled until the minimum forward-compatible version is v1.7.8.
