### PR TITLE
[PartitionStore] Introduce StorageFeatures as replacement for StorageVersion

### DIFF
--- a/crates/partition-store/src/features.rs
+++ b/crates/partition-store/src/features.rs
@@ -1,0 +1,671 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+mod scoped_promise_migration;
+mod scoped_state_migration;
+mod state_promise_migration_combined;
+
+use std::collections::BTreeMap;
+
+use anyhow::Context;
+use rocksdb::WriteBatch;
+use serde::{Deserialize, Serialize};
+use strum::VariantArray as _;
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info};
+
+use restate_rocksdb::{IoMode, Priority};
+use restate_storage_api::StorageError;
+use restate_types::SemanticRestateVersion;
+use restate_types::config::Configuration;
+use restate_types::partitions::StorageVersion;
+use restate_util_string::ReString;
+use restate_util_time::DurationExt;
+
+use crate::fsm_table::{
+    append_min_restate_version_to_wb, append_storage_features_to_wb, append_storage_version_to_wb,
+};
+use crate::{MigrationError, PartitionStore};
+
+/// An incompatible persisted storage-feature set.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "partition-store requires Restate version {required_min_version} or newer due to enabled storage features {features:?}"
+)]
+pub(crate) struct StorageFeatureVersionBarrier {
+    pub(crate) required_min_version: SemanticRestateVersion,
+    pub(crate) features: Vec<ReString>,
+}
+
+// Local storage features enabled for a partition store.
+//
+// These features describe local physical storage and must not leak outside this crate.
+//
+// Local partition store features are not coordinated between leader and followers, these features
+// may enable data layout changes, format upgrades, or may indicate the enablement of certain
+// lookup indexes. The presence of a feature _should not_ change the public API of the storage
+// layer but it may impact the efficiency of performing certain operations.
+//
+// Look at FSM's `PersistedFeatures` for cluster-coordinated features that may impact
+// the system behaviour in a way that can cause divergence between state machines' logical
+// states.
+//
+//
+// NOTE: When scanning for which features we should enable, we check each feature in the same
+// order as defined in this macro.
+//
+// *Since v1.7.9*
+storage_features! {
+    /// A meta feature to support compatibility with v1.7.x. This feature
+    /// implies that the two other features are also enabled.
+    MigratedToScopedPromiseAndStateTables,
+    /// If enabled, state `KeyKind::State` data tables are guaranteed to be empty.
+    /// In its presence, `KeyKind::ScopedState` will hold both scoped
+    /// and unscoped values and there is no need to ever read the old key kinds.
+    ///
+    /// In short:
+    /// * unscoped `state_table` -> scoped `state_table` (with `scope = None`)
+    pub MigratedToScopedStateTable,
+    /// If enabled, promise `KeyKind::Promise` data tables are guaranteed to be empty.
+    /// In its presence, `KeyKind::ScopedPromise` will hold both scoped
+    /// and unscoped values and there is no need to ever read the old key kinds.
+    ///
+    /// In short:
+    /// * unscoped `promise_table` -> scoped `promise_table` (with `scope = None`)
+    pub MigratedToScopedPromiseTable,
+}
+
+trait StorageFeature: Sized + 'static {
+    fn persisted_name() -> &'static ReString;
+    fn min_required_version() -> &'static SemanticRestateVersion;
+    fn should_enable(
+        config: &Configuration,
+        _current_version: &SemanticRestateVersion,
+        is_store_empty: bool,
+    ) -> bool;
+    fn is_enabled(features: &StorageFeatures) -> bool;
+    fn set_enabled(features: &mut StorageFeatures);
+
+    /// Prepares the new representation and appends feature-specific cutover operations to
+    /// `finalization`. The caller commits them atomically with the updated feature ledger.
+    ///
+    /// Implementors of this function must ensure that it's crash-proof by either batching
+    /// all changes into a single write batch or by performing idempotent operations.
+    ///
+    /// Note that `enable` will not be called if the partition-store is empty
+    /// (no LSNs have been applied).
+    fn enable(
+        storage: &mut PartitionStore,
+        cancel: &CancellationToken,
+        config: &Configuration,
+        finalization: &mut WriteBatch,
+    ) -> Result<(), MigrationError>;
+}
+
+/// Loaded feature state used while planning and applying storage migrations.
+#[derive(Debug, Default)]
+pub(crate) struct LoadedStorageFeatures {
+    enabled: StorageFeatures,
+    persisted: PersistedEnabledFeatures,
+    dirty: bool,
+}
+
+impl LoadedStorageFeatures {
+    pub(crate) fn load(
+        persisted: Option<PersistedEnabledFeatures>,
+        storage_version: StorageVersion,
+        binary_version: &SemanticRestateVersion,
+    ) -> Result<Self, StorageFeatureVersionBarrier> {
+        let dirty = persisted.is_none();
+        let persisted = persisted.unwrap_or_default();
+
+        // Compatibility must be checked before resolving feature names. This lets older binaries
+        // report future features without having to understand their behavior.
+        persisted.verify_compatible(binary_version)?;
+
+        let mut enabled = StorageFeatures::default();
+
+        for feature in KnownStorageFeature::VARIANTS {
+            if persisted.features.contains_key(feature.persisted_name()) {
+                feature.mark_as_enabled(&mut enabled);
+            }
+        }
+
+        let mut loaded = Self {
+            enabled,
+            persisted,
+            dirty,
+        };
+
+        // If the feature for this migration wasn't already recorded, we record it here.
+        //
+        // Key 5 (STORAGE_VERSION) remains the compatibility source for stores created before storage features were
+        // introduced. Keep the JSON ledger of features synchronized.
+        if storage_version.is_scope_migrated() {
+            // This marks the loaded features as dirty if it wasn't recorded before.
+            loaded.set_enabled::<MigratedToScopedPromiseAndStateTablesFeature>(None);
+        }
+
+        Ok(loaded)
+    }
+
+    fn is_enabled<F: StorageFeature>(&self) -> bool {
+        F::is_enabled(&self.enabled)
+    }
+
+    /// Marks the feature as enabled without performing any actual migration or data movement.
+    fn set_enabled<F: StorageFeature>(
+        &mut self,
+        enabled_by: Option<&SemanticRestateVersion>,
+    ) -> bool {
+        if self.is_enabled::<F>() {
+            return false;
+        }
+
+        F::set_enabled(&mut self.enabled);
+        // Update persisted ledger using F's metadata.
+        if !self.persisted.features.contains_key(F::persisted_name()) {
+            self.persisted.features.insert(
+                F::persisted_name().to_owned(),
+                FeatureBarrier {
+                    min_required_version: F::min_required_version().clone(),
+                    enabled_by_version: enabled_by.cloned(),
+                    unknown: BTreeMap::new(),
+                },
+            );
+            self.dirty = true;
+        }
+        true
+    }
+
+    pub(crate) fn enabled(&self) -> &StorageFeatures {
+        &self.enabled
+    }
+
+    pub(crate) fn ledger(&self) -> &PersistedEnabledFeatures {
+        &self.persisted
+    }
+
+    pub(crate) fn mark_persisted(&mut self) {
+        self.dirty = false;
+    }
+
+    pub(crate) fn is_dirty(&self) -> bool {
+        self.dirty
+    }
+
+    pub(crate) fn automatic_changes(
+        &self,
+        config: &Configuration,
+        current_version: &SemanticRestateVersion,
+        is_store_empty: bool,
+    ) -> Vec<KnownStorageFeature> {
+        KnownStorageFeature::VARIANTS
+            .iter()
+            .filter(|feature| !feature.is_enabled(self.enabled()))
+            .filter(|feature| {
+                current_version.is_equal_or_newer_than(feature.min_required_version())
+                    && feature.should_enable(config, current_version, is_store_empty)
+            })
+            .copied()
+            .collect()
+    }
+}
+
+/// Data model stored as JSON under `fsm_variable::STORAGE_FEATURES`.
+///
+/// Allows loading features that we can't recognize but will still let us gate opening
+/// the partition-store if the minimum required version isn't met.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct PersistedEnabledFeatures {
+    #[serde(default)]
+    features: BTreeMap<ReString, FeatureBarrier>,
+    // The unknown other attributes that we need to re-serialize for lossless read-modify-write
+    // operations.
+    #[serde(flatten)]
+    unknown: BTreeMap<ReString, serde_json::Value>,
+}
+
+impl PersistedEnabledFeatures {
+    fn verify_compatible(
+        &self,
+        current_version: &SemanticRestateVersion,
+    ) -> Result<(), StorageFeatureVersionBarrier> {
+        let mut required_min_version: Option<&SemanticRestateVersion> = None;
+        let mut features = Vec::with_capacity(self.features.len());
+
+        for (name, barrier) in &self.features {
+            match required_min_version {
+                None => {
+                    required_min_version = Some(&barrier.min_required_version);
+                    features.push(name.clone());
+                }
+                Some(required) => match barrier.min_required_version.cmp_precedence(required) {
+                    std::cmp::Ordering::Greater => {
+                        // raises the minimum version floor up
+                        required_min_version = Some(&barrier.min_required_version);
+                        features.clear();
+                        features.push(name.clone());
+                    }
+                    std::cmp::Ordering::Equal => features.push(name.clone()),
+                    std::cmp::Ordering::Less => {}
+                },
+            }
+        }
+
+        let Some(required_min_version) = required_min_version else {
+            return Ok(());
+        };
+
+        if current_version.is_equal_or_newer_than(required_min_version) {
+            return Ok(());
+        }
+
+        Err(StorageFeatureVersionBarrier {
+            required_min_version: required_min_version.clone(),
+            features,
+        })
+    }
+
+    /// Calculates the restate server version floor that is required for the currently enabled
+    /// features.
+    pub fn get_required_min_version(&self) -> Option<SemanticRestateVersion> {
+        self.features
+            .values()
+            .map(|v| &v.min_required_version)
+            .max()
+            .cloned()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct FeatureBarrier {
+    min_required_version: SemanticRestateVersion,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    enabled_by_version: Option<SemanticRestateVersion>,
+    // The unknown other attributes that we need to re-serialize for lossless read-modify-write
+    // operations.
+    #[serde(flatten)]
+    unknown: BTreeMap<ReString, serde_json::Value>,
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn enable_helper<F: StorageFeature>(
+    storage: &mut PartitionStore,
+    current_version: &SemanticRestateVersion,
+    current_min_restate_version: &mut SemanticRestateVersion,
+    current_storage_version: &mut StorageVersion,
+    is_store_empty: bool,
+    cancel: &CancellationToken,
+    config: &Configuration,
+    features: &mut LoadedStorageFeatures,
+) -> Result<(), MigrationError> {
+    if features.is_enabled::<F>() {
+        return Ok(());
+    }
+
+    let start = Instant::now();
+    debug!(
+        "Enabling partition-store storage feature '{}'",
+        F::persisted_name()
+    );
+
+    let partition_db = storage.partition_db().clone();
+    let cf_handle = partition_db.cf_handle().clone();
+    let partition_id = storage.partition_id();
+    let mut finalization = WriteBatch::default();
+
+    if !is_store_empty {
+        F::enable(storage, cancel, config, &mut finalization)?;
+    }
+
+    if cancel.is_cancelled() {
+        return Err(MigrationError::MigrationCancelled);
+    }
+
+    features.set_enabled::<F>(Some(current_version));
+    append_storage_features_to_wb(
+        &cf_handle,
+        &mut finalization,
+        partition_id,
+        features.ledger(),
+    )?;
+
+    // Bump up the min restate version
+    if F::min_required_version().is_newer_than(current_min_restate_version) {
+        append_min_restate_version_to_wb(
+            &cf_handle,
+            &mut finalization,
+            partition_id,
+            F::min_required_version().clone(),
+        )?;
+        *current_min_restate_version = F::min_required_version().clone();
+    }
+
+    // StorageVersion is the compatibility signal understood by v1.7.x binaries. Its
+    // ScopedStateAndPromise variant is equivalent to the feature ledger only when both table
+    // migrations are enabled, so write it atomically when this feature completes the pair.
+    //
+    // This can be removed when min_restate_version is v1.8 since v1.8 depends on StorageFeatures only.
+    // Estimated to be in v1.9
+    if MigratedToScopedPromiseAndStateTablesFeature::is_enabled(features.enabled())
+        && *current_storage_version < StorageVersion::ScopedStateAndPromise
+    {
+        append_storage_version_to_wb(
+            &cf_handle,
+            &mut finalization,
+            partition_id,
+            StorageVersion::ScopedStateAndPromise,
+        )?;
+        *current_storage_version = StorageVersion::ScopedStateAndPromise;
+    }
+
+    // The cutover marker cannot be persisted without its feature-specific finalization. FIFO
+    // memtable flush order also keeps this batch behind the preceding copy batches.
+    let mut opts = rocksdb::WriteOptions::default();
+    opts.disable_wal(true);
+    partition_db
+        .rocksdb()
+        .write_batch(
+            "storage-feature-migration-finalization",
+            Priority::High,
+            IoMode::Default,
+            opts,
+            finalization,
+        )
+        .await
+        .context("failed to commit storage feature migration finalization")
+        .map_err(StorageError::Generic)?;
+
+    features.mark_persisted();
+
+    if !is_store_empty {
+        info!(
+            "partition-store storage feature '{}' has been enabled in {}",
+            F::persisted_name(),
+            start.elapsed().friendly()
+        );
+    } else {
+        debug!(
+            "partition-store storage feature '{}' has been enabled in {}",
+            F::persisted_name(),
+            start.elapsed().friendly()
+        );
+    }
+
+    Ok(())
+}
+
+/// Defines a local storage (PartitionStore) feature from a list of feature names.
+macro_rules! storage_features {
+    (
+        $(
+            $(#[$attrs:meta])*
+            $visibility:vis $feature:ident
+        ),* $(,)?
+    ) => {
+        ::paste::paste! {
+            /// Local storage features enabled for a partition store.
+            ///
+            /// These features describe local physical storage and must not leak outside this crate.
+            ///
+            /// Local partition store features are not coordinated between leader and followers, these features
+            /// may enable data layout changes, format upgrades, or may indicate the enablement of certain
+            /// lookup indexes. The presence of a feature _should not_ change the public API of the storage
+            /// layer but it may impact the efficiency of performing certain operations.
+            ///
+            /// Look at FSM's `PersistedFeatures` for cluster-coordinated features that may impact
+            /// the system behaviour in a way that can cause divergence between state machines' logical
+            /// states.
+            ///
+            /// *Since v1.7.9*
+            #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+            pub(crate) struct StorageFeatures {
+                $(
+                    $(#[$attrs])*
+                    $visibility [<is_ $feature:snake>]: bool,
+                )*
+            }
+
+            // Per-feature no-value type.
+            $(
+                $(#[$attrs])*
+                $visibility enum [<$feature:camel Feature>] {}
+            )*
+
+
+            impl StorageFeatures {
+                /// Returns the list of enabled features by name
+                pub fn into_names(self) -> Vec<ReString> {
+                    [
+                        $(
+                            self.[<is_ $feature:snake>]
+                            .then_some(
+                                <[< $feature:camel Feature >] as
+                                StorageFeature>::persisted_name().clone()
+                            ),
+                        )*
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .collect()
+                }
+
+            }
+            /// Local storage features enabled for a partition store.
+            #[allow(clippy::enum_variant_names)]
+            #[derive(strum::VariantArray, Clone, Copy, PartialEq, Eq)]
+            pub(crate) enum KnownStorageFeature {
+                $(
+                    $(#[$attrs])*
+                    [<$feature:camel>],
+                )*
+            }
+
+            impl KnownStorageFeature {
+                pub fn persisted_name(self) -> &'static ReString {
+                    match self {
+                        $(
+                            Self::[<$feature:camel>] =>
+                                <[<$feature:camel Feature>] as StorageFeature>::persisted_name(),
+                        )*
+                    }
+                }
+
+                /// The minimum Restate version that can work with this feature when enabled.
+                fn min_required_version(self) -> &'static SemanticRestateVersion {
+                    match self {
+                        $(
+                            Self::[<$feature:camel>] =>
+                                <[<$feature:camel Feature>] as StorageFeature>::min_required_version(),
+                        )*
+                    }
+                }
+
+                /// Returns true if this feature is eligible to be enabled.
+                fn should_enable(
+                    self,
+                    config: &Configuration,
+                    current_version: &SemanticRestateVersion,
+                    is_store_empty: bool,
+                ) -> bool {
+                    match self {
+                        $(
+                            Self::[<$feature:camel>] =>
+                                <[<$feature:camel Feature>] as StorageFeature>::should_enable(
+                                    config,
+                                    current_version,
+                                    is_store_empty,
+                                ),
+                        )*
+                    }
+                }
+
+                /// Mutates [`StorageFeatures`] to reflect the enablement of this feature
+                fn mark_as_enabled(self, features: &mut StorageFeatures) {
+                    match self {
+                        $(
+                            Self::[<$feature:camel>] =>
+                                <[<$feature:camel Feature>] as StorageFeature>::set_enabled(features),
+                        )*
+                    }
+                }
+
+                /// Is this feature considered to be enabled in the set of `features`?
+                fn is_enabled(self, features: &StorageFeatures) -> bool {
+                    match self {
+                        $(
+                            Self::[<$feature:camel>] =>
+                                <[<$feature:camel Feature>] as StorageFeature>::is_enabled(features),
+                        )*
+                    }
+                }
+
+                /// Performs the necessary data migration if needed, then marks the feature as
+                /// enabled in the input set of `features`
+                #[allow(clippy::too_many_arguments)]
+                pub async fn enable(
+                    self,
+                    storage: &mut PartitionStore,
+                    current_version: &SemanticRestateVersion,
+                    min_restate_version: &mut SemanticRestateVersion,
+                    current_storage_version: &mut StorageVersion,
+                    is_store_empty: bool,
+                    cancel: &CancellationToken,
+                    config: &Configuration,
+                    features: &mut LoadedStorageFeatures,
+                ) -> Result<(), MigrationError> {
+                    match self {
+                        $(
+                            Self::[<$feature:camel>] => enable_helper::<[<$feature:camel Feature>]>(
+                                storage,
+                                current_version,
+                                min_restate_version,
+                                current_storage_version,
+                                is_store_empty,
+                                cancel,
+                                config,
+                                features,
+                            )
+                            .await,
+                        )*
+                    }
+                }
+            }
+
+            impl std::fmt::Display for KnownStorageFeature {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    f.write_str(self.persisted_name())
+                }
+            }
+
+            impl std::fmt::Debug for KnownStorageFeature {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    f.write_str(self.persisted_name())
+                }
+            }
+        }
+    };
+}
+
+use storage_features;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unknown_features_raise_the_barrier_and_survive_updates() {
+        let persisted: PersistedEnabledFeatures = serde_json::from_str(
+            r#"{
+                "features": {
+                    "future-a": {
+                        "min_required_version": "2.0.0",
+                        "enabled_by_version": "2.1.0",
+                        "future-metadata": { "value": 1 }
+                    },
+                    "future-b": {
+                        "min_required_version": "2.0.0"
+                    },
+                    "older-feature": {
+                        "min_required_version": "1.9.0"
+                    }
+                },
+                "future-document-field": { "value": 2 }
+            }"#,
+        )
+        .unwrap();
+
+        let error = LoadedStorageFeatures::load(
+            Some(persisted.clone()),
+            StorageVersion::None,
+            &SemanticRestateVersion::new(1, 9, 0),
+        )
+        .unwrap_err();
+        assert_eq!(
+            error.required_min_version,
+            SemanticRestateVersion::new(2, 0, 0)
+        );
+        assert_eq!(error.features, ["future-a", "future-b"]);
+
+        let mut loaded = LoadedStorageFeatures::load(
+            Some(persisted),
+            StorageVersion::None,
+            &SemanticRestateVersion::new(2, 0, 0),
+        )
+        .unwrap();
+        assert!(!loaded.enabled().is_migrated_to_scoped_state_table);
+        assert!(!loaded.enabled().is_migrated_to_scoped_promise_table);
+        loaded.set_enabled::<MigratedToScopedStateTableFeature>(Some(
+            &SemanticRestateVersion::new(2, 0, 0),
+        ));
+        loaded.set_enabled::<MigratedToScopedPromiseTableFeature>(Some(
+            &SemanticRestateVersion::new(2, 0, 0),
+        ));
+
+        let encoded = serde_json::to_value(loaded.ledger()).unwrap();
+        assert_eq!(
+            encoded["features"]["future-a"]["enabled_by_version"],
+            "2.1.0"
+        );
+        assert_eq!(
+            encoded["features"]["future-a"]["future-metadata"]["value"],
+            1
+        );
+        assert_eq!(encoded["future-document-field"]["value"], 2);
+        assert!(encoded["features"]["future-b"].is_object());
+        assert!(encoded["features"]["older-feature"].is_object());
+        assert!(encoded["features"]["scoped-state-table"].is_object());
+        assert!(encoded["features"]["scoped-promises-table"].is_object());
+    }
+
+    #[test]
+    fn scoped_tables_are_only_automatically_enabled_for_empty_stores() {
+        let current_version = SemanticRestateVersion::new(2, 0, 0);
+        let features =
+            LoadedStorageFeatures::load(None, StorageVersion::V1_5, &current_version).unwrap();
+        let config = Configuration::default();
+
+        assert!(
+            features
+                .automatic_changes(&config, &current_version, false)
+                .is_empty()
+        );
+        assert_eq!(
+            features.automatic_changes(&config, &current_version, true),
+            [
+                KnownStorageFeature::MigratedToScopedPromiseAndStateTables,
+                KnownStorageFeature::MigratedToScopedStateTable,
+                KnownStorageFeature::MigratedToScopedPromiseTable,
+            ]
+        );
+    }
+}

--- a/crates/partition-store/src/features/scoped_promise_migration.rs
+++ b/crates/partition-store/src/features/scoped_promise_migration.rs
@@ -1,0 +1,81 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use rocksdb::WriteBatch;
+use tokio_util::sync::CancellationToken;
+
+use restate_types::config::Configuration;
+use restate_types::{RESTATE_VERSION_1_7_9, RESTATE_VERSION_1_8_0, SemanticRestateVersion};
+use restate_util_string::ReString;
+
+use crate::migrations::MigrationContext;
+use crate::migrations::migrate_to_scoped_promise_table::{
+    append_delete_promise_data, migrate_to_scoped_promise_table,
+};
+use crate::{MigrationError, PartitionStore};
+
+use super::{StorageFeature, StorageFeatures};
+
+static SCOPED_PROMISE_ONLY: ReString = ReString::from_static("scoped-promises-table");
+
+impl StorageFeature for super::MigratedToScopedPromiseTableFeature {
+    fn persisted_name() -> &'static ReString {
+        &SCOPED_PROMISE_ONLY
+    }
+
+    fn min_required_version() -> &'static SemanticRestateVersion {
+        &RESTATE_VERSION_1_7_9
+    }
+
+    fn should_enable(
+        config: &Configuration,
+        current_version: &SemanticRestateVersion,
+        is_store_empty: bool,
+    ) -> bool {
+        if current_version.is_equal_or_newer_than(&RESTATE_VERSION_1_8_0) {
+            is_store_empty
+                || config
+                    .common
+                    .experimental
+                    .is_scoped_promise_table_migration_enabled()
+        } else {
+            config
+                .common
+                .experimental
+                .is_scoped_promise_table_migration_enabled()
+        }
+    }
+
+    fn is_enabled(features: &StorageFeatures) -> bool {
+        features.is_migrated_to_scoped_promise_table
+    }
+
+    fn set_enabled(features: &mut StorageFeatures) {
+        features.is_migrated_to_scoped_promise_table = true;
+    }
+
+    fn enable(
+        storage: &mut PartitionStore,
+        cancel: &CancellationToken,
+        config: &Configuration,
+        finalization: &mut WriteBatch,
+    ) -> Result<(), MigrationError> {
+        let partition_db = storage.partition_db().clone();
+        let mut ctx = MigrationContext::new(
+            config,
+            &partition_db,
+            storage.partition_key_range(),
+            cancel.clone(),
+        );
+        migrate_to_scoped_promise_table(&mut ctx)?;
+        append_delete_promise_data(&ctx, finalization);
+        Ok(())
+    }
+}

