### PR TITLE
Update the AWS SDK crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "aws-config"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b180a3c8b55960db3426d8964b8745e652466a1a49fe1a2eda828046d30b5e4"
+checksum = "a767267da9e2c2e189b2f9df8b5657e850ecf5352644734ba130d4a57095cf1b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -686,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.121.0"
+version = "1.123.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de999e21177c7513e70b4adfdc6656f438651b2de2c6690e058073da3a3082c"
+checksum = "dcd10d92058d5da989a7838fd09d70e9457390a81ba672abf5685099f3562bce"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -713,9 +713,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-lambda"
-version = "1.139.0"
+version = "1.141.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbbe615ec96230c3032b82e25d7613c2c9bf524784738bc3a0a4bd3247b4acd1"
+checksum = "2079ec20203cdabbc30ee450cfc1675ce5cf8ad20294d10b7925f7279d05b717"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -740,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.106.0"
+version = "1.108.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0efcee834347b6705eca3eea2defd88242f43774f55d7326604222e3c86260"
+checksum = "c15301b04372832947916607983b114b3374b9db0be058a00fb7513800de1f05"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -766,9 +766,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.108.0"
+version = "1.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a59312a04cf19c962cfee32b64ecfee758f8786407ff6da5b30fff46ae96f201"
+checksum = "72cc2c205cb27108183cf1856333f7d584c2ba0f505421b4209ca5828f9ea899"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -792,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.111.0"
+version = "1.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e7eb63457a9e547f9986fe3b273f77c43679da4d04f46359fa881c5e19b6e"
+checksum = "68182ecb449f7537db0f4d5d25917789cf41e32074a9fe47b6a0b847fe1d2032"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -886,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1c8a04cb31ba74d0115af5a890bb8c0d48fba64b52812fa13929a6ef0cc83c"
+checksum = "ebfd138fac0337cee7516c352757ea73b9f2266e57d0bcb5bc70e9547e45aef1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -943,9 +943,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483b858ff67522011c4786310c5cd8fd88d0be7ea3d5f1a48328446300c4269e"
+checksum = "b82e438d30e02a825d363bd639a9efaed68a8089d86101054b0081e7e0d3e606"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -969,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
+checksum = "954c563ce84507722d2679f07a35d21b9c6466b3872d513020d0281fc8112ac9"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,13 +117,13 @@ arrow = { version = "58.3.0", default-features = false }
 assert2 = "0.3.16"
 async-channel = "2.5.0"
 async-trait = "0.1.89"
-aws-config = "1.8.18"
-aws-credential-types = "1.2.14"
+aws-config = "1.11.0"
+aws-credential-types = "1.3.0"
 aws-msk-iam-sasl-signer = "1.0.0"
-aws-sdk-dynamodb = { version = "1.101.0", default-features = false, features = ["behavior-version-latest", "rt-tokio", "default-https-client"] }
-aws-smithy-async = { version = "1.2.14", default-features = false }
-aws-smithy-runtime-api = { version = "1.12.3", features = ["client", "http-1x"] }
-aws-smithy-types = { version = "1.5.0", features = ["http-body-1-x"] }
+aws-sdk-dynamodb = { version = "1.123.0", default-features = false, features = ["behavior-version-latest", "rt-tokio", "default-https-client"] }
+aws-smithy-async = { version = "1.3.0", default-features = false }
+aws-smithy-runtime-api = { version = "1.15.0", features = ["client", "http-1x"] }
+aws-smithy-types = { version = "1.6.2", features = ["http-body-1-x"] }
 axum = { version = "0.8.8", default-features = false }
 base64 = "0.22"
 bilrost = { version = "0.1014", default-features = false, features = ["std", "auto-optimize", "derive"] }

--- a/crates/service-client/Cargo.toml
+++ b/crates/service-client/Cargo.toml
@@ -24,8 +24,8 @@ aws-config = { workspace = true }
 aws-credential-types = { workspace = true }
 aws-smithy-runtime-api = { workspace = true }
 aws-smithy-types = { workspace = true }
