### PR TITLE
Detect stalled connections to the AWS Lambda API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8705,6 +8705,8 @@ dependencies = [
  "aws-credential-types",
  "aws-sdk-lambda",
  "aws-sdk-sts",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
  "base64",
  "bs58",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,8 +122,8 @@ aws-credential-types = "1.2.14"
 aws-msk-iam-sasl-signer = "1.0.0"
 aws-sdk-dynamodb = { version = "1.101.0", default-features = false, features = ["behavior-version-latest", "rt-tokio", "default-https-client"] }
 aws-smithy-async = { version = "1.2.14", default-features = false }
-aws-smithy-runtime-api = "1.12.3"
-aws-smithy-types = "1.5.0"
+aws-smithy-runtime-api = { version = "1.12.3", features = ["client", "http-1x"] }
+aws-smithy-types = { version = "1.5.0", features = ["http-body-1-x"] }
 axum = { version = "0.8.8", default-features = false }
 base64 = "0.22"
 bilrost = { version = "0.1014", default-features = false, features = ["std", "auto-optimize", "derive"] }

--- a/crates/service-client/Cargo.toml
+++ b/crates/service-client/Cargo.toml
@@ -22,6 +22,8 @@ ahash = { workspace = true }
 arc-swap = { workspace = true }
 aws-config = { workspace = true }
 aws-credential-types = { workspace = true }
+aws-smithy-runtime-api = { workspace = true }
+aws-smithy-types = { workspace = true }
 aws-sdk-lambda = {version = "1.112.0", default-features = false, features = ["behavior-version-latest", "rt-tokio", "default-https-client"]}
 aws-sdk-sts = {version = "1.95.0", default-features = false, features = ["behavior-version-latest", "rt-tokio", "default-https-client"]}
 base64 = { workspace = true }

--- a/crates/service-client/src/aws_http_client.rs
+++ b/crates/service-client/src/aws_http_client.rs
@@ -1,0 +1,572 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! HTTP client for the AWS Lambda API.
+//!
+//! The SDK ships its own hyper-backed client, but exposes none of hyper's HTTP/2
+//! settings. Each partition-local client multiplexes Lambda invocations onto
+//! long-lived HTTP/2 connections with no liveness detection. If a connection is
+//! silently blackholed, its in-flight requests hang until the kernel exhausts its
+//! retransmission budget, roughly 15 minutes later. This client enables keep-alive
+//! pings, which bound that delay to the ping interval plus its timeout.
+//!
+//! Everything else here reproduces the contract of the SDK's own adapter, which the
+//! Lambda client's interceptors rely on: capturing the pooled connection so that it
+//! can be poisoned after a transient failure, and classifying transport errors.
+
+use std::borrow::Cow;
+use std::error::Error;
+use std::fmt::Debug;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use aws_smithy_runtime_api::client::connection::{CaptureSmithyConnection, ConnectionMetadata};
+use aws_smithy_runtime_api::client::connector_metadata::ConnectorMetadata;
+use aws_smithy_runtime_api::client::http::{
+    HttpClient, HttpConnector, HttpConnectorFuture, HttpConnectorSettings, SharedHttpClient,
+    SharedHttpConnector,
+};
+use aws_smithy_runtime_api::client::orchestrator::{HttpRequest, HttpResponse};
+use aws_smithy_runtime_api::client::result::ConnectorError;
+use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
+use aws_smithy_types::body::SdkBody;
+use aws_smithy_types::error::display::DisplayErrorContext;
+use aws_smithy_types::retry::ErrorKind;
+use dashmap::DashMap;
+use h2::Reason;
+use http::Uri;
+use hyper_rustls::HttpsConnector;
+use hyper_util::client::legacy::Client;
+use hyper_util::client::legacy::connect::{
+    CaptureConnection, Connect, HttpConnector as TcpConnector, HttpInfo, capture_connection,
+};
+use hyper_util::rt::{TokioExecutor, TokioTimer};
+use tower::Service;
+
+use restate_types::config::Http2KeepAliveOptions;
+
+use crate::utils::TLS_CLIENT_CONFIG;
+
+type BoxError = Box<dyn Error + Send + Sync + 'static>;
+
+pub(crate) fn from_options(keep_alive: &Http2KeepAliveOptions) -> SharedHttpClient {
+    SharedHttpClient::new(AwsHttpClient {
+        keep_alive: KeepAlive::from_options(keep_alive),
+        connectors: Default::default(),
+    })
+}
+
+#[derive(Debug, Clone, Copy)]
+struct KeepAlive {
+    /// `None` disables keep-alive pings.
+    ping_interval: Option<Duration>,
+    ping_timeout: Duration,
+}
+
+impl KeepAlive {
+    fn from_options(options: &Http2KeepAliveOptions) -> Self {
+        let ping_interval: Duration = options.http2_keep_alive_interval.into();
+
+        Self {
+            ping_interval: (!ping_interval.is_zero()).then_some(ping_interval),
+            ping_timeout: options.http2_keep_alive_timeout.into(),
+        }
+    }
+}
+
+/// The timeouts the SDK asks for, which vary per operation and so cannot be baked
+/// into a single connector.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct Timeouts {
+    connect: Option<Duration>,
+    read: Option<Duration>,
+}
+
+#[derive(Debug, Clone)]
+struct AwsHttpClient {
+    keep_alive: KeepAlive,
+    connectors: Arc<DashMap<Timeouts, SharedHttpConnector>>,
+}
+
+impl HttpClient for AwsHttpClient {
+    fn http_connector(
+        &self,
+        settings: &HttpConnectorSettings,
+        _components: &RuntimeComponents,
+    ) -> SharedHttpConnector {
+        let timeouts = Timeouts {
+            connect: settings.connect_timeout(),
+            read: settings.read_timeout(),
+        };
+
+        self.connectors
+            .entry(timeouts)
+            .or_insert_with(|| {
+                SharedHttpConnector::new(AwsHttpConnector::new(self.keep_alive, timeouts))
+            })
+            .clone()
+    }
+
+    fn connector_metadata(&self) -> Option<ConnectorMetadata> {
+        Some(ConnectorMetadata::new("hyper", Some(Cow::Borrowed("1.x"))))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct AwsHttpConnector<C = ConnectTimeout<HttpsConnector<TcpConnector>>> {
+    client: Client<C, SdkBody>,
+    read_timeout: Option<Duration>,
+}
+
+impl AwsHttpConnector {
+    fn new(keep_alive: KeepAlive, timeouts: Timeouts) -> Self {
+        let mut tcp_connector = TcpConnector::new();
+        tcp_connector.enforce_http(false);
+        tcp_connector.set_nodelay(true);
+
+        // Not https_only: an endpoint override, such as a local test double, may be
+        // plain HTTP.
+        let connector = hyper_rustls::HttpsConnectorBuilder::new()
+            .with_tls_config(TLS_CLIENT_CONFIG.clone())
+            .https_or_http()
+            .enable_http1()
+            .enable_http2()
+            .wrap_connector(tcp_connector);
+        // The timeout covers the TLS handshake as well as the TCP connect, so that a
+        // peer that goes silent midway through the handshake is bounded too.
+        let connector = ConnectTimeout {
+            inner: connector,
+            timeout: timeouts.connect,
+        };
+
+        Self::with_connector(connector, keep_alive, timeouts.read)
+    }
+}
+
+impl<C> AwsHttpConnector<C>
+where
+    C: Connect + Clone,
+{
+    fn with_connector(connector: C, keep_alive: KeepAlive, read_timeout: Option<Duration>) -> Self {
+        let mut builder = Client::builder(TokioExecutor::default());
+        builder
+            .timer(TokioTimer::default())
+            .pool_timer(TokioTimer::default())
+            .http2_keep_alive_interval(keep_alive.ping_interval)
+            .http2_keep_alive_timeout(keep_alive.ping_timeout);
+
+        Self {
+            client: builder.build(connector),
+            read_timeout,
+        }
+    }
+}
+
+impl<C> HttpConnector for AwsHttpConnector<C>
+where
+    C: Connect + Clone + Debug + Send + Sync + 'static,
+{
+    fn call(&self, request: HttpRequest) -> HttpConnectorFuture {
+        let client = self.client.clone();
+        let read_timeout = self.read_timeout;
+
+        let mut request = match request.try_into_http1x() {
+            Ok(request) => request,
+            Err(err) => return HttpConnectorFuture::ready(Err(ConnectorError::user(err.into()))),
+        };
+
+        // Hands the pooled connection to the SDK's interceptors, which poison it
+        // when a request against it fails transiently.
+        let captured = capture_connection(&mut request);
+        if let Some(capture) = request.extensions().get::<CaptureSmithyConnection>() {
+            capture.set_connection_retriever(move || smithy_connection(&captured));
+        }
+
+        HttpConnectorFuture::new(async move {
+            let response = match read_timeout {
+                Some(read_timeout) => tokio::time::timeout(read_timeout, client.request(request))
+                    .await
+                    .map_err(|_| {
+                        ConnectorError::timeout(
+                            format!("no response received within {read_timeout:?}").into(),
+                        )
+                    })?,
+                None => client.request(request).await,
+            }
+            .map_err(connector_error)?;
+
+            let (parts, body) = response.into_parts();
+            HttpResponse::try_from(http::Response::from_parts(
+                parts,
+                SdkBody::from_body_1_x(body),
+            ))
+            .map_err(|err| ConnectorError::other(err.into(), None))
+        })
+    }
+}
+
+fn smithy_connection(captured: &CaptureConnection) -> Option<ConnectionMetadata> {
+    let poisoner = captured.clone();
+    let metadata = captured.connection_metadata();
+    let connection = metadata.as_ref()?;
+
+    let mut extensions = http::Extensions::new();
+    connection.get_extras(&mut extensions);
+    let http_info = extensions.get::<HttpInfo>();
+
+    let mut builder = ConnectionMetadata::builder()
+        .proxied(connection.is_proxied())
+        .poison_fn(move || match poisoner.connection_metadata().as_ref() {
+            Some(connection) => connection.poison(),
+            None => tracing::trace!("no connection existed to poison"),
+        });
+    builder
+        .set_local_addr(http_info.map(|info| info.local_addr()))
+        .set_remote_addr(http_info.map(|info| info.remote_addr()));
+
+    Some(builder.build())
+}
+
+fn connector_error(err: hyper_util::client::legacy::Error) -> ConnectorError {
+    let err: BoxError = err.into();
+
+    if find_source::<ConnectTimeoutError>(err.as_ref()).is_some() {
+        return ConnectorError::timeout(err);
+    }
+
+    if let Some(hyper_error) = find_source::<hyper::Error>(err.as_ref()) {
+        return classify_hyper_error(hyper_error)(err);
+    }
+
+    if let Some(hyper_util_error) = find_source::<hyper_util::client::legacy::Error>(err.as_ref())
+        && (hyper_util_error.is_connect()
+            || find_source::<std::io::Error>(hyper_util_error).is_some())
+    {
+        return ConnectorError::io(err);
+    }
+
+    ConnectorError::other(err, None)
+}
+
+fn classify_hyper_error(err: &hyper::Error) -> fn(BoxError) -> ConnectorError {
+    if err.is_timeout() {
+        return ConnectorError::timeout;
+    }
+    if err.is_user() {
+        return ConnectorError::user;
+    }
+    if err.is_closed() || err.is_canceled() || find_source::<std::io::Error>(err).is_some() {
+        return ConnectorError::io;
+    }
+    if err.is_incomplete_message() {
+        return |err| ConnectorError::other(err, Some(ErrorKind::TransientError));
+    }
+    if let Some(h2_error) = find_source::<h2::Error>(err)
+        && (h2_error.is_go_away()
+            || (h2_error.is_reset() && h2_error.reason() == Some(Reason::REFUSED_STREAM)))
+    {
+        return ConnectorError::io;
+    }
+
+    tracing::warn!(
+        err = %DisplayErrorContext(err),
+        "unrecognized error from Hyper; please report retryable errors"
+    );
+    |err| ConnectorError::other(err, None)
+}
+
+fn find_source<'a, E: Error + 'static>(err: &'a (dyn Error + 'static)) -> Option<&'a E> {
+    let mut source = Some(err);
+    while let Some(err) = source {
+        if let Some(matched) = err.downcast_ref::<E>() {
+            return Some(matched);
+        }
+        source = err.source();
+    }
+    None
+}
+
+/// Bounds how long establishing a connection may take, handshake included.
+#[derive(Debug, Clone)]
+struct ConnectTimeout<C> {
+    inner: C,
+    timeout: Option<Duration>,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("could not connect within {0:?}")]
+struct ConnectTimeoutError(Duration);
+
+impl<C> Service<Uri> for ConnectTimeout<C>
+where
+    C: Service<Uri>,
+    C::Future: Send + 'static,
+    C::Error: Into<BoxError>,
+{
+    type Response = C::Response;
+    type Error = BoxError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, uri: Uri) -> Self::Future {
+        let connect = self.inner.call(uri);
+        let timeout = self.timeout;
+
+        Box::pin(async move {
+            let Some(timeout) = timeout else {
+                return connect.await.map_err(Into::into);
+            };
+
+            tokio::time::timeout(timeout, connect)
+                .await
+                .map_err(|_| ConnectTimeoutError(timeout))?
+                .map_err(Into::into)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
+    use bytes::Bytes;
+    use googletest::prelude::*;
+    use http::{Response, StatusCode};
+    use hyper_util::client::legacy::connect::{Connected, Connection};
+    use hyper_util::rt::TokioIo;
+    use restate_util_time::{FriendlyDuration, NonZeroFriendlyDuration};
+
+    fn keep_alive(interval: Option<Duration>) -> KeepAlive {
+        KeepAlive {
+            ping_interval: interval,
+            ping_timeout: Duration::from_millis(50),
+        }
+    }
+
+    fn invoke_request() -> HttpRequest {
+        HttpRequest::try_from(
+            http::Request::builder()
+                .uri("https://lambda.example/invoke")
+                .body(SdkBody::empty())
+                .unwrap(),
+        )
+        .unwrap()
+    }
+
+    /// Serves h2 connections that go silent after accepting a request - answering
+    /// neither the response nor the pings - until `recover` is set, after which
+    /// requests are answered normally. This is the incident's connection as hyper
+    /// saw it, followed by a healthy replacement.
+    #[derive(Clone, Debug)]
+    struct StallingPeer {
+        connections: Arc<AtomicUsize>,
+        recover: Arc<AtomicBool>,
+        release_stalled_peer: Arc<tokio::sync::Notify>,
+    }
+
+    impl Service<Uri> for StallingPeer {
+        type Response = DuplexConnection;
+        type Error = BoxError;
+        type Future =
+            Pin<Box<dyn Future<Output = std::result::Result<Self::Response, Self::Error>> + Send>>;
+
+        fn poll_ready(
+            &mut self,
+            _cx: &mut Context<'_>,
+        ) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _uri: Uri) -> Self::Future {
+            self.connections.fetch_add(1, Ordering::Relaxed);
+            let recover = Arc::clone(&self.recover);
+            let release_stalled_peer = Arc::clone(&self.release_stalled_peer);
+
+            Box::pin(async move {
+                let (client, server) = tokio::io::duplex(64 * 1024);
+                tokio::spawn(async move {
+                    let mut server = h2::server::Builder::new()
+                        .handshake::<_, Bytes>(server)
+                        .await
+                        .unwrap();
+
+                    while let Some(request) = server.accept().await {
+                        let (_request, mut respond) = request.unwrap();
+                        if !recover.load(Ordering::Relaxed) {
+                            release_stalled_peer.notified().await;
+                            return;
+                        }
+                        let response = Response::builder().status(StatusCode::OK).body(()).unwrap();
+                        respond.send_response(response, true).unwrap();
+                    }
+                });
+                Ok(DuplexConnection(TokioIo::new(client)))
+            })
+        }
+    }
+
+    /// An in-memory stream that presents itself to hyper as a negotiated h2
+    /// connection.
+    #[derive(Debug)]
+    struct DuplexConnection(TokioIo<tokio::io::DuplexStream>);
+
+    impl Connection for DuplexConnection {
+        fn connected(&self) -> Connected {
+            Connected::new().negotiated_h2()
+        }
+    }
+
+    impl hyper::rt::Read for DuplexConnection {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: hyper::rt::ReadBufCursor<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut self.get_mut().0).poll_read(cx, buf)
+        }
+    }
+
+    impl hyper::rt::Write for DuplexConnection {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            Pin::new(&mut self.get_mut().0).poll_write(cx, buf)
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut self.get_mut().0).poll_flush(cx)
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Pin::new(&mut self.get_mut().0).poll_shutdown(cx)
+        }
+    }
+
+    /// The regression this client exists to prevent: a connection that goes silent
+    /// mid-flight must fail its in-flight request on the keep-alive timeout instead
+    /// of hanging until the kernel gives up on the socket, and the next request must
+    /// then succeed on a fresh connection.
+    #[tokio::test]
+    async fn silent_connection_fails_fast_and_the_next_request_recovers() {
+        let peer = StallingPeer {
+            connections: Arc::new(AtomicUsize::new(0)),
+            recover: Arc::new(AtomicBool::new(false)),
+            release_stalled_peer: Arc::new(tokio::sync::Notify::new()),
+        };
+        let connector = AwsHttpConnector::with_connector(
+            peer.clone(),
+            keep_alive(Some(Duration::from_millis(50))),
+            None,
+        );
+
+        let started = tokio::time::Instant::now();
+        let stalled =
+            tokio::time::timeout(Duration::from_secs(10), connector.call(invoke_request()))
+                .await
+                .expect("the keep-alive timeout must end the request");
+
+        assert!(stalled.as_ref().is_err_and(|err| err.is_timeout()));
+        assert_that!(started.elapsed(), lt(Duration::from_secs(5)));
+        assert_that!(peer.connections.load(Ordering::Relaxed), eq(1));
+
+        peer.recover.store(true, Ordering::Relaxed);
+        peer.release_stalled_peer.notify_waiters();
+        let recovered =
+            tokio::time::timeout(Duration::from_secs(10), connector.call(invoke_request()))
+                .await
+                .expect("the retry must not hang");
+
+        assert_that!(
+            recovered.map(|response| response.status().as_u16()),
+            ok(eq(200))
+        );
+        assert_that!(peer.connections.load(Ordering::Relaxed), eq(2));
+    }
+
+    #[tokio::test]
+    async fn connect_timeout_covers_the_tls_handshake() {
+        // Accepted by the kernel, but the handshake never completes.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let connector = AwsHttpConnector::new(
+            keep_alive(None),
+            Timeouts {
+                connect: Some(Duration::from_millis(100)),
+                read: None,
+            },
+        );
+
+        let request = HttpRequest::try_from(
+            http::Request::builder()
+                .uri(format!("https://{addr}/"))
+                .body(SdkBody::empty())
+                .unwrap(),
+        )
+        .unwrap();
+
+        let started = tokio::time::Instant::now();
+        let result = connector.call(request).await;
+        assert!(result.as_ref().is_err_and(|err| err.is_timeout()));
+        // The connect itself succeeds, so reaching the timeout is what ends the
+        // attempt - and it must end there rather than hanging on the handshake.
+        assert_that!(
+            started.elapsed(),
+            all!(ge(Duration::from_millis(100)), lt(Duration::from_secs(5)))
+        );
+    }
+
+    #[test]
+    fn connectors_are_cached_per_timeout_setting() {
+        let client = AwsHttpClient {
+            keep_alive: KeepAlive::from_options(&Http2KeepAliveOptions::default()),
+            connectors: Default::default(),
+        };
+        let components = RuntimeComponentsBuilder::for_tests().build().unwrap();
+
+        let settings = HttpConnectorSettings::builder()
+            .connect_timeout(Duration::from_secs(3))
+            .build();
+        client.http_connector(&settings, &components);
+        client.http_connector(&settings, &components);
+        assert_that!(client.connectors.len(), eq(1));
+
+        let other = HttpConnectorSettings::builder()
+            .connect_timeout(Duration::from_secs(5))
+            .build();
+        client.http_connector(&other, &components);
+        assert_that!(client.connectors.len(), eq(2));
+    }
+
+    #[test]
+    fn a_zero_interval_disables_pings() {
+        let disabled = KeepAlive::from_options(&Http2KeepAliveOptions {
+            http2_keep_alive_interval: FriendlyDuration::ZERO,
+            http2_keep_alive_timeout: NonZeroFriendlyDuration::from_secs_unchecked(20),
+            http2_keep_alive_jitter: 0.2,
+        });
+        assert_that!(disabled.ping_interval, none());
+
+        let default = KeepAlive::from_options(&Http2KeepAliveOptions::default());
+        assert_that!(default.ping_interval, some(eq(Duration::from_secs(40))));
+        assert_that!(default.ping_timeout, eq(Duration::from_secs(20)));
+    }
+}