--- a/crates/partition-store/src/features/scoped_state_migration.rs
+++ b/crates/partition-store/src/features/scoped_state_migration.rs
@@ -1,0 +1,81 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use rocksdb::WriteBatch;
+use tokio_util::sync::CancellationToken;
+
+use restate_types::config::Configuration;
+use restate_types::{RESTATE_VERSION_1_7_9, RESTATE_VERSION_1_8_0, SemanticRestateVersion};
+use restate_util_string::ReString;
+
+use crate::migrations::MigrationContext;
+use crate::migrations::migrate_to_scoped_state_table::{
+    append_delete_state_data, migrate_to_scoped_state_table,
+};
+use crate::{MigrationError, PartitionStore};
+
+use super::{StorageFeature, StorageFeatures};
+
+static SCOPED_STATE_ONLY: ReString = ReString::from_static("scoped-state-table");
+
+impl StorageFeature for super::MigratedToScopedStateTableFeature {
+    fn persisted_name() -> &'static ReString {
+        &SCOPED_STATE_ONLY
+    }
+
+    fn min_required_version() -> &'static SemanticRestateVersion {
+        &RESTATE_VERSION_1_7_9
+    }
+
+    fn should_enable(
+        config: &Configuration,
+        current_version: &SemanticRestateVersion,
+        is_store_empty: bool,
+    ) -> bool {
+        if current_version.is_equal_or_newer_than(&RESTATE_VERSION_1_8_0) {
+            is_store_empty
+                || config
+                    .common
+                    .experimental
+                    .is_scoped_state_table_migration_enabled()
+        } else {
+            config
+                .common
+                .experimental
+                .is_scoped_state_table_migration_enabled()
+        }
+    }
+
+    fn is_enabled(features: &StorageFeatures) -> bool {
+        features.is_migrated_to_scoped_state_table
+    }
+
+    fn set_enabled(features: &mut StorageFeatures) {
+        features.is_migrated_to_scoped_state_table = true;
+    }
+
+    fn enable(
+        storage: &mut PartitionStore,
+        cancel: &CancellationToken,
+        config: &Configuration,
+        finalization: &mut WriteBatch,
+    ) -> Result<(), MigrationError> {
+        let partition_db = storage.partition_db().clone();
+        let mut ctx = MigrationContext::new(
+            config,
+            &partition_db,
+            storage.partition_key_range(),
+            cancel.clone(),
+        );
+        migrate_to_scoped_state_table(&mut ctx)?;
+        append_delete_state_data(&ctx, finalization);
+        Ok(())
+    }
+}

