### PR TITLE
[VQueues] Purge obsolete metadata inline

### DIFF
--- a/crates/partition-store/src/vqueue_table/mod.rs
+++ b/crates/partition-store/src/vqueue_table/mod.rs
@@ -39,7 +39,7 @@ use restate_storage_api::vqueue_table::filters::{ScanEntryIdFilter, ScanMetaFilt
 use restate_storage_api::vqueue_table::metadata::{VQueueMeta, VQueueMetaRef};
 use restate_storage_api::vqueue_table::{
     EntryKey, EntryMetadata, EntryStatusHeader, EntryValue, ReadVQueueTable, ScanVQueueTable,
-    Stage, Status, WriteVQueueTable, stats::EntryStatistics,
+    Stage, Status, VQueueDisposition, WriteVQueueTable, stats::EntryStatistics,
 };
 use restate_storage_api::vqueue_table::{
     RawStatusHeader, RawStatusHeaderRef, ScanVQueueEntries, ScanVQueueEntryStatusTable,
@@ -223,45 +223,17 @@ impl WriteVQueueTable for PartitionStoreTransaction<'_> {
         meta: &mut VQueueMeta,
         update: &restate_storage_api::vqueue_table::metadata::Update,
         _entry_metadata: Option<&EntryMetadata>,
-    ) {
+    ) -> VQueueDisposition {
         // Vqueues that was touched more than 1 hour ago will always be fully written.
         const HOUR_MS: u64 = const { 60 * 60 * 1000 };
         // 1% Probability to perform a full write rather than a merge. (1 in a 100)
         const DEFAULT_SAMPLE_RATE: u64 = const { u64::MAX / 100 };
 
-        let key_buffer = MetaKey::from(qid).to_bytes();
-
         // Mutate the VQueue metadata
         let was_active_before = meta.is_active();
-
-        // The issue here is that rarely modified vqueues will not get full writes.
-        // We check if the vqueue was last modified long time ago
-        // and perform a full write for it. To determine that we find the
-        // `max(last_*_at)` from timestamps and compare it with `update.ts`.
-        if restate_util_random::pseudo_random() < DEFAULT_SAMPLE_RATE
-            || update.ts.saturating_sub_ms(meta.stats().last_modified_at()) > HOUR_MS
-        {
-            // mutate in-place
-            meta.apply_update(update);
-            // full write
-            let value_buf = {
-                let value_buf = self.cleared_value_buffer_mut(meta.encoded_len());
-                // unwrap is safe because we know the buffer is big enough.
-                meta.encode(value_buf).unwrap();
-                value_buf.split()
-            };
-            self.raw_put_cf(KeyKind::VQueueMeta, key_buffer, value_buf);
-        } else {
-            // Mutate the cache in-place
-            meta.apply_update(update);
-
-            self.raw_merge_cf(
-                KeyKind::VQueueMeta,
-                key_buffer,
-                update.encode_contiguous().into_vec(),
-            );
-        }
-
+        let should_write_full = restate_util_random::pseudo_random() < DEFAULT_SAMPLE_RATE
+            || update.ts.saturating_sub_ms(meta.stats().last_modified_at()) > HOUR_MS;
+        meta.apply_update(update);
         let is_active_now = meta.is_active();
 
         // Update active queue index
@@ -273,6 +245,33 @@ impl WriteVQueueTable for PartitionStoreTransaction<'_> {
                 self.mark_vqueue_as_dormant(qid);
             }
             (_, _) => {}
+        }
+
+        if meta.is_obsolete() {
+            self.delete_vqueue(qid);
+            VQueueDisposition::Purged
+        } else {
+            let key_buffer = MetaKey::from(qid).to_bytes();
+            // Rarely modified vqueues will not otherwise get full writes. Collapse
+            // their merge chain when the metadata has not been touched for an hour.
+            if should_write_full {
+                // full write
+                let value_buf = {
+                    let value_buf = self.cleared_value_buffer_mut(meta.encoded_len());
+                    // unwrap is safe because we know the buffer is big enough.
+                    meta.encode(value_buf).unwrap();
+                    value_buf.split()
+                };
+                self.raw_put_cf(KeyKind::VQueueMeta, key_buffer, value_buf);
+            } else {
+                self.raw_merge_cf(
+                    KeyKind::VQueueMeta,
+                    key_buffer,
+                    update.encode_contiguous().into_vec(),
+                );
+            }
+
+            VQueueDisposition::Retained
         }
     }
 

