### PR TITLE
[VQueues] Internalize vqueue index management to partition-store

### DIFF
--- a/crates/partition-store/src/vqueue_table/mod.rs
+++ b/crates/partition-store/src/vqueue_table/mod.rs
@@ -166,6 +166,44 @@ impl ScanVQueueTable for PartitionDb {
     }
 }
 
+// Helpers for internal management of vqueues
+impl PartitionStoreTransaction<'_> {
+    /// Adds a vqueue to the list of active vqueues
+    ///
+    /// A vqueue is considered active when it's of interest to the scheduler.
+    ///
+    /// The scheduler cares about vqueues that have entries that are already running or that are waiting
+    /// to run. With some special rules to consider when the queue is paused. When the vqueue is
+    /// paused, the scheduler will only be interested in its "running" entries and not in its
+    /// waiting entries. Therefore, it will remain to be "active" as long as it has running
+    /// entries. Once running entries are moved to waiting or completed, the vqueue is be
+    /// considered dormant until it's unpaused.
+    ///
+    /// A vqueue that is "not" active does not mean it's "empty". It could be paused or
+    /// only contains entries in parked or completed states. As such, it's not considered
+    /// by the scheduler and it's considered "dormant".
+    fn mark_vqueue_as_active(&mut self, qid: &VQueueId) {
+        let mut key_buffer = [0u8; ActiveKey::serialized_length_fixed()];
+        ActiveKeyRef::builder()
+            .qid(qid)
+            .serialize_to(&mut key_buffer.as_mut());
+        self.raw_put_cf(KeyKind::VQueueActive, key_buffer, []);
+    }
+
+    /// Removes the vqueue from the list of active vqueues
+    ///
+    /// A dormant vqueue is not necessarily `empty`. It's a vqueue _might_ have items (or not)
+    /// in parked or completed states, or it might have waiting items in its inbox but the
+    /// vqueue is paused and would not be visible to the scheduler.
+    fn mark_vqueue_as_dormant(&mut self, qid: &restate_types::vqueues::VQueueId) {
+        let mut key_buffer = [0u8; ActiveKey::serialized_length_fixed()];
+        ActiveKeyRef::builder()
+            .qid(qid)
+            .serialize_to(&mut key_buffer.as_mut());
+        self.raw_single_delete_cf(KeyKind::VQueueActive, key_buffer);
+    }
+}
+
 impl WriteVQueueTable for PartitionStoreTransaction<'_> {
     fn create_vqueue(&mut self, qid: &VQueueId, meta: &VQueueMeta) {
         let key_buffer = MetaKey::from(qid).to_bytes();
@@ -182,7 +220,9 @@ impl WriteVQueueTable for PartitionStoreTransaction<'_> {
     fn update_vqueue(
         &mut self,
         qid: &VQueueId,
+        meta: &mut VQueueMeta,
         update: &restate_storage_api::vqueue_table::metadata::Update,
+        _entry_metadata: Option<&EntryMetadata>,
     ) {
         let key_buffer = MetaKey::from(qid).to_bytes();
         self.raw_merge_cf(
@@ -190,6 +230,23 @@ impl WriteVQueueTable for PartitionStoreTransaction<'_> {
             key_buffer,
             update.encode_contiguous().into_vec(),
         );
+
+        // Mutate the VQueue metadata
+        let was_active_before = meta.is_active();
+        // mutate in-place
+        meta.apply_update(update);
+        let is_active_now = meta.is_active();
+
+        // Update active queue index
+        match (was_active_before, is_active_now) {
+            (false, true) => {
+                self.mark_vqueue_as_active(qid);
+            }
+            (true, false) => {
+                self.mark_vqueue_as_dormant(qid);
+            }
+            (_, _) => {}
+        }
     }
 
     fn put_vqueue_inbox(
@@ -232,22 +289,6 @@ impl WriteVQueueTable for PartitionStoreTransaction<'_> {
             KeyKind::VQueueInboxStage,
             inbox::encode_stage_key(stage, qid, key),
         );
-    }
-
-    fn mark_vqueue_as_active(&mut self, qid: &VQueueId) {
-        let mut key_buffer = [0u8; ActiveKey::serialized_length_fixed()];
-        ActiveKeyRef::builder()
-            .qid(qid)
-            .serialize_to(&mut key_buffer.as_mut());
-        self.raw_put_cf(KeyKind::VQueueActive, key_buffer, []);
-    }
-
-    fn mark_vqueue_as_dormant(&mut self, qid: &restate_types::vqueues::VQueueId) {
-        let mut key_buffer = [0u8; ActiveKey::serialized_length_fixed()];
-        ActiveKeyRef::builder()
-            .qid(qid)
-            .serialize_to(&mut key_buffer.as_mut());
-        self.raw_single_delete_cf(KeyKind::VQueueActive, key_buffer);
     }
 
     fn put_vqueue_entry_status(

--- a/crates/storage-api/src/vqueue_table/tables.rs
+++ b/crates/storage-api/src/vqueue_table/tables.rs
@@ -105,7 +105,17 @@ pub trait WriteVQueueTable {
     fn create_vqueue(&mut self, qid: &VQueueId, meta: &VQueueMeta);
 
     /// Update VQueueMeta with a set of differential updates.
-    fn update_vqueue(&mut self, qid: &VQueueId, update: &super::metadata::Update);
+    /// The `meta` **must** match the vqueue metadata on disk prior to the update,
+    /// then it gets updated in place.
+    ///
+    /// Pass `entry_metadata` if the update impacts a single entry.
+    fn update_vqueue(
+        &mut self,
+        qid: &VQueueId,
+        meta: &mut VQueueMeta,
+        update: &super::metadata::Update,
+        entry_metadata: Option<&EntryMetadata>,
+    );
 
     /// Places an entry onto an inbox stage
     fn put_vqueue_inbox(
@@ -126,29 +136,6 @@ pub trait WriteVQueueTable {
 
     /// Deletes entry from inbox unconditionally
     fn delete_vqueue_inbox(&mut self, qid: &VQueueId, stage: Stage, key: &EntryKey);
-
-    /// Adds a vqueue to the list of active vqueues
-    ///
-    /// A vqueue is considered active when it's of interest to the scheduler.
-    ///
-    /// The scheduler cares about vqueues that have entries that are already running or that are waiting
-    /// to run. With some special rules to consider when the queue is paused. When the vqueue is
-    /// paused, the scheduler will only be interested in its "running" entries and not in its
-    /// waiting entries. Therefore, it will remain to be "active" as long as it has running
-    /// entries. Once running entries are moved to waiting or completed, the vqueue is be
-    /// considered dormant until it's unpaused.
-    ///
-    /// A vqueue that is "not" active does not mean it's "empty". It could be paused or
-    /// only contains entries in parked or completed states. As such, it's not considered
-    /// by the scheduler and it's considered "dormant".
-    fn mark_vqueue_as_active(&mut self, qid: &VQueueId);
-
-    /// Removes the vqueue from the list of active vqueues
-    ///
-    /// A dormant vqueue is not necessarily `empty`. It's a vqueue _might_ have items (or not)
-    /// in parked or completed states, or it might have waiting items in its inbox but the
-    /// vqueue is paused and would not be visible to the scheduler.
-    fn mark_vqueue_as_dormant(&mut self, qid: &VQueueId);
 
     // Left intentionally for future reference if/when we need to store extra state
     // fn put_vqueue_entry_state<E>(

--- a/crates/vqueues/src/cache.rs
+++ b/crates/vqueues/src/cache.rs
@@ -14,7 +14,7 @@ use tracing::{debug, trace};
 
 use restate_platform::hash::HashMap;
 use restate_storage_api::StorageError;
-use restate_storage_api::vqueue_table::metadata::{self, VQueueMeta};
+use restate_storage_api::vqueue_table::metadata::VQueueMeta;
 use restate_storage_api::vqueue_table::{ReadVQueueTable, ScanVQueueTable};
 use restate_types::sharding::PartitionKey;
 use restate_types::vqueues::VQueueId;
@@ -100,14 +100,13 @@ impl Slot {
         &self.meta
     }
 
-    /// Returns is_active of the vqueue before and after all the updates
-    /// in the form of a tuple (before, after).
-    pub fn apply_update(&mut self, update: &metadata::Update) -> (bool, bool) {
-        let before = self.meta.is_active();
-        self.meta.apply_update(update);
-        let after = self.meta.is_active();
+    #[inline(always)]
+    pub(super) fn split_mut(&mut self) -> (&VQueueId, &mut VQueueMeta) {
+        (&self.qid, &mut self.meta)
+    }
 
-        (before, after)
+    pub(super) fn meta_mut(&mut self) -> &mut VQueueMeta {
+        &mut self.meta
     }
 }
 

--- a/crates/vqueues/src/lib.rs
+++ b/crates/vqueues/src/lib.rs
@@ -295,15 +295,9 @@ where
             },
         );
 
-        // Update cache
-        let (was_active_before, is_active_now) = meta.apply_update(&update);
-
-        // Update vqueue meta in storage
-        self.storage.update_vqueue(meta.vqueue_id(), &update);
-
-        if !was_active_before && is_active_now {
-            self.storage.mark_vqueue_as_active(meta.vqueue_id());
-        }
+        let (vqueue_id, q_meta) = meta.split_mut();
+        self.storage
+            .update_vqueue(vqueue_id, q_meta, &update, Some(&metadata));
 
         // We need to add the entry into the inbox vqueue.
         let value = EntryValue {
@@ -379,8 +373,8 @@ where
             },
         );
 
-        meta.apply_update(&update);
-        self.storage.update_vqueue(vqueue_id, &update);
+        self.storage
+            .update_vqueue(vqueue_id, meta.meta_mut(), &update, Some(header.metadata()));
 
         let stats = Self::mark_run_attempt(at, header.stats(), wait_stats);
 
@@ -489,14 +483,9 @@ where
             },
         );
 
