### PR TITLE
[VQueues] Make asynchronous refills opt-in

### DIFF
--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -843,6 +843,14 @@ experimental! {
     ///
     /// Since v1.7.8
     preflight_invocation_termination_retention,
+
+    /// # Asynchronous VQueue refills
+    ///
+    /// Moves VQueue storage refills to Tokio's blocking thread pool when the required data is not
+    /// already cached by RocksDB.
+    ///
+    /// Since v1.7.9
+    vqueues_async_refill,
 }
 
 serde_with::with_prefix!(pub prefix_tokio_console "tokio_console_");

--- a/crates/vqueues/src/lib.rs
+++ b/crates/vqueues/src/lib.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 pub use cache::{VQueueHandle, VQueuesMeta, VQueuesMetaCache};
 pub use metric_definitions::describe_metrics;
 pub use restate_worker_api::{ResourceKind, SchedulingStatus, VQueueSchedulerStatus};
-pub use scheduler::{ResourceManager, SchedulerService};
+pub use scheduler::{RefillMode, ResourceManager, SchedulerService};
 pub use util::*;
 
 use smallvec::SmallVec;

--- a/crates/vqueues/src/scheduler.rs
+++ b/crates/vqueues/src/scheduler.rs
@@ -43,6 +43,18 @@ mod vqueue_state;
 // Re-exports
 pub use resource_manager::ResourceManager;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefillMode {
+    Async,
+    Blocking,
+}
+
+impl RefillMode {
+    const fn allow_blocking_io(self) -> bool {
+        matches!(self, Self::Blocking)
+    }
+}
+
 type UnconfirmedAssignments = hashbrown::HashMap<EntryKey, (PermitBuilder, EntryMetadata)>;
 
 fn status_from_detailed_eligibility(value: DetailedEligibility) -> SchedulingStatus {
@@ -135,6 +147,7 @@ impl<S: VQueueStore> SchedulerService<S> {
         resource_manager: ResourceManager,
         storage: S,
         vqueues_cache: &VQueuesMetaCache,
+        refill_mode: RefillMode,
     ) -> Result<Self, StorageError>
     where
         S: ScanVQueueTable,
@@ -154,6 +167,7 @@ impl<S: VQueueStore> SchedulerService<S> {
             resource_manager,
             storage,
             vqueues_cache.view(),
+            refill_mode,
         )));
         Ok(Self { state })
     }

--- a/crates/vqueues/src/scheduler/drr.rs
+++ b/crates/vqueues/src/scheduler/drr.rs
@@ -40,6 +40,7 @@ use crate::scheduler::eligible::EligibilityTracker;
 use crate::scheduler::vqueue_state::Pop;
 
 use super::Decisions;
+use super::RefillMode;
 use super::ReservedResources;
 use super::ResourceManager;
 use super::VQueueSchedulerStatus;
@@ -61,6 +62,8 @@ pub struct DRRScheduler<S: VQueueStore> {
     /// Limits the number of items included in a single decision across all queues
     max_items_per_decision: NonZeroU16,
 
+    refill_mode: RefillMode,
+
     // SAFETY NOTE: **must** Keep this at the end since it needs to outlive all readers.
     storage: S,
 }
@@ -72,6 +75,7 @@ impl<S: VQueueStore> DRRScheduler<S> {
         resource_manager: ResourceManager,
         storage: S,
         vqueues: VQueuesMeta<'_>,
+        refill_mode: RefillMode,
     ) -> Self {
         let mut total_running = 0;
         let mut total_waiting = 0;
@@ -102,6 +106,7 @@ impl<S: VQueueStore> DRRScheduler<S> {
             storage,
             limit_qid_per_poll,
             max_items_per_decision,
+            refill_mode,
         }
     }
 
@@ -144,9 +149,9 @@ impl<S: VQueueStore> DRRScheduler<S> {
                 break;
             }
 