--- a/crates/storage-api/src/vqueue_table/metadata.rs
+++ b/crates/storage-api/src/vqueue_table/metadata.rs
@@ -109,6 +109,14 @@ impl VQueueStatistics {
         }
     }
 
+    fn is_fully_empty(&self) -> bool {
+        self.num_inbox == 0
+            && self.num_running == 0
+            && self.num_paused == 0
+            && self.num_suspended == 0
+            && self.num_finished == 0
+    }
+
     /// Returns the last timestamp that the vqueue was created, enqueued, started, attempted,
     /// or finished.
     pub fn last_modified_at(&self) -> UniqueTimestamp {
@@ -278,6 +286,12 @@ pub struct VQueueMetaRef<'a> {
 }
 
 impl<'a> VQueueMetaRef<'a> {
+    /// A vqueue is obsolete when it is unpaused and holds no entries in any stage,
+    /// including `Finished`. Obsolete vqueue metadata records can be purged from storage.
+    pub fn is_obsolete(&self) -> bool {
+        !self.queue_is_paused && self.stats.is_fully_empty()
+    }
+
     /// A vqueue is considered active when it's of interest to the scheduler.
     ///
     /// The scheduler cares about vqueues that have entries that are already running or that are waiting
@@ -379,10 +393,10 @@ impl VQueueMeta {
         self.len() == 0
     }
 
-    /// A vqueue is obsolete when it holds no entries in any stage, including
-    /// `Finished`. Obsolete vqueue metadata records can be purged from storage.
+    /// A vqueue is obsolete when it is unpaused and holds no entries in any stage,
+    /// including `Finished`. Obsolete vqueue metadata records can be purged from storage.
     pub fn is_obsolete(&self) -> bool {
-        self.is_empty() && self.stats.num_finished == 0
+        !self.queue_is_paused && self.stats.is_fully_empty()
     }
 
     pub fn total_waiting(&self) -> u64 {
@@ -613,6 +627,19 @@ mod tests {
             }),
             ..metrics(last_transition_at_ms, first_runnable_at_ms, has_started)
         }
+    }
+
+    #[test]
+    fn paused_empty_vqueue_is_not_obsolete() {
+        let at = ts(BASE_TS_MS);
+        let mut meta = VQueueMeta::new(at, None, LimitKey::None, VQueueLink::None);
+        assert!(meta.is_obsolete());
+
+        meta.apply_update(&Update::new(at, Action::PauseVQueue {}));
+        assert!(!meta.is_obsolete());
+
+        meta.apply_update(&Update::new(at, Action::ResumeVQueue {}));
+        assert!(meta.is_obsolete());
     }
 
     #[test]
@@ -934,5 +961,6 @@ mod tests {
         );
         assert_eq!(borrowed.stats.num_inbox(), owned.stats.num_inbox());
         assert_eq!(borrowed.is_active(), owned.is_active());
+        assert_eq!(borrowed.is_obsolete(), owned.is_obsolete());
     }
 }

--- a/crates/storage-api/src/vqueue_table/tables.rs
+++ b/crates/storage-api/src/vqueue_table/tables.rs
@@ -100,13 +100,22 @@ mod bilrost_encoding {
     );
 }
 