-        // Update cache
-        let (was_active_before, is_active_now) = meta.apply_update(&update);
         // Update vqueue meta in storage
-        self.storage.update_vqueue(vqueue_id, &update);
-
-        if !was_active_before && is_active_now {
-            self.storage.mark_vqueue_as_active(vqueue_id);
-        }
+        self.storage
+            .update_vqueue(vqueue_id, meta.meta_mut(), &update, Some(header.metadata()));
 
         // We can be asked to wake up but not run immediately (or get a lower run_at for priority
         // boosting). If that's the case, we mutate the entry key to reflect that.
@@ -722,15 +711,9 @@ where
             },
         );
 
-        // Update cache
-        let (was_active_before, is_active_now) = meta.apply_update(&update);
-
         // Update vqueue meta in storage
-        self.storage.update_vqueue(meta.vqueue_id(), &update);
-
-        if was_active_before && !is_active_now {
-            self.storage.mark_vqueue_as_dormant(meta.vqueue_id());
-        }
+        self.storage
+            .update_vqueue(vqueue_id, meta.meta_mut(), &update, Some(header.metadata()));
 
         let stats = match next_stage {
             Stage::Paused => Self::mark_pause(at, header.stats()),
@@ -797,13 +780,8 @@ where
             },
         );
 
-        // Update cache
-        let (was_active_before, is_active_now) = meta.apply_update(&update);
-        self.storage.update_vqueue(vqueue_id, &update);
-
-        if !was_active_before && is_active_now {
-            self.storage.mark_vqueue_as_active(meta.vqueue_id());
-        }
+        self.storage
+            .update_vqueue(vqueue_id, meta.meta_mut(), &update, Some(header.metadata()));
 
         // We can be asked to wake up but not run immediately (or get a lower run_at for priority
         // boosting). If that's the case, we mutate the entry key to reflect that.
