### PR TITLE
fix(schema): make duplicate Kafka subscriptions idempotent for same source and sink

### DIFF
--- a/crates/types/src/schema/metadata/updater/mod.rs
+++ b/crates/types/src/schema/metadata/updater/mod.rs
@@ -934,50 +934,56 @@ impl SchemaUpdater {
             }
         };
 
+        let mut metadata = metadata.unwrap_or_default();
+        check_ignored_kafka_properties(&metadata);
+
+        // Validate and merge cluster properties for Kafka sources
+        let cluster_properties = self
+            .schema
+            .get_kafka_cluster(cluster, Redaction::No)
+            .ok_or_else(|| {
+                SchemaError::Subscription(SubscriptionError::Validation(GenericError::from(
+                    format!(
+                        "Kafka cluster '{}' not found. Available clusters: {:?}",
+                        cluster,
+                        self.schema
+                            .list_kafka_clusters(Redaction::No)
+                            .iter()
+                            .map(|kc| kc.name.to_string())
+                            .collect::<Vec<String>>()
+                    ),
+                )))
+            })?
+            .properties;
+
+        let idempotency_group_id = metadata
+            .get("group.id")
+            .or_else(|| cluster_properties.get("group.id"))
+            .cloned();
+
         if let Some(existing) =
             self.schema.subscriptions.values().find(|subscription| {
-                subscription.source() == &source && subscription.sink() == &sink
+                subscription.source() == &source
+                    && subscription.sink() == &sink
+                    && match &idempotency_group_id {
+                        Some(group_id) => subscription.metadata().get("group.id") == Some(group_id),
+                        None => true,
+                    }
             })
         {
             return Ok(existing.id());
         }
 
-        let mut metadata = metadata.unwrap_or_default();
-        check_ignored_kafka_properties(&metadata);
+        // Set group.id (subscription metadata > cluster properties > subscription id)
+        let group_id = idempotency_group_id
+            .clone()
+            .unwrap_or_else(|| id.to_string());
+        metadata.insert("group.id".into(), group_id);
 
-        // Validate and merge cluster properties for Kafka sources
+        // Set client.id if unset
+        if !(cluster_properties.contains_key("client.id") || metadata.contains_key("client.id"))
         {
-            let cluster_properties = self
-                .schema
-                .get_kafka_cluster(cluster, Redaction::No)
-                .ok_or_else(|| {
-                    SchemaError::Subscription(SubscriptionError::Validation(GenericError::from(
-                        format!(
-                            "Kafka cluster '{}' not found. Available clusters: {:?}",
-                            cluster,
-                            self.schema
-                                .list_kafka_clusters(Redaction::No)
-                                .iter()
-                                .map(|kc| kc.name.to_string())
-                                .collect::<Vec<String>>()
-                        ),
-                    )))
-                })?
-                .properties;
-
-            // Set group.id (subscription metadata > cluster properties > subscription id)
-            let group_id = metadata
-                .get("group.id")
-                .or_else(|| cluster_properties.get("group.id"))
-                .cloned()
-                .unwrap_or_else(|| id.to_string());
-            metadata.insert("group.id".into(), group_id);
-
-            // Set client.id if unset
-            if !(cluster_properties.contains_key("client.id") || metadata.contains_key("client.id"))
-            {
-                metadata.insert("client.id".to_string(), "restate".to_string());
-            }
+            metadata.insert("client.id".to_string(), "restate".to_string());
         }
 
         let subscription = Subscription::new(id, source, sink, metadata);

--- a/crates/types/src/schema/metadata/updater/mod.rs
+++ b/crates/types/src/schema/metadata/updater/mod.rs
@@ -934,6 +934,14 @@ impl SchemaUpdater {
             }
         };
 
+        if let Some(existing) =
+            self.schema.subscriptions.values().find(|subscription| {
+                subscription.source() == &source && subscription.sink() == &sink
+            })
+        {
+            return Ok(existing.id());
+        }
+
         let mut metadata = metadata.unwrap_or_default();
         check_ignored_kafka_properties(&metadata);
 

