### PR TITLE
fix(ingress): apply CORS to oversized requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6061,7 +6061,7 @@ dependencies = [
  "snafu",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tracing",
  "url",
  "web-time",
@@ -7427,7 +7427,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -7467,7 +7467,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -7535,7 +7535,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tower",
- "tower-http",
+ "tower-http 0.7.1",
  "tracing",
  "urlencoding",
  "utoipa",
@@ -7853,7 +7853,7 @@ dependencies = [
  "tonic-prost-build",
  "tonic-reflection",
  "tower",
- "tower-http",
+ "tower-http 0.7.1",
  "tracing",
  "tracing-subscriber",
  "tracing-test",
@@ -8059,7 +8059,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.7.1",
  "tracing",
  "tracing-opentelemetry",
  "tracing-test",
@@ -9443,7 +9443,8 @@ dependencies = [
  "toml_parser",
  "tonic",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
+ "tower-http 0.7.1",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -11183,22 +11184,39 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "async-compression",
  "bitflags 2.13.1",
  "bytes",
- "futures-core",
  "futures-util",
  "http 1.5.0",
  "http-body 1.1.0",
- "http-body-util",
  "pin-project-lite",
- "tokio",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a05a66a4fdd61cbbe0a1d755ffe0ca6aba159dd4820936a0ff8a8278245b9c"
+dependencies = [
+ "async-compression",
+ "bitflags 2.13.1",
+ "bytes",
+ "futures-core",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,7 +276,7 @@ tonic-reflection = { version = "0.14.2" }
 tonic-prost = "0.14.2"
 tonic-prost-build = { version = "0.14.2" }
 tower = "0.5.2"
-tower-http = { version = "0.6.8", default-features = false }
+tower-http = { version = "0.7.1", default-features = false }
 tracing = { version = "0.1" }
 tracing-opentelemetry = { version = "0.32.0" }
 tracing-subscriber = { version = "0.3", features = [

--- a/crates/ingress-http/src/server.rs
+++ b/crates/ingress-http/src/server.rs
@@ -187,17 +187,11 @@ where
                     ),
             )
             .layer(NormalizePathLayer::trim_trailing_slash())
-            .layer(RequestBodyLimitLayer::new(request_size_limit))
             .layer(CorsLayer::very_permissive())
+            .layer(RequestBodyLimitLayer::new(request_size_limit))
             .layer(layers::load_shed::LoadShedLayer::new(concurrency_limit))
             .layer(layers::tracing_context_extractor::HttpTraceContextExtractorLayer)
             .service(Handler::new(schemas, dispatcher));
-
-        // todo(azmy): `CorsLayer` should sit above `RequestBodyLimitLayer` so CORS is applied
-        // as early as possible. This is currently blocked because `CorsLayer` requires the
-        // response body to implement `Default`, which `RequestBodyLimitLayer`'s body does not.
-        // Tracked upstream in https://github.com/tower-rs/tower-http/pull/679  once merged,
-        // move `CorsLayer` above `RequestBodyLimitLayer`.
 
         let shutdown = cancellation_token();
 
@@ -472,6 +466,7 @@ mod tests {
         bootstrap_test(
             Listeners::new_unix_listener(socket_path.clone()).unwrap(),
             mock_dispatcher,
+            10 * 1024 * 1024,
         )
         .await;
 
@@ -504,9 +499,50 @@ mod tests {
         restate_test_util::assert_eq!(response_value.greeting, "Igal");
     }
 
+    #[restate_core::test]
+    #[traced_test]
+    async fn oversized_request_includes_cors_headers() {
+        const REQUEST_SIZE_LIMIT: usize = 1024;
+        const REQUEST_ORIGIN: &str = "https://example.com";
+
+        let socket_dir = tempfile::tempdir().unwrap();
+        let socket_path = socket_dir.path().join("ingress.sock");
+        bootstrap_test(
+            Listeners::new_unix_listener(socket_path.clone()).unwrap(),
+            MockRequestDispatcher::default(),
+            REQUEST_SIZE_LIMIT,
+        )
+        .await;
+
+        let client = Client::builder(TokioExecutor::new())
+            .http2_only(true)
+            .build::<_, Full<Bytes>>(UnixSocketConnector::new(socket_path));
+        let body = Bytes::from(vec![b'a'; REQUEST_SIZE_LIMIT * 2]);
+        let response = client
+            .request(
+                http::Request::post("http://localhost/greeter.Greeter/greet")
+                    .header(http::header::ORIGIN, REQUEST_ORIGIN)
+                    .header(http::header::CONTENT_TYPE, "application/json")
+                    .header(http::header::CONTENT_LENGTH, body.len())
+                    .body(Full::new(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), http::StatusCode::PAYLOAD_TOO_LARGE);
+        assert_eq!(
+            response
+                .headers()
+                .get(http::header::ACCESS_CONTROL_ALLOW_ORIGIN),
+            Some(&http::HeaderValue::from_static(REQUEST_ORIGIN))
+        );
+    }
+
     async fn bootstrap_test(
         listeners: Listeners<HttpIngressPort>,
         mock_request_dispatcher: MockRequestDispatcher,
+        request_size_limit: usize,
     ) {
         let _env = TestCoreEnv::create_with_single_node(1, 1).await;
         let health = Health::default();
@@ -515,7 +551,7 @@ mod tests {
         let ingress = HyperServerIngress::new(
             listeners,
             Semaphore::MAX_PERMITS,
-            10 * 1024 * 1024, // 10MB
+            request_size_limit,
             None,
             Live::from_value(mock_schemas()),
             Arc::new(mock_request_dispatcher),

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -129,7 +129,7 @@ toml_edit = { version = "0.22", features = ["serde"] }
 toml_parser = { version = "1" }
 tonic = { version = "0.14", features = ["gzip", "tls-native-roots", "tls-ring", "zstd"] }
 tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
-tower-http = { version = "0.6", features = ["compression-br", "compression-gzip", "compression-zstd", "cors", "follow-redirect", "limit", "map-response-body", "normalize-path", "trace"] }
+tower-http-ca01ad9e24f5d932 = { package = "tower-http", version = "0.7", default-features = false, features = ["compression-br", "compression-gzip", "compression-zstd", "cors", "limit", "normalize-path", "trace"] }
 tracing = { version = "0.1", features = ["log", "max_level_trace", "release_max_level_debug"] }
 tracing-core = { version = "0.1" }
 tracing-log = { version = "0.2" }
@@ -266,7 +266,7 @@ toml_edit = { version = "0.22", features = ["serde"] }
 toml_parser = { version = "1" }
 tonic = { version = "0.14", features = ["gzip", "tls-native-roots", "tls-ring", "zstd"] }
 tower = { version = "0.5", default-features = false, features = ["balance", "buffer", "limit", "load-shed", "retry", "timeout"] }
-tower-http = { version = "0.6", features = ["compression-br", "compression-gzip", "compression-zstd", "cors", "follow-redirect", "limit", "map-response-body", "normalize-path", "trace"] }
+tower-http-ca01ad9e24f5d932 = { package = "tower-http", version = "0.7", default-features = false, features = ["compression-br", "compression-gzip", "compression-zstd", "cors", "limit", "normalize-path", "trace"] }
 tracing = { version = "0.1", features = ["log", "max_level_trace", "release_max_level_debug"] }
 tracing-core = { version = "0.1" }
 tracing-log = { version = "0.2" }
@@ -302,6 +302,7 @@ signal-hook = { version = "0.3" }
 tikv-jemalloc-ctl = { version = "0.7", features = ["stats", "use_std"] }
 tikv-jemalloc-sys = { version = "0.7", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["aws-lc-rs"] }
+tower-http-3b31131e45eafb45 = { package = "tower-http", version = "0.6", features = ["follow-redirect", "map-response-body", "trace"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
@@ -321,6 +322,7 @@ signal-hook = { version = "0.3" }
 tikv-jemalloc-ctl = { version = "0.7", features = ["stats", "use_std"] }
 tikv-jemalloc-sys = { version = "0.7", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["aws-lc-rs"] }
+tower-http-3b31131e45eafb45 = { package = "tower-http", version = "0.6", features = ["follow-redirect", "map-response-body", "trace"] }
 
 [target.aarch64-apple-darwin.dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
@@ -341,6 +343,7 @@ signal-hook = { version = "0.3" }
 tikv-jemalloc-ctl = { version = "0.7", features = ["stats", "use_std"] }
 tikv-jemalloc-sys = { version = "0.7", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["aws-lc-rs"] }
+tower-http-3b31131e45eafb45 = { package = "tower-http", version = "0.6", features = ["follow-redirect", "map-response-body", "trace"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
 bitflags = { version = "2", default-features = false, features = ["std"] }
@@ -361,6 +364,7 @@ signal-hook = { version = "0.3" }
 tikv-jemalloc-ctl = { version = "0.7", features = ["stats", "use_std"] }
 tikv-jemalloc-sys = { version = "0.7", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["aws-lc-rs"] }
+tower-http-3b31131e45eafb45 = { package = "tower-http", version = "0.6", features = ["follow-redirect", "map-response-body", "trace"] }
 
 ### END HAKARI SECTION
 


### PR DESCRIPTION
Aims to fix #4760

Apply CORS headers to ingress responses that reject oversized request bodies.

* Upgrade the direct `tower-http` dependency to 0.7.1
* Move `CorsLayer` outside `RequestBodyLimitLayer`
* Add a regression test for oversized cross-origin requests


The regression test runs the real HTTP ingress server over a Unix socket and sends an HTTP/2 request with a body twice the configured limit and:

```text
Origin: https://example.com
```

Before this change, the server returned HTTP 413 without an `Access-Control-Allow-Origin` header. With this change, the 413 response includes:

```text
Access-Control-Allow-Origin: https://example.com
```