@@ -964,13 +942,8 @@ where
             new_status,
         );
 
-        // Update cache
-        let (was_active_before, is_active_now) = meta.apply_update(&update);
-        self.storage.update_vqueue(meta.vqueue_id(), &update);
-
-        if was_active_before && !is_active_now {
-            self.storage.mark_vqueue_as_dormant(meta.vqueue_id());
-        }
+        self.storage
+            .update_vqueue(vqueue_id, meta.meta_mut(), &update, Some(header.metadata()));
 
         if let Some(collector) = self.action_collector.as_deref_mut() {
             let mut event = VQueueEvent::new(self.handle);
@@ -994,7 +967,13 @@ where
 
         if delete_after.is_zero() {
             // Delete immediately!
-            self.delete(at, vqueue_id, header.entry_id(), &modified_key);
+            self.delete(
+                at,
+                vqueue_id,
+                header.entry_id(),
+                &modified_key,
+                header.metadata(),
+            );
         }
     }
 
@@ -1008,6 +987,7 @@ where
         vqueue_id: &VQueueId,
         entry_id: &EntryId,
         entry_key: &EntryKey,
+        entry_metadata: &EntryMetadata,
     ) {
         let meta = self.cache.get_mut(self.handle).unwrap();
         assert_eq!(vqueue_id, meta.vqueue_id());
@@ -1034,9 +1014,8 @@ where
         // delete the inbox entry
         self.storage
             .delete_vqueue_inbox(vqueue_id, Stage::Finished, entry_key);
-        // update cache
-        let _ = meta.apply_update(&update);
-        self.storage.update_vqueue(vqueue_id, &update);
+        self.storage
+            .update_vqueue(vqueue_id, meta.meta_mut(), &update, Some(entry_metadata));
     }
 
     /// A specialized version of run designed for inline execution of an entry.