--- a/crates/partition-store/src/features/state_promise_migration_combined.rs
+++ b/crates/partition-store/src/features/state_promise_migration_combined.rs
@@ -1,0 +1,71 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use rocksdb::WriteBatch;
+use tokio_util::sync::CancellationToken;
+
+use restate_types::config::Configuration;
+use restate_types::{RESTATE_VERSION_1_7_0, SemanticRestateVersion};
+use restate_util_string::ReString;
+
+use crate::{MigrationError, PartitionStore};
+
+use super::{StorageFeature, StorageFeatures};
+
+static COMPOUND: ReString = ReString::from_static("scoped-promises-and-state-tables");
+
+impl StorageFeature for super::MigratedToScopedPromiseAndStateTablesFeature {
+    fn persisted_name() -> &'static ReString {
+        &COMPOUND
+    }
+
+    fn min_required_version() -> &'static SemanticRestateVersion {
+        &RESTATE_VERSION_1_7_0
+    }
+
+    fn should_enable(
+        config: &Configuration,
+        current_version: &SemanticRestateVersion,
+        is_store_empty: bool,
+    ) -> bool {
+        // Enable this feature if both sub-features are meant to be enabled
+        super::MigratedToScopedStateTableFeature::should_enable(
+            config,
+            current_version,
+            is_store_empty,
+        ) && super::MigratedToScopedPromiseTableFeature::should_enable(
+            config,
+            current_version,
+            is_store_empty,
+        )
+    }
+
+    fn is_enabled(features: &StorageFeatures) -> bool {
+        (features.is_migrated_to_scoped_promise_table && features.is_migrated_to_scoped_state_table)
+            || features.is_migrated_to_scoped_promise_and_state_tables
+    }
+
+    fn set_enabled(features: &mut StorageFeatures) {
+        features.is_migrated_to_scoped_state_table = true;
+        features.is_migrated_to_scoped_promise_table = true;
+        features.is_migrated_to_scoped_promise_and_state_tables = true;
+    }
+
+    fn enable(
+        storage: &mut PartitionStore,
+        cancel: &CancellationToken,
+        config: &Configuration,
+        finalization: &mut WriteBatch,
+    ) -> Result<(), MigrationError> {
+        super::MigratedToScopedPromiseTableFeature::enable(storage, cancel, config, finalization)?;
+        super::MigratedToScopedStateTableFeature::enable(storage, cancel, config, finalization)?;
+        Ok(())
+    }
+}

--- a/crates/partition-store/src/fsm_table/mod.rs
+++ b/crates/partition-store/src/fsm_table/mod.rs
@@ -24,6 +24,7 @@ use restate_types::schema::Schema;
 use restate_types::storage::{StorageCodec, StorageDecode};
 
 use crate::TableKind::PartitionStateMachine;
+use crate::features::PersistedEnabledFeatures;
 use crate::keys::{EncodeTableKey, KeyKind, define_table_key};
 use crate::{
     PaddedPartitionId, PartitionDb, PartitionSeal, PartitionStore, PartitionStoreTransaction,
@@ -112,6 +113,15 @@ pub(crate) mod fsm_variable {
     ///
     /// *Since v1.7.3*
     pub(crate) const SEAL_MARKER: u64 = 11;
+
+    /// A local set of storage features (not replicated) written to mark which
+    /// storage features are fully enabled. For instance, a feature for a secondary
+    /// index will be enabled _after_ the index gets persisted consistently with the data.
+    ///
+    /// Persisted as plain JSON.
+    ///
+    /// *Since v1.7.9*
+    pub(crate) const STORAGE_FEATURES: u64 = 12;
 }
 
 fn get<T: PartitionStoreProtobufValue, S: StorageAccess>(
@@ -171,6 +181,54 @@ pub(crate) fn get_storage_version_from_partition_db(db: &PartitionDb) -> Result<
     })
 }
 
+pub(crate) fn get_storage_features_from_partition_db(
+    db: &PartitionDb,
+) -> Result<Option<PersistedEnabledFeatures>> {
+    let cf = db.cf_handle();
+    let key = create_key(db.partition().id(), fsm_variable::STORAGE_FEATURES);
+    db.rocksdb()
+        .inner()
+        .as_raw_db()
+        .get_pinned_cf(cf, key.to_bytes())
+        .map_err(|err| StorageError::Generic(err.into()))?
+        .map(|value| {
+            serde_json::from_slice(&value).map_err(|err| StorageError::Conversion(err.into()))
+        })
+        .transpose()
+}
+
+#[cfg(test)]
+pub(crate) async fn put_storage_features_json<S: StorageAccess>(
+    storage: &mut S,
+    partition_id: PartitionId,
+    value: &[u8],
+) -> Result<()> {
+    let key = PartitionStateMachineKey {
+        partition_id: partition_id.into(),
+        state_id: fsm_variable::STORAGE_FEATURES,
+    };
+    storage.put_kv_raw(key, value)?;
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) async fn delete_storage_features<S: StorageAccess>(
+    storage: &mut S,
+    partition_id: PartitionId,
+) -> Result<()> {
+    storage.delete_key(&PartitionStateMachineKey {
+        partition_id: partition_id.into(),
+        state_id: fsm_variable::STORAGE_FEATURES,
+    })
+}
+
+pub(crate) fn get_min_restate_version_from_partition_db(
+    db: &PartitionDb,
+) -> Result<SemanticRestateVersion> {
+    get_proto_from_partition_db(db, fsm_variable::RESTATE_VERSION_BARRIER)
+        .map(|version| version.unwrap_or_default())
+}
+
 pub(crate) async fn put_storage_version<S: StorageAccess>(
     storage: &mut S,
     partition_id: PartitionId,
@@ -184,30 +242,81 @@ pub(crate) async fn put_storage_version<S: StorageAccess>(
     )
 }
 
-/// Append a `STORAGE_VERSION = version` put to `wb`.
 pub(crate) fn append_storage_version_to_wb(
     cf_handle: &std::sync::Arc<rocksdb::BoundColumnFamily<'_>>,
     wb: &mut rocksdb::WriteBatch,
     partition_id: PartitionId,
     version: StorageVersion,
 ) -> Result<()> {
-    use bytes::BytesMut;
-    use restate_types::storage::StorageCodec;
-
     let key = create_key(partition_id, fsm_variable::STORAGE_VERSION);
-    let key_buffer = key.to_bytes();
-
-    let value = SequenceNumber::from(version as u64);
-    let mut value_buffer = BytesMut::new();
+    let mut value = bytes::BytesMut::new();
     StorageCodec::encode(
         &ProtobufStorageWrapper::<<SequenceNumber as PartitionStoreProtobufValue>::ProtobufType>(
-            value.into(),
+            SequenceNumber::from(version as u64).into(),
         ),
-        &mut value_buffer,
+        &mut value,
     )
-    .map_err(|e| restate_storage_api::StorageError::Generic(e.into()))?;
+    .map_err(|err| StorageError::Generic(err.into()))?;
+    wb.put_cf(cf_handle, key.to_bytes(), value);
+    Ok(())
+}
 
-    wb.put_cf(cf_handle, key_buffer, &value_buffer);
+pub(crate) fn put_storage_features<S: StorageAccess>(
+    storage: &mut S,
+    partition_id: PartitionId,
+    features: &PersistedEnabledFeatures,
+) -> Result<()> {
+    let key = PartitionStateMachineKey {
+        partition_id: partition_id.into(),
+        state_id: fsm_variable::STORAGE_FEATURES,
+    };
+    let value = serde_json::to_vec(features).map_err(|err| StorageError::Conversion(err.into()))?;
+    storage.put_kv_raw(key, value)?;
+    Ok(())
+}
+
+pub(crate) fn append_storage_features_to_wb(
+    cf_handle: &std::sync::Arc<rocksdb::BoundColumnFamily<'_>>,
+    wb: &mut rocksdb::WriteBatch,
+    partition_id: PartitionId,
+    features: &PersistedEnabledFeatures,
+) -> Result<()> {
+    let key = create_key(partition_id, fsm_variable::STORAGE_FEATURES);
+    let value = serde_json::to_vec(features).map_err(|err| StorageError::Conversion(err.into()))?;
+    wb.put_cf(cf_handle, key.to_bytes(), value);
+    Ok(())
+}
+
+pub(crate) async fn put_min_restate_version<S: StorageAccess>(
+    storage: &mut S,
+    partition_id: PartitionId,
+    version: &SemanticRestateVersion,
+) -> Result<()> {
+    put(
+        storage,
+        partition_id,
+        fsm_variable::RESTATE_VERSION_BARRIER,
+        version,
+    )
+}
+
+pub(crate) fn append_min_restate_version_to_wb(
+    cf_handle: &std::sync::Arc<rocksdb::BoundColumnFamily<'_>>,
+    wb: &mut rocksdb::WriteBatch,
+    partition_id: PartitionId,
+    version: SemanticRestateVersion,
+) -> Result<()> {
+    let key = create_key(partition_id, fsm_variable::RESTATE_VERSION_BARRIER);
+
+    let mut value = bytes::BytesMut::new();
+    StorageCodec::encode(
+        &ProtobufStorageWrapper::<
+            <SemanticRestateVersion as PartitionStoreProtobufValue>::ProtobufType,
+        >(version.into()),
+        &mut value,
+    )
+    .map_err(|err| StorageError::Generic(err.into()))?;
+    wb.put_cf(cf_handle, key.to_bytes(), value);
     Ok(())
 }
 

--- a/crates/partition-store/src/lib.rs
+++ b/crates/partition-store/src/lib.rs
@@ -11,6 +11,7 @@
 pub mod deduplication_table;
 mod durable_lsn_tracking;
 pub mod error;
+mod features;
 pub mod fsm_table;
 pub mod inbox_table;
 pub mod invocation_status_table;

--- a/crates/partition-store/src/migrations.rs
+++ b/crates/partition-store/src/migrations.rs
@@ -9,147 +9,45 @@
 // by the Apache License, Version 2.0.
 
 pub mod migrate_to_locks_table;
-mod migrate_to_scoped_promise_table;
-mod migrate_to_scoped_state_table;
+pub mod migrate_to_scoped_promise_table;
+pub mod migrate_to_scoped_state_table;
 
 use std::num::NonZeroU16;
 use std::sync::Arc;
 
-use anyhow::Context;
 use bytes::BytesMut;
-use rocksdb::WriteBatch;
-use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
-use tracing::debug;
 
 use restate_clock::{AtomicStorage, HlcClock, WallClock};
-use restate_rocksdb::{IoMode, Priority};
 use restate_storage_api::StorageError;
+use restate_types::SemanticRestateVersion;
 use restate_types::config::Configuration;
-use restate_types::partitions::StorageVersion;
 use restate_types::sharding::KeyRange;
 use restate_types::sharding::subsharding::ShardPlan;
-use restate_util_time::DurationExt;
+use restate_util_string::ReString;
 