--- a/crates/service-client/src/http.rs
+++ b/crates/service-client/src/http.rs
@@ -12,7 +12,6 @@ use std::error::Error;
 use std::fmt;
 use std::fmt::Debug;
 use std::pin::Pin;
-use std::sync::{Arc, LazyLock};
 use std::task::{Context, Poll, ready};
 use std::time::Duration;
 
@@ -25,9 +24,8 @@ use hyper::body::{Body, Incoming};
 use hyper::http::HeaderValue;
 use hyper::http::uri::PathAndQuery;
 use hyper::{HeaderMap, Method, Request, Response, Uri};
-use hyper_rustls::{ConfigBuilderExt, HttpsConnector};
+use hyper_rustls::HttpsConnector;
 use hyper_util::client::legacy::connect::HttpConnector;
-use rustls::{ClientConfig, KeyLogFile};
 use tower::Layer;
 
 use restate_types::config::HttpOptions;
@@ -35,27 +33,11 @@ use restate_types::config::HttpOptions;
 use crate::pool::conn::PermittedRecvStream;
 use crate::pool::tls::TlsConnector;
 use crate::pool::{self, Pool, TcpConnector};
-use crate::utils::ErrorExt;
+use crate::utils::{ErrorExt, TLS_CLIENT_CONFIG};
 
 use super::proxy::ProxyConnector;
 
 type ProxiedHttpsConnector = ProxyConnector<HttpsConnector<HttpConnector>>;