-            let Some(handle) = this
-                .eligible
-                .next_eligible(cx, metas, this.storage, this.q)?
+            let Some(handle) =
+                this.eligible
+                    .next_eligible(cx, metas, this.storage, this.q, *this.refill_mode)?
             else {
                 break;
             };
@@ -712,6 +717,7 @@ mod tests {
             create_resource_manager(db, Concurrency::new_unlimited()).await,
             db.clone(),
             cache.view(),
+            RefillMode::Blocking,
         )
     }
 
@@ -730,6 +736,7 @@ mod tests {
             .await,
             db.clone(),
             cache.view(),
+            RefillMode::Blocking,
         )
     }
 
@@ -1075,6 +1082,7 @@ mod tests {
             create_resource_manager(db, Concurrency::new_unlimited()).await,
             db.clone(),
             cache.view(),
+            RefillMode::Blocking,
         );
 
         let Poll::Ready(Ok(decision)) = poll_scheduler(Pin::new(&mut scheduler), cache.view())
@@ -1215,6 +1223,7 @@ mod tests {
             .await,
             db.clone(),
             cache.view(),
+            RefillMode::Blocking,
         );
 
         let Poll::Ready(Ok(decision)) = poll_scheduler(Pin::new(&mut scheduler), cache.view())
@@ -1296,6 +1305,7 @@ mod tests {
             .await,
             db.clone(),
             cache.view(),
+            RefillMode::Blocking,
         );
 
         let Poll::Ready(Ok(_decision)) = poll_scheduler(Pin::new(&mut scheduler), cache.view())
