### PR TITLE
docs: repoint stale /operate/ documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The basic primitives Restate offers to simplify application development are the 
 * **Durable Promises and Timers**: Register Promises/Futures and timers in Restate to make them resilient to failures (e.g. sleep, webhooks, timers). Restate can recover them across failures, processes, and time.
 * **Consistent State**: Implement [stateful entities](https://docs.restate.dev/concepts/services) with isolated K/V state per entity. Restate persists the K/V state updates together with the execution progress to ensure consistent state. Restate attaches the K/V state to the request on invocation, and writes it back upon completion. This is particularly efficient for FaaS deployments (stateful serverless, yay!).
 * **Suspending User Code**: long-running code suspends when awaiting on a Promise/Future and resumes when that promise is resolved. This is particularly useful in combination with serverless deployments.
-* **Observability & Introspection**: Restate includes a UI and CLI to inspect the [state of your application](https://docs.restate.dev/operate/introspection) across services and invocations. Restate automatically generates Open Telemetry traces for the interactions between handlers.
+* **Observability & Introspection**: Restate includes a UI and CLI to inspect the [state of your application](https://docs.restate.dev/services/introspection) across services and invocations. Restate automatically generates Open Telemetry traces for the interactions between handlers.
 
 ## Contributing
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -43,7 +43,7 @@ The profiler will generate a flamegraph under `target/criterion/<name_of_benchma
 ## Changing Restate's configuration
 
 The benchmarks spawn Restate with a default configuration.
-You can [overwrite this configuration by specifying environment variables](https://docs.restate.dev/operate/configuration) of the form `RESTATE_WORKER__PARTITIONS=1337`.
+You can [overwrite this configuration by specifying environment variables](https://docs.restate.dev/server/configuration#overrides) of the form `RESTATE_WORKER__PARTITIONS=1337`.
 
 ## Changing the benchmark parameters
 

--- a/crates/admin-rest-model/src/deployments.rs
+++ b/crates/admin-rest-model/src/deployments.rs
@@ -151,7 +151,7 @@ pub enum RegisterDeploymentRequest {
         /// If `true`, it allows registering new service revisions with
         /// schemas incompatible with previous service revisions, such as changing the service type.
         ///
-        /// See the [versioning documentation](https://docs.restate.dev/operate/versioning) for more information.
+        /// See the [versioning documentation](https://docs.restate.dev/services/versioning) for more information.
         #[serde(default = "restate_serde_util::default::bool::<false>")]
         breaking: bool,
 
@@ -162,7 +162,7 @@ pub enum RegisterDeploymentRequest {
         ///
         /// When set to `true`, it implies `breaking = true`.
         ///
-        /// See the [versioning documentation](https://docs.restate.dev/operate/versioning) for more information.
+        /// See the [versioning documentation](https://docs.restate.dev/services/versioning) for more information.
         #[cfg_attr(feature = "schema", schema(default = true))]
         force: Option<bool>,
 
@@ -213,7 +213,7 @@ pub enum RegisterDeploymentRequest {
         /// If `true`, it allows registering new service revisions with
         /// schemas incompatible with previous service revisions, such as changing the service type.
         ///
-        /// See the [versioning documentation](https://docs.restate.dev/operate/versioning) for more information.
+        /// See the [versioning documentation](https://docs.restate.dev/services/versioning) for more information.
         #[serde(default = "restate_serde_util::default::bool::<false>")]
         breaking: bool,
 
@@ -224,7 +224,7 @@ pub enum RegisterDeploymentRequest {
         ///
         /// This implies `breaking = true`.
         ///
-        /// See the [versioning documentation](https://docs.restate.dev/operate/versioning) for more information.
+        /// See the [versioning documentation](https://docs.restate.dev/services/versioning) for more information.
         #[cfg_attr(feature = "schema", schema(default = true))]
         force: Option<bool>,
 

--- a/crates/admin/src/rest_api/mod.rs
+++ b/crates/admin/src/rest_api/mod.rs
@@ -44,19 +44,19 @@ pub use version::{MAX_ADMIN_API_VERSION, MIN_ADMIN_API_VERSION};
     info(
         title = "Admin API",
         version = env!("CARGO_PKG_VERSION"),
-        description = "This API exposes the admin operations of a Restate cluster, such as registering new service deployments, interacting with running invocations, register Kafka subscriptions, retrieve service metadata. For an overview, check out the [Operate documentation](https://docs.restate.dev/operate/). If you're looking for how to call your services, check out the [Ingress HTTP API](https://docs.restate.dev/invoke/http) instead.",
+        description = "This API exposes the admin operations of a Restate cluster, such as registering new service deployments, interacting with running invocations, register Kafka subscriptions, retrieve service metadata. For an overview, check out the [Server documentation](https://docs.restate.dev/server/overview). If you're looking for how to call your services, check out the [Ingress HTTP API](https://docs.restate.dev/invoke/http) instead.",
         license(
             name = "MIT",
             url = "https://opensource.org/license/mit"
         ),
     ),
-    external_docs(url = "https://docs.restate.dev/operate/", description = "Restate operations documentation"),
+    external_docs(url = "https://docs.restate.dev/server/overview", description = "Restate server documentation"),
     tags(
         (name = "deployment", description = "Service Deployment management"),
         (name = "invocation", description = "Invocation management",
-         external_docs(url = "https://docs.restate.dev/operate/invocation", description = "Invocations documentation")),
+         external_docs(url = "https://docs.restate.dev/services/invocation/http", description = "Invocations documentation")),
         (name = "subscription", description = "Subscription management",
-         external_docs(url = "https://docs.restate.dev/operate/invocation#managing-kafka-subscriptions", description = "Kafka subscriptions documentation")),
+         external_docs(url = "https://docs.restate.dev/services/invocation/kafka#managing-kafka-subscriptions", description = "Kafka subscriptions documentation")),
         (name = "kafka_cluster", description = "Kafka cluster management"),
         (name = "service", description = "Service management"),
         (name = "service_handler", description = "Service handlers metadata"),

--- a/crates/admin/src/rest_api/services.rs
+++ b/crates/admin/src/rest_api/services.rs
@@ -186,7 +186,7 @@ where
 
 /// Modify service state
 ///
-/// Modifies the K/V state of a Virtual Object. For a detailed description of this API and how to use it, see the [state documentation](https://docs.restate.dev/operate/invocation#modifying-service-state).
+/// Modifies the K/V state of a Virtual Object. For a detailed description of this API and how to use it, see the [state documentation](https://docs.restate.dev/services/introspection#inspecting-application-state).
 #[utoipa::path(
     post,
     path = "/services/{service}/state",

--- a/crates/admin/src/rest_api/subscriptions.rs
+++ b/crates/admin/src/rest_api/subscriptions.rs
@@ -25,7 +25,7 @@ use restate_types::schema::registry::MetadataService;
 /// Create subscription
 ///
 /// Creates a new subscription that connects an event source (e.g., a Kafka topic) to a Restate service handler.
-/// For more information, see the [subscription documentation](https://docs.restate.dev/operate/invocation#managing-kafka-subscriptions).
+/// For more information, see the [subscription documentation](https://docs.restate.dev/services/invocation/kafka#managing-kafka-subscriptions).
 #[utoipa::path(
     post,
     path = "/subscriptions",

--- a/crates/errors/src/error_codes/META0004.md
+++ b/crates/errors/src/error_codes/META0004.md
@@ -7,4 +7,4 @@ Make sure, when updating a deployment, to assign it a new uri/arn.
 
 You can force the override using the `"force": true` field in the discover request, but beware that this can lead in-flight invocations to an unrecoverable error state.  
 
-See the [versioning documentation](https://docs.restate.dev/operate/versioning) for more information.
+See the [versioning documentation](https://docs.restate.dev/services/versioning) for more information.

--- a/crates/errors/src/error_codes/META0006.md
+++ b/crates/errors/src/error_codes/META0006.md
@@ -6,4 +6,4 @@ When implementing a new service revision, make sure that:
 
 * The service type is the same as the previous revision.
 
-See the [versioning documentation](https://docs.restate.dev/operate/versioning) for more information.
+See the [versioning documentation](https://docs.restate.dev/services/versioning) for more information.

--- a/crates/errors/src/error_codes/META0016.md
+++ b/crates/errors/src/error_codes/META0016.md
@@ -9,4 +9,4 @@ When updating a deployment, make sure that:
 * The updated deployment contains at least all the services that it previously did.
 * The updated deployment has exactly the same supported protocol versions, which generally means you want to use the same SDK minor version.
 
-See the [versioning documentation](https://docs.restate.dev/operate/versioning) for more information.
+See the [versioning documentation](https://docs.restate.dev/services/versioning) for more information.

--- a/crates/errors/src/error_codes/META0017.md
+++ b/crates/errors/src/error_codes/META0017.md
@@ -10,4 +10,4 @@ When using the `PUT /deployments/{deployment_id}` API to update a deployment in 
 This is intended to be a temporary measure to fix failing invocations on a draining deployment. While in this state, it is not possible to force deploy that same destination.
 Instead, one of the two deployments must be deleted (`DELETE /deployments/{deployment_id}`) so that there is an unambiguous deployment to replace.
 
-See the [versioning documentation](https://docs.restate.dev/operate/versioning) for more information.
+See the [versioning documentation](https://docs.restate.dev/services/versioning) for more information.

--- a/crates/errors/src/error_codes/RT0002.md
+++ b/crates/errors/src/error_codes/RT0002.md
@@ -2,4 +2,4 @@
 
 Cannot start Restate because the configuration cannot be parsed. Check the configuration file and the environment variables provided.
 
-For a complete list of configuration options, and a sample configuration, check https://docs.restate.dev/operate/configuration
+For a complete list of configuration options, and a sample configuration, check https://docs.restate.dev/references/server-config

--- a/crates/errors/src/error_codes/RT0015.md
+++ b/crates/errors/src/error_codes/RT0015.md
@@ -6,5 +6,5 @@ This indicates that the SDK was updated to a new version that dropped support fo
 Suggestions:
 
 * For in-flight invocations, downgrade the SDK version back to the previous version.
-* For new invocations, register a new deployment with a new endpoint as described here: https://docs.restate.dev/operate/versioning#deploying-new-service-versions.  
-* Make sure the new SDK is compatible with this runtime version, for more info check out https://docs.restate.dev/operate/upgrading#service-compatibility.
+* For new invocations, register a new deployment with a new endpoint as described here: https://docs.restate.dev/services/versioning#manual-versioning.  
+* Make sure the new SDK is compatible with this runtime version, for more info check out https://docs.restate.dev/server/upgrading#service-compatibility.

--- a/crates/errors/src/error_codes/RT0016.md
+++ b/crates/errors/src/error_codes/RT0016.md
@@ -5,8 +5,8 @@ This indicates that either the service code was changed (e.g. the service contai
 
 To fix it:
 
-* Update the deployment in place, fixing the bug, as described in https://docs.restate.dev/operate/versioning/#updating-deployments-in-place
-* If you can afford to lose partial progress, then kill the invocation as described in https://docs.restate.dev/operate/invocation/#killing-invocations
+* Update the deployment in place, fixing the bug, as described in https://docs.restate.dev/services/versioning#fixing-a-bug-by-updating-deployed-code
+* If you can afford to lose partial progress, then kill the invocation as described in https://docs.restate.dev/services/invocation/managing-invocations#kill
 
 Some common mistakes that lead to non-deterministic errors are:
 

--- a/crates/partition-store/src/partition_store_manager.rs
+++ b/crates/partition-store/src/partition_store_manager.rs
@@ -309,7 +309,7 @@ impl PartitionStoreManager {
                 // Play it safe and keep the partition store intact; we can't do much else at this
                 // point. We'll likely halt again as soon as the processor starts up.
                 let recovery_guide_msg = "The partition's log is trimmed to a point from which this processor can not resume. \
-                Visit https://docs.restate.dev/operate/clusters#handling-missing-snapshots \
+                Visit https://docs.restate.dev/server/clusters#handling-missing-snapshots \
                 to learn more about how to recover this processor.";
 
                 if let Some(snapshot) = maybe_snapshot {

--- a/crates/service-protocol-v4/src/discovery.rs
+++ b/crates/service-protocol-v4/src/discovery.rs
@@ -274,7 +274,7 @@ impl DiscoveryClient for ServiceDiscovery {
             warn!(
                 "The registered endpoint is using a service protocol version that will be removed in the future releases. \
                      Please update the SDK to the latest release and re-register the deployment. \
-                     For more info, check https://docs.restate.dev/operate/versioning#deploying-new-service-versions",
+                     For more info, check https://docs.restate.dev/services/versioning#manual-versioning",
             );
         }
 

--- a/crates/storage-query-datafusion/src/inbox/schema.rs
+++ b/crates/storage-query-datafusion/src/inbox/schema.rs
@@ -24,7 +24,7 @@ define_table!(sys_inbox(
     /// The key of the virtual object/workflow.
     service_key: DataType::LargeUtf8,
 
-    /// [Invocation ID](/operate/invocation#invocation-identifier).
+    /// [Invocation ID](/services/invocation/managing-invocations#invocation-id).
     id: DataType::LargeUtf8,
 
     /// Sequence number in the inbox.

--- a/crates/storage-query-datafusion/src/invocation_state/schema.rs
+++ b/crates/storage-query-datafusion/src/invocation_state/schema.rs
@@ -18,7 +18,7 @@ define_table!(sys_invocation_state(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.
     partition_key: DataType::UInt64,
 
-    /// [Invocation ID](/operate/invocation#invocation-identifier).
+    /// [Invocation ID](/services/invocation/managing-invocations#invocation-id).
     id: DataType::LargeUtf8,
 
     /// If true, the invocation is currently in-flight

--- a/crates/storage-query-datafusion/src/invocation_status/schema.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/schema.rs
@@ -18,7 +18,7 @@ define_table!(sys_invocation_status(
     /// Internal column that is used for partitioning the services invocations. Can be ignored.
     partition_key: DataType::UInt64,
 
-    /// [Invocation ID](/operate/invocation#invocation-identifier).
+    /// [Invocation ID](/services/invocation/managing-invocations#invocation-id).
     id: DataType::LargeUtf8,
 
     /// The VQueue assigned to the the invocation. NULL if invocation was not migrated to vqueues.
@@ -69,7 +69,7 @@ define_table!(sys_invocation_status(
     /// * `restart_as_new` if the invocation was created by restarting an old invocation as new.
     invoked_by: DataType::LargeUtf8,
 
-    /// The caller [Invocation ID](/operate/invocation#invocation-identifier) if `invoked_by = 'service'`.
+    /// The caller [Invocation ID](/services/invocation/managing-invocations#invocation-id) if `invoked_by = 'service'`.
     invoked_by_id: DataType::LargeUtf8,
 
     /// The subscription id if `invoked_by = 'subscription'`.

--- a/crates/storage-query-datafusion/src/journal/schema.rs
+++ b/crates/storage-query-datafusion/src/journal/schema.rs
@@ -20,7 +20,7 @@ define_table!(sys_journal (
     /// Internal column that is used for partitioning the services invocations. Can be ignored.
     partition_key: DataType::UInt64,
 
-    /// [Invocation ID](/operate/invocation#invocation-identifier).
+    /// [Invocation ID](/services/invocation/managing-invocations#invocation-id).
     id: DataType::LargeUtf8,
 
     /// The index of this journal entry.

--- a/crates/storage-query-datafusion/src/journal_events/schema.rs
+++ b/crates/storage-query-datafusion/src/journal_events/schema.rs
@@ -18,7 +18,7 @@ define_table!(sys_journal_events (
     /// Internal column that is used for partitioning the services invocations. Can be ignored.
     partition_key: DataType::UInt64,
 
-    /// [Invocation ID](/operate/invocation#invocation-identifier).
+    /// [Invocation ID](/services/invocation/managing-invocations#invocation-id).
     id: DataType::LargeUtf8,
 
     /// The journal index after which this event happened. This can be used to establish a total order between events and journal entries.

--- a/crates/storage-query-datafusion/src/keyed_service_status/schema.rs
+++ b/crates/storage-query-datafusion/src/keyed_service_status/schema.rs
@@ -24,6 +24,6 @@ define_table!(sys_keyed_service_status(
     /// The key of the virtual object/workflow.
     service_key: DataType::LargeUtf8,
 
-    /// [Invocation ID](/operate/invocation#invocation-identifier).
+    /// [Invocation ID](/services/invocation/managing-invocations#invocation-id).
     invocation_id: DataType::LargeUtf8,
 ));

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -1069,7 +1069,7 @@ fn is_default_max_successive_merges(i: &u16) -> bool {
 /// Partition store object-store snapshotting settings. At a minimum, set `destination` to enable
 /// manual snapshotting via `restatectl`. Additionally, `snapshot-interval` and
 /// `snapshot-interval-num-records` can be used to configure automated periodic snapshots. For a
-/// complete example, see [Snapshots](https://docs.restate.dev/operate/snapshots).
+/// complete example, see [Snapshots](https://docs.restate.dev/server/snapshots).
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, derive_builder::Builder)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]

--- a/crates/worker/src/partition/leadership/durability_tracker.rs
+++ b/crates/worker/src/partition/leadership/durability_tracker.rs
@@ -93,7 +93,7 @@ impl DurabilityTracker {
                     %durability_mode,
                     "Detected cluster environment with no snapshot repository configured. \
                     Automatic log trimming is disabled, please refer to \
-                    https://docs.restate.dev/operate/snapshots/ for more."
+                    https://docs.restate.dev/server/snapshots for more."
                 );
             }
         };
@@ -105,7 +105,7 @@ impl DurabilityTracker {
                     Due to the configured durability mode '{durability_mode}', the cluster might \
                     not be able to move partitions to other nodes for fail-over or rebalancing. \
                     Please configure the cluster to use a shared snapshot repository. Please refer \
-                    to https://docs.restate.dev/operate/snapshots/ for more."
+                    to https://docs.restate.dev/server/snapshots for more."
                 );
             }
         };


### PR DESCRIPTION
The docs site no longer has an /operate/ section; its pages moved under /services/ and /server/ some time ago. 33 links across error codes, API descriptions, log messages and READMEs still pointed there.

Most still resolve, because docs-restate carries redirect rules for /operate/*, but three groups do not:

- Anchors that did not survive the move. /operate/invocation redirects to /services/invocation/http, which has no #invocation-identifier, #killing-invocations, #managing-kafka-subscriptions or #modifying-service-state heading. The invocation-identifier link is the most visible: it is repeated seven times in the storage-query-datafusion column docs and is rendered into the SQL introspection reference.
- The bare /operate/ overview link used twice in the Admin API OpenAPI description. No redirect covers it.
- /operate/configuration, likewise uncovered.

Repointed each at the page that now holds the content, verified against the current docs site:

```
  /operate/                    -> /server/overview
  /operate/versioning          -> /services/versioning
  /operate/invocation          -> /services/invocation/http
  #invocation-identifier       -> /services/invocation/managing-invocations#invocation-id
  #killing-invocations         -> /services/invocation/managing-invocations#kill
  #managing-kafka-subscriptions-> /services/invocation/kafka#managing-kafka-subscriptions
  #modifying-service-state     -> /services/introspection#inspecting-application-state
  #deploying-new-service-versions -> /services/versioning#manual-versioning
  #updating-deployments-in-place  -> /services/versioning#fixing-a-bug-by-updating-deployed-code
  /operate/upgrading           -> /server/upgrading
  /operate/snapshots           -> /server/snapshots
  /operate/clusters            -> /server/clusters
  /operate/introspection       -> /services/introspection
  /operate/configuration       -> /references/server-config (RT0002)
                                  /server/configuration#overrides (benchmarks)
```