### PR TITLE
fix(service-client): preserve active streams during graceful GOAWAY

### DIFF
--- a/crates/service-client/src/pool/README.md
+++ b/crates/service-client/src/pool/README.md
@@ -93,8 +93,12 @@ WaitingConnection ─┘
 - **InFlight**: Request sent; waiting for response headers.
 
 Errors during `Driving` or `PreFlight/poll_ready` are connection-level (close
-the connection). Errors during `send_request()` or `InFlight` are stream-level
-(only the individual request fails).
+the connection), except graceful GOAWAY (`NO_ERROR`) during `PreFlight`.
+That retires the connection from admission without cancelling active streams,
+and the pool retries the unsent request on another connection. Callers that
+reserved capacity before draining began also return their unsent requests.
+Errors during `send_request()` or `InFlight` remain stream-level (only the
+individual request fails); the pool does not replay these requests.
 
 ## TLS
 

--- a/crates/service-client/src/pool/conn.rs
+++ b/crates/service-client/src/pool/conn.rs
@@ -124,12 +124,18 @@ impl ConnectionShared {
 
     /// Stop admission while the connection task finishes accepted streams.
     fn drain(&self) {
-        let _ = self.state.compare_exchange(
-            STATE_CONNECTED,
-            STATE_DRAINING,
-            Ordering::Relaxed,
-            Ordering::Relaxed,
-        );
+        if self
+            .state
+            .compare_exchange(
+                STATE_CONNECTED,
+                STATE_DRAINING,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            )
+            .is_ok()
+        {
+            self.concurrency.wake_waiters();
+        }
     }
 
     /// Mark the connection as closed and wake any pending waiters.
@@ -1001,6 +1007,60 @@ mod test {
             .await
             .unwrap();
         resp.into_body()
+    }
+
+    #[tokio::test]
+    async fn draining_wakes_all_capacity_waiters_without_releasing_permits() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        };
+        use std::task::Context;
+
+        use futures::FutureExt;
+        use futures::task::{ArcWake, waker};
+
+        struct WakeFlag(AtomicBool);
+        impl ArcWake for WakeFlag {
+            fn wake_by_ref(flag: &Arc<Self>) {
+                flag.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let shared = super::ConnectionShared::new(
+            ConnectionConfigBuilder::default()
+                .streams_per_connection_limit(1)
+                .build()
+                .unwrap(),
+        );
+        shared
+            .state
+            .store(super::STATE_CONNECTED, Ordering::Release);
+        let active = shared.concurrency.acquire().await;
+        let mut waiters = Vec::new();
+        for _ in 0..8 {
+            let flag = Arc::new(WakeFlag(AtomicBool::new(false)));
+            let waker = waker(flag.clone());
+            let mut waiter = Box::pin(shared.concurrency.acquire());
+            assert!(
+                waiter
+                    .poll_unpin(&mut Context::from_waker(&waker))
+                    .is_pending()
+            );
+            waiters.push((waiter, flag));
+        }
+
+        shared.drain();
+
+        assert_eq!(shared.state.load(Ordering::Acquire), super::STATE_DRAINING);
+        assert_eq!(shared.concurrency.acquired(), 1);
+        for (_, flag) in &waiters {
+            assert!(
+                flag.0.load(Ordering::SeqCst),
+                "capacity waiter was not woken"
+            );
+        }
+        drop(active);
     }
 
     #[tokio::test]

--- a/crates/service-client/src/pool/conn.rs
+++ b/crates/service-client/src/pool/conn.rs
@@ -60,12 +60,16 @@ pub enum ConnectionError<R> {
     /// on a different connection. The original request is returned inside.
     #[error("permit to use the connection was reclaimed")]
     PermitReclaimed(R),
+    /// A graceful GOAWAY rejected this request before any bytes were sent.
+    #[error("connection is draining after GOAWAY")]
+    Draining(R),
 }
 
 const STATE_NEW: u8 = 0;
 const STATE_CONNECTING: u8 = 1;
 const STATE_CONNECTED: u8 = 2;
 const STATE_CLOSED: u8 = 3;
+const STATE_DRAINING: u8 = 4;
 
 /// The H2 handle obtained after a successful handshake. Set exactly once.
 #[derive(Debug)]
@@ -76,7 +80,8 @@ struct H2Handle {
 
 /// Lock-free shared state for an H2 connection.
 ///
-/// State transitions: `New → Connecting → Connected → Closed`.
+/// State transitions: `New → Connecting → Connected → Draining → Closed`.
+/// Fatal errors can transition directly to `Closed`.
 /// The `state` field tracks the discriminant atomically. The `h2` handle is set
 /// once via `OnceLock` when transitioning to `Connected`. Only the waiter list
 /// requires a brief lock during the `Connecting` phase.
@@ -115,6 +120,16 @@ impl ConnectionShared {
             created_at: now,
             last_used_at: AtomicU64::new(now.as_u64()),
         }
+    }
+
+    /// Stop admission while the connection task finishes accepted streams.
+    fn drain(&self) {
+        let _ = self.state.compare_exchange(
+            STATE_CONNECTED,
+            STATE_DRAINING,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        );
     }
 
     /// Mark the connection as closed and wake any pending waiters.
@@ -285,9 +300,12 @@ where
         self.shared.concurrency.size()
     }
 