@@ -1073,8 +1052,8 @@ where
             },
         );
 
-        meta.apply_update(&update);
-        self.storage.update_vqueue(vqueue_id, &update);
+        self.storage
+            .update_vqueue(vqueue_id, meta.meta_mut(), &update, Some(header.metadata()));
         let stats = Self::mark_run_attempt(at, header.stats(), wait_stats);
 
         // Move to finish
@@ -1089,12 +1068,8 @@ where
 
         let stats = Self::mark_transition(at, &stats);
 
-        let (was_active_before, is_active_now) = meta.apply_update(&update);
-        self.storage.update_vqueue(vqueue_id, &update);
-
-        if was_active_before && !is_active_now {
-            self.storage.mark_vqueue_as_dormant(meta.vqueue_id());
-        }
+        self.storage
+            .update_vqueue(vqueue_id, meta.meta_mut(), &update, Some(header.metadata()));
 
         // Move the entry to Finished stage
         // for future: Use this to set the deletion time.
@@ -1153,32 +1128,26 @@ where
         // delete the inbox entry
         self.storage
             .delete_vqueue_inbox(vqueue_id, Stage::Finished, &modified_key);
-        // update cache
-        let _ = meta.apply_update(&update);
-        self.storage.update_vqueue(vqueue_id, &update);
+
+        self.storage
+            .update_vqueue(vqueue_id, meta.meta_mut(), &update, Some(header.metadata()));
     }
 
     /// Marks this vqueue as paused
     pub fn pause_queue(&mut self, at: UniqueTimestamp) {
-        let meta = self.cache.get_mut(self.handle).unwrap();
+        let slot = self.cache.get_mut(self.handle).unwrap();
 
-        if meta.meta().queue_is_paused() {
+        if slot.meta().queue_is_paused() {
             // queue is already paused
             return;
         }
 
-        debug!(qid = %meta.vqueue_id(), "Pausing vqueue");
+        debug!(qid = %slot.vqueue_id(), "Pausing vqueue");
         let update = metadata::Update::new(at, metadata::Action::PauseVQueue {});
 
-        // Update cache
-        let (was_active_before, is_active_now) = meta.apply_update(&update);
-
         // Update vqueue meta in storage
-        self.storage.update_vqueue(meta.vqueue_id(), &update);
-
-        if was_active_before && !is_active_now {
-            self.storage.mark_vqueue_as_dormant(meta.vqueue_id());
-        }
+        let (vqueue_id, meta) = slot.split_mut();
+        self.storage.update_vqueue(vqueue_id, meta, &update, None);
 
         if let Some(collector) = self.action_collector.as_deref_mut() {
             let mut event = VQueueEvent::new(self.handle);
@@ -1189,26 +1158,22 @@ where
 
     /// Marks this vqueue as resumed
     pub fn resume_queue(&mut self, at: UniqueTimestamp) {
-        let meta = self.cache.get_mut(self.handle).unwrap();
+        let slot = self.cache.get_mut(self.handle).unwrap();
 
-        if !meta.meta().queue_is_paused() {
+        if !slot.meta().queue_is_paused() {
             // queue is not paused
             return;
         }
-        debug!(qid = %meta.vqueue_id(), "Resuming vqueue");
+        debug!(qid = %slot.vqueue_id(), "Resuming vqueue");
         let update = metadata::Update::new(at, metadata::Action::ResumeVQueue {});
 
-        // Update cache
-        let (was_active_before, is_active_now) = meta.apply_update(&update);
-
         // Update vqueue meta in storage
-        self.storage.update_vqueue(meta.vqueue_id(), &update);
+        let (vqueue_id, meta) = slot.split_mut();
+        self.storage.update_vqueue(vqueue_id, meta, &update, None);
 
-        if !was_active_before && is_active_now {
-            self.storage.mark_vqueue_as_active(meta.vqueue_id());
-        }
-
-        if is_active_now && let Some(collector) = self.action_collector.as_deref_mut() {
+        if meta.is_active()
+            && let Some(collector) = self.action_collector.as_deref_mut()
+        {
             let mut event = VQueueEvent::new(self.handle);
             event.push(EventDetails::QueueResumed);
             collector.push(A::from(event));
@@ -1387,15 +1352,9 @@ where
             },
         );
 
-        // Update vqueue meta cache
-        let (was_active_before, is_active_now) = meta.apply_update(&update);
-
-        // Update vqueue meta in storage
-        self.storage.update_vqueue(meta.vqueue_id(), &update);
-
-        if !was_active_before && is_active_now {
-            self.storage.mark_vqueue_as_active(meta.vqueue_id());
-        }
+        let (vqueue_id, q_meta) = meta.split_mut();
+        self.storage
+            .update_vqueue(vqueue_id, q_meta, &update, Some(&metadata));
 
         // We need to add the entry into the inbox vqueue.
         let value = EntryValue {
@@ -1508,11 +1467,9 @@ where
             },
         );
 
-        // Update vqueue meta cache
-        meta.apply_update(&update);
-
-        // Update vqueue meta in storage
-        self.storage.update_vqueue(meta.vqueue_id(), &update);
+        let (vqueue_id, q_meta) = meta.split_mut();
+        self.storage
+            .update_vqueue(vqueue_id, q_meta, &update, Some(&metadata));
 
         // We need to add the entry into the inbox vqueue.
         let value = EntryValue {
@@ -1624,15 +1581,9 @@ where
             },
         );
 
-        // Update vqueue meta cache
-        let (was_active_before, is_active_now) = meta.apply_update(&update);
-
-        // Update vqueue meta in storage
-        self.storage.update_vqueue(meta.vqueue_id(), &update);
-
-        if !was_active_before && is_active_now {
-            self.storage.mark_vqueue_as_active(meta.vqueue_id());
-        }
+        let (vqueue_id, q_meta) = meta.split_mut();
+        self.storage
+            .update_vqueue(vqueue_id, q_meta, &update, Some(&metadata));
 
         // We need to add the entry into the inbox vqueue.
         let value = EntryValue {

--- a/crates/worker/src/partition/state_machine/lifecycle/purge.rs
+++ b/crates/worker/src/partition/state_machine/lifecycle/purge.rs
@@ -93,7 +93,13 @@ where
                     )
                     .await?
                     .expect("purging in a non-existent vqueue")
-                    .delete(at, vqueue_id, &entry_id, header.entry_key());
+                    .delete(
+                        at,
+                        vqueue_id,
+                        &entry_id,
+                        header.entry_key(),
+                        header.metadata(),
+                    );
                 }
 
                 let pinned_service_protocol_version = pinned_deployment


### PR DESCRIPTION

Moves the vqueue metadata index management to be an implementation detail. This also moves the concern of cache coherence to be handled consistently along with the storage update in partition store.

The API for `update_vqueue` has been changed to allow for recording differential updates into secondary indexes. Additionally, the currently unused `entry_metadata` field will be used by follow up changes
to update partition-level aggregated metrics.