+/// Whether updating a vqueue retained or purged its metadata.
+#[must_use]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VQueueDisposition {
+    Retained,
+    Purged,
+}
+
 pub trait WriteVQueueTable {
     /// Initializes a new vqueue
     fn create_vqueue(&mut self, qid: &VQueueId, meta: &VQueueMeta);
 
     /// Update VQueueMeta with a set of differential updates.
     /// The `meta` **must** match the vqueue metadata on disk prior to the update,
-    /// then it gets updated in place.
+    /// then it gets updated in place. Obsolete metadata is deleted atomically
+    /// with the update and reported through the returned disposition.
     ///
     /// Pass `entry_metadata` if the update impacts a single entry.
     fn update_vqueue(
@@ -115,7 +124,7 @@ pub trait WriteVQueueTable {
         meta: &mut VQueueMeta,
         update: &super::metadata::Update,
         entry_metadata: Option<&EntryMetadata>,
-    );
+    ) -> VQueueDisposition;
 
     /// Deletes a vqueue's metadata record.
     ///

--- a/crates/vqueues/src/cache.rs
+++ b/crates/vqueues/src/cache.rs
@@ -104,10 +104,6 @@ impl Slot {
     pub(super) fn split_mut(&mut self) -> (&VQueueId, &mut VQueueMeta) {
         (&self.qid, &mut self.meta)
     }
-
-    pub(super) fn meta_mut(&mut self) -> &mut VQueueMeta {
-        &mut self.meta
-    }
 }
 
 // Needs rewriting after the workload pattern becomes more clear.
@@ -151,24 +147,22 @@ impl VQueuesMetaCache {
         storage: &mut S,
         qid: &VQueueId,
     ) -> Result<bool> {
-        let is_purgeable = |meta: &VQueueMeta| meta.is_obsolete() && !meta.queue_is_paused();
-
         if let Some(handle) = self.queues.get(qid).copied() {
             let slot = self.slab.get(handle).expect("cached vqueue has a slot");
-            if !is_purgeable(slot.meta()) {
+            if !slot.meta().is_obsolete() {
                 return Ok(false);
             }
 
             debug!(qid = %slot.vqueue_id(), "Purging obsolete vqueue metadata");
             storage.delete_vqueue(qid);
-            self.defer_purge(qid, handle);
+            self.defer_purge(handle);
             return Ok(true);
         }
 
         let Some(meta) = storage.get_vqueue(qid).await? else {
             return Ok(false);
         };
-        if !is_purgeable(&meta) {
+        if !meta.is_obsolete() {
             return Ok(false);
         }
 
@@ -208,8 +202,9 @@ impl VQueuesMetaCache {
         evicted
     }
 
-    fn defer_purge(&mut self, qid: &VQueueId, handle: VQueueHandle) {
-        let removed = self.queues.remove(qid);
+    pub(super) fn defer_purge(&mut self, handle: VQueueHandle) {
+        let slot = self.slab.get(handle).expect("cached vqueue has a slot");
+        let removed = self.queues.remove(slot.vqueue_id());
         debug_assert_eq!(removed, Some(handle));
         self.pending_purges.push(handle);
     }
@@ -487,7 +482,7 @@ mod tests {
         let active = cache.insert(VQueueId::custom(3, "active"), active_meta);
         assert!(cache.should_run_compaction);
 
-        cache.defer_purge(&purged_qid, purged);
+        cache.defer_purge(purged);
         assert_eq!(cache.try_compact(), 1);
 
         assert!(!cache.should_run_compaction);

--- a/crates/vqueues/src/lib.rs
+++ b/crates/vqueues/src/lib.rs
@@ -40,7 +40,7 @@ use restate_storage_api::vqueue_table::metadata::{VQueueLink, VQueueMeta};
 use restate_storage_api::vqueue_table::stats::{EntryStatistics, WaitStats};
 use restate_storage_api::vqueue_table::{
     EntryKey, EntryMetadata, EntryStatusHeader, EntryValue, ReadVQueueTable, Stage, Status,
-    WriteVQueueTable, metadata,
+    VQueueDisposition, WriteVQueueTable, metadata,
 };
 use restate_storage_api::{StorageError, lock_table};
 use restate_types::ServiceName;
@@ -72,6 +72,8 @@ pub enum EventDetails {
         scope: Option<Scope>,
         lock_name: LockName,
     },
+    /// The vqueue is now obsolete.
+    VQueuePurged,
 }
 
 #[derive(Debug)]
@@ -132,6 +134,31 @@ where
 
     pub fn meta(&self) -> &VQueueMeta {
         self.cache.get(self.handle).unwrap().meta()
+    }
+
+    fn update_vqueue(&mut self, update: &metadata::Update, entry_metadata: Option<&EntryMetadata>) {
+        let (vqueue_id, disposition) = {
+            let slot = self.cache.get_mut(self.handle).unwrap();
+            let (vqueue_id, meta) = slot.split_mut();
+            (
+                vqueue_id,
+                self.storage
+                    .update_vqueue(vqueue_id, meta, update, entry_metadata),
+            )
+        };
+
+        if matches!(disposition, VQueueDisposition::Purged) {
+            debug!(qid = %vqueue_id, "Purged obsolete vqueue metadata");
+            self.cache.defer_purge(self.handle);
+            if let Some(collector) = self.action_collector.as_deref_mut() {
+                // Let the scheduler know about the fact that vqueue's handle is about to become
+                // obsolete.
+                let mut event = VQueueEvent::new(self.handle);
+                event.push(EventDetails::VQueuePurged);
+
+                collector.push(A::from(event));
+            }
+        }
     }
 
     /// Get access to the vqueue if it exists, otherwise this returns None.
@@ -263,8 +290,6 @@ where
         entry_id: impl Into<EntryId>,
         metadata: impl Into<EntryMetadata>,
     ) {
-        let meta = self.cache.get_mut(self.handle).unwrap();
-
         let created_at_unix = created_at.to_unix_millis();
         let (run_at, status) = match run_at {
             // Future: ceil to the next whole second so we never fire early.
@@ -295,9 +320,9 @@ where
             },
         );
 
-        let (vqueue_id, q_meta) = meta.split_mut();
-        self.storage
-            .update_vqueue(vqueue_id, q_meta, &update, Some(&metadata));
+        self.update_vqueue(&update, Some(&metadata));
+
+        let meta = self.cache.get(self.handle).unwrap();
 
         // We need to add the entry into the inbox vqueue.
         let value = EntryValue {
@@ -353,8 +378,7 @@ where
     ) -> EntryKey {
         let vqueue_id = header.vqueue_id();
         let partition_key = vqueue_id.partition_key();
-        let meta = self.cache.get_mut(self.handle).unwrap();
-        assert_eq!(vqueue_id, meta.vqueue_id());
+        assert_eq!(vqueue_id, self.cache.get(self.handle).unwrap().vqueue_id());
         assert!(matches!(header.stage(), Stage::Inbox));
 
         // Remove from inbox and move to ready
@@ -373,8 +397,9 @@ where
             },
         );
 
-        self.storage
-            .update_vqueue(vqueue_id, meta.meta_mut(), &update, Some(header.metadata()));
+        self.update_vqueue(&update, Some(header.metadata()));
+
+        let meta = self.cache.get(self.handle).unwrap();
 
         let stats = Self::mark_run_attempt(at, header.stats(), wait_stats);
 
@@ -466,8 +491,7 @@ where
         updated_metadata: Option<EntryMetadata>,
     ) {
         let vqueue_id = header.vqueue_id();
-        let meta = self.cache.get_mut(self.handle).unwrap();
-        assert_eq!(vqueue_id, meta.vqueue_id());
+        assert_eq!(vqueue_id, self.cache.get(self.handle).unwrap().vqueue_id());
         assert!(matches!(header.stage(), Stage::Paused | Stage::Suspended));
 
         // Delete the old inbox entry
@@ -484,8 +508,7 @@ where
         );
 
         // Update vqueue meta in storage
-        self.storage
-            .update_vqueue(vqueue_id, meta.meta_mut(), &update, Some(header.metadata()));
+        self.update_vqueue(&update, Some(header.metadata()));
 
         // We can be asked to wake up but not run immediately (or get a lower run_at for priority
         // boosting). If that's the case, we mutate the entry key to reflect that.
@@ -686,8 +709,7 @@ where
         next_stage: Stage,
     ) {
         let vqueue_id = header.vqueue_id();
-        let meta = self.cache.get_mut(self.handle).unwrap();
-        assert_eq!(vqueue_id, meta.vqueue_id());
+        assert_eq!(vqueue_id, self.cache.get(self.handle).unwrap().vqueue_id());
         assert!(matches!(next_stage, Stage::Paused | Stage::Suspended));
 
         debug!(
@@ -712,8 +734,7 @@ where
         );
 
         // Update vqueue meta in storage
-        self.storage
-            .update_vqueue(vqueue_id, meta.meta_mut(), &update, Some(header.metadata()));
+        self.update_vqueue(&update, Some(header.metadata()));
 
         let stats = match next_stage {
             Stage::Paused => Self::mark_pause(at, header.stats()),
@@ -764,8 +785,7 @@ where
         reason: YieldReason,
     ) {
         let vqueue_id = header.vqueue_id();
-        let meta = self.cache.get_mut(self.handle).unwrap();
-        assert_eq!(vqueue_id, meta.vqueue_id());
+        assert_eq!(vqueue_id, self.cache.get(self.handle).unwrap().vqueue_id());
 
         // Remove from running and move to waiting
         self.storage
@@ -780,8 +800,7 @@ where
             },
         );
 
-        self.storage
-            .update_vqueue(vqueue_id, meta.meta_mut(), &update, Some(header.metadata()));
+        self.update_vqueue(&update, Some(header.metadata()));
 
         // We can be asked to wake up but not run immediately (or get a lower run_at for priority
         // boosting). If that's the case, we mutate the entry key to reflect that.
@@ -877,14 +896,14 @@ where
 
     /// The entry has completed execution and it needs to be removed from the vqueue.
     pub fn end(
-        &mut self,
+        mut self,
         at: UniqueTimestamp,
         header: &impl EntryStatusHeader,
         new_status: Status,
         delete_after: Duration,
     ) {
         let vqueue_id = header.vqueue_id();
-        let meta = self.cache.get_mut(self.handle).unwrap();
+        let meta = self.cache.get(self.handle).unwrap();
         assert_eq!(vqueue_id, meta.vqueue_id());
 
         // Remove from the current stage
@@ -942,10 +961,10 @@ where
             new_status,
         );
 
-        self.storage
-            .update_vqueue(vqueue_id, meta.meta_mut(), &update, Some(header.metadata()));
+        self.update_vqueue(&update, Some(header.metadata()));
 
         if let Some(collector) = self.action_collector.as_deref_mut() {
+            let meta = self.cache.get(self.handle).unwrap();
             let mut event = VQueueEvent::new(self.handle);
             // Release the lock if this entry has been holding a lock already
             if header.has_lock()
@@ -982,15 +1001,14 @@ where
     /// It's the caller's responsibility to ensure that the entry is in the `Finished` stage
     /// before calling this method.
     pub fn delete(
-        &mut self,
+        mut self,
         at: UniqueTimestamp,
         vqueue_id: &VQueueId,
         entry_id: &EntryId,
         entry_key: &EntryKey,
         entry_metadata: &EntryMetadata,
     ) {
-        let meta = self.cache.get_mut(self.handle).unwrap();
-        assert_eq!(vqueue_id, meta.vqueue_id());
+        assert_eq!(vqueue_id, self.cache.get(self.handle).unwrap().vqueue_id());
 
         debug!(
             entry = %entry_id.display(vqueue_id.partition_key()),
@@ -1014,8 +1032,7 @@ where
         // delete the inbox entry
         self.storage
             .delete_vqueue_inbox(vqueue_id, Stage::Finished, entry_key);
-        self.storage
-            .update_vqueue(vqueue_id, meta.meta_mut(), &update, Some(entry_metadata));
+        self.update_vqueue(&update, Some(entry_metadata));
     }
 
     /// A specialized version of run designed for inline execution of an entry.
@@ -1024,15 +1041,14 @@ where
     /// the scheduler as if it was a regular invocation but takes a few shortcuts
     /// since there is no actual time spent that can be tracked.
     pub fn run_then_finish(
-        &mut self,
+        mut self,
         at: UniqueTimestamp,
         header: &impl EntryStatusHeader,
         wait_stats: WaitStats,
         status: Status,
     ) {
         let vqueue_id = header.vqueue_id();
-        let meta = self.cache.get_mut(self.handle).unwrap();
-        assert_eq!(vqueue_id, meta.vqueue_id());
+        assert_eq!(vqueue_id, self.cache.get(self.handle).unwrap().vqueue_id());
         assert!(matches!(header.stage(), Stage::Inbox));
 
         // Remove from inbox and move to ready
@@ -1052,8 +1068,7 @@ where
             },
         );
 
-        self.storage
-            .update_vqueue(vqueue_id, meta.meta_mut(), &update, Some(header.metadata()));
+        self.update_vqueue(&update, Some(header.metadata()));
         let stats = Self::mark_run_attempt(at, header.stats(), wait_stats);
 
         // Move to finish
@@ -1068,8 +1083,7 @@ where
 
         let stats = Self::mark_transition(at, &stats);
 
-        self.storage
-            .update_vqueue(vqueue_id, meta.meta_mut(), &update, Some(header.metadata()));
+        self.update_vqueue(&update, Some(header.metadata()));
 
         // Move the entry to Finished stage
         // for future: Use this to set the deletion time.
@@ -1129,13 +1143,12 @@ where
         self.storage
             .delete_vqueue_inbox(vqueue_id, Stage::Finished, &modified_key);
 
-        self.storage
-            .update_vqueue(vqueue_id, meta.meta_mut(), &update, Some(header.metadata()));
+        self.update_vqueue(&update, Some(header.metadata()));
     }
 
     /// Marks this vqueue as paused
     pub fn pause_queue(&mut self, at: UniqueTimestamp) {
-        let slot = self.cache.get_mut(self.handle).unwrap();
+        let slot = self.cache.get(self.handle).unwrap();
 
         if slot.meta().queue_is_paused() {
             // queue is already paused
@@ -1145,9 +1158,7 @@ where
         debug!(qid = %slot.vqueue_id(), "Pausing vqueue");
         let update = metadata::Update::new(at, metadata::Action::PauseVQueue {});
 
-        // Update vqueue meta in storage
-        let (vqueue_id, meta) = slot.split_mut();
-        self.storage.update_vqueue(vqueue_id, meta, &update, None);
+        self.update_vqueue(&update, None);
 
         if let Some(collector) = self.action_collector.as_deref_mut() {
             let mut event = VQueueEvent::new(self.handle);
@@ -1157,8 +1168,8 @@ where
     }
 
     /// Marks this vqueue as resumed
-    pub fn resume_queue(&mut self, at: UniqueTimestamp) {
-        let slot = self.cache.get_mut(self.handle).unwrap();
+    pub fn resume_queue(mut self, at: UniqueTimestamp) {
+        let slot = self.cache.get(self.handle).unwrap();
 
         if !slot.meta().queue_is_paused() {
             // queue is not paused
@@ -1167,11 +1178,9 @@ where
         debug!(qid = %slot.vqueue_id(), "Resuming vqueue");
         let update = metadata::Update::new(at, metadata::Action::ResumeVQueue {});
 
-        // Update vqueue meta in storage
-        let (vqueue_id, meta) = slot.split_mut();
-        self.storage.update_vqueue(vqueue_id, meta, &update, None);
+        self.update_vqueue(&update, None);
 
-        if meta.is_active()
+        if self.meta().is_active()
             && let Some(collector) = self.action_collector.as_deref_mut()
         {
             let mut event = VQueueEvent::new(self.handle);
@@ -1278,7 +1287,7 @@ where
         invocation_id: &InvocationId,
         invoked: &InFlightInvocationMetadata,
     ) {
-        let meta = self.cache.get_mut(self.handle).unwrap();
+        let meta = self.cache.get(self.handle).unwrap();
 
         // We use a special value (0) for all running invocations under the following assumptions:
         // - We don't allow two invocations with the same ID to co-exist (prior to vqueues)
@@ -1352,9 +1361,9 @@ where
             },
         );
 
-        let (vqueue_id, q_meta) = meta.split_mut();
-        self.storage
-            .update_vqueue(vqueue_id, q_meta, &update, Some(&metadata));
+        self.update_vqueue(&update, Some(&metadata));
+
+        let meta = self.cache.get(self.handle).unwrap();
 
         // We need to add the entry into the inbox vqueue.
         let value = EntryValue {
@@ -1382,8 +1391,6 @@ where
         invocation_id: &InvocationId,
         completed: &CompletedInvocation,
     ) {
-        let meta = self.cache.get_mut(self.handle).unwrap();
-
         // We use a special value (0) for invocations under the following assumptions:
         // - We don't allow two invocations with the same ID to co-exist (prior to vqueues)
         // - Any new invocation with the same ID will be created with Lsn > 0 after migration.
@@ -1467,9 +1474,9 @@ where
             },
         );
 
-        let (vqueue_id, q_meta) = meta.split_mut();
-        self.storage
-            .update_vqueue(vqueue_id, q_meta, &update, Some(&metadata));
+        self.update_vqueue(&update, Some(&metadata));
+
+        let meta = self.cache.get(self.handle).unwrap();
 
         // We need to add the entry into the inbox vqueue.
         let value = EntryValue {
@@ -1499,7 +1506,7 @@ where
         stage: Stage,
     ) {
         debug_assert_matches!(stage, Stage::Paused | Stage::Suspended);
-        let meta = self.cache.get_mut(self.handle).unwrap();
+        let meta = self.cache.get(self.handle).unwrap();
 
         // We use a special value (0) for all running invocations under the following assumptions:
         // - We don't allow two invocations with the same ID to co-exist (prior to vqueues)
@@ -1581,9 +1588,9 @@ where
             },
         );
 
-        let (vqueue_id, q_meta) = meta.split_mut();
-        self.storage
-            .update_vqueue(vqueue_id, q_meta, &update, Some(&metadata));
+        self.update_vqueue(&update, Some(&metadata));
+
+        let meta = self.cache.get(self.handle).unwrap();
 
         // We need to add the entry into the inbox vqueue.
         let value = EntryValue {
@@ -1718,5 +1725,96 @@ mod tests {
             .unwrap()
             .expect("paused vqueue meta is retained");
         assert!(paused_meta.queue_is_paused());
+    }
+
+    #[restate_core::test]
+    async fn resuming_empty_vqueue_purges_metadata() {
+        let mut store = storage_test_environment().await;
+        let mut cache = VQueuesMetaCache::new_empty(16);
+        let at = UniqueTimestamp::try_from(1_744_000_000_000u64).unwrap();
+        let qid = VQueueId::custom(1, "paused");
+
+        let mut txn = store.transaction();
+        {
+            let mut vqueue =
+                VQueue::<VQueueEvent, _>::get_or_insert_with(&qid, &mut txn, &mut cache, || {
+                    VQueueMeta::new(at, None, LimitKey::None, VQueueLink::None)
+                })
+                .await
+                .unwrap();
+            vqueue.pause_queue(at);
+        }
+        txn.commit().await.unwrap();
+        drop(txn);
+
+        let handle = cache.view().handle_for(&qid).unwrap();
+        let mut txn = store.transaction();
+        {
+            let vqueue = VQueue::<VQueueEvent, _>::get(&qid, &mut txn, &mut cache, None)
+                .await
+                .unwrap()
+                .unwrap();
+            vqueue.resume_queue(at);
+        }
+
+        assert!(txn.get_vqueue(&qid).await.unwrap().is_none());
+        assert!(cache.view().handle_for(&qid).is_none());
+        assert!(cache.get(handle).is_some());
+        txn.commit().await.unwrap();
+        drop(txn);
+
+        assert_eq!(cache.try_compact(), 1);
+        assert!(cache.get(handle).is_none());
+        let txn = store.transaction();
+        assert!(txn.get_vqueue(&qid).await.unwrap().is_none());
+    }
+
+    #[restate_core::test]
+    async fn update_purges_only_after_removing_the_final_entry() {
+        let mut store = storage_test_environment().await;
+        let at = UniqueTimestamp::try_from(1_744_000_000_000u64).unwrap();
+        let qid = VQueueId::custom(1, "finished");
+        let mut meta = VQueueMeta::new(at, None, LimitKey::None, VQueueLink::None);
+        let mut txn = store.transaction();
+        txn.create_vqueue(&qid, &meta);
+
+        let add_finished = metadata::Update::new(
+            at,
+            metadata::Action::Move {
+                prev_stage: None,
+                next_stage: Stage::Finished,
+                metrics: metadata::MoveMetrics {
+                    last_transition_at: at,
+                    has_started: false,
+                    first_runnable_at: at.to_unix_millis(),
+                    scheduler_wait_stats: None,
+                },
+            },
+        );
+        assert_eq!(
+            txn.update_vqueue(&qid, &mut meta, &add_finished, None),
+            VQueueDisposition::Retained
+        );
+        assert_eq!(
+            txn.update_vqueue(&qid, &mut meta, &add_finished, None),
+            VQueueDisposition::Retained
+        );
+
+        let remove_finished = metadata::Update::new(
+            at,
+            metadata::Action::RemoveEntry {
+                stage: Stage::Finished,
+            },
+        );
+        assert_eq!(
+            txn.update_vqueue(&qid, &mut meta, &remove_finished, None),
+            VQueueDisposition::Retained
+        );
+        assert!(txn.get_vqueue(&qid).await.unwrap().is_some());
+        assert_eq!(
+            txn.update_vqueue(&qid, &mut meta, &remove_finished, None),
+            VQueueDisposition::Purged
+        );
+        assert!(txn.get_vqueue(&qid).await.unwrap().is_none());
     }
 }

--- a/crates/vqueues/src/scheduler/drr.rs
+++ b/crates/vqueues/src/scheduler/drr.rs
@@ -249,6 +249,17 @@ impl<S: VQueueStore> DRRScheduler<S> {
     pub fn on_inbox_event(&mut self, metas: VQueuesMeta<'_>, event: VQueueEvent) {
         for update in &event.updates {
             match update {
+                EventDetails::VQueuePurged => {
+                    if !self.q.contains_key(event.queue) {
+                        continue;
+                    };
+
+                    let Some(slot) = metas.get(event.queue) else {
+                        panic!("vqueue meta must be in cache: {event:?}");
+                    };
+
+                    self.mark_vqueue_as_dormant(slot.vqueue_id(), event.queue);
+                }
                 EventDetails::LockReleased { scope, lock_name } => {
                     self.release_lock(scope, lock_name);
                 }
@@ -854,7 +865,7 @@ mod tests {
         let mut txn = rocksdb.transaction();
         let header = read_header(&txn, &qid, key.entry_id()).await;
         {
-            let mut vqueue = VQueue::get(&qid, &mut txn, &mut cache, Some(&mut events))
+            let vqueue = VQueue::get(&qid, &mut txn, &mut cache, Some(&mut events))
                 .await
                 .unwrap()
                 .unwrap();
@@ -866,8 +877,9 @@ mod tests {
             );
         }
 
-        assert!(cache.purge_meta_if_obsolete(&mut txn, &qid).await.unwrap());
+        // The final entry removal purges the metadata and detaches the ID immediately.
         let old_handle = handle;
+        assert!(txn.get_vqueue(&qid).await.unwrap().is_none());
         assert!(cache.view().handle_for(&qid).is_none());
         enqueue_entry(&mut txn, &mut cache, &qid, 2, 0, Some(&mut events)).await;
         let new_handle = cache.view().handle_for(&qid).unwrap();
@@ -890,6 +902,14 @@ mod tests {
             txn.get_vqueue(&qid).await.unwrap().unwrap().total_waiting(),
             1
         );
+        drop(txn);
+
+        let fresh_cache =
+            VQueuesMetaCache::create(rocksdb.partition_db().clone(), TEST_VQUEUES_CAPACITY)
+                .await
+                .unwrap();
+        assert!(fresh_cache.view().handle_for(&qid).is_some());
+        assert_eq!(fresh_cache.view().num_active(), 1);
     }
 
     #[restate_core::test]

--- a/crates/vqueues/src/scheduler/eligible.rs
+++ b/crates/vqueues/src/scheduler/eligible.rs
@@ -159,7 +159,13 @@ impl EligibilityTracker {
                 continue;
             };
 
-            let slot = metas.get(handle).unwrap();
+            let Some(slot) = metas.get(handle) else {
+                // The vqueue is not eligible anymore. This can happen if the vqueue became dormant
+                // due to items being removed externally (killed, etc.)
+                self.remove(handle);
+                self.ready_ring.pop_front();
+                continue;
+            };
 
             match current_state {
                 State::NeedsPoll => {

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -649,7 +649,7 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
 
                 let at = UniqueTimestamp::from_unix_millis_unchecked(self.record_created_at);
                 for qid in resume.vqueues.iter() {
-                    let Some(mut vqueue) = VQueue::get(
+                    let Some(vqueue) = VQueue::get(
                         qid,
                         self.storage,
                         self.processor.vqueues_mut(),


### PR DESCRIPTION

Delete unpaused VQueue metadata when the last entry is removed. Return a disposition so cache detachment remains event-safe and same-batch recreation uses a fresh handle.

---
[//]: # (BEGIN SAPLING FOOTER)
* #5309
* __->__ #5308