### PR TITLE
Update chacha20 to 0.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,9 +1556,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
```
error[yanked]: detected yanked crate (try `cargo update -p chacha20`)
124 │ chacha20 0.10.1 registry+https://github.com/rust-lang/crates.io-index
```

Both `chacha20` 0.10.0 and 0.10.1 are yanked from crates.io. 0.10.2, released 2026-08-27, fixes an SSE4.1 intrinsic used in the SSE2 backend of the RNG and legacy 64-bit-counter variants ([RustCrypto/stream-ciphers#580](https://github.com/RustCrypto/stream-ciphers/pull/580)), where a CPU without SSE4.1 could be asked to execute an instruction it does not have.

Restate reaches `chacha20` transitively through `rand` → `google-cloud-gax` → `google-cloud-auth` → `restate-service-client`. Server CPUs in practice have SSE4.1, so this is a correctness fix rather than a response to an observed fault.

The change is two lines of `Cargo.lock`. `cargo deny --all-features check` now reports `advisories ok, bans ok, licenses ok, sources ok`, and `cargo nextest run --all-features` passes (1456 tests).

Note that the `advisories` job is `continue-on-error` in `deps.yml`, so this was never blocking a merge — it was making every dependency-touching PR report a red job.
