### PR TITLE
[PartitionStore] Clean up obsolete VQueue metadata

### DIFF
--- a/crates/partition-store/src/features.rs
+++ b/crates/partition-store/src/features.rs
@@ -11,6 +11,7 @@
 mod scoped_promise_migration;
 mod scoped_state_migration;
 mod state_promise_migration_combined;
+mod vqueue_meta_cleanup;
 
 use std::collections::BTreeMap;
 
@@ -81,6 +82,13 @@ storage_features! {
     /// In short:
     /// * unscoped `promise_table` -> scoped `promise_table` (with `scope = None`)
     pub MigratedToScopedPromiseTable,
+    /// The first one-time cleanup of obsolete vqueue metadata has completed on
+    /// this partition store.
+    ///
+    /// This records one sweep rather than requiring repeated startup scans.
+    ///
+    /// *Since v1.7.10*
+    pub VqueueMetadataCleanupV1,
 }
 
 trait StorageFeature: Sized + 'static {
@@ -102,7 +110,7 @@ trait StorageFeature: Sized + 'static {
     ///
     /// Note that `enable` will not be called if the partition-store is empty
     /// (no LSNs have been applied).
-    fn enable(
+    async fn enable(
         storage: &mut PartitionStore,
         cancel: &CancellationToken,
         config: &Configuration,
@@ -324,7 +332,7 @@ async fn enable_helper<F: StorageFeature>(
     let mut finalization = WriteBatch::default();
 
     if !is_store_empty {
-        F::enable(storage, cancel, config, &mut finalization)?;
+        F::enable(storage, cancel, config, &mut finalization).await?;
     }
 
     if cancel.is_cancelled() {
@@ -654,10 +662,9 @@ mod tests {
             LoadedStorageFeatures::load(None, StorageVersion::V1_5, &current_version).unwrap();
         let config = Configuration::default();
 
-        assert!(
-            features
-                .automatic_changes(&config, &current_version, false)
-                .is_empty()
+        assert_eq!(
+            features.automatic_changes(&config, &current_version, false),
+            [KnownStorageFeature::VqueueMetadataCleanupV1]
         );
         assert_eq!(
             features.automatic_changes(&config, &current_version, true),
@@ -665,6 +672,7 @@ mod tests {
                 KnownStorageFeature::MigratedToScopedPromiseAndStateTables,
                 KnownStorageFeature::MigratedToScopedStateTable,
                 KnownStorageFeature::MigratedToScopedPromiseTable,
+                KnownStorageFeature::VqueueMetadataCleanupV1,
             ]
         );
     }

--- a/crates/partition-store/src/features/scoped_promise_migration.rs
+++ b/crates/partition-store/src/features/scoped_promise_migration.rs
@@ -61,7 +61,7 @@ impl StorageFeature for super::MigratedToScopedPromiseTableFeature {
         features.is_migrated_to_scoped_promise_table = true;
     }
 
-    fn enable(
+    async fn enable(
         storage: &mut PartitionStore,
         cancel: &CancellationToken,
         config: &Configuration,

--- a/crates/partition-store/src/features/scoped_state_migration.rs
+++ b/crates/partition-store/src/features/scoped_state_migration.rs
@@ -61,7 +61,7 @@ impl StorageFeature for super::MigratedToScopedStateTableFeature {
         features.is_migrated_to_scoped_state_table = true;
     }
 
-    fn enable(
+    async fn enable(
         storage: &mut PartitionStore,
         cancel: &CancellationToken,
         config: &Configuration,

--- a/crates/partition-store/src/features/state_promise_migration_combined.rs
+++ b/crates/partition-store/src/features/state_promise_migration_combined.rs
@@ -58,14 +58,16 @@ impl StorageFeature for super::MigratedToScopedPromiseAndStateTablesFeature {
         features.is_migrated_to_scoped_promise_and_state_tables = true;
     }
 
-    fn enable(
+    async fn enable(
         storage: &mut PartitionStore,
         cancel: &CancellationToken,
         config: &Configuration,
         finalization: &mut WriteBatch,
     ) -> Result<(), MigrationError> {
-        super::MigratedToScopedPromiseTableFeature::enable(storage, cancel, config, finalization)?;
-        super::MigratedToScopedStateTableFeature::enable(storage, cancel, config, finalization)?;
+        super::MigratedToScopedPromiseTableFeature::enable(storage, cancel, config, finalization)
+            .await?;
+        super::MigratedToScopedStateTableFeature::enable(storage, cancel, config, finalization)
+            .await?;
         Ok(())
     }
 }

--- a/crates/partition-store/src/features/vqueue_meta_cleanup.rs
+++ b/crates/partition-store/src/features/vqueue_meta_cleanup.rs
@@ -1,0 +1,287 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::{Duration, Instant};
+
+use anyhow::Context;
+use bilrost::BorrowedMessage;
+use bytes::BytesMut;
+use rocksdb::{ReadOptions, WriteBatch, WriteOptions};
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
+use restate_rocksdb::{Priority, StorageTaskKind};
+use restate_storage_api::StorageError;
+use restate_storage_api::vqueue_table::metadata::VQueueMetaRef;
+use restate_types::config::Configuration;
+use restate_types::sharding::KeyRange;
+use restate_types::{RESTATE_VERSION_1_7_10, RESTATE_VERSION_1_9_0, SemanticRestateVersion};
+use restate_util_string::ReString;
+use restate_util_time::DurationExt;
+
+use super::{StorageFeature, StorageFeatures, VqueueMetadataCleanupV1Feature};
+use crate::migrations::MigrationError;
+use crate::scan::{PhysicalScan, TableScan};
+use crate::vqueue_table::MetaKey;
+use crate::{PartitionDb, PartitionStore, convert_to_upper_bound};
+
+static VQUEUE_METADATA_CLEANUP_V1: ReString = ReString::from_static("vqueue-metadata-cleanup-v1");
+
+#[cfg(not(test))]
+const MAX_BATCH_SIZE: usize = 1024 * 1024;
+#[cfg(test)]
+const MAX_BATCH_SIZE: usize = 1;
+#[cfg(not(test))]
+const MAX_ROWS_PER_CHUNK: usize = 1_000_000;
+#[cfg(test)]
+const MAX_ROWS_PER_CHUNK: usize = 3;
+const PROGRESS_INTERVAL: Duration = Duration::from_secs(5);
+
+impl StorageFeature for VqueueMetadataCleanupV1Feature {
+    fn persisted_name() -> &'static ReString {
+        &VQUEUE_METADATA_CLEANUP_V1
+    }
+
+    fn min_required_version() -> &'static SemanticRestateVersion {
+        &RESTATE_VERSION_1_7_10
+    }
+
+    fn should_enable(
+        config: &Configuration,
+        current_version: &SemanticRestateVersion,
+        _is_store_empty: bool,
+    ) -> bool {
+        current_version.is_equal_or_newer_than(&RESTATE_VERSION_1_9_0)
+            || config
+                .common
+                .experimental
+                .is_vqueue_obsolete_cleanup_enabled()
+    }
+
+    fn is_enabled(features: &StorageFeatures) -> bool {
+        features.is_vqueue_metadata_cleanup_v1
+    }
+
+    fn set_enabled(features: &mut StorageFeatures) {
+        features.is_vqueue_metadata_cleanup_v1 = true;
+    }
+
+    async fn enable(
+        storage: &mut PartitionStore,
+        cancel: &CancellationToken,
+        _config: &Configuration,
+        _finalization: &mut WriteBatch,
+    ) -> Result<(), MigrationError> {
+        purge_obsolete_vqueue_metadata(storage, cancel).await
+    }
+}
+
+async fn purge_obsolete_vqueue_metadata(
+    storage: &PartitionStore,
+    cancel: &CancellationToken,
+) -> Result<(), MigrationError> {
+    let started = Instant::now();
+    let mut last_reported = Instant::now();
+    let mut scanned = 0u64;
+    let mut purged = 0u64;
+    let partition_db = storage.partition_db().clone();
+    let key_range = storage.partition_key_range();
+    let rocks = partition_db.rocksdb().clone();
+    let mut next_key = None;
+
+    loop {
+        let chunk = rocks
+            .clone()
+            .run_background_read_op(
+                "purge-obsolete-vqueue-metadata",
+                StorageTaskKind::BackgroundIterator,
+                Priority::Low,
+                {
+                    let partition_db = partition_db.clone();
+                    let cancel = cancel.clone();
+                    move |_| purge_chunk(&partition_db, key_range, next_key, &cancel)
+                },
+            )
+            .await
+            .map_err(|_| StorageError::OperationalError)??;
+
+        scanned += chunk.scanned;
+        purged += chunk.purged;
+
+        if scanned > 0 && last_reported.elapsed() >= PROGRESS_INTERVAL {
+            info!(
+                scanned,
+                purged,
+                elapsed = %started.elapsed().friendly(),
+                "Purging obsolete vqueue metadata"
+            );
+            last_reported = Instant::now();
+        }
+
+        let Some(key) = chunk.next_key else {
+            break;
+        };
+        next_key = Some(key);
+    }
+
+    if purged > 0 {
+        info!(
+            scanned,
+            purged,
+            elapsed = %started.elapsed().friendly(),
+            "Finished purging obsolete vqueue metadata"
+        );
+    }
+    Ok(())
+}
+
+struct CleanupChunk {
+    next_key: Option<Vec<u8>>,
+    scanned: u64,
+    purged: u64,
+}
+
+fn purge_chunk(
+    partition_db: &PartitionDb,
+    key_range: KeyRange,
+    start_key: Option<Vec<u8>>,
+    cancel: &CancellationToken,
+) -> Result<CleanupChunk, MigrationError> {
+    let rocks = partition_db.rocksdb();
+    let cf = partition_db.cf_handle();
+    let mut arena = BytesMut::new();
+    let mut read_options = ReadOptions::default();
+    read_options.fill_cache(false);
+    let mut iterator = partition_db.scan(
+        PhysicalScan::from(
+            TableScan::ScanPartitionKeyRange::<MetaKey>(key_range),
+            &mut arena,
+        ),
+        read_options,
+    )?;
+    if let Some(start_key) = start_key.as_deref() {
+        iterator.seek(start_key);
+    }
+
+    let mut write_options = WriteOptions::default();
+    write_options.disable_wal(true);
+    let mut write_batch = WriteBatch::with_capacity_bytes(MAX_BATCH_SIZE);
+    let mut last_key = Vec::with_capacity(MetaKey::serialized_length_fixed());
+    let mut scanned = 0u64;
+    let mut purged = 0u64;
+    let mut pending_purges = 0u64;
+
+    while iterator.valid() && scanned < MAX_ROWS_PER_CHUNK as u64 {
+        if cancel.is_cancelled() {
+            return Err(MigrationError::MigrationCancelled);
+        }
+
+        let (key, value) = iterator.item().expect("valid iterator has an item");
+        let meta = VQueueMetaRef::decode_borrowed(value).map_err(StorageError::BilrostDecode)?;
+        last_key.clear();
+        last_key.extend_from_slice(key);
+        scanned += 1;
+
+        if meta.is_obsolete() {
+            write_batch.delete_cf(cf, key);
+            pending_purges += 1;
+        }
+        iterator.next();
+
+        if write_batch.size_in_bytes() >= MAX_BATCH_SIZE {
+            rocks
+                .inner()
+                .write_batch(&write_batch, &write_options)
+                .context("failed to delete obsolete vqueue metadata batch")
+                .map_err(StorageError::Generic)?;
+            write_batch.clear();
+            purged += pending_purges;
+            pending_purges = 0;
+        }
+    }
+
+    iterator
+        .status()
+        .context("iterating over vqueue metadata")
+        .map_err(StorageError::Generic)?;
+    let next_key = iterator.valid().then(|| {
+        assert!(
+            convert_to_upper_bound(&mut last_key),
+            "vqueue metadata key must have a successor"
+        );
+        last_key
+    });
+    drop(iterator);
+
+    if !write_batch.is_empty() {
+        rocks
+            .inner()
+            .write_batch(&write_batch, &write_options)
+            .context("failed to delete final obsolete vqueue metadata batch")
+            .map_err(StorageError::Generic)?;
+        purged += pending_purges;
+    }
+
+    Ok(CleanupChunk {
+        next_key,
+        scanned,
+        purged,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn activation_respects_version_and_config() {
+        assert_eq!(
+            VqueueMetadataCleanupV1Feature::min_required_version(),
+            &*RESTATE_VERSION_1_7_10
+        );
+
+        let mut config = Configuration::default();
+        assert!(!VqueueMetadataCleanupV1Feature::should_enable(
+            &config,
+            &SemanticRestateVersion::new(1, 7, 9),
+            false,
+        ));
+        assert!(!VqueueMetadataCleanupV1Feature::should_enable(
+            &config,
+            &RESTATE_VERSION_1_7_10,
+            false,
+        ));
+        config.common.experimental.set_vqueue_obsolete_cleanup(true);
+        assert!(VqueueMetadataCleanupV1Feature::should_enable(
+            &config,
+            &RESTATE_VERSION_1_7_10,
+            false,
+        ));
+
+        let config = Configuration::default();
+        let v1_8_0 = SemanticRestateVersion::new(1, 8, 0);
+        assert!(!VqueueMetadataCleanupV1Feature::should_enable(
+            &config, &v1_8_0, false,
+        ));
+        assert!(!VqueueMetadataCleanupV1Feature::should_enable(
+            &config, &v1_8_0, true,
+        ));
+        assert!(VqueueMetadataCleanupV1Feature::should_enable(
+            &config,
+            &RESTATE_VERSION_1_9_0,
+            false,
+        ));
+        assert!(VqueueMetadataCleanupV1Feature::should_enable(
+            &config,
+            &RESTATE_VERSION_1_9_0,
+            true,
+        ));
+    }
+}

--- a/crates/partition-store/src/tests/migrations_test/verify_and_run_migrations.rs
+++ b/crates/partition-store/src/tests/migrations_test/verify_and_run_migrations.rs
@@ -15,6 +15,7 @@ use bytes::{Bytes, BytesMut};
 use bytestring::ByteString;
 use tokio_util::sync::CancellationToken;
 
+use restate_limiter::LimitKey;
 use restate_rocksdb::RocksDbManager;
 use restate_storage_api::Transaction;
 use restate_storage_api::fsm_table::{ReadFsmTable, WriteFsmTable};
@@ -22,12 +23,18 @@ use restate_storage_api::promise_table::{
     Promise, PromiseState, ReadPromiseTable, WritePromiseTable,
 };
 use restate_storage_api::state_table::{ReadStateTable, WriteStateTable};
+use restate_storage_api::vqueue_table::metadata::{
+    Action, MoveMetrics, Update, VQueueLink, VQueueMeta,
+};
+use restate_storage_api::vqueue_table::{ReadVQueueTable, Stage, WriteVQueueTable};
+use restate_types::clock::UniqueTimestamp;
 use restate_types::config::{Configuration, set_current_config};
 use restate_types::identifiers::{PartitionId, PartitionKey, ServiceId};
 use restate_types::logs::Lsn;
 use restate_types::partitions::{Partition, StorageVersion};
 use restate_types::sharding::KeyRange;
-use restate_types::{RESTATE_VERSION_1_7_9, SemanticRestateVersion};
+use restate_types::vqueues::VQueueId;
+use restate_types::{RESTATE_VERSION_1_7_9, RESTATE_VERSION_1_7_10, SemanticRestateVersion};
 
 use crate::PartitionStoreManager;
 use crate::fsm_table::{
@@ -385,7 +392,7 @@ async fn scoped_tables_migrate_independently_and_bump_version() {
 }
 
 #[restate_core::test]
-async fn does_not_automatically_migrate_at_1_8() {
+async fn does_not_automatically_migrate_scoped_tables_at_1_8() {
     with_migrate_scoped_tables(false);
     RocksDbManager::init();
     let manager = PartitionStoreManager::create(true)
@@ -516,6 +523,142 @@ async fn flag_on_writes_post_migration_land_in_scoped() {
 
     assert_eq!(count_legacy_state(&store), 0);
     assert_eq!(count_scoped_state(&store), 1);
+
+    RocksDbManager::get().shutdown().await;
+}
+
+#[restate_core::test]
+async fn obsolete_vqueue_metadata_cleanup_is_version_gated_and_idempotent() {
+    with_migrate_scoped_tables(false);
+    RocksDbManager::init();
+    let manager = PartitionStoreManager::create(true)
+        .await
+        .expect("manager create");
+    let mut store = manager
+        .open(
+            &Partition::new(PartitionId::MIN, KeyRange::new(10, 20)),
+            None,
+        )
+        .await
+        .expect("open");
+
+    let at = UniqueTimestamp::try_from(1_744_000_000_000u64).unwrap();
+    let below_range_qid = VQueueId::custom(9, "below-range");
+    let obsolete_qid = VQueueId::custom(10, "obsolete");
+    let paused_qid = VQueueId::custom(11, "paused");
+    let busy_qid = VQueueId::custom(12, "busy");
+    let finished_qid = VQueueId::custom(13, "finished");
+    let upper_bound_qid = VQueueId::custom(20, "upper-bound");
+    let above_range_qid = VQueueId::custom(21, "above-range");
+    let new_meta = || VQueueMeta::new(at, None, LimitKey::None, VQueueLink::None);
+
+    let mut paused_meta = new_meta();
+    paused_meta.apply_update(&Update::new(at, Action::PauseVQueue {}));
+
+    let move_to_stage = |stage| {
+        Update::new(
+            at,
+            Action::Move {
+                prev_stage: None,
+                next_stage: stage,
+                metrics: MoveMetrics {
+                    last_transition_at: at,
+                    has_started: false,
+                    first_runnable_at: at.to_unix_millis(),
+                    scheduler_wait_stats: None,
+                },
+            },
+        )
+    };
+    let mut busy_meta = new_meta();
+    busy_meta.apply_update(&move_to_stage(Stage::Inbox));
+    let mut finished_meta = new_meta();
+    finished_meta.apply_update(&move_to_stage(Stage::Finished));
+
+    {
+        let mut txn = store.transaction();
+        txn.create_vqueue(&below_range_qid, &new_meta());
+        txn.create_vqueue(&obsolete_qid, &new_meta());
+        txn.create_vqueue(&paused_qid, &paused_meta);
+        txn.create_vqueue(&busy_qid, &busy_meta);
+        txn.create_vqueue(&finished_qid, &finished_meta);
+        txn.create_vqueue(&upper_bound_qid, &new_meta());
+        txn.create_vqueue(&above_range_qid, &new_meta());
+        txn.put_applied_lsn(Lsn::from(1)).expect("lsn write");
+        txn.commit().await.expect("seed vqueue metadata");
+    }
+    let partition_id = store.partition_id();
+    put_storage_version(&mut store, partition_id, StorageVersion::V1_5 as u16)
+        .await
+        .expect("seed V1_5");
+
+    let mut config = Configuration::pinned().clone();
+    config.common.experimental.set_vqueue_obsolete_cleanup(true);
+    store
+        .verify_and_run_migrations_at_version(
+            &SemanticRestateVersion::new(1, 7, 9),
+            CancellationToken::new(),
+            &config,
+        )
+        .await
+        .expect("1.7.9 must not enable cleanup");
+    assert!(!store.storage_features().is_vqueue_metadata_cleanup_v1);
+    {
+        let txn = store.transaction();
+        assert!(txn.get_vqueue(&obsolete_qid).await.unwrap().is_some());
+    }
+
+    let cancelled = CancellationToken::new();
+    cancelled.cancel();
+    assert!(matches!(
+        store
+            .verify_and_run_migrations_at_version(&RESTATE_VERSION_1_7_10, cancelled, &config)
+            .await,
+        Err(MigrationError::MigrationCancelled)
+    ));
+    assert!(!store.storage_features().is_vqueue_metadata_cleanup_v1);
+
+    store
+        .verify_and_run_migrations_at_version(
+            &RESTATE_VERSION_1_7_10,
+            CancellationToken::new(),
+            &config,
+        )
+        .await
+        .expect("1.7.10 enables cleanup");
+
+    assert!(store.storage_features().is_vqueue_metadata_cleanup_v1);
+    assert_eq!(min_restate_version(&store), *RESTATE_VERSION_1_7_10);
+    {
+        let txn = store.transaction();
+        assert!(txn.get_vqueue(&obsolete_qid).await.unwrap().is_none());
+        assert!(txn.get_vqueue(&paused_qid).await.unwrap().is_some());
+        assert!(txn.get_vqueue(&busy_qid).await.unwrap().is_some());
+        assert!(txn.get_vqueue(&finished_qid).await.unwrap().is_some());
+        assert!(txn.get_vqueue(&upper_bound_qid).await.unwrap().is_none());
+        assert!(txn.get_vqueue(&below_range_qid).await.unwrap().is_some());
+        assert!(txn.get_vqueue(&above_range_qid).await.unwrap().is_some());
+    }
+
+    // The marker records one cleanup pass and avoids repeated startup scans.
+    let after_cleanup_qid = VQueueId::custom(14, "after-cleanup");
+    {
+        let mut txn = store.transaction();
+        txn.create_vqueue(&after_cleanup_qid, &new_meta());
+        txn.commit().await.expect("seed after cleanup");
+    }
+    store
+        .verify_and_run_migrations_at_version(
+            &RESTATE_VERSION_1_7_10,
+            CancellationToken::new(),
+            &config,
+        )
+        .await
+        .expect("completed cleanup is not repeated");
+    {
+        let txn = store.transaction();
+        assert!(txn.get_vqueue(&after_cleanup_qid).await.unwrap().is_some());
+    }
 
     RocksDbManager::get().shutdown().await;
 }

--- a/crates/types/src/config/common.rs
+++ b/crates/types/src/config/common.rs
@@ -867,6 +867,16 @@ experimental! {
     ///
     /// Since v1.8.0
     schema_bilrost_encoding,
+
+    /// # Enable cleanup of obsolete VQueue metadata
+    ///
+    /// Enabling this is safe and is recommended if the cluster nodes run
+    /// restate >= v1.7.10.
+    ///
+    /// The cleanup is enabled unconditionally from v1.9.0.
+    ///
+    /// Since v1.7.10
+    vqueue_obsolete_cleanup,
 }
 
 serde_with::with_prefix!(pub prefix_tokio_console "tokio_console_");

--- a/crates/types/src/restate_version.rs
+++ b/crates/types/src/restate_version.rs
@@ -246,9 +246,16 @@ pub static RESTATE_VERSION_1_7_8: LazyLock<SemanticRestateVersion> =
 pub static RESTATE_VERSION_1_7_9: LazyLock<SemanticRestateVersion> =
     LazyLock::new(|| SemanticRestateVersion::parse("1.7.9-dev").expect("valid semver version"));
 
+/// Why isn't this value simply v1.7.10? See description of [`RESTATE_VERSION_1_6_0`].
+pub static RESTATE_VERSION_1_7_10: LazyLock<SemanticRestateVersion> =
+    LazyLock::new(|| SemanticRestateVersion::parse("1.7.10-dev").expect("valid semver version"));
+
 /// Why isn't this value simply v1.8.0? See description of [`RESTATE_VERSION_1_6_0`].
 pub static RESTATE_VERSION_1_8_0: LazyLock<SemanticRestateVersion> =
     LazyLock::new(|| SemanticRestateVersion::parse("1.8.0-dev").expect("valid semver version"));
+
+pub static RESTATE_VERSION_1_9_0: LazyLock<SemanticRestateVersion> =
+    LazyLock::new(|| SemanticRestateVersion::parse("1.9.0-dev").expect("valid semver version"));
 
 #[cfg(test)]
 mod tests {

--- a/crates/worker/src/partition/state_machine/mod.rs
+++ b/crates/worker/src/partition/state_machine/mod.rs
@@ -627,6 +627,8 @@ impl<S, P: ProcessorContext> StateMachineApplyContext<'_, S, P> {
                     .into_inner()?;
                 let at = UniqueTimestamp::from_unix_millis_unchecked(self.record_created_at);
                 for qid in pause.vqueues.iter() {
+                    // NOTE: Before shipping pausing vqueues feature, we must make sure we enable
+                    // vqueue meta cleanup StorageFeature.
                     let Some(mut vqueue) = VQueue::get(
                         qid,
                         self.storage,

--- a/release-notes/unreleased/vqueue-metadata-cleanup.md
+++ b/release-notes/unreleased/vqueue-metadata-cleanup.md
@@ -1,0 +1,45 @@
+# Release Notes: Automatically clean up obsolete VQueue metadata
+
+## Bug Fix
+
+### What Changed
+
+Restate now deletes a VQueue's metadata when an update leaves the queue unpaused and fully empty,
+including its finished-entry stage. Empty paused queues are retained so their pause state is
+preserved.
+
+Starting with Restate v1.7.10, a one-time local storage migration can also remove obsolete VQueue
+metadata accumulated by earlier versions. The migration is enabled with
+`experimental-enable-vqueue-obsolete-cleanup` in v1.7.10 and v1.8, and is enabled unconditionally
+from v1.9. The migration scans the partition's VQueue metadata in bounded, low-priority chunks and
+records a local storage feature when it completes.
+
+### Why This Matters
+
+Workloads that create many short-lived VQueues could previously retain an unbounded number of empty
+metadata records. Automatically removing them limits partition-store growth and avoids increasingly
+expensive VQueue metadata scans.
+
+### Impact on Users
+
+- Fully empty, unpaused queues disappear from `sys_vqueue_meta` and the VQueue CLI.
+- Historical timestamps and exponential moving averages stored in deleted metadata are discarded.
+  If the same VQueue is created again, these statistics restart from a new metadata record.
+- Empty paused queues remain visible and keep their pause state.
+- The first start after enabling the migration may take longer while each local partition-store
+  replica performs its cleanup scan. Deleting a large backlog can temporarily increase RocksDB
+  compaction and disk I/O.
+- A partition store that completed this cleanup requires Restate v1.7.10 or newer.
+
+### Migration Guidance
+
+On v1.7.10 and v1.8, enable the migration on each node after upgrading the cluster:
+
+```toml
+[common]
+experimental-enable-vqueue-obsolete-cleanup = true
+```
+
+Restate v1.9 enables the migration without configuration. For clusters with a large metadata
+backlog, roll the setting or upgrade through replicas gradually and allow cleanup and subsequent
+RocksDB compaction to settle before restarting additional replicas.


### PR DESCRIPTION

Add a one-time local StorageFeature that removes obsolete metadata in bounded background batches. Gate non-empty stores behind the experimental flag from v1.7.10, preserve paused and live queues, and document startup and compaction impact.

---
[//]: # (BEGIN SAPLING FOOTER)
* __->__ #5309
* #5308