--- a/crates/types/src/schema/metadata/updater/tests.rs
+++ b/crates/types/src/schema/metadata/updater/tests.rs
@@ -2935,6 +2935,58 @@ mod kafka_cluster {
     }
 
     #[test]
+    fn add_subscription_same_source_and_sink_is_idempotent() {
+        let schema = Schema::default();
+
+        let ((first_id, second_id, third_id), schema) =
+            SchemaUpdater::update_and_return(schema, |updater| {
+                updater
+                    .add_deployment(add_deployment_request(vec![greeter_service()]))
+                    .unwrap();
+                updater
+                    .add_kafka_cluster("my-cluster".parse().unwrap(), kafka_cluster_properties())
+                    .unwrap();
+
+                let source = "kafka://my-cluster/my-topic".parse().unwrap();
+                let sink = format!("service://{}/greet", GREETER_SERVICE_NAME)
+                    .parse()
+                    .unwrap();
+
+                let first_id = updater
+                    .add_subscription(source.clone(), sink.clone(), None)
+                    .unwrap();
+                let mut retry_options = HashMap::new();
+                retry_options.insert("group.id".to_string(), "custom-group".to_string());
+                let second_id = updater
+                    .add_subscription(source, sink.clone(), Some(retry_options))
+                    .unwrap();
+                let third_id = updater
+                    .add_subscription(
+                        "kafka://my-cluster/other-topic".parse().unwrap(),
+                        sink,
+                        None,
+                    )
+                    .unwrap();
+                Ok::<_, SchemaError>((first_id, second_id, third_id))
+            })
+            .unwrap();
+
+        assert_eq!(first_id, second_id);
+        assert_ne!(first_id, third_id);
+
+        let subscriptions = schema.list_subscriptions(&[], Redaction::No);
+        assert_eq!(subscriptions.len(), 2);
+        let original = subscriptions
+            .iter()
+            .find(|subscription| subscription.id() == first_id)
+            .expect("original subscription");
+        assert_ne!(
+            original.metadata().get("group.id").map(String::as_str),
+            Some("custom-group")
+        );
+    }
+
+    #[test]
     fn subscription_with_nonexistent_kafka_cluster() {
         let mut updater = SchemaUpdater::default();
 

--- a/crates/types/src/schema/metadata/updater/tests.rs
+++ b/crates/types/src/schema/metadata/updater/tests.rs
@@ -2938,7 +2938,7 @@ mod kafka_cluster {
     fn add_subscription_same_source_and_sink_is_idempotent() {
         let schema = Schema::default();
 
-        let ((first_id, second_id, third_id), schema) =
+        let ((first_id, retry_id, custom_group_id, same_group_id, other_topic_id), schema) =
             SchemaUpdater::update_and_return(schema, |updater| {
                 updater
                     .add_deployment(add_deployment_request(vec![greeter_service()]))
@@ -2955,35 +2955,43 @@ mod kafka_cluster {
                 let first_id = updater
                     .add_subscription(source.clone(), sink.clone(), None)
                     .unwrap();
-                let mut retry_options = HashMap::new();
-                retry_options.insert("group.id".to_string(), "custom-group".to_string());
-                let second_id = updater
-                    .add_subscription(source, sink.clone(), Some(retry_options))
+                let retry_id = updater
+                    .add_subscription(source.clone(), sink.clone(), None)
                     .unwrap();
-                let third_id = updater
+                let mut custom_group_options = HashMap::new();
+                custom_group_options.insert("group.id".to_string(), "custom-group".to_string());
+                let custom_group_id = updater
+                    .add_subscription(source.clone(), sink.clone(), Some(custom_group_options))
+                    .unwrap();
+                let mut same_group_options = HashMap::new();
+                same_group_options.insert("group.id".to_string(), "custom-group".to_string());
+                let same_group_id = updater
+                    .add_subscription(source.clone(), sink.clone(), Some(same_group_options))
+                    .unwrap();
+                let other_topic_id = updater
                     .add_subscription(
                         "kafka://my-cluster/other-topic".parse().unwrap(),
                         sink,
                         None,
                     )
                     .unwrap();
-                Ok::<_, SchemaError>((first_id, second_id, third_id))
+                Ok::<_, SchemaError>((
+                    first_id,
+                    retry_id,
+                    custom_group_id,
+                    same_group_id,
+                    other_topic_id,
+                ))
             })
             .unwrap();
 
-        assert_eq!(first_id, second_id);
-        assert_ne!(first_id, third_id);
+        assert_eq!(first_id, retry_id);
+        assert_ne!(first_id, custom_group_id);
+        assert_eq!(custom_group_id, same_group_id);
+        assert_ne!(first_id, other_topic_id);
 
         let subscriptions = schema.list_subscriptions(&[], Redaction::No);
-        assert_eq!(subscriptions.len(), 2);
-        let original = subscriptions
-            .iter()
-            .find(|subscription| subscription.id() == first_id)
-            .expect("original subscription");
-        assert_ne!(
-            original.metadata().get("group.id").map(String::as_str),
-            Some("custom-group")
-        );
+        assert_eq!(subscriptions.len(), 3);
     }
 
     #[test]

--- a/release-notes/unreleased/2007-idempotent-kafka-subscriptions.md
+++ b/release-notes/unreleased/2007-idempotent-kafka-subscriptions.md
@@ -4,8 +4,10 @@
 
 ### What Changed
 
-Creating a Kafka subscription with the same source topic and sink handler as an existing
-subscription now returns the existing subscription instead of inserting a second one.
+Creating a Kafka subscription with the same source topic, sink handler, and effective
+`group.id` as an existing subscription now returns the existing subscription instead of
+inserting a second one. When no `group.id` is set on the subscription or its Kafka cluster,
+matching is based on source and sink only.
 
 ### Why This Matters
 
@@ -14,10 +16,10 @@ used to create two independent consumers, so the same records were delivered (an
 
 ### Impact on Users
 
-- Repeated `POST /subscriptions` calls (or `restate subscriptions create`) with the same source
-  and sink are now idempotent and keep a single consumer.
-- Distinct source or sink URIs still create distinct subscriptions.
-- Options on a retry are ignored when a matching subscription already exists.
+- Repeated `POST /subscriptions` calls (or `restate subscriptions create`) with the same source,
+  sink, and effective `group.id` are now idempotent and keep a single consumer.
+- Distinct source, sink, or `group.id` values still create distinct subscriptions.
+- Other options on a retry are ignored when a matching subscription already exists.
 
 ### Migration Guidance
 

--- a/release-notes/unreleased/2007-idempotent-kafka-subscriptions.md
+++ b/release-notes/unreleased/2007-idempotent-kafka-subscriptions.md
@@ -1,0 +1,29 @@
+# Release Notes for Issue #2007: Idempotent Kafka subscription creation
+
+## Bug Fix
+
+### What Changed
+
+Creating a Kafka subscription with the same source topic and sink handler as an existing
+subscription now returns the existing subscription instead of inserting a second one.
+
+### Why This Matters
+
+Each subscription starts its own Kafka consumer group. Registering the same source and sink twice
+used to create two independent consumers, so the same records were delivered (and invoked) twice.
+
+### Impact on Users
+
+- Repeated `POST /subscriptions` calls (or `restate subscriptions create`) with the same source
+  and sink are now idempotent and keep a single consumer.
+- Distinct source or sink URIs still create distinct subscriptions.
+- Options on a retry are ignored when a matching subscription already exists.
+
+### Migration Guidance
+
+No action is required. Existing duplicate subscriptions are not removed automatically; delete the
+unwanted ones if you already created extras.
+
+### Related Issues
+
+- Issue #2007: Kafka subscriptions can be made multiple times for the same source and sink


### PR DESCRIPTION
## Summary

- Return the existing subscription ID when `add_subscription` is called with the same Kafka source topic and service sink as an existing entry
- Prevents a second consumer group from starting and delivering duplicate invocations

Fixes #2007

## Test plan

- [x] `cargo test -p restate-types add_subscription_same_source_and_sink_is_idempotent`