-aws-sdk-lambda = {version = "1.112.0", default-features = false, features = ["behavior-version-latest", "rt-tokio", "default-https-client"]}
-aws-sdk-sts = {version = "1.95.0", default-features = false, features = ["behavior-version-latest", "rt-tokio", "default-https-client"]}
+aws-sdk-lambda = {version = "1.141.0", default-features = false, features = ["behavior-version-latest", "rt-tokio", "default-https-client"]}
+aws-sdk-sts = {version = "1.113.0", default-features = false, features = ["behavior-version-latest", "rt-tokio", "default-https-client"]}
 base64 = { workspace = true }
 bs58 = { workspace = true }
 bytes = { workspace = true }


### PR DESCRIPTION
Assorted AWS crates bumps.

Stacked on #5255: a routine refresh of the AWS SDK crates, split out so that neither it nor the Lambda connection-liveness fix has to be reviewed or bisected through the other. Base this on #5255 rather than `main`; retarget to `main` once that merges.

Worth stating explicitly, because an earlier revision of that PR bundled these: the fix needs none of them. `aws-smithy-runtime-api` 1.12.3 already exposes `HttpClient` and `try_into_http1x`, and `aws-smithy-types` 1.5.0 already has the `http-body-1-x` feature. What that PR needed was those two crates as direct dependencies with the right features, which is a `Cargo.toml` change, not a version change.

## What moves

| Crate | From | To |
|-|-|-|
| `aws-config` | 1.10.1 | 1.11.0 |
| `aws-sdk-lambda` | 1.139.0 | 1.141.0 |
| `aws-sdk-sts` | 1.111.0 | 1.113.0 |
| `aws-sdk-dynamodb` | 1.121.0 | 1.123.0 |
| `aws-sdk-sso` | 1.106.0 | 1.108.0 |
| `aws-sdk-ssooidc` | 1.108.0 | 1.110.0 |
| `aws-smithy-http-client` | 1.3.0 | 1.4.0 |
| `aws-smithy-runtime` | 1.13.1 | 1.14.0 |
| `aws-smithy-runtime-api` | 1.14.0 | 1.15.0 |

`aws-credential-types` and `aws-smithy-async` appear in the `Cargo.toml` diff but not the lockfile: their declared minimums were behind what was already resolved (1.3.0 in both cases), so this only catches the declaration up.

## Changelog highlights

Spanning the aws-sdk-rust releases of 2026-08-20 through 2026-08-27. SDK-wide changes in that window:

- **`pool_max_idle_per_host` setter** added to the HTTP client `Builder` and `ConnectorBuilder`, exposing hyper's cap on idle connections kept per host. This is the only new configuration surface in `aws-smithy-http-client` 1.4.0 — the HTTP/2 keep-alive and socket settings remain unexposed, which is why #5255 carries its own adapter rather than waiting for an upgrade.
- **`credential_process` fixed on Windows** when the executable path contains spaces. No effect on our deployments.
- **`lru` bumped to 0.18.2** for RUSTSEC-2026-0253. This one does not reach us: `lru` is not in our lockfile at all, so the advisory never applied to this build.

Service-crate changes:

- **`aws-sdk-lambda` 1.140.0** adds full JSON resource-based policies, so function resource policies can be created, read, updated and deleted as complete JSON documents. Restate does not call those operations.
- `aws-sdk-lambda` 1.141.0, and the `sts`, `dynamodb`, `sso` and `ssooidc` bumps, carry no service changes in this window — they are routine re-releases that follow the shared runtime crates.

Nothing here changes behaviour Restate depends on.

## Validation

`cargo nextest run --all-features` passes (1460 tests), with clippy `-D warnings` and `fmt --check` clean, and `cargo hakari generate` reports no changes.

`cargo deny` flags a pre-existing yanked `chacha20 0.10.1`, which arrives via `rand` → `google-cloud-gax` and is untouched by these bumps; #5256 fixes that against `main` separately.