-use crate::fsm_table::append_storage_version_to_wb;
-use crate::{PartitionDb, PartitionStore, Result};
-
-use self::migrate_to_scoped_promise_table::{
-    append_delete_promise_data, migrate_to_scoped_promise_table,
-};
-use self::migrate_to_scoped_state_table::{
-    append_delete_state_data, migrate_to_scoped_state_table,
-};
+use crate::{PartitionDb, Result};
 
 /// Migration error
 #[derive(Debug, thiserror::Error)]
 pub enum MigrationError {
     #[error("migration barrier: {0}")]
     MigrationBarrier(String),
+    #[error("partition requires Restate version {required_min_version} or newer")]
+    VersionBarrier {
+        required_min_version: SemanticRestateVersion,
+    },
+    #[error(
+        "partition storage requires Restate version {required_min_version} or newer due to enabled storage features {storage_features:?}"
+    )]
+    StorageFeatureVersionBarrier {
+        required_min_version: SemanticRestateVersion,
+        storage_features: Vec<ReString>,
+    },
     #[error("migration was cancelled")]
     MigrationCancelled,
     #[error("error during migration: {0}")]
     StorageError(#[from] StorageError),
-}
-/// Runs the migrations needed to transition the [`StorageVersion`] from current to the target
-/// storage version. A failure can leave the storage version at any valid version between current
-/// and target.
-pub async fn run_migrations_up_to(
-    mut current: StorageVersion,
-    target: StorageVersion,
-    storage: &mut PartitionStore,
-    cancel: CancellationToken,
-    config: &Configuration,
-) -> Result<StorageVersion, MigrationError> {
-    while current < target {
-        if cancel.is_cancelled() {
-            return Err(MigrationError::MigrationCancelled);
-        }
-        current = do_migration(current, storage, cancel.clone(), config).await?;
-    }
-    Ok(current)
-}
-
-/// Runs the migration for the given storage version and returns the new
-/// storage version.
-///
-/// Each migration arm is responsible for atomically (with respect to crashes)
-/// persisting the storage-version bump together with any destructive cleanup
-/// (range deletes, etc.). See the `V1_5` arm for an example: copy passes run
-/// with WAL disabled, then a single final `WriteBatch` (also WAL off)
-/// commits the storage-version put together with the legacy `delete_range_cf`s.
-/// RocksDB's FIFO memtable flush order guarantees that the final batch can
-/// only become durable on SST after the copy writes are already on SST.
-async fn do_migration(
-    current: StorageVersion,
-    storage: &mut PartitionStore,
-    cancel: CancellationToken,
-    config: &Configuration,
-) -> Result<StorageVersion, MigrationError> {
-    let new_storage_version = match current {
-        StorageVersion::None => {
-            // Version 1.6+ does not support upgrading from pre-1.5
-            // The InvocationStatusV1 migration was removed in 1.6
-            return Err(MigrationError::MigrationBarrier(
-                "Cannot upgrade from version <1.5 directly to 1.6 or later. \
-                 Please upgrade to version 1.5 first, which will migrate your data, \
-                 and then upgrade to 1.6+"
-                    .to_owned(),
-            ));
-        }
-        StorageVersion::V1_5 => {
-            let start = Instant::now();
-            let key_range = storage.partition_key_range();
-            let partition_id = storage.partition_id();
-            let partition_db = storage.partition_db().clone();
-            let mut ctx = MigrationContext::new(config, &partition_db, key_range, cancel);
-            let new_storage_version = StorageVersion::ScopedStateAndPromise;
-
-            migrate_to_scoped_state_table(&mut ctx)?;
-            migrate_to_scoped_promise_table(&mut ctx)?;
-
-            // Atomic final step: delete legacy ranges + bump storage version
-            // in a single `WriteBatch`. WAL off so the FIFO memtable order
-            // pins the version bump behind the copy writes — see the
-            // doc-comment on `do_migration` for the durability argument.
-            let cf_handle = partition_db.cf_handle().clone();
-            let mut wb = WriteBatch::default();
-            append_delete_state_data(&ctx, &mut wb);
-            append_delete_promise_data(&ctx, &mut wb);
-            append_storage_version_to_wb(&cf_handle, &mut wb, partition_id, new_storage_version)?;
-
-            ctx.fail_if_cancelled()?;
-            let mut opts = rocksdb::WriteOptions::default();
-            opts.disable_wal(true);
-            partition_db
-                .rocksdb()
-                .write_batch(
-                    "scoped-state-promise-table-migration",
-                    Priority::High,
-                    IoMode::Default,
-                    opts,
-                    wb,
-                )
-                .await
-                .context("failed to commit scoped-state-and-promise final write batch")
-                .map_err(StorageError::Generic)?;
-            debug!(
-                %partition_id,
-                "Finalized scoped state/promise migration in {}", start.elapsed().friendly()
-            );
-
-            // todo: Add flush + compact_range(s) to the deleted data to reduce the space
-            // amplification expected after the state migration. Alternatively, one compaction
-            // after all migrations are done.
-            new_storage_version
-        }
-        StorageVersion::ScopedStateAndPromise => {
-            // Latest version, nothing further to do.
-            StorageVersion::ScopedStateAndPromise
-        }
-    };
-
-    Ok(new_storage_version)
 }
 
 #[allow(dead_code)]

