### PR TITLE
[VQueues] Introduce PurgeVQueueMeta WAL command

### DIFF
--- a/crates/partition-store/src/vqueue_table/mod.rs
+++ b/crates/partition-store/src/vqueue_table/mod.rs
@@ -249,6 +249,12 @@ impl WriteVQueueTable for PartitionStoreTransaction<'_> {
         }
     }
 
+    fn delete_vqueue(&mut self, qid: &VQueueId) {
+        // Cannot use single delete: the meta key is written once with put and
+        // updated many times with merge afterwards.
+        self.raw_delete_cf(KeyKind::VQueueMeta, MetaKey::from(qid).to_bytes());
+    }
+
     fn put_vqueue_inbox(
         &mut self,
         qid: &VQueueId,

--- a/crates/storage-api/src/vqueue_table/metadata.rs
+++ b/crates/storage-api/src/vqueue_table/metadata.rs
@@ -362,6 +362,12 @@ impl VQueueMeta {
         self.len() == 0
     }
 
+    /// A vqueue is obsolete when it holds no entries in any stage, including
+    /// `Finished`. Obsolete vqueue metadata records can be purged from storage.
+    pub fn is_obsolete(&self) -> bool {
+        self.is_empty() && self.stats.num_finished == 0
+    }
+
     pub fn total_waiting(&self) -> u64 {
         self.stats.num_inbox
     }

--- a/crates/storage-api/src/vqueue_table/tables.rs
+++ b/crates/storage-api/src/vqueue_table/tables.rs
@@ -117,6 +117,13 @@ pub trait WriteVQueueTable {
         entry_metadata: Option<&EntryMetadata>,
     );
 
+    /// Deletes a vqueue's metadata record.
+    ///
+    /// Must only be used on obsolete vqueues (see
+    /// [`super::metadata::VQueueMeta::is_obsolete`]); the metadata merge
+    /// operator cannot apply updates to a deleted vqueue.
+    fn delete_vqueue(&mut self, qid: &VQueueId);
+
     /// Places an entry onto an inbox stage
     fn put_vqueue_inbox(
         &mut self,

--- a/crates/vqueues/src/cache.rs
+++ b/crates/vqueues/src/cache.rs
@@ -15,7 +15,7 @@ use tracing::{debug, trace};
 use restate_platform::hash::HashMap;
 use restate_storage_api::StorageError;
 use restate_storage_api::vqueue_table::metadata::VQueueMeta;
-use restate_storage_api::vqueue_table::{ReadVQueueTable, ScanVQueueTable};
+use restate_storage_api::vqueue_table::{ReadVQueueTable, ScanVQueueTable, WriteVQueueTable};
 use restate_types::sharding::PartitionKey;
 use restate_types::vqueues::VQueueId;
 
@@ -115,6 +115,9 @@ impl Slot {
 pub struct VQueuesMetaCache {
     queues: HashMap<VQueueId, VQueueHandle>,
     slab: SlotMap<VQueueHandle, Slot>,
+    /// Purged slots detached from `queues` but retained until the scheduler has
+    /// handled all events from the committed WAL batch.
+    pending_purges: Vec<VQueueHandle>,
     /// Soft cap; partition processor triggers `compact()` once `len()` reaches
     /// this number. The slab/hashmap will still grow past this if compaction
     /// frees nothing.
@@ -135,6 +138,43 @@ impl VQueuesMetaCache {
 
     pub fn get_mut(&mut self, key: VQueueHandle) -> Option<&mut Slot> {
         self.slab.get_mut(key)
+    }
+
+    /// Deletes an obsolete, unpaused vqueue without loading uncached metadata.
+    ///
+    /// Cached slots are detached from ID lookup immediately but retained until
+    /// [`Self::try_compact`] so pending scheduler events can still use their handles.
+    /// Detaching also allows a later operation in the same storage batch to recreate
+    /// the queue with a new cache handle.
+    pub async fn purge_meta_if_obsolete<S: ReadVQueueTable + WriteVQueueTable>(
+        &mut self,
+        storage: &mut S,
+        qid: &VQueueId,
+    ) -> Result<bool> {
+        let is_purgeable = |meta: &VQueueMeta| meta.is_obsolete() && !meta.queue_is_paused();
+
+        if let Some(handle) = self.queues.get(qid).copied() {
+            let slot = self.slab.get(handle).expect("cached vqueue has a slot");
+            if !is_purgeable(slot.meta()) {
+                return Ok(false);
+            }
+
+            debug!(qid = %slot.vqueue_id(), "Purging obsolete vqueue metadata");
+            storage.delete_vqueue(qid);
+            self.defer_purge(qid, handle);
+            return Ok(true);
+        }
+
+        let Some(meta) = storage.get_vqueue(qid).await? else {
+            return Ok(false);
+        };
+        if !is_purgeable(&meta) {
+            return Ok(false);
+        }
+
+        debug!(qid = %qid, "Purging obsolete vqueue metadata");
+        storage.delete_vqueue(qid);
+        Ok(true)
     }
 
     pub fn len(&self) -> usize {
@@ -168,27 +208,42 @@ impl VQueuesMetaCache {
         evicted
     }
 
-    /// Runs compaction if the cache exceeds its target capacity and the cache contains possibly
-    /// compactable entries. Returns the number of compacted entries.
+    fn defer_purge(&mut self, qid: &VQueueId, handle: VQueueHandle) {
+        let removed = self.queues.remove(qid);
+        debug_assert_eq!(removed, Some(handle));
+        self.pending_purges.push(handle);
+    }
+
+    /// Evicts pending purges, then runs compaction if the cache exceeds its target capacity and
+    /// possibly contains compactable entries. This must be called only after the scheduler has
+    /// handled all events emitted by the batch because those events refer to cache handles.
+    /// Returns the total number of evicted entries.
     pub fn try_compact(&mut self) -> usize {
+        let mut evicted = 0;
+        for handle in self.pending_purges.drain(..) {
+            evicted += usize::from(self.slab.remove(handle).is_some());
+        }
+
         if self.should_run_compaction {
             // disarm to prevent running compactions again until we are compactable again
             self.should_run_compaction = false;
 
-            let evicted = self.compact();
-            if evicted == 0 {
-                trace!(
-                    "vqueue cache at {} entries with no inactive queues to evict; cache will grow past target_capacity={}",
-                    self.slab.len(),
-                    self.target_capacity,
-                );
-            } else {
-                trace!("vqueue cache compaction freed {evicted} entries");
+            if self.slab.len() > self.target_capacity {
+                let compacted = self.compact();
+                if compacted == 0 {
+                    trace!(
+                        "vqueue cache at {} entries with no inactive queues to evict; cache will grow past target_capacity={}",
+                        self.slab.len(),
+                        self.target_capacity,
+                    );
+                } else {
+                    trace!("vqueue cache compaction freed {compacted} entries");
+                }
+                evicted += compacted;
             }
-            evicted
-        } else {
-            0
         }
+
+        evicted
     }
 
     #[cfg(any(test, feature = "test-util"))]
@@ -196,6 +251,7 @@ impl VQueuesMetaCache {
         Self {
             slab: SlotMap::with_capacity_and_key(target_capacity),
             queues: HashMap::with_capacity(target_capacity),
+            pending_purges: Vec::new(),
             target_capacity,
             should_run_compaction: false,
         }
@@ -237,6 +293,7 @@ impl VQueuesMetaCache {
         Ok(Self {
             slab,
             queues,
+            pending_purges: Vec::new(),
             target_capacity,
             should_run_compaction: false,
         })
@@ -415,6 +472,30 @@ mod tests {
                 .handle_for(&VQueueId::custom(99, "fresh"))
                 .is_some()
         );
+    }
+
+    #[test]
+    fn pending_purges_can_disarm_capacity_compaction() {
+        let now = ts(1_744_000_000_000);
+        let mut cache = VQueuesMetaCache::new_empty(2);
+
+        let purged_qid = VQueueId::custom(1, "purged");
+        let purged = cache.insert(purged_qid.clone(), empty_meta(now));
+        let retained = cache.insert(VQueueId::custom(2, "retained"), empty_meta(now));
+        let mut active_meta = empty_meta(now);
+        enqueue_to_inbox(&mut active_meta, now);
+        let active = cache.insert(VQueueId::custom(3, "active"), active_meta);
+        assert!(cache.should_run_compaction);
+
+        cache.defer_purge(&purged_qid, purged);
+        assert_eq!(cache.try_compact(), 1);
+
+        assert!(!cache.should_run_compaction);
+        assert_eq!(cache.len(), 2);
+        assert!(cache.get(purged).is_none());
+        assert!(cache.view().handle_for(&purged_qid).is_none());
+        assert!(cache.get(retained).is_some());
+        assert!(cache.get(active).is_some());
     }
 
     #[test]

--- a/crates/vqueues/src/lib.rs
+++ b/crates/vqueues/src/lib.rs
@@ -1605,3 +1605,118 @@ where
         );
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use restate_core::TaskCenter;
+    use restate_partition_store::{PartitionStore, PartitionStoreManager};
+    use restate_rocksdb::RocksDbManager;
+    use restate_storage_api::Transaction;
+    use restate_types::identifiers::PartitionId;
+    use restate_types::partitions::Partition;
+    use restate_types::sharding::KeyRange;
+    use restate_types::vqueues::EntryKind;
+
+    use super::*;
+
+    async fn storage_test_environment() -> PartitionStore {
+        let rocksdb_manager = RocksDbManager::init();
+        TaskCenter::set_on_shutdown(Box::pin(async {
+            rocksdb_manager.shutdown().await;
+        }));
+
+        let manager = PartitionStoreManager::create(true)
+            .await
+            .expect("DB storage creation succeeds");
+        manager
+            .open(
+                &Partition::new(PartitionId::MIN, KeyRange::new(0, PartitionKey::MAX - 1)),
+                None,
+            )
+            .await
+            .expect("DB storage creation succeeds")
+    }
+
+    #[restate_core::test]
+    async fn purge_meta_only_purges_obsolete_unpaused_vqueues() {
+        let mut store = storage_test_environment().await;
+        let mut cache = VQueuesMetaCache::new_empty(16);
+
+        let at = UniqueTimestamp::try_from(1_744_000_000_000u64).unwrap();
+        let empty_qid = VQueueId::custom(1, "empty");
+        let busy_qid = VQueueId::custom(2, "busy");
+        let paused_qid = VQueueId::custom(3, "paused");
+        let uncached_qid = VQueueId::custom(4, "uncached");
+        let new_meta = || VQueueMeta::new(at, None, LimitKey::None, VQueueLink::None);
+
+        let mut txn = store.transaction();
+
+        // Obsolete: created but never used.
+        VQueue::<VQueueEvent, _>::get_or_insert_with(&empty_qid, &mut txn, &mut cache, new_meta)
+            .await
+            .unwrap();
+
+        // Non-obsolete: holds an inbox entry.
+        let mut busy =
+            VQueue::<VQueueEvent, _>::get_or_insert_with(&busy_qid, &mut txn, &mut cache, new_meta)
+                .await
+                .unwrap();
+        busy.enqueue_new(
+            at,
+            1u64,
+            None,
+            EntryId::new(EntryKind::Invocation, [1; EntryId::REMAINDER_LEN]),
+            EntryMetadata::default(),
+        );
+
+        // Empty but paused: the pause flag must survive a purge attempt.
+        let mut paused = VQueue::<VQueueEvent, _>::get_or_insert_with(
+            &paused_qid,
+            &mut txn,
+            &mut cache,
+            new_meta,
+        )
+        .await
+        .unwrap();
+        paused.pause_queue(at);
+
+        // Obsolete and intentionally not loaded into the cache.
+        txn.create_vqueue(&uncached_qid, &new_meta());
+
+        txn.commit().await.unwrap();
+        drop(txn);
+
+        let empty_handle = cache.view().handle_for(&empty_qid).unwrap();
+        let mut txn = store.transaction();
+        for (qid, expect_purged) in [
+            (&empty_qid, true),
+            (&busy_qid, false),
+            (&paused_qid, false),
+            (&uncached_qid, true),
+        ] {
+            let purged = cache.purge_meta_if_obsolete(&mut txn, qid).await.unwrap();
+            assert_eq!(purged, expect_purged, "{qid}");
+        }
+        assert!(cache.view().handle_for(&empty_qid).is_none());
+        assert!(cache.get(empty_handle).is_some());
+        assert!(cache.view().handle_for(&uncached_qid).is_none());
+        txn.commit().await.unwrap();
+        drop(txn);
+
+        cache.try_compact();
+
+        // Purged: gone from both storage and cache; the others are retained.
+        let txn = store.transaction();
+        assert!(txn.get_vqueue(&empty_qid).await.unwrap().is_none());
+        assert!(cache.view().handle_for(&empty_qid).is_none());
+        assert!(txn.get_vqueue(&uncached_qid).await.unwrap().is_none());
+        assert!(txn.get_vqueue(&busy_qid).await.unwrap().is_some());
+        assert!(cache.view().handle_for(&busy_qid).is_some());
+        let paused_meta = txn
+            .get_vqueue(&paused_qid)
+            .await
+            .unwrap()
+            .expect("paused vqueue meta is retained");
+        assert!(paused_meta.queue_is_paused());
+    }
+}

--- a/crates/vqueues/src/scheduler/drr.rs
+++ b/crates/vqueues/src/scheduler/drr.rs
@@ -470,7 +470,7 @@ mod tests {
     use restate_storage_api::vqueue_table::scheduler::SchedulerAction;
     use restate_storage_api::vqueue_table::stats::WaitStats;
     use restate_storage_api::vqueue_table::{
-        EntryKey, EntryMetadata, EntryStatusHeader, ReadVQueueTable, Stage,
+        EntryKey, EntryMetadata, EntryStatusHeader, ReadVQueueTable, Stage, Status,
     };
     use restate_types::ServiceName;
     use restate_types::clock::UniqueTimestamp;
@@ -825,6 +825,64 @@ mod tests {
         assert_eq!(decision.num_run(), 1);
         assert_eq!(decision.num_queues(), 1);
         assert_eq!(decision.total_items(), 1);
+    }
+
+    #[restate_core::test]
+    async fn purged_meta_is_retained_while_same_batch_recreation_uses_a_new_handle() {
+        let mut rocksdb = storage_test_environment().await;
+        let mut cache = VQueuesMetaCache::new_empty(TEST_VQUEUES_CAPACITY);
+        let qid = test_qid(2_050);
+
+        let mut txn = rocksdb.transaction();
+        let key = enqueue_entry(&mut txn, &mut cache, &qid, 1, 0, None).await;
+        txn.commit().await.expect("commit should succeed");
+        drop(txn);
+
+        let db = rocksdb.partition_db();
+        let mut scheduler = create_scheduler(db, &cache).await;
+        let handle = cache.view().handle_for(&qid).unwrap();
+        assert!(scheduler.q.get(handle).is_some());
+
+        let mut events = Vec::new();
+        let mut txn = rocksdb.transaction();
+        let header = read_header(&txn, &qid, key.entry_id()).await;
+        {
+            let mut vqueue = VQueue::get(&qid, &mut txn, &mut cache, Some(&mut events))
+                .await
+                .unwrap()
+                .unwrap();
+            vqueue.run_then_finish(
+                UniqueTimestamp::try_from(1_200u64).unwrap(),
+                &header,
+                WaitStats::default(),
+                Status::Succeeded,
+            );
+        }
+
+        assert!(cache.purge_meta_if_obsolete(&mut txn, &qid).await.unwrap());
+        let old_handle = handle;
+        assert!(cache.view().handle_for(&qid).is_none());
+        enqueue_entry(&mut txn, &mut cache, &qid, 2, 0, Some(&mut events)).await;
+        let new_handle = cache.view().handle_for(&qid).unwrap();
+        assert_ne!(old_handle, new_handle);
+        txn.commit().await.expect("commit should succeed");
+        drop(txn);
+
+        assert!(cache.get(old_handle).is_some());
+        for event in events {
+            scheduler.on_inbox_event(cache.view(), event);
+        }
+        assert!(scheduler.q.get(old_handle).is_none());
+        assert!(scheduler.q.get(new_handle).is_some());
+
+        assert_eq!(cache.try_compact(), 1);
+        assert!(cache.get(old_handle).is_none());
+        assert_eq!(cache.view().handle_for(&qid), Some(new_handle));
+        let txn = rocksdb.transaction();
+        assert_eq!(
+            txn.get_vqueue(&qid).await.unwrap().unwrap().total_waiting(),
+            1
+        );
     }
 
     #[restate_core::test]

--- a/crates/wal-protocol/src/v2.rs
+++ b/crates/wal-protocol/src/v2.rs
@@ -72,6 +72,7 @@ impl Header {
             CommandKind::VQSchedulerDecisions
             | CommandKind::VQueuesPause
             | CommandKind::VQueuesResume
+            | CommandKind::PurgeVQueueMeta
             | CommandKind::PatchState
             | CommandKind::TerminateInvocation
             | CommandKind::PurgeInvocation
@@ -366,6 +367,11 @@ pub enum CommandKind {
     /// payload is bilrost encoded [`invocation::PauseInvocationCommand`]
     /// *Since v1.7.0
     PauseInvocation = 25,
+
+    /// Purge obsolete (fully-empty) vqueue metadata records.
+    /// payload is bilrost encoded [`vqueues::PurgeVQueueMetaCommand`]
+    /// *Since v1.7.9
+    PurgeVQueueMeta = 26,
 }
 
 mod bilrost_encoding {

--- a/crates/wal-protocol/src/v2/commands.rs
+++ b/crates/wal-protocol/src/v2/commands.rs
@@ -26,7 +26,7 @@ pub use crate::control::UpsertRuleBookCommand;
 use crate::timer;
 // Re-epxort vqueues commands
 pub use crate::invocation::PauseInvocationCommand;
-pub use crate::vqueues::{VQueuesPauseCommand, VQueuesResumeCommand};
+pub use crate::vqueues::{PurgeVQueueMetaCommand, VQueuesPauseCommand, VQueuesResumeCommand};
 
 pub use crate::control::{
     AnnounceLeaderCommand, UpdatePartitionDurabilityCommand, UpsertSchemaCommand,
@@ -472,4 +472,9 @@ command! {
 command! {
     @kind=CommandKind::VQueuesResume,
     @command=VQueuesResumeCommand
+}
+
+command! {
+    @kind=CommandKind::PurgeVQueueMeta,
+    @command=PurgeVQueueMetaCommand
 }

--- a/crates/wal-protocol/src/vqueues.rs
+++ b/crates/wal-protocol/src/vqueues.rs
@@ -31,6 +31,21 @@ pub struct VQueuesResumeCommand {
 
 bilrost_storage_encode_decode!(VQueuesResumeCommand);
 
+/// Purges the metadata records of obsolete vqueues from the partition store.
+///
+/// Appliers re-validate at apply time: only vqueues that are still obsolete
+/// (fully empty, including the `Finished` stage) and not paused are deleted;
+/// all other ids are skipped.
+///
+/// Note: Within a single command, all VQueue IDs must be on the same partition-key
+#[derive(Debug, Clone, bilrost::Message)]
+pub struct PurgeVQueueMetaCommand {
+    #[bilrost(tag(1))]
+    pub vqueues: Vec<VQueueId>,
+}
+
+bilrost_storage_encode_decode!(PurgeVQueueMetaCommand);
+
 impl VQueuesPauseCommand {
     pub fn bilrost_encode<B: BufMut>(&self, b: &mut B) -> Result<(), bilrost::EncodeError> {
         bilrost::Message::encode(self, b)

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -664,6 +664,20 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
                 }
                 Ok(())
             }
+            CommandKind::PurgeVQueueMeta => {
+                let purge = envelope
+                    .into_typed::<commands::PurgeVQueueMetaCommand>()
+                    .into_inner()?;
+                for qid in purge.vqueues.iter() {
+                    // Re-validated at apply time: only vqueues that are still
+                    // obsolete (fully empty) and not paused are deleted.
+                    self.processor
+                        .vqueues_mut()
+                        .purge_meta_if_obsolete(self.storage, qid)
+                        .await?;
+                }
+                Ok(())
+            }
         }
     }
 

--- a/release-notes/unreleased/purge-vqueue-meta-command.md
+++ b/release-notes/unreleased/purge-vqueue-meta-command.md
@@ -1,0 +1,31 @@
+# Release Notes: New `PurgeVQueueMeta` WAL command
+
+## New Feature (forward-compatibility groundwork)
+
+### What Changed
+
+A new partition-processor WAL command, `PurgeVQueueMeta`, has been introduced. It carries a
+list of vqueue ids (all on the same partition key) and deletes their vqueue metadata records
+from the partition store and the in-memory cache. Deletion is re-validated at apply time:
+only vqueues that are still obsolete (fully empty in all stages, including `Finished`) and
+not paused are purged; all other ids are skipped.
+
+No component proposes this command in this release; it is inert.
+
+### Why This Matters
+
+Vqueue metadata records currently live forever, even after a vqueue drains and is never used
+again. A future release will introduce a background vacuum that proposes `PurgeVQueueMeta`
+commands to reclaim this space. Shipping the apply-side handling now ensures that, by the
+time the vacuum is enabled, the minimum supported server version can already process the
+command.
+
+### Impact on Users
+
+None in this release. Note for mixed-version clusters in future releases: servers older than
+this version cannot apply `PurgeVQueueMeta` commands, which is why proposing them is deferred
+until this version is the minimum supported version.
+
+### Migration Guidance
+
+No action required.


### PR DESCRIPTION

Adds a new key-scoped partition-processor command that deletes the
metadata records of obsolete vqueues (fully empty in all stages,
including Finished) from the partition store and the in-memory cache.
Deletion is re-validated at apply time; paused vqueues are skipped so
the pause flag is never silently dropped.

Nothing proposes this command yet. It ships now so a future background
vacuum can start proposing it once this version is the minimum
supported server version.
