### PR TITLE
[VQueues] Automatic full write of VQueueMeta probabilistically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8556,6 +8556,7 @@ dependencies = [
  "restate-test-util",
  "restate-types",
  "restate-util-bytecount",
+ "restate-util-random",
  "restate-util-string",
  "restate-util-time",
  "restate-workspace-hack",

--- a/crates/partition-store/Cargo.toml
+++ b/crates/partition-store/Cargo.toml
@@ -24,6 +24,7 @@ restate-rocksdb = { workspace = true }
 restate-storage-api = { workspace = true }
 restate-types = { workspace = true }
 restate-util-bytecount = { workspace = true, features = ["serde"] }
+restate-util-random = { workspace = true }
 restate-util-time = { workspace = true }
 
 ahash = { workspace = true }

--- a/crates/partition-store/src/vqueue_table/mod.rs
+++ b/crates/partition-store/src/vqueue_table/mod.rs
@@ -224,17 +224,44 @@ impl WriteVQueueTable for PartitionStoreTransaction<'_> {
         update: &restate_storage_api::vqueue_table::metadata::Update,
         _entry_metadata: Option<&EntryMetadata>,
     ) {
+        // Vqueues that was touched more than 1 hour ago will always be fully written.
+        const HOUR_MS: u64 = const { 60 * 60 * 1000 };
+        // 1% Probability to perform a full write rather than a merge. (1 in a 100)
+        const DEFAULT_SAMPLE_RATE: u64 = const { u64::MAX / 100 };
+
         let key_buffer = MetaKey::from(qid).to_bytes();
-        self.raw_merge_cf(
-            KeyKind::VQueueMeta,
-            key_buffer,
-            update.encode_contiguous().into_vec(),
-        );
 
         // Mutate the VQueue metadata
         let was_active_before = meta.is_active();
-        // mutate in-place
-        meta.apply_update(update);
+
+        // The issue here is that rarely modified vqueues will not get full writes.
+        // We check if the vqueue was last modified long time ago
+        // and perform a full write for it. To determine that we find the
+        // `max(last_*_at)` from timestamps and compare it with `update.ts`.
+        if restate_util_random::pseudo_random() < DEFAULT_SAMPLE_RATE
+            || update.ts.saturating_sub_ms(meta.stats().last_modified_at()) > HOUR_MS
+        {
+            // mutate in-place
+            meta.apply_update(update);
+            // full write
+            let value_buf = {
+                let value_buf = self.cleared_value_buffer_mut(meta.encoded_len());
+                // unwrap is safe because we know the buffer is big enough.
+                meta.encode(value_buf).unwrap();
+                value_buf.split()
+            };
+            self.raw_put_cf(KeyKind::VQueueMeta, key_buffer, value_buf);
+        } else {
+            // Mutate the cache in-place
+            meta.apply_update(update);
+
+            self.raw_merge_cf(
+                KeyKind::VQueueMeta,
+                key_buffer,
+                update.encode_contiguous().into_vec(),
+            );
+        }
+
         let is_active_now = meta.is_active();
 
         // Update active queue index

--- a/crates/storage-api/src/vqueue_table/metadata.rs
+++ b/crates/storage-api/src/vqueue_table/metadata.rs
@@ -109,6 +109,23 @@ impl VQueueStatistics {
         }
     }
 
+    /// Returns the last timestamp that the vqueue was created, enqueued, started, attempted,
+    /// or finished.
+    pub fn last_modified_at(&self) -> UniqueTimestamp {
+        [
+            Some(self.created_at),
+            self.last_enqueued_at,
+            self.last_start_at,
+            self.last_finish_at,
+            self.last_attempt_at,
+        ]
+        .into_iter()
+        .flatten()
+        .max()
+        // Safe because created_at is always present
+        .unwrap()
+    }
+
     fn update_avg_queue_duration(&mut self, latency_ms: u64) {
         self.avg_queue_duration_ms = Self::ema(self.avg_queue_duration_ms, latency_ms);
     }
@@ -544,9 +561,9 @@ pub enum Action {
 #[derive(Debug, Clone, bilrost::Message)]
 pub struct Update {
     #[bilrost(tag(1), encoding(fixed))]
-    pub(super) ts: UniqueTimestamp,
+    pub ts: UniqueTimestamp,
     #[bilrost(oneof(2, 3, 4, 5))]
-    pub(super) action: Action,
+    pub action: Action,
 }
 
 impl Update {
@@ -606,13 +623,14 @@ mod tests {
         // Enqueue: caller has already computed
         // first_runnable_at = max(created_at, original_run_at).
         meta.apply_update(&Update::new(
-            created_at,
+            ts(BASE_TS_MS + 11_000),
             Action::Move {
                 prev_stage: None,
                 next_stage: Stage::Inbox,
                 metrics: metrics(BASE_TS_MS + 10_000, BASE_TS_MS + 12_000, false),
             },
         ));
+        assert_eq!(meta.stats.last_modified_at(), ts(BASE_TS_MS + 11_000));
 
         // First transition to Running: first-attempt wait is
         // now(14_000) - first_runnable_at(12_000) = 2_000 ms.
@@ -644,6 +662,7 @@ mod tests {
         assert_eq!(meta.stats.avg_queue_duration_ms, 2_000);
         assert_eq!(meta.stats.last_start_at, Some(ts(BASE_TS_MS + 14_000)));
         assert_eq!(meta.stats.last_attempt_at, Some(ts(BASE_TS_MS + 15_000)));
+        assert_eq!(meta.stats.last_modified_at(), ts(BASE_TS_MS + 15_000));
     }
 
     #[test]

--- a/crates/types/src/config/worker.rs
+++ b/crates/types/src/config/worker.rs
@@ -39,7 +39,9 @@ const MIN_ROCKSDB_MEMORY: NonZeroByteCount =
 const X_RESTATE_CLUSTER_NAME: http::HeaderName =
     http::HeaderName::from_static("x-restate-cluster-name");
 
-const DEFAULT_MAX_SUCCESSIVE_MERGES: u16 = 5000;
+// Max successive merges are disabled by default to reduce the CPU during
+// writes/flushes.
+const DEFAULT_MAX_SUCCESSIVE_MERGES: u16 = 0;
 
 /// # Worker options
 #[serde_as]


### PR DESCRIPTION

Periodically collapse VQueueMeta merge chains by writing full metadata for a 1% sample of updates or when tracked queue activity is more than one hour old. Continue using merge operands for other updates.

Disable the default RocksDB max-successive-merges threshold to avoid resolving long merge chains on the write path.