--- a/crates/partition-store/src/migrations/migrate_to_scoped_promise_table.rs
+++ b/crates/partition-store/src/migrations/migrate_to_scoped_promise_table.rs
@@ -112,8 +112,8 @@ pub fn migrate_to_scoped_promise_table(
 /// Appends a `delete_range_cf` for the legacy unscoped promise range to `wb`.
 ///
 /// The caller is responsible for committing `wb`. Bundling the range delete
-/// with the schema-version bump in a single [`WriteBatch`] keeps the two
-/// changes atomic with respect to RocksDB's memtable / SST flush.
+/// with the feature marker in a single [`WriteBatch`] keeps the cutover atomic
+/// with respect to RocksDB's memtable / SST flush.
 pub fn append_delete_promise_data(ctx: &MigrationContext<'_>, wb: &mut WriteBatch) {
     let mut start_key_buf = [0u8; KEY_PREFIX_LEN];
     EncodeTableKeyPrefix::serialize_to(

--- a/crates/partition-store/src/migrations/migrate_to_scoped_state_table.rs
+++ b/crates/partition-store/src/migrations/migrate_to_scoped_state_table.rs
@@ -109,8 +109,8 @@ pub fn migrate_to_scoped_state_table(ctx: &mut MigrationContext<'_>) -> Result<(
 /// Appends a `delete_range_cf` for the legacy unscoped state range to `wb`.
 ///
 /// The caller is responsible for committing `wb`. Bundling the range delete
-/// with the schema-version bump in a single [`WriteBatch`] keeps the two
-/// changes atomic with respect to RocksDB's memtable / SST flush.
+/// with the feature marker in a single [`WriteBatch`] keeps the cutover atomic
+/// with respect to RocksDB's memtable / SST flush.
 pub fn append_delete_state_data(ctx: &MigrationContext<'_>, wb: &mut WriteBatch) {
     let mut start_key_buf = [0u8; KEY_PREFIX_LEN];
     EncodeTableKeyPrefix::serialize_to(

--- a/crates/partition-store/src/partition_store.rs
+++ b/crates/partition-store/src/partition_store.rs
@@ -27,34 +27,38 @@ use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, trace};
+use tracing::{instrument, trace, warn};
 
 use restate_core::ShutdownError;
 use restate_rocksdb::{IoMode, IterAction, Priority, RocksDb, RocksError};
 use restate_storage_api::fsm_table::ReadFsmTable;
 use restate_storage_api::protobuf_types::{PartitionStoreProtobufValue, ProtobufStorageWrapper};
 use restate_storage_api::{IsolationLevel, Storage, StorageError, Transaction};
+use restate_types::SemanticRestateVersion;
 use restate_types::config::Configuration;
 use restate_types::identifiers::{PartitionId, PartitionKey, SnapshotId, WithPartitionKey};
 use restate_types::logs::Lsn;
 use restate_types::partitions::Partition;
+use restate_types::partitions::StorageVersion;
 use restate_types::sharding::KeyRange;
 use restate_types::storage::StorageCodec;
 use restate_types::storage::StorageDecode;
 use restate_types::storage::StorageEncode;
+use restate_util_string::ReString;
 
-use restate_types::partitions::StorageVersion;
-
+use crate::features::{LoadedStorageFeatures, StorageFeatures};
 use crate::fsm_table::get_partition_seal;
+use crate::fsm_table::put_min_restate_version;
+use crate::fsm_table::put_storage_features;
 use crate::fsm_table::put_storage_version;
 use crate::fsm_table::seal_partition;
 use crate::fsm_table::{
-    get_locally_durable_lsn, get_storage_version_from_partition_db, is_jc_orphan_cleanup_done,
-    put_jc_orphan_cleanup_done,
+    get_locally_durable_lsn, get_min_restate_version_from_partition_db,
+    get_storage_features_from_partition_db, get_storage_version_from_partition_db,
+    is_jc_orphan_cleanup_done, put_jc_orphan_cleanup_done,
 };
 use crate::keys::{EncodeTableKey, EncodeTableKeyPrefix, KeyKind};
 use crate::migrations::MigrationError;
-use crate::migrations::run_migrations_up_to;
 use crate::partition_db::PartitionDb;
 use crate::scan::PhysicalScan;
 use crate::scan::TableScan;
@@ -217,7 +221,7 @@ impl TableKind {
 
 pub struct PartitionStore {
     db: PartitionDb,
-    storage_version: OnceLock<StorageVersion>,
+    storage_features: OnceLock<StorageFeatures>,
     key_buffer: BytesMut,
     value_buffer: BytesMut,
 }
@@ -237,7 +241,7 @@ impl Clone for PartitionStore {
     fn clone(&self) -> Self {
         PartitionStore {
             db: self.db.clone(),
-            storage_version: self.storage_version.clone(),
+            storage_features: self.storage_features.clone(),
             key_buffer: BytesMut::default(),
             value_buffer: BytesMut::default(),
         }
@@ -254,27 +258,46 @@ impl PartitionStore {
     pub(crate) fn new(db: PartitionDb) -> Self {
         Self {
             db,
-            storage_version: OnceLock::new(),
+            storage_features: OnceLock::new(),
             key_buffer: BytesMut::new(),
             value_buffer: BytesMut::new(),
         }
     }
 
-    /// Returns the on-disk storage version, reading it from RocksDB on the first
+    /// Returns the on-disk storage features, reading it from RocksDB on the first
     /// call and memoizing it. Clones of PartitionStore will copy the memoized value.
-    #[inline]
-    pub fn storage_version(&self) -> StorageVersion {
-        *self.storage_version.get_or_init(|| {
-            get_storage_version_from_partition_db(self.partition_db())
-                .expect("storage version must exist")
+    pub(crate) fn storage_features(&self) -> StorageFeatures {
+        *self.storage_features.get_or_init(|| {
+            // NOTE: Using `default` is definitely the wrong value, but it prevents the server
+            // from crashing when data-fusion tries to access the partition-store prior
+            // or during the migration phase.
+            //
+            // This is a shortcut until better isolation and ownership model is implemented.
+            let storage_version =
+                get_storage_version_from_partition_db(self.partition_db()).unwrap_or_default();
+            let persisted =
+                get_storage_features_from_partition_db(self.partition_db()).unwrap_or_default();
+            let loaded = LoadedStorageFeatures::load(
+                persisted,
+                storage_version,
+                SemanticRestateVersion::current(),
+            )
+            .inspect_err(|err| {
+                warn!(
+                    partition_id = %self.partition_id(),
+                    "Failed to verify feature/version compatibility of partition-store: {}",
+                    err
+                )
+            })
+            .unwrap_or_default();
+            *loaded.enabled()
         })
     }
 
-    /// Overwrites the memoized storage version. Requires exclusive access to PartitionStore.
-    fn set_storage_version(&mut self, version: StorageVersion) {
-        // Clear first: the lock is empty afterwards, so `set` cannot fail.
-        self.storage_version.take();
-        let _ = self.storage_version.set(version);
+    /// Overwrites the memoized storage features after their finalization batch commits.
+    fn set_storage_features(&mut self, features: StorageFeatures) {
+        self.storage_features.take();
+        let _ = self.storage_features.set(features);
     }
 
     pub fn partition_db(&self) -> &PartitionDb {
@@ -573,9 +596,9 @@ impl PartitionStore {
         };
 
         // 99.9% of the time, this will return an already loaded value.
-        // If PartitionStore.storage_version() was never called before,
+        // If PartitionStore.storage_features() was never called before,
         // this will fetch the value and cache it.
-        let storage_version = self.storage_version();
+        let storage_features = self.storage_features();
 
         PartitionStoreTransaction {
             write_batch_with_index: Some(rocksdb::WriteBatchWithIndex::new(0, true)),
@@ -584,7 +607,7 @@ impl PartitionStore {
             key_buffer: &mut self.key_buffer,
             value_buffer: &mut self.value_buffer,
             meta: self.db.partition(),
-            storage_version,
+            storage_features,
             snapshot,
         }
     }
@@ -674,57 +697,126 @@ impl PartitionStore {
         put_jc_orphan_cleanup_done(self, self.partition_id()).await
     }
 
+    #[instrument(level = "info", skip_all, fields(partition_id = %self.partition().id()))]
     pub async fn verify_and_run_migrations(
         &mut self,
         cancel: CancellationToken,
         config: &Configuration,
     ) -> Result<(), MigrationError> {
-        // The target schema version is gated by the operator opt-in. Without
-        // the flag we leave the partition at `V1_5` so a downgrade to a
-        // pre-`ScopedStateAndPromise` binary stays possible. With the flag
-        // enabled we migrate the unscoped state and promise tables into their
-        // scoped variants and bump to `ScopedStateAndPromise`.
-        let target = if config
-            .common
-            .experimental
-            .is_migrate_scoped_tables_enabled()
-        {
-            StorageVersion::ScopedStateAndPromise
-        } else {
-            StorageVersion::V1_5
+        self.verify_and_run_migrations_at_version(SemanticRestateVersion::current(), cancel, config)
+            .await
+    }
+
+    pub(crate) async fn verify_and_run_migrations_at_version(
+        &mut self,
+        current_restate_version: &SemanticRestateVersion,
+        cancel: CancellationToken,
+        config: &Configuration,
+    ) -> Result<(), MigrationError> {
+        // Migration decisions use authoritative on-disk metadata rather than either memoized
+        // value. A transaction created before initialization may have populated a stale cache.
+        let mut storage_version = get_storage_version_from_partition_db(self.partition_db())?;
+        let persisted_features = get_storage_features_from_partition_db(self.partition_db())?;
+        let mut current_min_restate_version =
+            get_min_restate_version_from_partition_db(self.partition_db())?;
+
+        let mut storage_features = match LoadedStorageFeatures::load(
+            persisted_features,
+            storage_version,
+            current_restate_version,
+        ) {
+            Ok(features) => features,
+            Err(barrier) => {
+                return Err(MigrationError::StorageFeatureVersionBarrier {
+                    required_min_version: barrier.required_min_version,
+                    storage_features: barrier.features,
+                });
+            }
         };
 
-        // We assume the partition store to be empty if it does not contain any applied lsn. The
-        // reason is that we always commit changes to the partition store via a transaction which
-        // also updates the applied lsn field.
-        let is_empty = self.get_applied_lsn().await?.is_none();
-        if is_empty {
-            put_storage_version(self, self.partition().id(), target as u16).await?;
-            // A fresh partition store cannot have orphaned jc index entries, so mark the
-            // cleanup as already done to avoid a needless scan on first startup.
-            put_jc_orphan_cleanup_done(self, self.partition().id()).await?;
-            self.set_storage_version(target);
-            return Ok(());
+        // There is another reason (other than storage features) why the min version is set high.
+        // NOTE: We do the version check _after_ `LoadedStorageFeatures::load()` because the former
+        // will give higher-quality details about the features blocking the startup.
+        if !current_restate_version.is_equal_or_newer_than(&current_min_restate_version) {
+            return Err(MigrationError::VersionBarrier {
+                required_min_version: current_min_restate_version,
+            });
         }
 
-        // Read the authoritative on-disk version rather than the memoized
-        // `storage_version()`: the cache may hold a stale value (e.g. `None`
-        // memoized by a transaction created before the version was stamped),
-        // and migration decisions must be based on what's actually persisted.
-        let mut storage_version = get_storage_version_from_partition_db(self.partition_db())?;
-        if storage_version < target {
-            // We need to run some migrations!
-            if !is_empty {
-                info!(
-                    "Running storage migration from {:?} to {:?}",
-                    storage_version, target
-                );
-            }
-            storage_version =
-                run_migrations_up_to(storage_version, target, self, cancel, config).await?;
+        // A store without an applied LSN is empty because normal state changes and the applied LSN
+        // are committed in the same partition-store transaction.
+        let is_store_empty = self.get_applied_lsn().await?.is_none();
+        if !is_store_empty && matches!(storage_version, StorageVersion::None) {
+            // Version 1.6+ does not support upgrading from pre-1.5 because the invocation-status V1
+            // migration was removed in 1.6.
+            return Err(MigrationError::MigrationBarrier(
+                "Cannot upgrade from version <1.5 directly to 1.6 or later. \
+             Please upgrade to version 1.5 first, which will migrate your data, \
+             and then upgrade to 1.6+"
+                    .to_owned(),
+            ));
         }
-        self.set_storage_version(storage_version);
+
+        // Changes might be empty, but storage_features can still be dirty due to the automatic
+        // convergence that happens based on storage-version or if the store is empty.
+        let features_to_enable =
+            storage_features.automatic_changes(config, current_restate_version, is_store_empty);
+
+        // Do we need to perform migrations or data movement for these features?
+        for feature in features_to_enable {
+            // Enable each feature independently
+            feature
+                .enable(
+                    self,
+                    current_restate_version,
+                    &mut current_min_restate_version,
+                    &mut storage_version,
+                    is_store_empty,
+                    &cancel,
+                    config,
+                    &mut storage_features,
+                )
+                .await?;
+        }
+
+        if storage_features.is_dirty() {
+            put_storage_features(self, self.partition().id(), storage_features.ledger())?;
+            storage_features.mark_persisted();
+        }
+        self.set_storage_features(*storage_features.enabled());
+
+        // Keep StorageVersion aligned for older binaries that used it as the sole signal for these
+        // migrations. The combined variant is accurate only when both features are enabled; a
+        // migration that completes the pair writes it atomically in its finalization batch above.
+        // This fallback also converges stores initialized from older or incomplete metadata.
+        let min_storage_version = if storage_features
+            .enabled()
+            .is_migrated_to_scoped_promise_table
+            && storage_features.enabled().is_migrated_to_scoped_state_table
+        {
+            StorageVersion::ScopedStateAndPromise
+        } else if is_store_empty && matches!(storage_version, StorageVersion::None) {
+            StorageVersion::V1_5
+        } else {
+            storage_version
+        };
+        if min_storage_version > storage_version {
+            put_storage_version(self, self.partition().id(), min_storage_version as u16).await?;
+        }
+
+        // Another safety net.
+        if let Some(new_min) = storage_features.ledger().get_required_min_version()
+            && new_min.is_newer_than(&current_min_restate_version)
+        {
+            put_min_restate_version(self, self.partition().id(), &new_min).await?;
+        }
+
+        debug_assert_eq!(self.storage_features(), *storage_features.enabled());
         Ok(())
+    }
+
+    pub fn get_storage_features_names(&self) -> Vec<ReString> {
+        self.storage_features().into_names()
     }
 }
 
@@ -863,7 +955,7 @@ pub struct PartitionStoreTransaction<'a> {
     data_cf_handle: &'a Arc<BoundColumnFamily<'a>>,
     key_buffer: &'a mut BytesMut,
     value_buffer: &'a mut BytesMut,
-    storage_version: StorageVersion,
+    storage_features: StorageFeatures,
     snapshot: Option<SnapshotWithThreadMode<'a, rocksdb::DB>>,
 }
 
@@ -940,8 +1032,8 @@ impl PartitionStoreTransaction<'_> {
     }
 
     #[inline]
-    pub(crate) fn storage_version(&self) -> StorageVersion {
-        self.storage_version
+    pub(crate) fn storage_features(&self) -> StorageFeatures {
+        self.storage_features
     }
 
     #[inline]

--- a/crates/partition-store/src/promise_table/mod.rs
+++ b/crates/partition-store/src/promise_table/mod.rs
@@ -12,6 +12,7 @@ use bytes::Bytes;
 use bytestring::ByteString;
 use std::sync::Arc;
 
+use crate::features::StorageFeatures;
 use crate::keys::{DecodeTableKey, KeyKind, define_table_key};
 use crate::scan::TableScan;
 use crate::{
@@ -25,7 +26,6 @@ use restate_storage_api::promise_table::{
 use restate_storage_api::protobuf_types::PartitionStoreProtobufValue;
 use restate_storage_api::{Result, StorageError};
 use restate_types::identifiers::{PartitionKey, ServiceId, WithPartitionKey};
-use restate_types::partitions::StorageVersion;
 use restate_types::sharding::KeyRange;
 use restate_types::{Scope, ServiceName};
 use restate_util_string::ReString;
@@ -63,23 +63,20 @@ fn create_key(service_id: &ServiceId, key: &ByteString) -> PromiseKey {
     }
 }
 
-/// Returns `true` if the call should use the scoped promise table — either
-/// because the partition store has migrated past
-/// [`StorageVersion::ScopedStateAndPromise`] (so scope = None entries also live
-/// in the scoped table) or because the [`ServiceId`] carries an explicit scope.
+/// Returns `true` if the call should use the scoped promise table for all queries.
 #[inline]
-fn use_scoped_promise(storage_version: StorageVersion, service_id: &ServiceId) -> bool {
-    storage_version.is_scope_migrated() || service_id.scope.is_some()
+fn use_scoped_promise(storage_features: StorageFeatures, service_id: &ServiceId) -> bool {
+    storage_features.is_migrated_to_scoped_promise_table || service_id.scope.is_some()
 }
 
 fn get_promise<S: StorageAccess>(
     storage: &mut S,
-    storage_version: StorageVersion,
+    storage_features: StorageFeatures,
     service_id: &ServiceId,
     key: &ByteString,
 ) -> Result<Option<Promise>> {
     let _x = RocksDbReadPerfGuard::new("get-promise");
-    if use_scoped_promise(storage_version, service_id) {
+    if use_scoped_promise(storage_features, service_id) {
         // todo(tillrohrmann) remove once ServiceId uses ServiceName and ReString internally
         let service_name = ServiceName::new(&service_id.service_name);
         let service_key = ReString::new(&service_id.key);
@@ -102,12 +99,12 @@ fn get_promise<S: StorageAccess>(
 
 fn put_promise<S: StorageAccess>(
     storage: &mut S,
-    storage_version: StorageVersion,
+    storage_features: StorageFeatures,
     service_id: &ServiceId,
     key: &ByteString,
     metadata: &Promise,
 ) -> Result<()> {
-    if use_scoped_promise(storage_version, service_id) {
+    if use_scoped_promise(storage_features, service_id) {
         // todo(tillrohrmann) remove once ServiceId uses ServiceName and ReString internally
         let service_name = ServiceName::new(&service_id.service_name);
         let service_key = ReString::new(&service_id.key);
@@ -131,10 +128,10 @@ fn put_promise<S: StorageAccess>(
 
 fn delete_all_promises<S: StorageAccess>(
     storage: &mut S,
-    storage_version: StorageVersion,
+    storage_features: StorageFeatures,
     service_id: &ServiceId,
 ) -> Result<()> {
-    if use_scoped_promise(storage_version, service_id) {
+    if use_scoped_promise(storage_features, service_id) {
         // todo(tillrohrmann) remove once ServiceId uses ServiceName and ReString internally
         let service_name = ServiceName::new(&service_id.service_name);
         let service_key = ReString::new(&service_id.key);
@@ -182,7 +179,7 @@ impl ReadPromiseTable for PartitionStore {
         key: &ByteString,
     ) -> Result<Option<Promise>> {
         self.assert_partition_key(service_id)?;
-        get_promise(self, self.storage_version(), service_id, key)
+        get_promise(self, self.storage_features(), service_id, key)
     }
 }
 
@@ -201,7 +198,7 @@ impl ScanPromiseTable for PartitionStore {
 
         // Only scan the legacy unscoped table while we may still hold data there.
         // After migration the range was deleted, so the scoped scan covers everything.
-        let unscoped = if self.storage_version().is_scope_migrated() {
+        let unscoped = if self.storage_features().is_migrated_to_scoped_promise_table {
             None
         } else {
             let f_unscoped = Arc::clone(&f);
@@ -278,7 +275,7 @@ impl ReadPromiseTable for PartitionStoreTransaction<'_> {
         key: &ByteString,
     ) -> Result<Option<Promise>> {
         self.assert_partition_key(service_id)?;
-        get_promise(self, self.storage_version(), service_id, key)
+        get_promise(self, self.storage_features(), service_id, key)
     }
 }
 
@@ -290,11 +287,11 @@ impl WritePromiseTable for PartitionStoreTransaction<'_> {
         promise: &Promise,
     ) -> Result<()> {
         self.assert_partition_key(service_id)?;
-        put_promise(self, self.storage_version(), service_id, key, promise)
+        put_promise(self, self.storage_features(), service_id, key, promise)
     }
 
     fn delete_all_promises(&mut self, service_id: &ServiceId) -> Result<()> {
         self.assert_partition_key(service_id)?;
-        delete_all_promises(self, self.storage_version(), service_id)
+        delete_all_promises(self, self.storage_features(), service_id)
     }
 }

--- a/crates/partition-store/src/state_table/mod.rs
+++ b/crates/partition-store/src/state_table/mod.rs
@@ -30,12 +30,12 @@ use restate_types::{Scope, ServiceName};
 use restate_util_string::ReString;
 
 use crate::TableKind::State;
+use crate::features::StorageFeatures;
 use crate::keys::{DecodeTableKey, KeyKind, define_table_key};
 use crate::{
     PartitionStore, PartitionStoreTransaction, StorageAccess, TableScan,
     TableScanIterationDecision, break_on_err,
 };
-use restate_types::partitions::StorageVersion;
 
 define_table_key!(
     State,
@@ -128,23 +128,20 @@ impl<DB: DBAccess> Iterator for StateEntryIter<'_, DB> {
     }
 }
 
-/// Returns `true` if the call should use the scoped state table — either because
-/// the partition store has migrated past
-/// [`StorageVersion::ScopedStateAndPromise`] (so scope = None entries also live
-/// in the scoped table) or because the [`ServiceId`] carries an explicit scope.
+/// Returns `true` if the call should use the scoped state table exclusively
 #[inline]
-fn use_scoped_state(storage_version: StorageVersion, service_id: &ServiceId) -> bool {
-    storage_version.is_scope_migrated() || service_id.scope.is_some()
+fn use_scoped_state(storage_features: StorageFeatures, service_id: &ServiceId) -> bool {
+    storage_features.is_migrated_to_scoped_state_table || service_id.scope.is_some()
 }
 
 fn put_user_state<S: StorageAccess>(
     storage: &mut S,
-    storage_version: StorageVersion,
+    storage_features: StorageFeatures,
     service_id: &ServiceId,
     state_key: &Bytes,
     state_value: impl AsRef<[u8]>,
 ) -> Result<()> {
-    if use_scoped_state(storage_version, service_id) {
+    if use_scoped_state(storage_features, service_id) {
         //todo(tillrohrmann) remove once ServiceId carries the right types
         let service_name = ServiceName::new(service_id.service_name.as_ref());
         let service_key = ReString::new(&service_id.key);
@@ -168,11 +165,11 @@ fn put_user_state<S: StorageAccess>(
 
 fn delete_user_state<S: StorageAccess>(
     storage: &mut S,
-    storage_version: StorageVersion,
+    storage_features: StorageFeatures,
     service_id: &ServiceId,
     state_key: &Bytes,
 ) -> Result<()> {
-    if use_scoped_state(storage_version, service_id) {
+    if use_scoped_state(storage_features, service_id) {
         //todo(tillrohrmann) remove once ServiceId carries the right types
         let service_name = ServiceName::new(service_id.service_name.as_ref());
         let service_key = ReString::new(&service_id.key);
@@ -196,10 +193,10 @@ fn delete_user_state<S: StorageAccess>(
 
 fn delete_all_user_state<S: StorageAccess>(
     storage: &mut S,
-    storage_version: StorageVersion,
+    storage_features: StorageFeatures,
     service_id: &ServiceId,
 ) -> Result<()> {
-    if use_scoped_state(storage_version, service_id) {
+    if use_scoped_state(storage_features, service_id) {
         //todo(tillrohrmann) remove once ServiceId carries the right types
         let service_name = ServiceName::new(service_id.service_name.as_ref());
         let service_key = ReString::new(&service_id.key);
@@ -242,12 +239,12 @@ fn delete_all_user_state<S: StorageAccess>(
 
 fn get_user_state<S: StorageAccess>(
     storage: &mut S,
-    storage_version: StorageVersion,
+    storage_features: StorageFeatures,
     service_id: &ServiceId,
     state_key: &Bytes,
 ) -> Result<Option<Bytes>> {
     let _x = RocksDbReadPerfGuard::new("get-user-state");
-    if use_scoped_state(storage_version, service_id) {
+    if use_scoped_state(storage_features, service_id) {
         //todo(tillrohrmann) remove once ServiceId carries the right types
         let service_name = ServiceName::new(service_id.service_name.as_ref());
         let service_key = ReString::new(&service_id.key);
@@ -271,12 +268,12 @@ fn get_user_state<S: StorageAccess>(
 
 fn get_all_user_states_for_service<'a, S: StorageAccess>(
     storage: &'a S,
-    storage_version: StorageVersion,
+    storage_features: StorageFeatures,
     service_id: &ServiceId,
 ) -> Result<StateEntryIter<'a, S::DBAccess<'a>>> {
     let _x = RocksDbReadPerfGuard::new("get-all-user-state-iter-setup");
 
-    if use_scoped_state(storage_version, service_id) {
+    if use_scoped_state(storage_features, service_id) {
         //todo(tillrohrmann) remove once ServiceId carries the right types
         let service_name = ServiceName::new(service_id.service_name.as_ref());
         let service_key = ReString::new(&service_id.key);
@@ -308,7 +305,7 @@ impl ReadStateTable for PartitionStore {
         state_key: &Bytes,
     ) -> Result<Option<Bytes>> {
         self.assert_partition_key(service_id)?;
-        get_user_state(self, self.storage_version(), service_id, state_key)
+        get_user_state(self, self.storage_features(), service_id, state_key)
     }
 
     fn get_all_user_states_for_service<'a>(
@@ -318,7 +315,7 @@ impl ReadStateTable for PartitionStore {
         self.assert_partition_key(service_id)?;
         Ok(stream::iter(get_all_user_states_for_service(
             self,
-            self.storage_version(),
+            self.storage_features(),
             service_id,
         )?))
     }
@@ -334,7 +331,7 @@ impl ReadStateTable for PartitionStore {
         + 'a,
     > {
         self.assert_partition_key(service_id)?;
-        let iter = get_all_user_states_for_service(self, self.storage_version(), service_id)?;
+        let iter = get_all_user_states_for_service(self, self.storage_features(), service_id)?;
         Ok(budgeted_state_stream(iter, budget))
     }
 }
@@ -354,7 +351,7 @@ impl ScanStateTable for PartitionStore {
 
         // Only scan the legacy unscoped table while we may still hold data there.
         // After migration the range was deleted, so the scoped scan covers everything.
-        let unscoped = if self.storage_version().is_scope_migrated() {
+        let unscoped = if self.storage_features().is_migrated_to_scoped_state_table {
             None
         } else {
             let f_unscoped = Arc::clone(&f);
@@ -412,7 +409,7 @@ impl ReadStateTable for PartitionStoreTransaction<'_> {
         state_key: &Bytes,
     ) -> Result<Option<Bytes>> {
         self.assert_partition_key(service_id)?;
-        get_user_state(self, self.storage_version(), service_id, state_key)
+        get_user_state(self, self.storage_features(), service_id, state_key)
     }
 
     fn get_all_user_states_for_service<'a>(
@@ -422,7 +419,7 @@ impl ReadStateTable for PartitionStoreTransaction<'_> {
         self.assert_partition_key(service_id)?;
         Ok(stream::iter(get_all_user_states_for_service(
             self,
-            self.storage_version(),
+            self.storage_features(),
             service_id,
         )?))
     }
@@ -438,7 +435,7 @@ impl ReadStateTable for PartitionStoreTransaction<'_> {
         + 'a,
     > {
         self.assert_partition_key(service_id)?;
-        let iter = get_all_user_states_for_service(self, self.storage_version(), service_id)?;
+        let iter = get_all_user_states_for_service(self, self.storage_features(), service_id)?;
         Ok(budgeted_state_stream(iter, budget))
     }
 }
@@ -453,7 +450,7 @@ impl WriteStateTable for PartitionStoreTransaction<'_> {
         self.assert_partition_key(service_id)?;
         put_user_state(
             self,
-            self.storage_version(),
+            self.storage_features(),
             service_id,
             state_key,
             state_value,
@@ -462,12 +459,12 @@ impl WriteStateTable for PartitionStoreTransaction<'_> {
 
     fn delete_user_state(&mut self, service_id: &ServiceId, state_key: &Bytes) -> Result<()> {
         self.assert_partition_key(service_id)?;
-        delete_user_state(self, self.storage_version(), service_id, state_key)
+        delete_user_state(self, self.storage_features(), service_id, state_key)
     }
 
     fn delete_all_user_state(&mut self, service_id: &ServiceId) -> Result<()> {
         self.assert_partition_key(service_id)?;
-        delete_all_user_state(self, self.storage_version(), service_id)
+        delete_all_user_state(self, self.storage_features(), service_id)
     }
 }
 

--- a/crates/partition-store/src/tests/migrations_test/verify_and_run_migrations.rs
+++ b/crates/partition-store/src/tests/migrations_test/verify_and_run_migrations.rs
@@ -17,7 +17,7 @@ use tokio_util::sync::CancellationToken;
 
 use restate_rocksdb::RocksDbManager;
 use restate_storage_api::Transaction;
-use restate_storage_api::fsm_table::WriteFsmTable;
+use restate_storage_api::fsm_table::{ReadFsmTable, WriteFsmTable};
 use restate_storage_api::promise_table::{
     Promise, PromiseState, ReadPromiseTable, WritePromiseTable,
 };
@@ -25,24 +25,53 @@ use restate_storage_api::state_table::{ReadStateTable, WriteStateTable};
 use restate_types::config::{Configuration, set_current_config};
 use restate_types::identifiers::{PartitionId, PartitionKey, ServiceId};
 use restate_types::logs::Lsn;
-use restate_types::partitions::Partition;
+use restate_types::partitions::{Partition, StorageVersion};
 use restate_types::sharding::KeyRange;
+use restate_types::{RESTATE_VERSION_1_7_9, SemanticRestateVersion};
 
 use crate::PartitionStoreManager;
-use crate::fsm_table::put_storage_version;
+use crate::fsm_table::{
+    delete_storage_features, get_min_restate_version_from_partition_db,
+    get_storage_features_from_partition_db, get_storage_version_from_partition_db,
+    put_storage_features_json, put_storage_version,
+};
 use crate::keys::DecodeTableKey;
+use crate::migrations::MigrationError;
 use crate::promise_table::{PromiseKey, ScopedPromiseKey};
 use crate::scan::{PhysicalScan, TableScan};
 use crate::state_table::{ScopedStateKey, StateKey};
-use restate_types::partitions::StorageVersion;
 
 fn with_migrate_scoped_tables(enabled: bool) {
+    with_scoped_table_migrations(enabled, enabled);
+}
+
+fn with_scoped_table_migrations(state: bool, promise: bool) {
     let mut config = Configuration::default();
     config
         .common
         .experimental
-        .set_migrate_scoped_tables(enabled);
+        .set_scoped_state_table_migration(state);
+    config
+        .common
+        .experimental
+        .set_scoped_promise_table_migration(promise);
     set_current_config(config);
+}
+
+fn storage_version(store: &crate::PartitionStore) -> StorageVersion {
+    get_storage_version_from_partition_db(store.partition_db()).expect("read storage version")
+}
+
+fn min_restate_version(store: &crate::PartitionStore) -> SemanticRestateVersion {
+    get_min_restate_version_from_partition_db(store.partition_db()).expect(
+        "read min restate
+    version",
+    )
+}
+
+fn scoped_tables_migrated(store: &crate::PartitionStore) -> bool {
+    let features = store.storage_features();
+    features.is_migrated_to_scoped_state_table && features.is_migrated_to_scoped_promise_table
 }
 
 async fn seed_unscoped_data(
@@ -201,7 +230,13 @@ async fn flag_off_keeps_partition_at_v1_5() {
         .await
         .expect("verify with flag off");
 
-    assert_eq!(store.storage_version(), StorageVersion::V1_5);
+    assert_eq!(storage_version(&store), StorageVersion::V1_5);
+    assert!(!scoped_tables_migrated(&store));
+    assert!(
+        get_storage_features_from_partition_db(store.partition_db())
+            .expect("read storage features")
+            .is_some()
+    );
     assert_eq!(count_legacy_state(&store), legacy_state_before);
     assert_eq!(count_legacy_promise(&store), legacy_promise_before);
     assert_eq!(count_scoped_state(&store), 0);
@@ -211,8 +246,8 @@ async fn flag_off_keeps_partition_at_v1_5() {
 }
 
 #[restate_core::test]
-async fn flag_on_migrates_and_bumps_version() {
-    with_migrate_scoped_tables(true);
+async fn scoped_tables_migrate_independently_and_bump_version() {
+    with_migrate_scoped_tables(false);
     RocksDbManager::init();
     let manager = PartitionStoreManager::create(true)
         .await
@@ -225,8 +260,6 @@ async fn flag_on_migrates_and_bumps_version() {
         .await
         .expect("open");
 
-    // Switch the flag back off so that seeding via WriteStateTable hits the legacy table.
-    with_migrate_scoped_tables(false);
     let (state_entries, service_ids) = seed_unscoped_data(&mut store).await;
     let partition_id = store.partition_id();
     put_storage_version(&mut store, partition_id, StorageVersion::V1_5 as u16)
@@ -236,17 +269,62 @@ async fn flag_on_migrates_and_bumps_version() {
     assert_eq!(count_legacy_state(&store), state_entries.len());
     assert_eq!(count_legacy_promise(&store), service_ids.len());
 
-    // Now turn the flag back on and run migrations.
-    with_migrate_scoped_tables(true);
-    let cancel = CancellationToken::new();
+    // Migrate state independently and persist a valid intermediate layout.
+    with_scoped_table_migrations(true, false);
+    let config = Configuration::pinned().clone();
     store
-        .verify_and_run_migrations(cancel, &Configuration::pinned())
+        .verify_and_run_migrations(CancellationToken::new(), &config)
         .await
-        .expect("verify with flag on");
+        .expect("migrate state table");
+
+    assert_eq!(storage_version(&store), StorageVersion::V1_5);
+    assert_eq!(min_restate_version(&store), *RESTATE_VERSION_1_7_9);
+    let features = store.storage_features();
+    assert!(features.is_migrated_to_scoped_state_table);
+    assert!(!features.is_migrated_to_scoped_promise_table);
+    assert_eq!(count_legacy_state(&store), 0);
+    assert_eq!(count_scoped_state(&store), state_entries.len());
+    assert_eq!(count_legacy_promise(&store), service_ids.len());
+    assert_eq!(count_scoped_promise(&store), 0);
+
+    // Reopen with both options disabled to prove the intermediate marker is authoritative.
+    let mut store = crate::PartitionStore::from(store.into_inner());
+    with_migrate_scoped_tables(false);
+    let config = Configuration::pinned().clone();
+    store
+        .verify_and_run_migrations(CancellationToken::new(), &config)
+        .await
+        .expect("verify intermediate layout");
+    assert!(store.storage_features().is_migrated_to_scoped_state_table);
+    let (service_id, state_key) = &state_entries[0];
+    assert_eq!(
+        store.get_user_state(service_id, state_key).await.unwrap(),
+        Some(Bytes::from_static(b"v1"))
+    );
+    assert!(
+        store
+            .get_promise(&service_ids[0], &ByteString::from_static("p"))
+            .await
+            .unwrap()
+            .is_some()
+    );
+
+    // Enabling the second feature immediately advances the compatibility version.
+    with_scoped_table_migrations(false, true);
+    let config = Configuration::pinned().clone();
+    store
+        .verify_and_run_migrations(CancellationToken::new(), &config)
+        .await
+        .expect("migrate promise table");
 
     assert_eq!(
-        store.storage_version(),
+        storage_version(&store),
         StorageVersion::ScopedStateAndPromise
+    );
+    assert!(scoped_tables_migrated(&store));
+    assert_eq!(
+        store.get_min_restate_version().await.unwrap(),
+        (*RESTATE_VERSION_1_7_9).clone()
     );
     assert_eq!(count_legacy_state(&store), 0);
     assert_eq!(count_legacy_promise(&store), 0);
@@ -276,11 +354,128 @@ async fn flag_on_migrates_and_bumps_version() {
         .await
         .expect("second verify");
     assert_eq!(
-        store.storage_version(),
+        storage_version(&store),
         StorageVersion::ScopedStateAndPromise
     );
+    assert!(scoped_tables_migrated(&store));
     assert_eq!(count_legacy_state(&store), 0);
     assert_eq!(count_scoped_state(&store), state_entries.len());
+
+    // A store migrated before key 12 existed derives the feature from the mirrored StorageVersion
+    // and persists the new JSON ledger without requiring the experimental option again.
+    let partition_id = store.partition_id();
+    delete_storage_features(&mut store, partition_id)
+        .await
+        .expect("remove storage features");
+    let mut store = crate::PartitionStore::from(store.into_inner());
+    with_migrate_scoped_tables(false);
+    let config = Configuration::pinned().clone();
+    store
+        .verify_and_run_migrations(CancellationToken::new(), &config)
+        .await
+        .expect("bootstrap storage features from StorageVersion");
+    assert!(scoped_tables_migrated(&store));
+    assert!(
+        get_storage_features_from_partition_db(store.partition_db())
+            .expect("read bootstrapped storage features")
+            .is_some()
+    );
+
+    RocksDbManager::get().shutdown().await;
+}
+
+#[restate_core::test]
+async fn does_not_automatically_migrate_at_1_8() {
+    with_migrate_scoped_tables(false);
+    RocksDbManager::init();
+    let manager = PartitionStoreManager::create(true)
+        .await
+        .expect("manager create");
+    let mut store = manager
+        .open(
+            &Partition::new(PartitionId::MIN, KeyRange::new(0, PartitionKey::MAX - 1)),
+            None,
+        )
+        .await
+        .expect("open");
+
+    let (state_entries, service_ids) = seed_unscoped_data(&mut store).await;
+    let partition_id = store.partition_id();
+    put_storage_version(&mut store, partition_id, StorageVersion::V1_5 as u16)
+        .await
+        .expect("seed V1_5");
+
+    let config = Configuration::pinned().clone();
+    store
+        .verify_and_run_migrations_at_version(
+            &SemanticRestateVersion::parse("1.8.0-dev").unwrap(),
+            CancellationToken::new(),
+            &config,
+        )
+        .await
+        .expect("verify without automatic migration");
+
+    assert_eq!(storage_version(&store), StorageVersion::V1_5);
+    assert!(!scoped_tables_migrated(&store));
+    assert_eq!(count_legacy_state(&store), state_entries.len());
+    assert_eq!(count_legacy_promise(&store), service_ids.len());
+    assert_eq!(count_scoped_state(&store), 0);
+    assert_eq!(count_scoped_promise(&store), 0);
+
+    RocksDbManager::get().shutdown().await;
+}
+
+#[restate_core::test]
+async fn future_unknown_features_report_the_names_raising_the_barrier() {
+    with_migrate_scoped_tables(false);
+    RocksDbManager::init();
+    let manager = PartitionStoreManager::create(true)
+        .await
+        .expect("manager create");
+    let mut store = manager
+        .open(
+            &Partition::new(PartitionId::MIN, KeyRange::new(0, PartitionKey::MAX - 1)),
+            None,
+        )
+        .await
+        .expect("open");
+    let partition_id = store.partition_id();
+
+    put_storage_features_json(
+        &mut store,
+        partition_id,
+        br#"{
+            "features": {
+                "future-a": { "min_required_version": "2.0.0" },
+                "future-b": { "min_required_version": "2.0.0" },
+                "older-feature": { "min_required_version": "1.9.0" }
+            }
+        }"#,
+    )
+    .await
+    .expect("seed future storage features");
+
+    let config = Configuration::pinned().clone();
+    let error = store
+        .verify_and_run_migrations_at_version(
+            &SemanticRestateVersion::new(1, 9, 0),
+            CancellationToken::new(),
+            &config,
+        )
+        .await
+        .unwrap_err();
+
+    match error {
+        MigrationError::StorageFeatureVersionBarrier {
+            required_min_version,
+            storage_features,
+        } => {
+            assert_eq!(required_min_version, SemanticRestateVersion::new(2, 0, 0));
+            assert_eq!(storage_features, ["future-a", "future-b"]);
+        }
+        other => panic!("unexpected error: {other}"),
+    }
+    assert_eq!(storage_version(&store), StorageVersion::None);
 
     RocksDbManager::get().shutdown().await;
 }
@@ -307,14 +502,8 @@ async fn flag_on_writes_post_migration_land_in_scoped() {
         .await
         .expect("verify fresh");
     assert_eq!(
-        store.storage_version(),
+        storage_version(&store),
         StorageVersion::ScopedStateAndPromise
-    );
-    assert!(
-        !store
-            .needs_jc_orphan_cleanup()
-            .await
-            .expect("fresh stores are marked cleanup-complete")
     );
 
     let service_id = ServiceId::new(None, "svc", "k");

--- a/crates/platform/src/network.rs
+++ b/crates/platform/src/network.rs
@@ -11,6 +11,8 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use restate_util_string::ReString;
+
 use crate::hash::HashMap;
 
 /// A marker trait for types that can be serialized and sent over the network.
@@ -53,6 +55,7 @@ impl_net_serde!(
     i64,
     i128,
     String,
+    ReString,
     bytes::Bytes,
     std::time::Duration
 );

--- a/crates/storage-query-datafusion/src/partition_state/row.rs
+++ b/crates/storage-query-datafusion/src/partition_state/row.rs
@@ -76,7 +76,5 @@ pub(crate) fn append_partition_row(
 
     row.enabled_features(state.enabled_features.enabled_names().map(Some));
 
-    if let Some(version) = state.storage_version {
-        row.storage_version(version as u32);
-    }
+    row.enabled_storage_features(state.enabled_storage_features.iter().map(Some));
 }

--- a/crates/storage-query-datafusion/src/partition_state/schema.rs
+++ b/crates/storage-query-datafusion/src/partition_state/schema.rs
@@ -67,12 +67,11 @@ define_table!(
         /// Query membership with `array_has(enabled_features, 'vqueues')`.
         enabled_features: Utf8List,
 
-        /// Partition-store on-disk storage version (StorageVersion discriminant).
-        /// Set once on partition open.
-        storage_version: DataType::UInt32,
-
         /// Why the node gave up on running this partition processor, if it did.
         /// NULL while the processor is healthy.
         broken_reason: DataType::Utf8,
+
+        /// Partition-store on-disk local storage features.
+        enabled_storage_features: Utf8List,
     )
 );

--- a/crates/types/protobuf/restate/cluster.proto
+++ b/crates/types/protobuf/restate/cluster.proto
@@ -83,7 +83,7 @@ enum BrokenReason {
 }
 
 message PartitionProcessorStatus {
-  reserved 8;
+  reserved 8, 16;
   google.protobuf.Timestamp updated_at = 1;
   RunMode planned_mode = 2;
   RunMode effective_mode = 3;
@@ -102,12 +102,13 @@ message PartitionProcessorStatus {
   // processor. Carried as strings so that older clients can render feature
   // names they don't recognise.
   repeated string enabled_features = 15;
-  // Partition-store on-disk storage version (StorageVersion discriminant).
-  optional uint32 storage_version = 16;
   DetailedRunMode detailed_effective_mode = 17;
   // Set when this node has parked the partition processor instead of retrying
   // it. All other fields carry their defaults in that case.
   BrokenReason broken_reason = 18;
+
+  // Partition-store on-disk local storage features
+  repeated string enabled_storage_features = 19;
 }
 
 message ReplicationProperty { string replication_property = 1; }

--- a/crates/types/src/cluster/cluster_state.rs
+++ b/crates/types/src/cluster/cluster_state.rs
@@ -14,10 +14,10 @@ use std::time::{Duration, Instant};
 use prost_dto::IntoProst;
 
 use restate_encoding::NetSerde;
+use restate_util_string::ReString;
 
 use crate::identifiers::{LeaderEpoch, PartitionId};
 use crate::logs::Lsn;
-use crate::partitions::StorageVersion;
 use crate::partitions::features::PersistedFeatures;
 pub use crate::protobuf::cluster::{BrokenReason, DetailedRunMode};
 use crate::time::MillisSinceEpoch;
@@ -161,7 +161,7 @@ pub enum ReplayStatus {
 
 #[derive(Debug, Clone, IntoProst, bilrost::Message, NetSerde)]
 #[prost(target = "crate::protobuf::cluster::PartitionProcessorStatus")]
-#[bilrost(reserved_tags(8))]
+#[bilrost(reserved_tags(8, 16))]
 pub struct PartitionProcessorStatus {
     #[prost(required)]
     #[bilrost(1)]
@@ -202,22 +202,20 @@ pub struct PartitionProcessorStatus {
     #[into_prost(map = "enabled_features_to_proto", map_by_ref)]
     #[bilrost(15)]
     pub enabled_features: PersistedFeatures,
-    /// Partition-store on-disk storage version (StorageVersion discriminant).
-    /// Set once on partition open by `verify_and_run_migrations`.
-    #[bilrost(16)]
-    #[into_prost(map = "storage_version_to_u32")]
-    pub storage_version: Option<StorageVersion>,
-
     /// Since v1.7.3 (if Unknown, use effective_mode)
     #[bilrost(17)]
     pub detailed_effective_mode: DetailedRunMode,
-
     /// Set when the node has parked this partition processor instead of retrying it.
     /// All other fields carry their defaults in that case.
     ///
     /// Since v1.7.3
     #[bilrost(18)]
     pub broken_reason: BrokenReason,
+    /// Partition-store on-disk storage features.
+    /// Set once on partition open by `verify_and_run_migrations`.
+    #[into_prost(map = "enabled_storage_features_to_proto")]
+    #[bilrost(19)]
+    pub enabled_storage_features: Vec<ReString>,
 }
 
 impl PartitionProcessorStatus {
@@ -255,12 +253,12 @@ impl From<DetailedRunMode> for RunMode {
     }
 }
 
-fn storage_version_to_u32(v: StorageVersion) -> u32 {
-    v as u32
-}
-
 fn enabled_features_to_proto(f: &PersistedFeatures) -> Vec<String> {
     f.enabled_names().map(String::from).collect()
+}
+
+fn enabled_storage_features_to_proto(i: ReString) -> String {
+    i.to_string()
 }
 
 impl Default for PartitionProcessorStatus {
@@ -281,8 +279,8 @@ impl Default for PartitionProcessorStatus {
             last_applied_rule_book_version: None,
             last_applied_schema_version: None,
             enabled_features: PersistedFeatures::default(),
-            storage_version: None,
             broken_reason: BrokenReason::NotBroken,
+            enabled_storage_features: Vec::new(),
         }
     }
 }

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -794,18 +794,31 @@ experimental! {
     /// Since v1.7.0
     unique_random_seeds,
 
-    /// # Migrate the unscoped state and promise tables into their scoped variants
+    /// # Migrate the unscoped promise table into its scoped variant
     ///
     /// When enabled, partition stores migrate every entry of the legacy unscoped
-    /// state and promise tables into their scoped variants (with `scope = None`)
-    /// on open, and route all subsequent state/promise reads and writes through
+    /// promise table into its scoped variant (with `scope = None`)
+    /// on open, and route all subsequent promise reads and writes through
     /// the scoped tables.
     ///
     /// Once enabled, you **cannot** roll back to a Restate-server version that
     /// did not yet recognize the resulting on-disk schema version.
     ///
-    /// Since v1.7.0
-    migrate_scoped_tables,
+    /// Since v1.7.9
+    scoped_promise_table_migration,
+
+    /// # Migrate the unscoped state table into its scoped variant
+    ///
+    /// When enabled, partition stores migrate every entry of the legacy unscoped
+    /// state table into its scoped variant (with `scope = None`)
+    /// on open, and route all subsequent promise reads and writes through
+    /// the scoped tables.
+    ///
+    /// Once enabled, you **cannot** roll back to a Restate-server version that
+    /// did not yet recognize the resulting on-disk schema version.
+    ///
+    /// Since v1.7.9
+    scoped_state_table_migration,
 
     /// # Allow scope on Virtual Object targets
     ///

--- a/crates/types/src/restate_version.rs
+++ b/crates/types/src/restate_version.rs
@@ -242,6 +242,10 @@ pub static RESTATE_VERSION_1_7_5: LazyLock<SemanticRestateVersion> =
 pub static RESTATE_VERSION_1_7_8: LazyLock<SemanticRestateVersion> =
     LazyLock::new(|| SemanticRestateVersion::parse("1.7.8-dev").expect("valid semver version"));
 
+/// Why isn't this value simply v1.7.9? See description of [`RESTATE_VERSION_1_6_0`].
+pub static RESTATE_VERSION_1_7_9: LazyLock<SemanticRestateVersion> =
+    LazyLock::new(|| SemanticRestateVersion::parse("1.7.9-dev").expect("valid semver version"));
+
 /// Why isn't this value simply v1.8.0? See description of [`RESTATE_VERSION_1_6_0`].
 pub static RESTATE_VERSION_1_8_0: LazyLock<SemanticRestateVersion> =
     LazyLock::new(|| SemanticRestateVersion::parse("1.8.0-dev").expect("valid semver version"));

--- a/crates/worker/src/partition/mod.rs
+++ b/crates/worker/src/partition/mod.rs
@@ -53,7 +53,7 @@ use restate_core::network::{
 use restate_core::{Metadata, ShutdownError, TaskCenter, TaskKind, cancellation_token};
 use restate_ingestion_client::IngestionClient;
 use restate_partition_store::{
-    MigrationError, PartitionDb, PartitionSeal, PartitionStore, PartitionStoreTransaction,
+    PartitionDb, PartitionSeal, PartitionStore, PartitionStoreTransaction,
 };
 use restate_platform::memory::EstimatedMemorySize;
 use restate_storage_api::deduplication_table::{
@@ -82,6 +82,7 @@ use restate_types::storage::{
 };
 use restate_types::time::MillisSinceEpoch;
 use restate_types::{GenerationalNodeId, SemanticRestateVersion, Version};
+use restate_util_string::ReString;
 use restate_util_time::DurationExt;
 use restate_vqueues::context::HasVQueues;
 use restate_wal_protocol::control::{CurrentReplicaSetConfiguration, NextReplicaSetConfiguration};
@@ -286,12 +287,13 @@ pub enum ProcessorError {
     },
     #[error(
         "partition is blocked; requires an upgrade to restate-server version \
-        {required_min_version} or higher; reason='{barrier_reason}'; feature changes={feature_changes:?}"
+        {required_min_version} or higher; reason='{barrier_reason}'; feature changes={feature_changes:?}; storage features={storage_features:?}"
     )]
     VersionBarrier {
         required_min_version: SemanticRestateVersion,
         barrier_reason: String,
         feature_changes: Vec<u16>,
+        storage_features: Vec<ReString>,
     },
     #[error(transparent)]
     Storage(#[from] StorageError),
@@ -372,37 +374,6 @@ where
         debug!("Starting the partition processor.");
 
         let cancel = cancellation_token();
-        // Run migrations first.
-        //
-        // Important to note: This only runs the migration for the given partition store. In a setup,
-        // where not every node runs every partition, it can happen that partition data remains
-        // untouched when going from one version to the next.
-        // todo https://github.com/restatedev/restate/issues/4175.
-        //
-        // This will fail with StorageError::MigrationCancelled if the current task was cancelled
-        // during the migration phase.
-        match self
-            .partition_store
-            .verify_and_run_migrations(cancel.clone(), self.node_ctx.config.live_load())
-            .await
-        {
-            Ok(()) => {}
-            Err(MigrationError::MigrationCancelled) => {
-                debug!(
-                    "Shutting partition processor during data migration because it was cancelled."
-                );
-                return Ok(());
-            }
-            Err(MigrationError::MigrationBarrier(reason)) => {
-                return Err(ProcessorError::MigrationBarrier { reason });
-            }
-            Err(MigrationError::StorageError(err)) => {
-                warn!(
-                    "Shutting partition processor during data migration down because of error: {err}"
-                );
-                return Err(err.into());
-            }
-        }
 
         // Note: Boxing because it's a rather large future (>35KiB)
         let res = match cancel.run_until_cancelled(Box::pin(self.run_inner())).await {
@@ -588,6 +559,14 @@ where
         let mut cloned_partition_store = self.partition_store.clone();
         let mut txn = cloned_partition_store.transaction();
         let partition_id = self.ctx.partition_id().into();
+
+        // Migrations and local storage features have been enabled prior to this point.
+        // let's set it once into the partition processor watch.
+        self.status_watch_tx.send_modify(|old| {
+            self.ctx.merge_with_status(old);
+            old.enabled_storage_features = self.partition_store.get_storage_features_names();
+            old.updated_at = MillisSinceEpoch::now();
+        });
 
         loop {
             let config = self.node_ctx.config.live_load();
@@ -831,7 +810,6 @@ where
         self.status_watch_tx.send_modify(|old| {
             self.ctx.merge_with_status(old);
             old.durable_lsn = Some(durable_lsn);
-            old.storage_version = Some(self.partition_store.storage_version());
             old.effective_mode = self.leadership_state.detailed_effective_mode().into();
             old.detailed_effective_mode = self.leadership_state.detailed_effective_mode();
             old.updated_at = MillisSinceEpoch::now();

--- a/crates/worker/src/partition/processor/commands/version_barrier.rs
+++ b/crates/worker/src/partition/processor/commands/version_barrier.rs
@@ -86,6 +86,7 @@ impl<L: LeaderPromotion> ApplyPartitionCommand<VersionBarrierCommand>
                 required_min_version: barrier.version,
                 barrier_reason: barrier.human_reason.unwrap_or_default(),
                 feature_changes: barrier.feature_changes,
+                storage_features: Vec::new(),
             });
         }
 
@@ -397,8 +398,24 @@ mod tests {
             err(pat!(ProcessorError::VersionBarrier {
                 required_min_version: eq(unrealistic_future_version),
                 barrier_reason: eq("testing"),
+                storage_features: empty(),
             }))
         );
+    }
+
+    #[test]
+    fn version_barrier_error_displays_unknown_storage_features() {
+        let error = ProcessorError::VersionBarrier {
+            required_min_version: SemanticRestateVersion::new(2, 0, 0),
+            barrier_reason: "enabled storage features".to_owned(),
+            feature_changes: Vec::new(),
+            storage_features: vec!["future-a".into(), "future-b".into()],
+        };
+
+        let message = error.to_string();
+        assert!(message.contains("future-a"));
+        assert!(message.contains("future-b"));
+        assert!(message.contains("2.0.0"));
     }
 
     #[restate_core::test]

--- a/crates/worker/src/partition/processor/context.rs
+++ b/crates/worker/src/partition/processor/context.rs
@@ -84,6 +84,7 @@ impl ProcessorRawContext {
                 required_min_version: fsm_cache.min_restate_version().clone(),
                 barrier_reason: String::new(),
                 feature_changes: Vec::default(),
+                storage_features: Vec::default(),
             });
         }
 

--- a/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
+++ b/crates/worker/src/partition_processor_manager/spawn_processor_task.rs
@@ -12,12 +12,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::sync::watch;
-use tracing::{info, instrument, warn};
+use tracing::{debug, info, instrument, warn};
 
 use restate_core::network::{ShardSender, TransportConnect};
 use restate_core::{RuntimeTaskHandle, TaskCenter, TaskKind, cancellation_token};
 use restate_ingestion_client::IngestionClient;
-use restate_partition_store::PartitionStoreManager;
+use restate_partition_store::{MigrationError, PartitionStoreManager};
 use restate_platform::prelude::ReString;
 use restate_types::cluster::cluster_state::PartitionProcessorStatus;
 use restate_types::logs::Lsn;
@@ -76,7 +76,7 @@ where
         RuntimeTaskHandle<Result<(), ProcessorError>>,
     )> {
         let Self {
-            node_ctx,
+            mut node_ctx,
             task_name,
             partition,
             partition_store_manager,
@@ -87,8 +87,6 @@ where
         let (control_tx, control_rx) = watch::channel(TargetLeaderState::Follower);
         let (net_tx, net_rx) = ShardSender::new();
         let (watch_tx, watch_rx) = watch::channel(PartitionProcessorStatus::default());
-
-        let pp_builder = PartitionProcessorBuilder::new(control_rx, net_rx, watch_tx, node_ctx);
 
         let key_range = partition.key_range;
 
@@ -145,7 +143,57 @@ where
                         return Err(ProcessorError::from(seal));
                     }
 
+                    // Verify local feature compatibility before decoding the FSM and finish any
+                    // physical migration before its table-specific caches are constructed. Only
+                    // this local partition copy is migrated; inactive replicas can remain on an
+                    // older physical layout until they are started.
+                    let config = node_ctx.config.live_load().clone();
+                    match partition_store
+                        .verify_and_run_migrations(cancellation.clone(), &config)
+                        .await
+                    {
+                        Ok(()) => {}
+                        Err(MigrationError::MigrationCancelled) => {
+                            debug!(
+                                "Shutting partition processor during data migration because it was cancelled."
+                            );
+                            return Ok(());
+                        }
+                        Err(MigrationError::MigrationBarrier(reason)) => {
+                            return Err(ProcessorError::MigrationBarrier { reason });
+                        }
+                        Err(MigrationError::VersionBarrier {
+                            required_min_version,
+                        }) => {
+                            return Err(ProcessorError::VersionBarrier {
+                                required_min_version,
+                                barrier_reason: String::new(),
+                                feature_changes: Vec::new(),
+                                storage_features: Vec::new(),
+                            });
+                        }
+                        Err(MigrationError::StorageFeatureVersionBarrier {
+                            required_min_version,
+                            storage_features,
+                        }) => {
+                            return Err(ProcessorError::VersionBarrier {
+                                required_min_version,
+                                barrier_reason: "enabled storage features".to_owned(),
+                                feature_changes: Vec::new(),
+                                storage_features,
+                            });
+                        }
+                        Err(MigrationError::StorageError(err)) => {
+                            warn!(
+                                "Shutting partition processor during data migration down because of error: {err}"
+                            );
+                            return Err(err.into());
+                        }
+                    }
+
                     let db = partition_store.into_inner();
+                    let pp_builder =
+                        PartitionProcessorBuilder::new(control_rx, net_rx, watch_tx, node_ctx);
 
                     let run_result = async move {
                         let pp = pp_builder

--- a/tools/restate-doctor/src/util/decode_value.rs
+++ b/tools/restate-doctor/src/util/decode_value.rs
@@ -59,6 +59,8 @@ mod fsm_variable {
     pub const STATE_MACHINE_FEATURES: u64 = 10;
     /// *Since v1.7.3*
     pub const SEAL_MARKER: u64 = 11;
+    /// *Since v1.7.9*
+    pub const STORAGE_FEATURES: u64 = 12;
 }
 
 /// Result of decoding a value, including codec metadata
@@ -397,6 +399,9 @@ fn decode_fsm_value(key: &[u8], value: &[u8]) -> DecodedValue {
     if state_id == fsm_variable::SEAL_MARKER {
         return decode_fsm_seal_marker(value);
     }
+    if state_id == fsm_variable::STORAGE_FEATURES {
+        return decode_fsm_storage_features(value);
+    }
 
     // Read codec byte
     let codec_byte = value[0];
@@ -481,6 +486,17 @@ fn decode_fsm_seal_marker(value: &[u8]) -> DecodedValue {
             ),
             Err(_) => DecodedValue::error(None, payload_size, format!("{err}")),
         },
+    }
+}
+
+/// Decode local storage features without interpreting their names.
+fn decode_fsm_storage_features(value: &[u8]) -> DecodedValue {
+    let payload_size = value.len();
+    match serde_json::from_slice::<serde_json::Value>(value) {
+        Ok(features) => {
+            DecodedValue::decoded(None, payload_size, format!("StorageFeatures({features})"))
+        }
+        Err(err) => DecodedValue::error(None, payload_size, format!("{err}")),
     }
 }
 
@@ -670,6 +686,18 @@ mod tests {
         assert!(
             matches!(&decoded.content, DecodedContent::Decoded(s) if s.contains("<unrecognized>")),
             "unknown seal variant should fall back to raw json, got: {decoded}"
+        );
+
+        // Storage features: plain json with names that this binary need not recognize.
+        let decoded = decode_value(
+            KeyKind::Fsm,
+            &fsm_key(fsm_variable::STORAGE_FEATURES),
+            br#"{"features":{"future-feature":{"min_required_version":"2.0.0"}}}"#,
+        );
+        assert_eq!(decoded.codec, None);
+        assert!(
+            matches!(&decoded.content, DecodedContent::Decoded(s) if s.contains("future-feature")),
+            "storage features should preserve unknown names, got: {decoded}"
         );
     }
 }

--- a/tools/restatectl/src/commands/partition/list.rs
+++ b/tools/restatectl/src/commands/partition/list.rs
@@ -120,7 +120,6 @@ pub async fn list_partitions(
         "DURABLE",
         "ARCHIVED",
         "LSN-LAG",
-        "STORAGE",
         "SCHEMA",
         "RULE-BOOK",
         "FEATURES",
@@ -226,13 +225,6 @@ pub async fn list_partitions(
                             // (tail - 1) - applied_lsn = tail - (applied_lsn + 1)
                             tail.value.saturating_sub(applied.value + 1).to_string()
                         })
-                        .unwrap_or_else(|| "-".to_owned()),
-                ),
-                Cell::new(
-                    processor
-                        .status
-                        .storage_version
-                        .map(|v| (v as u16).to_string())
                         .unwrap_or_else(|| "-".to_owned()),
                 ),
                 Cell::new(


### PR DESCRIPTION

StorageVersion serializes every physical layout change into one monotonic
schema level. It cannot represent independent changes such as migrating only
the state or only the promise table, and makes unrelated future migrations
share one global order.

Introduce StorageFeature to model a local, per-partition-copy physical storage
capability. Unlike cluster-coordinated FSM features, these features describe
data layouts and indexes without changing the logical storage API. Each feature
defines a stable persisted name, its minimum reader version, its enablement
policy, and an independent migration/finalization step.

Persist enabled features as a forward-compatible JSON ledger. Unknown features
and metadata survive read-modify-write, allowing a feature-aware older binary
to reject an incompatible store and report the feature names that raised its
minimum-version barrier. Use the resolved StorageFeatures set as the runtime
source of truth for PartitionStore and expose its names in processor status.

Split the scoped state and promise migrations and experimental options so each
table can migrate independently. Route each table using its own feature marker,
and atomically commit destructive cleanup with the corresponding ledger update.
Run this verification and migration before constructing processor state and its
table-specific caches.

Deprecate StorageVersion as the source of truth, but retain its FSM value during
the v1.7 compatibility window. Stores already marked ScopedStateAndPromise seed
both new features, while new migrations mirror ScopedStateAndPromise only after
both features are enabled so v1.7.x binaries still see an accurate layout. The
mirror can be removed once the minimum supported Restate version is v1.8.

NOTE:
This does **not** fix the existing race that can happen between datafusion accessing the partition-store while migrations
are ongoing. The working assumption is that `verify_and_run_migrations` will run _before_ datafusion queries but this cannot
be guaranteed. This PR changes the behavious such that we prevent the server panic but some partition-store queries that run
during this race window may return wrong results.
