### PR TITLE
fix(tracing): set semantic span kinds

### DIFF
--- a/crates/ingress-http/src/handler/tracing.rs
+++ b/crates/ingress-http/src/handler/tracing.rs
@@ -12,7 +12,7 @@ use super::ConnectInfo;
 
 use http::Request;
 use opentelemetry::global::ObjectSafeSpan;
-use opentelemetry::trace::{SpanContext, TraceContextExt};
+use opentelemetry::trace::{SpanContext, SpanKind, TraceContextExt};
 use restate_tracing_instrumentation as instrumentation;
 use restate_types::identifiers::InvocationId;
 use restate_types::invocation::{InvocationTarget, SpanRelation};
@@ -52,7 +52,8 @@ pub(crate) fn prepare_tracing_span<B>(
             tags = (
                 client.socket.address = client_addr,
                 client.socket.port = port as i64
-            )
+            ),
+            fields = (with_kind = SpanKind::Server)
         )
     } else {
         // unix sockets connections don't have a port, address is also likely "anonymous"
@@ -61,7 +62,8 @@ pub(crate) fn prepare_tracing_span<B>(
             prefix = "ingress",
             id = invocation_id,
             target = invocation_target,
-            tags = (client.socket.address = client_addr)
+            tags = (client.socket.address = client_addr),
+            fields = (with_kind = SpanKind::Server)
         )
     };
 

--- a/crates/tracing-instrumentation/src/lib.rs
+++ b/crates/tracing-instrumentation/src/lib.rs
@@ -19,7 +19,7 @@ use std::fmt::Display;
 use std::sync::OnceLock;
 
 use opentelemetry::global::{BoxedSpan, BoxedTracer};
-use opentelemetry::trace::{SpanContext, Status, TracerProvider};
+use opentelemetry::trace::{SpanContext, SpanKind, Status, TracerProvider};
 use opentelemetry::{
     Context, trace,
     trace::{Link, TraceContextExt, Tracer},
@@ -760,6 +760,7 @@ pub fn create_invocation_start_span(
 
     let builder = tracer
         .span_builder(format!("invocation-start {}", invocation_target.short()))
+        .with_kind(SpanKind::Consumer)
         .with_start_time(start_time)
         .with_trace_id(span_ctx.span_context().trace_id())
         .with_span_id(span_ctx.span_context().span_id())


### PR DESCRIPTION
This fixes #5097 by assigning the correct OpenTelemetry span kinds to the top level Restate spans.

Ingress is now `Server`, invocation start is `Consumer`, and invocation attempt/end remain `Internal`.

I reproduced the issue on `upstream/main` with the TypeScript SDK 1.17.0 and confirmed all spans were incorrectly exported as `Internal`. On this branch, the same request exports the expected span kinds and trace context still propagates correctly.

Tested with Rust `1.96.1` and `cargo-nextest v0.9.98`. Full tests, formatting, Clippy, and the end to end OTLP check all pass.

So all good imo :)