-
-static TLS_CLIENT_CONFIG: LazyLock<ClientConfig> = LazyLock::new(|| {
-    // We need to explicitly configure the crypto provider since we activate the ring as well as
-    // aws_lc_rs rustls feature, and they are mutually exclusive wrt auto installation. Moreover,
-    // we don't want that tests need to install a crypto provider when using the HttpClient
-    let mut builder = ClientConfig::builder_with_provider(Arc::new(
-        rustls::crypto::aws_lc_rs::default_provider(),
-    ))
-    .with_protocol_versions(rustls::DEFAULT_VERSIONS)
-    .expect("default versions are supported")
-    .with_native_roots()
-    .expect("Can load native certificates")
-    .with_no_client_auth();
-    builder.dangerous().cfg.key_log = Arc::new(KeyLogFile::new());
-    builder
-});
 
 // TODO
 //  for the time being we use BoxBody here to simplify the migration to hyper 1.0.

--- a/crates/service-client/src/lambda.rs
+++ b/crates/service-client/src/lambda.rs
@@ -11,6 +11,7 @@
 //! Some parts copied from https://github.com/awslabs/aws-sdk-rust/blob/0.55.x/sdk/aws-config/src/sts/assume_role.rs
 //! License Apache-2.0
 
+use crate::aws_http_client;
 use crate::utils::ErrorExt;
 use arc_swap::ArcSwap;
 use assume_role::AssumeRoleProvider;
