### PR TITLE
fix: download binaries page link

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Run via npx:
 npx @restatedev/restate
 ```
 
-You can also download the binaries from the [release page](https://github.com/restatedev/restate/releases) or our [download page](https://restate.dev/get-restate/).
+You can also download the binaries from the [release page](https://github.com/restatedev/restate/releases) or our [download page](https://docs.restate.dev/installation#download-binaries).
 
 ## Community
 


### PR DESCRIPTION
https://restate.dev/get-restate doesn't exist anymore.