### PR TITLE
[invoker] read journal via a direct get rather than an iterator to determine journal kind

### DIFF
--- a/crates/worker/src/partition/invoker_storage_reader.rs
+++ b/crates/worker/src/partition/invoker_storage_reader.rs
@@ -211,13 +211,13 @@ where
 
         if let InvocationStatus::Invoked(invoked_status) = invocation_status {
             // Check if using journal v2 by seeing if v2 has any entries
-            let mut journal_v2_stream =
-                std::pin::pin!(journal_table_v2::ReadJournalTable::get_journal(
-                    &self.txn,
-                    *invocation_id,
-                    1, // Just check first entry to determine version
-                )?);
-            let journal_kind = if journal_v2_stream.next().await.transpose()?.is_some() {
+            let journal_v2_entry = journal_table_v2::ReadJournalTable::get_journal_entry(
+                &mut self.txn,
+                *invocation_id,
+                0, // Just check first entry to determine version
+            )
+            .await?;
+            let journal_kind = if journal_v2_entry.is_some() {
                 JournalKind::V2
             } else {
                 JournalKind::V1


### PR DESCRIPTION

Currently, to determine whether an invocation is using journal v1 or v2, we call `get_journal` which starts a journal iterator that we use to only read the first entry. In a cpu profile, this seems to be taking almost 3% of the CPU.

<img width="3854" height="1204" alt="image" src="https://github.com/user-attachments/assets/77e2c5df-295d-4c4a-8619-fd415ccc83e1" />

Looking at the init_journal function (https://github.com/restatedev/restate/blob/3a775aaa62f7ce89daf2c3afa697239d29fcf9ac/crates/worker/src/partition/state_machine/mod.rs#L1323-L1343) it seems like we're always writing the input as the first journal entry at index 0. Changing this to a direct read for the first journal entry (idx 0) should be cheaper.