@@ -1344,6 +1354,7 @@ mod tests {
             create_resource_manager(db, Concurrency::new_unlimited()).await,
             db.clone(),
             cache.view(),
+            RefillMode::Blocking,
         );
 
         if let Poll::Ready(Ok(decision)) = poll_scheduler(Pin::new(&mut scheduler), cache.view()) {
@@ -1373,6 +1384,7 @@ mod tests {
             create_resource_manager(db, Concurrency::new_unlimited()).await,
             db.clone(),
             cache.view(),
+            RefillMode::Blocking,
         );
 
         let Poll::Ready(Ok(decision)) = poll_scheduler(Pin::new(&mut scheduler), cache.view())
@@ -1449,6 +1461,7 @@ mod tests {
                 .await,
             db.clone(),
             cache.view(),
+            RefillMode::Blocking,
         );
 
         let h_qid1 = cache.view().handle_for(&qid1).unwrap();

--- a/crates/vqueues/src/scheduler/eligible.rs
+++ b/crates/vqueues/src/scheduler/eligible.rs
@@ -24,6 +24,7 @@ use restate_types::time::MillisSinceEpoch;
 use restate_util_string::ReString;
 use restate_worker_api::{ResourceKind, SchedulingStatus};
 
+use super::RefillMode;
 use super::clock::SchedulerClock;
 use super::vqueue_state::VQueueState;
 use crate::VQueuesMeta;
@@ -133,6 +134,7 @@ impl EligibilityTracker {
         metas: VQueuesMeta<'_>,
         storage: &S,
         vqueues: &mut SecondaryMap<VQueueHandle, VQueueState<S>>,
+        refill_mode: RefillMode,
     ) -> Result<Option<VQueueHandle>, StorageError> {
         let n = self.ready_ring.len();
         // avoid rescanning the ready ring multiple rounds
@@ -162,7 +164,7 @@ impl EligibilityTracker {
             match current_state {
                 State::NeedsPoll => {
                     // update the state based on eligibility.
-                    match qstate.poll_eligibility(cx, slot, storage) {
+                    match qstate.poll_eligibility(cx, slot, storage, refill_mode) {
                         Poll::Ready(Ok(Eligibility::Eligible)) => {
                             *current_state = State::Ready;
                             return Ok(Some(handle));

--- a/crates/vqueues/src/scheduler/queue.rs
+++ b/crates/vqueues/src/scheduler/queue.rs
@@ -27,7 +27,7 @@ use restate_storage_api::{StorageError, vqueue_table};
 use restate_types::vqueues::VQueueId;
 use restate_util_time::DurationExt;
 
-use super::UnconfirmedAssignments;
+use super::{RefillMode, UnconfirmedAssignments};
 
 /// The number of entries we are willing to keep in cache
 const INBOX_CACHE_CAPACITY: usize = 24;
@@ -509,7 +509,7 @@ impl<S: VQueueStore> Queue<S> {
         skip: &UnconfirmedAssignments,
         qid: &VQueueId,
         effectively_empty: bool,
-        allow_blocking_io: bool,
+        refill_mode: RefillMode,
     ) -> Poll<Result<QueueItem<'_>, StorageError>> {
         loop {
             let needs_advance = match self.stage {
@@ -536,7 +536,7 @@ impl<S: VQueueStore> Queue<S> {
                         break;
                     }
                     // A) try refill immediate refill if allowed
-                    match self.try_refill(storage, qid, skip, allow_blocking_io) {
+                    match self.try_refill(storage, qid, skip, refill_mode) {
                         Ok(_) => {}
                         Err(CursorError::WouldBlock) => {
                             // B) start an async refill task
@@ -641,10 +641,15 @@ impl<S: VQueueStore> Queue<S> {
         storage: &S,
         qid: &VQueueId,
         skip: &UnconfirmedAssignments,
-        allow_blocking_io: bool,
+        refill_mode: RefillMode,
     ) -> Result<(), CursorError> {
         let start = Instant::now();
-        let mut reader = storage.new_inbox_reader(qid, vqueue_table::Options { allow_blocking_io });
+        let mut reader = storage.new_inbox_reader(
+            qid,
+            vqueue_table::Options {
+                allow_blocking_io: refill_mode.allow_blocking_io(),
+            },
+        );
         let RefillState::Standby { refill_anchor } = &mut self.refill_state else {
             panic!("refill state must be standby");
         };

--- a/crates/vqueues/src/scheduler/queue_test.rs
+++ b/crates/vqueues/src/scheduler/queue_test.rs
@@ -86,7 +86,7 @@ fn poll_once_expect_pending<S: VQueueStore>(
     qid: &VQueueId,
 ) {
     let mut cx = Context::from_waker(Waker::noop());
-    match queue.poll_advance_if_needed(&mut cx, storage, skip, qid, false, false) {
+    match queue.poll_advance_if_needed(&mut cx, storage, skip, qid, false, RefillMode::Async) {
         Poll::Pending => {}
         Poll::Ready(Ok(item)) => panic!("expected Pending, got Ready({item:?})"),
         Poll::Ready(Err(e)) => panic!("expected Pending, got error: {e:?}"),
@@ -103,7 +103,7 @@ async fn drive_until_ready<S: VQueueStore>(
 ) {
     let mut cx = Context::from_waker(Waker::noop());
     loop {
-        match queue.poll_advance_if_needed(&mut cx, storage, skip, qid, false, false) {
+        match queue.poll_advance_if_needed(&mut cx, storage, skip, qid, false, RefillMode::Async) {
             Poll::Ready(Ok(_)) => return,
             Poll::Ready(Err(e)) => panic!("queue error: {e:?}"),
             Poll::Pending => tokio::time::sleep(std::time::Duration::from_millis(1)).await,
@@ -120,6 +120,24 @@ fn drain_cache<S: VQueueStore>(queue: &mut Queue<S>) -> Vec<EntryKey> {
         queue.try_advance().unwrap();
     }
     keys
+}
+
+#[test]
+fn blocking_refill_completes_inline() {
+    let entry = entry_at_seq(1);
+    let storage = GatedStore::new(vec![entry.clone()]);
+    storage.release_refill_thread();
+    let qid = test_qid(1);
+    let mut queue = Queue::new(0, &storage, &qid);
+    let skip = UnconfirmedAssignments::new();
+    let mut cx = Context::from_waker(Waker::noop());
+
+    let Poll::Ready(Ok(QueueItem::Inbox { key, .. })) =
+        queue.poll_advance_if_needed(&mut cx, &storage, &skip, &qid, false, RefillMode::Blocking)
+    else {
+        panic!("blocking refill should complete inline");
+    };
+    assert_eq!(*key, entry.0);
 }
 
 // ---------- fake VQueueStore ----------

--- a/crates/vqueues/src/scheduler/vqueue_state.rs
+++ b/crates/vqueues/src/scheduler/vqueue_state.rs
@@ -35,7 +35,7 @@ use crate::scheduler::queue::QueueItem;
 use super::clock::SchedulerClock;
 use super::queue::Queue;
 use super::resource_manager::{AcquireOutcome, PermitBuilder};
-use super::{ResourceManager, RunAction, UnconfirmedAssignments, YieldAction};
+use super::{RefillMode, ResourceManager, RunAction, UnconfirmedAssignments, YieldAction};
 
 const QUANTUM: i32 = 1;
 
@@ -327,6 +327,7 @@ impl<S: VQueueStore> VQueueState<S> {
         cx: &mut std::task::Context<'_>,
         slot: &cache::Slot,
         storage: &S,
+        refill_mode: RefillMode,
     ) -> Poll<Result<Eligibility, StorageError>> {
         ready!(self.queue.poll_advance_if_needed(
             cx,
@@ -334,7 +335,7 @@ impl<S: VQueueStore> VQueueState<S> {
             &self.unconfirmed_assignments,
             slot.vqueue_id(),
             self.num_waiting_inbox(slot.meta()) == 0,
-            false,
+            refill_mode,
         ))?;
 
         Poll::Ready(Ok(self.check_eligibility(slot.meta()).as_compact()))

--- a/crates/worker/src/partition/leadership/mod.rs
+++ b/crates/worker/src/partition/leadership/mod.rs
@@ -64,7 +64,7 @@ use restate_util_string::format_restring;
 use restate_util_time::DurationExt;
 use restate_vqueues::context::{HasVQueues, HasVQueuesMut};
 use restate_vqueues::scheduler::{self};
-use restate_vqueues::{ResourceManager, SchedulerService, VQueuesMeta};
+use restate_vqueues::{RefillMode, ResourceManager, SchedulerService, VQueuesMeta};
 use restate_wal_protocol::control::{
     AnnounceLeaderCommand, UpdatePartitionDurabilityCommand, VersionBarrierCommand,
 };
@@ -723,6 +723,11 @@ where
                 );
                 SchedulerService::new_disabled()
             } else {
+                let refill_mode = if config.common.experimental.is_vqueues_async_refill_enabled() {
+                    RefillMode::Async
+                } else {
+                    RefillMode::Blocking
+                };
                 SchedulerService::create(
                     ResourceManager::create(
                         partition_store.partition_db().clone(),
@@ -734,6 +739,7 @@ where
                     .await?,
                     partition_store.partition_db().clone(),
                     processor.vqueues_mut(),
+                    refill_mode,
                 )
                 .await?
             };

--- a/release-notes/unreleased/vqueue-blocking-refill-default.md
+++ b/release-notes/unreleased/vqueue-blocking-refill-default.md
@@ -1,0 +1,17 @@
+# Use Blocking VQueue Refills by Default
+
+## Behavioral Change
+
+### What Changed
+
+VQueue storage refills now run synchronously by default. The previous asynchronous refill path can
+be restored with the experimental option:
+
+```toml
+experimental-enable-vqueues-async-refill = true
+```
+
+### Impact on Users
+
+No configuration changes are required. Existing deployments will use synchronous VQueue refills
+after upgrading.


### PR DESCRIPTION
The asynchronous refill path has caused several correctness issues recently. Default to blocking refills while it is properly hardened, while keeping asynchronous refills available through a hidden experimental worker option.