@@ -28,7 +29,7 @@ use http::uri::PathAndQuery;
 use http::{HeaderMap, HeaderValue, Method, Response, StatusCode};
 use http_body_util::{BodyExt, Full};
 use hyper::body::Body;
-use restate_types::config::AwsLambdaOptions;
+use restate_types::config::{AwsLambdaOptions, Http2KeepAliveOptions};
 use restate_types::identifiers::LambdaARN;
 use restate_types::schema::deployment::EndpointLambdaCompression;
 use serde::ser::Error as _;
@@ -82,15 +83,21 @@ struct LambdaClientInner {
 }
 
 impl LambdaClient {
-    pub fn new(
-        profile_name: Option<String>,
-        assume_role_external_id: Option<String>,
-        request_compression_threshold: Option<usize>,
+    pub fn from_options(
+        options: &AwsLambdaOptions,
+        keep_alive: &Http2KeepAliveOptions,
         assume_role_cache_mode: AssumeRoleCacheMode,
     ) -> Self {
+        let assume_role_external_id = options.aws_assume_role_external_id.clone();
+        let request_compression_threshold = options
+            .request_compression_threshold
+            .map(|bc| bc.as_usize())
+            .unwrap_or_default();
+        let lambda_http_client = aws_http_client::from_options(keep_alive);
+
         // create client for a default region, region can be overridden per request
         let mut config = aws_config::defaults(BehaviorVersion::latest());
-        if let Some(profile_name) = profile_name {
+        if let Some(profile_name) = options.aws_profile.clone() {
             config = config.profile_name(profile_name);
         };
 
@@ -100,7 +107,11 @@ impl LambdaClient {
             let sts_conf = aws_sdk_sts::Config::from(&config);
             let sts_client = aws_sdk_sts::Client::from_conf(sts_conf);
 
-            let lambda_client_builder = aws_sdk_lambda::config::Builder::from(&config);
+            let lambda_client_builder = aws_sdk_lambda::config::Builder::from(&config)
+                // Only the Lambda transport gets our own HTTP client: the credential
+                // chain and STS keep the SDK's, which is tested against the endpoints
+                // they talk to.
+                .http_client(lambda_http_client);
 
             // Restate has its own retry mechanisms, and the built in retry policy in this library could just confuse things
             let lambda_client_builder =
@@ -120,27 +131,13 @@ impl LambdaClient {
                 lambda_client_builder,
                 role_to_lambda_clients,
                 assume_role_external_id,
-                request_compression_threshold: request_compression_threshold.unwrap_or_default(),
+                request_compression_threshold,
             })
         }
         .boxed()
         .shared();
 
         Self { inner }
-    }
-
-    pub fn from_options(
-        options: &AwsLambdaOptions,
-        assume_role_cache_mode: AssumeRoleCacheMode,
-    ) -> LambdaClient {
-        LambdaClient::new(
-            options.aws_profile.clone(),
-            options.aws_assume_role_external_id.clone(),
-            options
-                .request_compression_threshold
-                .map(|bc| bc.as_usize()),
-            assume_role_cache_mode,
-        )
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/service-client/src/lib.rs
+++ b/crates/service-client/src/lib.rs
@@ -36,6 +36,7 @@ pub use crate::lambda::AssumeRoleCacheMode;
 use crate::lambda::LambdaClient;
 use crate::request_identity::SignRequest;
 
+mod aws_http_client;
 mod gcp;
 mod http;
 mod lambda;
@@ -109,7 +110,11 @@ impl ServiceClient {
 
         Ok(Self::new(
             HttpClient::from_options(&options.http),
-            LambdaClient::from_options(&options.lambda, assume_role_cache_mode),
+            LambdaClient::from_options(
+                &options.lambda,
+                &options.http.http_keep_alive_options,
+                assume_role_cache_mode,
+            ),
             GcpTokenClient::new(gcp_cache_mode),
             request_identity_key,
             options

--- a/crates/service-client/src/utils.rs
+++ b/crates/service-client/src/utils.rs
@@ -8,8 +8,30 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::{Arc, LazyLock};
+
 use aws_sdk_lambda::error::SdkError;
 use hyper::http;
+use hyper_rustls::ConfigBuilderExt;
+use rustls::{ClientConfig, KeyLogFile};
+
+/// Shared by every outbound TLS client in this crate.
+///
+/// We need to explicitly configure the crypto provider since we activate the ring as well as
+/// aws_lc_rs rustls feature, and they are mutually exclusive wrt auto installation. Moreover,
+/// we don't want that tests need to install a crypto provider when using the HttpClient
+pub(crate) static TLS_CLIENT_CONFIG: LazyLock<ClientConfig> = LazyLock::new(|| {
+    let mut builder = ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_protocol_versions(rustls::DEFAULT_VERSIONS)
+    .expect("default versions are supported")
+    .with_native_roots()
+    .expect("Can load native certificates")
+    .with_no_client_auth();
+    builder.dangerous().cfg.key_log = Arc::new(KeyLogFile::new());
+    builder
+});
 
 pub trait ErrorExt {
     /// Retryable errors are those which can be caused by transient faults and where

--- a/crates/types/src/config/http.rs
+++ b/crates/types/src/config/http.rs
@@ -302,7 +302,8 @@ pub struct Http2KeepAliveOptions {
     /// # HTTP/2 Keep-alive interval
     ///
     /// Sets an interval for HTTP/2 PING frames should be sent to keep a
-    /// connection alive.
+    /// connection alive. This governs connections to HTTP deployments as well as
+    /// to the AWS Lambda API.
     ///
     /// `0` disables keep-alive pings entirely. Defaults to `40s`.
     ///

--- a/release-notes/unreleased/lambda-connection-liveness.md
+++ b/release-notes/unreleased/lambda-connection-liveness.md
@@ -1,0 +1,31 @@
+# Detect stalled connections to the AWS Lambda API
+
+## Behavioral Change
+
+### What Changed
+
+Restate now enables HTTP/2 keep-alive pings for AWS Lambda invocations. The existing
+`worker.invoker.http2-keep-alive-interval` and
+`worker.invoker.http2-keep-alive-timeout` options now apply to Lambda and HTTP deployments. Their
+defaults remain `40s` and `20s`.
+
+AWS credential providers and STS continue to use the AWS SDK's HTTP client.
+
+### Why This Matters
+
+Lambda invocations share long-lived HTTP/2 connections. A silently dropped connection previously
+left its invocations stuck until the kernel exhausted its TCP retransmission budget, which can take
+around 15 minutes. Restate now detects the failure within the keep-alive interval plus its timeout
+and retries the affected invocations.
+
+### Impact on Users
+
+- Existing deployments require no configuration changes.
+- With the defaults, a silent Lambda connection fails within about one minute instead of remaining
+  stuck for the kernel's retransmission period.
+- Setting `worker.invoker.http2-keep-alive-interval` to `0` disables pings, which restores the old
+  behaviour for both HTTP deployments and Lambda.
+
+### Migration Guidance
+
+No action required.


### PR DESCRIPTION
> ⚠️ AI-generated (Codex (GPT-5.6))

## Summary

This change prevents Lambda invocations from remaining stuck for 15–17 minutes when a long-lived HTTP/2 connection to the AWS Lambda API silently stops carrying traffic. Because requests share an HTTP/2 connection, one failed connection can stall many concurrent invocations. When Hyper eventually replays requests that never reached the wire, their original SigV4 signatures may already have expired.

This change gives only the Lambda SDK client a Hyper transport configured with HTTP/2 keep-alive pings. With the existing `40s` interval and `20s` timeout defaults, a silent connection should fail in about one minute so the invoker can retry on a new connection.

## Review guide

- `aws_http_client.rs` is the new adapter. Its reason to exist is the two HTTP/2 keep-alive settings. The remaining code preserves the Smithy adapter contract: per-settings connector caching, connect/read timeouts, connector metadata, transport error classification, and connection capture so transient failures retire the pooled connection.
- The custom client is installed on `aws_sdk_lambda::config::Builder` only. Credential providers and STS retain the AWS SDK transport.
- The existing `worker.invoker.http2-keep-alive-interval` and `worker.invoker.http2-keep-alive-timeout` settings also govern Lambda connections. No configuration keys or defaults change. An interval of `0` disables pings.
- Hyper's canceled-request replay remains enabled. Once liveness detection bounds a stall to about one minute, replayed SigV4 signatures should still be fresh, while disabling replay would expose races involving stale pooled connections to the invoker.
- There is no additional socket timeout. Keep-alive pings are the single liveness mechanism, so disabling them restores the previous behavior without a hidden backstop.

## Impact

Each active partition leader owns its own service client, so the existing architecture already provides partition-level bulkheading. This change limits the effect of a dead multiplexed connection within each client by detecting it promptly. It does not add another client or connection-sharding layer.

## Validation

- `cargo check`
- `cargo nextest run --all-features`: 1460 passed, 10 skipped
- `cargo fmt --all -- --check`
- `cargo clippy --all-features --all-targets --workspace -- -D warnings`
- `cargo hakari generate`: no changes

The regression test covers an HTTP/2 connection to an in-process peer that stops acknowledging responses and pings. It verifies a timeout-classified failure and that the next request succeeds on exactly one new connection. A second test verifies that the connect timeout covers a stalled TLS handshake. The test does not reproduce a kernel-level TCP blackhole or call AWS.

`cargo deny --all-features check` still reports the pre-existing yanked `chacha20 0.10.1` through `rand 0.10.2`; this PR does not change that dependency path.
