### PR TITLE
docs: describe the keep-alive and object store retry options

### DIFF
--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -1143,9 +1143,16 @@ pub struct MetadataClientOptions {
     pub connect_timeout: NonZeroFriendlyDuration,
 
     /// # Metadata Store Keep Alive Interval
+    ///
+    /// Interval at which keep-alive probes are sent on the connection to the
+    /// metadata store, to keep it alive and to detect a store that has become
+    /// unreachable.
     pub keep_alive_interval: NonZeroFriendlyDuration,
 
     /// # Metadata Store Keep Alive Timeout
+    ///
+    /// How long to wait for a keep-alive probe to be acknowledged by the
+    /// metadata store before treating the connection as dead and closing it.
     pub keep_alive_timeout: NonZeroFriendlyDuration,
 
     /// # Backoff policy used by the metadata client
@@ -1250,6 +1257,14 @@ pub enum MetadataClientKind {
         object_store: ObjectStoreOptions,
 
         /// # Error retry policy
+        ///
+        /// Retry policy for the object store requests the metadata client
+        /// makes, covering both reads of the current metadata version and the
+        /// conditional writes used to update it.
+        ///
+        /// Retries here absorb the transient errors and throttling responses
+        /// object stores return under load, so a short or non-retrying policy
+        /// can surface those as metadata operation failures.
         #[serde(default = "MetadataClientKind::default_object_store_retry_policy")]
         object_store_retry_policy: RetryPolicy,
     },

--- a/crates/types/src/config/networking.rs
+++ b/crates/types/src/config/networking.rs
@@ -50,9 +50,20 @@ pub struct NetworkingOptions {
     pub handshake_timeout: NonZeroFriendlyDuration,
 
     /// # HTTP/2 Keep Alive Interval
+    ///
+    /// Interval at which HTTP/2 PING frames are sent on node-to-node
+    /// connections, to keep them alive and to detect peers that have become
+    /// unreachable.
+    ///
+    /// Applies both to the gRPC channels a node opens to its peers and to the
+    /// connections it accepts from them.
     pub http2_keep_alive_interval: NonZeroFriendlyDuration,
 
     /// # HTTP/2 Keep Alive Timeout
+    ///
+    /// How long to wait for a peer to acknowledge a keep-alive PING on a
+    /// node-to-node connection. If the acknowledgement does not arrive within
+    /// this timeout, the connection is closed and re-established.
     pub http2_keep_alive_timeout: NonZeroFriendlyDuration,
 
     /// # HTTP/2 Adaptive Window


### PR DESCRIPTION
Five config options had only a `# Title` and no body, so the generated config reference fell through to the referenced type and rendered "HTTP/2 Keep Alive Interval: Non-zero duration string in either jiff human friendly or ISO8601 format" -- a title followed by a blurb about duration syntax that says nothing about what the option does.

Documents the networking and metadata-client keep-alive pairs and the object store metadata retry policy, based on where each value is used.