-    /// Returns `true` if the connection has been closed or encountered a fatal error.
+    /// Returns `true` if the connection no longer accepts new requests.
     pub fn is_closed(&self) -> bool {
-        self.shared.state.load(Ordering::Relaxed) == STATE_CLOSED
+        matches!(
+            self.shared.state.load(Ordering::Relaxed),
+            STATE_CLOSED | STATE_DRAINING
+        )
     }
 
     /// Must be polled before each request. This makes sure we acquire the permit
@@ -305,7 +323,7 @@ where
                     return Poll::Ready(Err(err));
                 }
             }
-            STATE_CLOSED => {
+            STATE_CLOSED | STATE_DRAINING => {
                 return Poll::Ready(Err(Error::Closed));
             }
             STATE_CONNECTED => {
@@ -415,6 +433,7 @@ where
                             .clone(),
                     };
                 }
+                STATE_DRAINING => return ResponseFutureState::Draining,
                 STATE_CLOSED => return ResponseFutureState::error(Error::Closed),
                 _ => unreachable!(),
             }
@@ -542,8 +561,10 @@ where
 /// - **WaitingConnection** – another request is driving the handshake; we wait for notification.
 /// - **PreFlight** – we have a `SendRequest` handle and are waiting for H2 stream capacity.
 /// - **InFlight** – the request has been sent; we are waiting for the response.
