### PR TITLE
fix(sql): project scheduled start time

### DIFF
--- a/crates/storage-query-datafusion/src/invocation_status/row.rs
+++ b/crates/storage-query-datafusion/src/invocation_status/row.rs
@@ -104,11 +104,6 @@ pub(crate) fn append_invocation_status_row<'a>(
                     invocation_status.created_using_restate_version()?,
                 );
             }
-            if row.is_scheduled_at_defined()
-                && let Some(execution_time) = invocation_status.inner.execution_time
-            {
-                row.scheduled_start_at(execution_time as i64)
-            }
             if row.is_completion_retention_defined() {
                 row.completion_retention(
                     invocation_status
@@ -129,11 +124,6 @@ pub(crate) fn append_invocation_status_row<'a>(
                 row.created_using_restate_version(
                     invocation_status.created_using_restate_version()?,
                 );
-            }
-            if row.is_scheduled_at_defined()
-                && let Some(execution_time) = invocation_status.inner.execution_time
-            {
-                row.scheduled_start_at(execution_time as i64)
             }
             if row.is_completion_retention_defined() {
                 row.completion_retention(
@@ -201,11 +191,6 @@ pub(crate) fn append_invocation_status_row<'a>(
                     invocation_status.created_using_restate_version()?,
                 );
             }
-            if row.is_scheduled_at_defined()
-                && let Some(execution_time) = invocation_status.inner.execution_time
-            {
-                row.scheduled_start_at(execution_time as i64)
-            }
             if row.is_completion_retention_defined() {
                 row.completion_retention(
                     invocation_status
@@ -262,11 +247,6 @@ fn fill_in_flight_invocation_metadata(
     }
     // journal_metadata and stats are filled by other functions
     fill_pinned_deployment(row, status)?;
-    if row.is_scheduled_start_at_defined()
-        && let Some(execution_time) = status.inner.execution_time
-    {
-        row.scheduled_start_at(execution_time as i64)
-    }
     if row.is_completion_retention_defined() {
         row.completion_retention(status.completion_retention_duration()?.as_millis() as i64);
     }
@@ -359,6 +339,9 @@ fn fill_timestamps(row: &mut SysInvocationStatusRowBuilder, status: &InvocationS
     }
     if let Some(scheduled_at) = status.inner.scheduled_transition_time {
         row.scheduled_at(scheduled_at as i64);
+    }
+    if let Some(scheduled_start_at) = status.inner.execution_time {
+        row.scheduled_start_at(scheduled_start_at as i64);
     }
     if let Some(running_at) = status.inner.running_transition_time {
         row.running_at(running_at as i64);

--- a/crates/storage-query-datafusion/src/tests.rs
+++ b/crates/storage-query-datafusion/src/tests.rs
@@ -24,7 +24,8 @@ use googletest::unordered_elements_are;
 use restate_limiter::{Level, LimitKey};
 use restate_storage_api::Transaction;
 use restate_storage_api::invocation_status_table::{
-    CompletedInvocation, InFlightInvocationMetadata, InvocationStatus, WriteInvocationStatusTable,
+    CompletedInvocation, InFlightInvocationMetadata, InvocationStatus, PreFlightInvocationMetadata,
+    ScheduledInvocation, WriteInvocationStatusTable,
 };
 use restate_storage_api::state_table::WriteStateTable;
 use restate_storage_api::vqueue_table::stats::WaitStats;
@@ -38,6 +39,7 @@ use restate_types::journal_v2::NotificationId;
 use restate_types::journal_v2::UnresolvedFuture;
 use restate_types::service_protocol::ServiceProtocolVersion;
 use restate_types::sharding::KeyRange;
+use restate_types::time::MillisSinceEpoch;
 use restate_types::vqueues::EntryId;
 use restate_types::vqueues::VQueueId;
 use restate_util_string::{ReString, RestateString, RestrictedValue};
@@ -309,6 +311,51 @@ async fn query_sys_invocation() {
         .remove(0)
         .unwrap();
     assert_rows(records);
+}
+
+#[restate_core::test(flavor = "multi_thread", worker_threads = 2)]
+async fn query_sys_invocation_projects_scheduled_start_at() {
+    let invocation_id = InvocationId::mock_random();
+    let scheduled_at = MillisSinceEpoch::new(1_767_225_600_000);
+    let scheduled_start_at = MillisSinceEpoch::new(1_767_229_200_000);
+    let mut metadata = PreFlightInvocationMetadata::mock();
+    metadata.execution_time = Some(scheduled_start_at);
+
+    let mut engine = MockQueryEngine::create().await;
+    let mut tx = engine.partition_store().transaction();
+    tx.put_invocation_status(
+        &invocation_id,
+        &InvocationStatus::Scheduled(ScheduledInvocation::from_pre_flight_invocation_metadata(
+            metadata,
+            scheduled_at,
+        )),
+    )
+    .unwrap();
+    tx.commit().await.unwrap();
+    drop(tx);
+
+    let records = engine
+        .execute(format!(
+            "SELECT id, scheduled_start_at FROM sys_invocation WHERE id = '{invocation_id}'"
+        ))
+        .await
+        .unwrap()
+        .stream
+        .collect::<Vec<datafusion::common::Result<RecordBatch>>>()
+        .await
+        .remove(0)
+        .unwrap();
+
+    assert_that!(
+        records,
+        all!(row!(
+            0,
+            {
+                "id" => LargeStringArray: eq(invocation_id.to_string()),
+                "scheduled_start_at" => TimestampMillisecondArray: eq(scheduled_start_at.as_u64() as i64),
+            }
+        ))
+    );
 }
 
 #[restate_core::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
Another low hanging fruit I found is this #4118

The issue was that `scheduled_start_at` came back as `null` from `sys_invocation` when it was selected without `scheduled_at`. I fixed this by setting `scheduled_start_at` in the shared timestamp helper for all invocation statuses and removing the duplicated status-specific logic

As always, I reproduced it on latest `main` and added a regression test for the exact query from the issue thread. The test now passes, and I also checked it against a running Restate server with a delayed invocation. The query now returns the expected `scheduled_start_at` timestamp

Feel free to checkout the branch and test locally. 