+/// - **Draining** – graceful GOAWAY requires retrying the unsent request elsewhere.
 /// - **Error** – a terminal error was captured for the caller to consume.
 enum ResponseFutureState {
+    Draining,
     Driving {
         fut: BoxFuture<'static, Result<(SendRequest<Bytes>, DropGuard), Error>>,
     },
@@ -617,7 +638,9 @@ where
     //
     // **Connection-level** (close the entire connection via `shared.close()`):
     //   - Errors during `Driving` (handshake failures).
-    //   - Errors from `send_request.poll_ready()` in `PreFlight`.
+    //   - Errors from `send_request.poll_ready()` in `PreFlight`, except graceful GOAWAY.
+    //     Graceful GOAWAY retires the connection and returns the unsent request
+    //     for another connection without cancelling accepted streams.
     //   These go through the `Error` state which cancels the h2 handle and marks
     //   the connection as closed.
     //
@@ -630,13 +653,15 @@ where
     //   (triggering a connection close in PreFlight), or via the background
     //   connection task detecting the h2 shutdown and calling `shared.close()`.
     //
-    // This simplifies error handling here: we don't need to distinguish h2
-    // connection errors from stream errors ourselves — we let the phase of
-    // the lifecycle determine the behavior.
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
         loop {
             match this.state {
+                ResponseFutureState::Draining => {
+                    return Poll::Ready(Err(ConnectionError::Draining(
+                        this.request.take().expect("unsent request"),
+                    )));
+                }
                 ResponseFutureState::Error { ref mut err } => {
                     this.shared.close();
                     return Poll::Ready(Err(err
@@ -714,6 +739,13 @@ where
                 } => {
                     match send_request.poll_ready(cx) {
                         Poll::Ready(Ok(_)) => {}
+                        Poll::Ready(Err(err))
+                            if err.is_go_away() && err.reason() == Some(Reason::NO_ERROR) =>
+                        {
+                            this.shared.drain();
+                            this.state = ResponseFutureState::Draining;
+                            continue;
+                        }
                         Poll::Ready(Err(err)) => {
                             this.state = ResponseFutureState::error(err);
                             continue;
@@ -969,6 +1001,106 @@ mod test {
             .await
             .unwrap();
         resp.into_body()
+    }
+
+    #[tokio::test]
+    async fn goaway_preserves_active_response() {
+        let scenario = async {
+            let (client, server) = tokio::io::duplex(64 * 1024);
+            let socket = std::sync::Arc::new(parking_lot::Mutex::new(Some(client)));
+            let connector = tower::service_fn(move |_: http::Uri| {
+                let socket = socket.lock().take().unwrap();
+                async move { Ok::<_, std::io::Error>(socket) }
+            });
+            let (drain_tx, drain_rx) = tokio::sync::oneshot::channel();
+            let (finish_tx, finish_rx) = tokio::sync::oneshot::channel();
+            let server = tokio::spawn(async move {
+                let mut server = h2::server::handshake(server).await.unwrap();
+                let (_, mut response) = server.accept().await.unwrap().unwrap();
+                let mut body = response
+                    .send_response(http::Response::new(()), false)
+                    .unwrap();
+                tokio::select! {
+                    result = server.accept() => panic!("unexpected request before drain: {result:?}"),
+                    result = drain_rx => result.unwrap(),
+                }
+                server.graceful_shutdown();
+                tokio::select! {
+                    result = server.accept() => panic!("active stream closed during drain: {result:?}"),
+                    _ = finish_rx => {}
+                }
+                body.send_data(Bytes::from_static(b"completed"), true)
+                    .unwrap();
+                assert!(server.accept().await.is_none());
+            });
+            let mut connection = Connection::new(
+                connector,
+                ConnectionConfigBuilder::default().build().unwrap(),
+            );
+            connection.ready().await.unwrap();
+            let response = connection
+                .request(
+                    Request::builder()
+                        .uri("http://test-host")
+                        .body(http_body_util::Empty::<Bytes>::new())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            // Reserve a stream before the peer starts draining, as a concurrent caller can.
+            connection.ready().await.unwrap();
+            let mut concurrent = connection.clone();
+            concurrent.ready().await.unwrap();
+            drain_tx.send(()).unwrap();
+            let mut sender = connection.shared.h2.get().unwrap().send_request.clone();
+            loop {
+                match futures::future::poll_fn(|cx| sender.poll_ready(cx)).await {
+                    Err(err) => {
+                        assert!(err.is_go_away());
+                        break;
+                    }
+                    Ok(()) => tokio::task::yield_now().await,
+                }
+            }
+            let result = connection
+                .request(
+                    Request::builder()
+                        .uri("http://test-host")
+                        .body(http_body_util::Empty::<Bytes>::new())
+                        .unwrap(),
+                )
+                .await;
+            assert!(matches!(result, Err(super::ConnectionError::Draining(_))));
+            let request = Request::builder()
+                .method("POST")
+                .uri("http://test-host/unsent")
+                .body(http_body_util::Full::new(Bytes::from_static(b"not sent")))
+                .unwrap();
+            let Err(super::ConnectionError::Draining(request)) = concurrent.request(request).await
+            else {
+                panic!("a reserved caller must also retry without cancelling the connection");
+            };
+            assert_eq!(request.method(), http::Method::POST);
+            assert_eq!(request.uri().path(), "/unsent");
+            assert_eq!(
+                request.into_body().collect().await.unwrap().to_bytes(),
+                Bytes::from_static(b"not sent")
+            );
+            assert!(connection.is_closed());
+            assert!(!connection.shared.h2.get().unwrap().cancel.is_cancelled());
+            finish_tx.send(()).unwrap();
+            let body = response
+                .into_body()
+                .collect()
+                .await
+                .expect("GOAWAY must not cancel an accepted stream")
+                .to_bytes();
+            assert_eq!(body, Bytes::from_static(b"completed"));
+            server.await.unwrap();
+        };
+        tokio::time::timeout(std::time::Duration::from_secs(5), scenario)
+            .await
+            .expect("GOAWAY regression timed out");
     }
 
     #[test]

--- a/crates/service-client/src/pool/conn/concurrency.rs
+++ b/crates/service-client/src/pool/conn/concurrency.rs
@@ -76,6 +76,11 @@ impl Concurrency {
         }
     }
 
+    /// Wake capacity waiters so they can recheck the owning connection's state.
+    pub(super) fn wake_waiters(&self) {
+        self.inner.capacity.notify_waiters();
+    }
+
     /// Returns the current concurrency limit.
     pub fn size(&self) -> usize {
         self.inner.size.load(Ordering::Relaxed)

--- a/crates/service-client/src/pool/mod.rs
+++ b/crates/service-client/src/pool/mod.rs
@@ -143,6 +143,10 @@ where
                 match authority_pool.call(request).await {
                     Ok(result) => return Ok(result),
                     Err(conn::ConnectionError::Error(err)) => return Err(err),
+                    Err(conn::ConnectionError::Draining(req)) => {
+                        debug!("H2 connection draining, retrying unsent request");
+                        request = req;
+                    }
                     Err(conn::ConnectionError::PermitReclaimed(req)) => {
                         debug!("H2 request lost stream permit, retrying");
                         request = req;

--- a/release-notes/unreleased/http2-goaway-drain.md
+++ b/release-notes/unreleased/http2-goaway-drain.md
@@ -1,0 +1,12 @@
+# Preserve active HTTP/2 streams during graceful GOAWAY
+
+## Bug Fix
+
+A graceful GOAWAY received before a new service request is sent now retires the
+connection from the pool without cancelling streams already in progress. The
+unsent request is retried on another connection with its body intact.
+
+Previously, a readiness error on the new request cancelled the shared connection
+and could interrupt unrelated service invocations. Hard connection failures still
+propagate normally; requests already sent are not automatically replayed by this
+change. No configuration or migration is required.


### PR DESCRIPTION
## Problem

When an HTTP/2 peer begins graceful shutdown, a new request can encounter GOAWAY while other service requests are still active on the same connection. The pool treats the new request's readiness error as a fatal connection error and cancels the shared connection task, potentially interrupting those active invocations.

I encountered this with Cloud Run when instance rotation is high.

## Change

Introduce a draining state for graceful GOAWAY (`NO_ERROR`). Retire that connection from new admission while allowing its existing streams to finish. Return only requests rejected before `send_request()` to the pool for retry on another connection, preserving their bodies. Hard connection errors retain their existing behavior; this patch does not replay already-sent requests.

The regression uses an in-memory HTTP/2 server, keeps a response open during graceful shutdown, and checks both the first caller encountering GOAWAY and another caller that reserved capacity before draining began.